### PR TITLE
docs: redefine CatGo as 'AI-driven workbench for computational materials science'

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: `CatGo`,
   description:
-    `An open-source, browser-based platform for interactive visualization, structure building, and AI-assisted workflow automation in computational materials science and catalysis research.`,
+    `AI-driven workbench for computational materials science. Build structures, run workflows on HPC, and chat with CatBot — all from one desktop app.`,
   lang: `en-US`,
 
   // Deploy as static site under /docs/ or root — adjust as needed

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -1,6 +1,6 @@
 # CatGo Documentation
 
-**CatGo** (Catalysis Visualization System) is an open-source, browser-based platform for interactive visualization, structure building, and AI-assisted workflow automation in computational materials science and catalysis research. It runs in the browser, as a desktop application (Tauri), and as a VSCode extension, providing 3D crystal and molecular structure viewers, periodic tables, band structure plots, phase diagrams, trajectory players, and a node-based workflow editor with integrated HPC orchestration.
+**CatGo** is an **AI-driven workbench for computational materials science**. It combines an interactive 3D structure viewer, a visual DAG workflow engine, integrated HPC orchestration, and a natural-language AI assistant (**CatBot**) into a single desktop application (Tauri) — with an additional VS Code extension for in-editor workflows. The viewer handles crystals, molecules, and surfaces; the workflow engine generates DFT/MD/ML inputs, submits and monitors jobs on remote clusters, and post-processes results through band structure plots, phase diagrams, trajectory players, and more.
 
 ## Key Features
 
@@ -63,44 +63,44 @@ CatGo
 
 ### Core
 
-| Module | Description | Docs |
-|--------|-------------|------|
-| [Structure Viewer](/modules/core/structure-viewer) | 3D interactive visualization of atoms, bonds, and lattices | [Link](/modules/core/structure-viewer) |
-| [File I/O](/modules/core/file-io) | Parse and export crystal/molecular structure files | [Link](/modules/core/file-io) |
-| [Lattice & Cell](/modules/core/lattice-cell) | Lattice parameters, coordinate transforms, cell operations | [Link](/modules/core/lattice-cell) |
-| [Bonding](/modules/core/bonding) | Bond detection, editing, and coordination analysis | [Link](/modules/core/bonding) |
+| Module | Description |
+|--------|-------------|
+| [Structure Viewer](/modules/core/structure-viewer) | 3D interactive visualization of atoms, bonds, and lattices |
+| [File I/O](/modules/core/file-io) | Parse and export crystal/molecular structure files |
+| [Lattice & Cell](/modules/core/lattice-cell) | Lattice parameters, coordinate transforms, cell operations |
+| [Bonding](/modules/core/bonding) | Bond detection, editing, and coordination analysis |
 
 ### Crystallography
 
-| Module | Description | Docs |
-|--------|-------------|------|
-| [Surfaces & Slabs](/modules/crystallography/surfaces-slabs) | Miller index slab generation, vacuum layers, adsorption sites | [Link](/modules/crystallography/surfaces-slabs) |
-| [Symmetry](/modules/crystallography/symmetry) | Space group detection, Wyckoff positions, Bravais lattices | [Link](/modules/crystallography/symmetry) |
-| [Supercells](/modules/crystallography/supercells) | Periodic cell expansion and transformation | [Link](/modules/crystallography/supercells) |
+| Module | Description |
+|--------|-------------|
+| [Surfaces & Slabs](/modules/crystallography/surfaces-slabs) | Miller index slab generation, vacuum layers, adsorption sites |
+| [Symmetry](/modules/crystallography/symmetry) | Space group detection, Wyckoff positions, Bravais lattices |
+| [Supercells](/modules/crystallography/supercells) | Periodic cell expansion and transformation |
 
 ### Dynamics & Optimization
 
-| Module | Description | Docs |
-|--------|-------------|------|
-| [Trajectories](/modules/dynamics/trajectories) | MD trajectory playback, frame indexing, streaming | [Link](/modules/dynamics/trajectories) |
-| [Optimization](/modules/dynamics/optimization) | Structure relaxation with multiple calculators | [Link](/modules/dynamics/optimization) |
+| Module | Description |
+|--------|-------------|
+| [Trajectories](/modules/dynamics/trajectories) | MD trajectory playback, frame indexing, streaming |
+| [Optimization](/modules/dynamics/optimization) | Structure relaxation with multiple calculators |
 
 ### Analysis & Spectroscopy
 
