### PR TITLE
Fix desktop and HPC build workflows

### DIFF
--- a/.github/workflows/hpc-bundle.yml
+++ b/.github/workflows/hpc-bundle.yml
@@ -11,11 +11,18 @@ on:
       - main
       - dev
     paths:
+      - '.github/workflows/hpc-bundle.yml'
+      - 'desktop/**'
+      - 'docs/**'
+      - 'extensions/**'
+      - 'scripts/build-doc-chunks.js'
       - 'src/**'
       - 'server/**'
+      - 'static/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
-      - 'vite.config.ts'
+      - 'vite.desktop.config.ts'
+      - 'vite.shared.ts'
       - 'svelte.config.js'
   workflow_dispatch:
 
@@ -37,8 +44,32 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Generate SvelteKit tsconfig + ambient types
+        run: pnpm exec svelte-kit sync
+
+      - name: Build WASM extensions
+        run: |
+          export PATH=$PATH:$HOME/.cargo/bin
+
+          cd extensions/rust
+          wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
+
+          cd ../chgdiff-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+      - name: Build documentation chunks
+        run: pnpm run build:doc-chunks
+
       - name: Build frontend
-        run: pnpm build
+        run: pnpm run deploy:build
 
       - name: Create HPC bundle
         run: |
@@ -46,7 +77,7 @@ jobs:
           mkdir -p "$BUNDLE_DIR"
 
           # Copy pre-built frontend
-          cp -r build "$BUNDLE_DIR/frontend"
+          cp -r build-desktop "$BUNDLE_DIR/frontend"
 
           # Copy server (Python backend)
           cp -r server "$BUNDLE_DIR/server"

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -53,7 +62,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          conda install -y -c conda-forge openbabel
+          conda install -y -c conda-forge openbabel pip
           python -m pip install --upgrade pip
           pip install pyinstaller
           grep -iv '^openbabel' server/requirements.txt > reqs_no_ob.txt
@@ -77,33 +86,46 @@ jobs:
           mkdir -p ../src-tauri/binaries
           cp dist/catgo-server.exe ../src-tauri/binaries/catgo-server-${{ matrix.backend_target }}.exe
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'pnpm'
-
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.target }}, wasm32-unknown-unknown
+
+      - name: Install frontend dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build WASM extensions
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+          export PATH=$PATH:$HOME/.cargo/bin
+
+          cd extensions/rust
+          wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
+
+          cd ../chgdiff-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+      - name: Generate documentation chunks
+        run: pnpm run build:doc-chunks
+
+      - name: Verify generated build assets
+        run: |
+          ls -la extensions/rust-wasm/pkg/ferrox_bg.wasm
+          ls -la src/lib/electronic/chgdiff-wasm-pkg/chgdiff_wasm_bg.wasm
+          ls -la src/lib/chat/docs-chunks.json
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
 
-      - name: Install frontend dependencies
-        run: pnpm install --no-frozen-lockfile
-
       - name: Generate icons
         run: node scripts/generate-icons.js
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tauri-test-build.yml
+++ b/.github/workflows/tauri-test-build.yml
@@ -19,6 +19,9 @@ jobs:
     if: ${{ inputs.platform == 'all' || inputs.platform == 'windows' }}
     runs-on: windows-latest
     name: Build Windows
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
       - name: Checkout repository
@@ -33,8 +36,34 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
 
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: '3.11'
+          channels: conda-forge
+          auto-activate-base: false
+          activate-environment: catgo
+
+      - name: Install Python dependencies
+        run: |
+          conda install -y -c conda-forge openbabel pip
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          grep -iv '^openbabel' server/requirements.txt > reqs_no_ob.txt
+          pip install -r reqs_no_ob.txt
+          rm reqs_no_ob.txt
+
+      - name: Build backend
+        run: |
+          cd server
+          python -m PyInstaller catgo_server.spec --noconfirm
+          mkdir -p ../src-tauri/binaries
+          cp dist/catgo-server.exe ../src-tauri/binaries/catgo-server-x86_64-pc-windows-msvc.exe
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -42,7 +71,26 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install frontend dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build WASM extensions
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+          export PATH=$PATH:$HOME/.cargo/bin
+
+          cd extensions/rust
+          wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
+
+          cd ../chgdiff-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+      - name: Generate documentation chunks
+        run: pnpm run build:doc-chunks
+
+      - name: Generate icons
+        run: node scripts/generate-icons.js
 
       - name: Build Tauri app
         run: pnpm tauri:build
