### PR TITLE
fix(backend): bundle pywin32 lib helpers so HPC connect works on Windows

### DIFF
--- a/server/catgo_server.spec
+++ b/server/catgo_server.spec
@@ -138,6 +138,24 @@ a = Analysis(
         'mcp',
         'mcp.server',
         'mcp.types',
+
+        # ---------------------------------------------------------------
+        # Windows: pywin32 helper modules in win32/lib/
+        #
+        # PyInstaller's pywin32 hook captures the .pyd C extensions but does
+        # NOT run pywin32's .pth file, which is what makes the pure-Python
+        # helpers in win32/lib/ importable at the top level (e.g.
+        # `import win32timezone`). pywin32 itself and some of its dependents
+        # lazy-import these helpers from inside C code paths; without them,
+        # HPC connect raises `ModuleNotFoundError: No module named 'win32timezone'`
+        # at runtime even though all the .pyd files are present.
+        #
+        # Listed explicitly so PyInstaller's importer finds the .py files and
+        # packs them. Build is unaffected on macOS/Linux — unresolved hidden
+        # imports emit a warning but do not fail the build.
+        # ---------------------------------------------------------------
+        'win32timezone',
+        'pywin32_bootstrap',
     ],
     hookspath=[str(server_dir / 'pyinstaller_hooks')],
     hooksconfig={},


### PR DESCRIPTION
PyInstaller's pywin32 hook captures the .pyd C extensions but does not process pywin32's .pth file, so the pure-Python helpers in win32/lib/ (win32timezone, pywin32_bootstrap, etc.) never become importable at the top level inside the frozen bundle. Cluster connect on Windows then raises ModuleNotFoundError: No module named 'win32timezone' from asyncssh's GSSAPI / SSH-agent code path, even though every .pyd is present.

Adding win32timezone and pywin32_bootstrap as explicit hidden imports makes PyInstaller pack the .py files into the embedded PYZ archive. Verified by inspecting the PYZ TOC of the v1.0.0 release bundle vs. a rebuild with this spec change, and by end-to-end cluster connect on Windows.

No-op on macOS / Linux: unresolved hidden imports emit a build warning but do not fail the build.