-| Module | Description | Docs |
-|--------|-------------|------|
-| [Spectroscopy](/modules/analysis/spectroscopy) | XRD, RDF, band structure, density of states | [Link](/modules/analysis/spectroscopy) |
-| [Phase Diagrams](/modules/analysis/phase-diagrams) | Thermodynamic stability and convex hulls | [Link](/modules/analysis/phase-diagrams) |
-| [Composition](/modules/analysis/composition) | Chemical formula handling and composition charts | [Link](/modules/analysis/composition) |
-| [Periodic Table](/modules/analysis/periodic-table) | Interactive element explorer with property data | [Link](/modules/analysis/periodic-table) |
+| Module | Description |
+|--------|-------------|
+| [Spectroscopy](/modules/analysis/spectroscopy) | XRD, RDF, band structure, density of states |
+| [Phase Diagrams](/modules/analysis/phase-diagrams) | Thermodynamic stability and convex hulls |
+| [Composition](/modules/analysis/composition) | Chemical formula handling and composition charts |
+| [Periodic Table](/modules/analysis/periodic-table) | Interactive element explorer with property data |
 
 ### Integrations
 
-| Module | Description | Docs |
-|--------|-------------|------|
-| [Density Visualization](/modules/integrations/density-visualization) | CUBE file isosurfaces and slice planes | [Link](/modules/integrations/density-visualization) |
-| [Database Integration](/modules/integrations/database-integration) | OPTIMADE, Materials Project, PubChem search | [Link](/modules/integrations/database-integration) |
-| [Settings](/modules/core/settings) | 40+ configurable properties across platforms | [Link](/modules/core/settings) |
+| Module | Description |
+|--------|-------------|
+| [Density Visualization](/modules/integrations/density-visualization) | CUBE file isosurfaces and slice planes |
+| [Database Integration](/modules/integrations/database-integration) | OPTIMADE, Materials Project, PubChem search |
+| [Settings](/modules/core/settings) | 40+ configurable properties across platforms |
 
 ## Deployment Targets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: CatGo
-  text: Catalysis Visualization System
-  tagline: An Interactive Web-Based Platform for Materials Visualization, Structure Building, and AI-Assisted Computational Workflows.
+  text: AI-Driven Workbench for Computational Materials Science
+  tagline: Build structures, run workflows, and chat with CatBot — all from one window.
   actions:
     - theme: brand
       text: Get Started

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -4,7 +4,7 @@
 
 ### What is CatGo?
 
-CatGo (Catalysis Visualization System) is an open-source desktop application for computational materials science and catalysis research. It combines a 3D structure viewer, a node-based workflow editor with HPC orchestration, and a natural-language AI assistant (CatBot). CatGo is available as a desktop application (Tauri) and as a VSCode extension.
+CatGo is an **AI-driven workbench for computational materials science**. It combines a 3D structure viewer, a node-based workflow editor with HPC orchestration, and a natural-language AI assistant (CatBot). Available as a desktop application (Tauri) and as a VS Code extension.
 
 ### What file formats are supported?
 


### PR DESCRIPTION
## Summary

Aligns the docs/website definition of CatGo with the README's current framing — **\"AI-driven workbench for computational materials science\"** — and drops the legacy *Catalysis Visualization System* expansion (CatGo's scope has grown beyond catalysis).

Four surfaces updated:

| File | What changed |
|---|---|
| `docs/.vitepress/config.ts` | Site `description:` (HTML meta tag used by SEO + link previews) |
| `docs/index.md` | Hero `text:` and `tagline:` on the landing page |
| `docs/guide/overview.md` | First paragraph of the Guide |
| `docs/reference/faq.md` | \"What is CatGo?\" answer |

Also drops a redundant \"Docs\" column from the module tables in `overview.md` — column 1 was already a link to the same pages, and the `[Link]` text tripped MD059 markdownlint.

## Test plan

- [x] `cat docs/.vitepress/config.ts | grep description` shows the new line
- [x] `cat docs/index.md` shows the new hero `text:` and `tagline:`
- [x] markdownlint passes (was failing before because of the `[Link]` column)
- [ ] `pnpm docs:dev` and visually confirm the landing page hero