@@ -60,6 +108,9 @@ jobs:
     if: ${{ inputs.platform == 'all' || inputs.platform == 'macos' }}
     runs-on: macos-latest
     name: Build macOS (Apple Silicon)
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
       - name: Checkout repository
@@ -74,10 +125,35 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
 
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: '3.11'
+          channels: conda-forge
+          auto-activate-base: false
+          activate-environment: catgo
+
+      - name: Install Python dependencies
+        run: |
+          conda install -y -c conda-forge openbabel pip
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          grep -iv '^openbabel' server/requirements.txt > reqs_no_ob.txt
+          pip install -r reqs_no_ob.txt
+          rm reqs_no_ob.txt
+
+      - name: Build backend
+        run: |
+          cd server
+          python -m PyInstaller catgo_server.spec --noconfirm
+          mkdir -p ../src-tauri/binaries
+          cp dist/catgo-server ../src-tauri/binaries/catgo-server-aarch64-apple-darwin
+          chmod +x ../src-tauri/binaries/catgo-server-aarch64-apple-darwin
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin, wasm32-unknown-unknown
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -85,7 +161,26 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install frontend dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build WASM extensions
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+          export PATH=$PATH:$HOME/.cargo/bin
+
+          cd extensions/rust
+          wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
+
+          cd ../chgdiff-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+      - name: Generate documentation chunks
+        run: pnpm run build:doc-chunks
+
+      - name: Generate icons
+        run: node scripts/generate-icons.js
 
       - name: Build Tauri app
         run: pnpm tauri:build -- --target aarch64-apple-darwin
@@ -101,8 +196,11 @@ jobs:
 
   build-macos-intel:
     if: ${{ inputs.platform == 'all' || inputs.platform == 'macos-intel' }}
-    runs-on: macos-15
+    runs-on: macos-13
     name: Build macOS (Intel)
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
       - name: Checkout repository
@@ -117,10 +215,35 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
 
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: '3.11'
+          channels: conda-forge
+          auto-activate-base: false
+          activate-environment: catgo
+
+      - name: Install Python dependencies
+        run: |
+          conda install -y -c conda-forge openbabel pip
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          grep -iv '^openbabel' server/requirements.txt > reqs_no_ob.txt
+          pip install -r reqs_no_ob.txt
+          rm reqs_no_ob.txt
+
+      - name: Build backend
+        run: |
+          cd server
+          python -m PyInstaller catgo_server.spec --noconfirm
+          mkdir -p ../src-tauri/binaries
+          cp dist/catgo-server ../src-tauri/binaries/catgo-server-x86_64-apple-darwin
+          chmod +x ../src-tauri/binaries/catgo-server-x86_64-apple-darwin
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-apple-darwin
+          targets: x86_64-apple-darwin, wasm32-unknown-unknown
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -128,7 +251,26 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: Install frontend dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build WASM extensions
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+          export PATH=$PATH:$HOME/.cargo/bin
+
+          cd extensions/rust
+          wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
+
+          cd ../chgdiff-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+      - name: Generate documentation chunks
+        run: pnpm run build:doc-chunks
+
+      - name: Generate icons
+        run: node scripts/generate-icons.js
 
       - name: Build Tauri app
         run: pnpm tauri:build -- --target x86_64-apple-darwin


### PR DESCRIPTION
## Summary
- generate required Rust WASM packages and docs chunks before Tauri desktop packaging
- make the manual desktop build workflow build the bundled backend before Tauri packaging
- switch the HPC bundle workflow to the actual static build output, build-desktop

## Verification
- ruby -ryaml parsed updated workflow YAML
- pnpm exec svelte-kit sync
- pnpm run build:doc-chunks
- wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
- wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
- pnpm run deploy:build