### PR TITLE
fix: stale work_dir blocking resubmission + ConvergencePlot live-monitor autoscale

### DIFF
--- a/server/catgo/workflow/engine/error_handler.py
+++ b/server/catgo/workflow/engine/error_handler.py
@@ -63,6 +63,7 @@ def handle_errors(db: WorkflowDB, workflow_id: str, config: dict[str, Any]) -> l
                 status=TaskState.READY.value,
                 retry_count=retry_count + 1,
                 error_message=f"Auto-fix applied: {diagnosis['diagnosis']}",
+                work_dir=None,  # force recompute (prior attempt may have stickied a bad path)
             )
             retried.append(task_id)
             logger.info("Task %s: smart recovery applied (%s)", task_id, diagnosis["diagnosis"])
@@ -79,6 +80,7 @@ def handle_errors(db: WorkflowDB, workflow_id: str, config: dict[str, Any]) -> l
                 status=TaskState.READY.value,
                 retry_count=retry_count + 1,
                 error_message=None,
+                work_dir=None,  # force recompute (prior attempt may have stickied a bad path)
             )
             retried.append(task_id)
             logger.info("Task %s: REMOTE_ERROR -> READY (retry %d/%d)", task_id, retry_count + 1, max_retries)

--- a/server/catgo/workflow/engine/hpc_utils.py
+++ b/server/catgo/workflow/engine/hpc_utils.py
@@ -42,13 +42,31 @@ async def get_hpc_connection(task: dict, config: dict) -> Any | None:
     return None
 
 
+# States in which the stored tasks.work_dir is authoritative — these only
+# occur after `mkdir -p` has succeeded on the remote in submitter.py.
+# For any other state the column may hold a stale path from a failed prior
+# attempt, or a local preview path written by the advancer, and must be
+# recomputed from the current run config.
+_REMOTE_DIR_EXISTS_STATES = frozenset({
+    "UPLOADING", "SUBMITTED", "QUEUED", "RUNNING",
+    "COMPLETED_REMOTE", "COLLECTING", "COMPLETED",
+})
+
+
 def resolve_work_dir(task: dict, workflow_id: str, config: dict) -> str:
-    """Build remote work directory path for a task."""
+    """Build remote work directory path for a task.
+
+    The stored ``tasks.work_dir`` is only trusted when the task is past
+    the upload step; for pre-submission states it is recomputed from the
+    current run config so that a stale path from a failed prior attempt
+    (or a since-corrected ``base_work_dir``) cannot be stickied indefinitely.
+    """
     import logging
     _logger = logging.getLogger(__name__)
 
-    if task.get("work_dir"):
-        return task["work_dir"]
+    existing = task.get("work_dir")
+    if existing and task.get("status") in _REMOTE_DIR_EXISTS_STATES:
+        return existing
 
     template = config.get("paths", {}).get(
         "work_dir_template", "{base_dir}/{workflow_id}/{task_id}"

--- a/server/catgo/workflow/engine/submitter.py
+++ b/server/catgo/workflow/engine/submitter.py
@@ -233,9 +233,12 @@ async def _submit_one(
         task_for_resolve = {**task, "work_dir": ""}
     work_dir = resolve_work_dir(task_for_resolve, workflow_id, config)
 
-    # 5. Create remote directory
-    db.update_task(task_id, status=TaskState.GENERATING.value, work_dir=work_dir)
+    # 5. Create remote directory. Persist work_dir only AFTER mkdir succeeds
+    # so a failed attempt does not leave a stale path stickied to the row —
+    # otherwise resolve_work_dir will reuse it on every subsequent retry.
+    db.update_task(task_id, status=TaskState.GENERATING.value)
     await hpc.run_on_owner(lambda: hpc.conn.run(f"mkdir -p {work_dir}", check=True))
+    db.update_task(task_id, work_dir=work_dir)
 
     # 5.5 Check if preview files exist (from PENDING_REVIEW local generation)
     from pathlib import Path

--- a/server/catgo/workflow/service.py
+++ b/server/catgo/workflow/service.py
@@ -106,6 +106,7 @@ def retry_task(db: WorkflowDB, task_id: str) -> list[str]:
             error_message=None,
             error_type=None,
             retry_count=0,
+            work_dir=None,  # force recompute (prior attempt may have stickied a bad path)
         )
     return list(to_reset)
 

--- a/src/lib/workflow/ConvergencePlot.svelte
+++ b/src/lib/workflow/ConvergencePlot.svelte
@@ -6,16 +6,10 @@
     points = [],
     is_orca = false,
     running = false,
-    max_steps = 0,
   }: {
     points: ConvergencePoint[]
     is_orca: boolean
     running?: boolean
-    /** Target step count (NSW / max_steps). When > 0, the x-axis is pinned
-     * to [0, max_steps] so a 57-of-500-steps NEB visibly shows ~11% progress
-     * across the plot width instead of filling the whole axis. Pass 0 to
-     * let Plotly auto-scale. */
-    max_steps?: number
   } = $props()
 
   let plot_div: HTMLDivElement | undefined = $state()
@@ -56,22 +50,14 @@
     }
 
     const axis_color = `var(--text-color, #374151)`
-    // Pin x-axis to the target step count when provided so the user sees
-    // their progress as a fraction of the planned run (e.g. 57/500 = 11 %
-    // of the plot width). When max_steps is 0 or unknown, fall back to
-    // Plotly auto-scaling.
-    const x_current_max = steps[steps.length - 1] ?? 1
-    const x_range = max_steps > x_current_max
-      ? [0, max_steps]
-      : [0, Math.max(x_current_max, 10)]
 
     const layout = base_layout({
       height: 260,
       margin: { l: 60, r: 60, t: 15, b: 50 },
       xaxis: {
-        title: max_steps > 0 ? `Step (of ${max_steps})` : `Step`,
+        title: `Step`,
         showgrid: true, zeroline: false, color: axis_color,
-        range: x_range, autorange: false,
+        autorange: true,
       },
       yaxis: { title: is_orca ? `Energy (Eh)` : `Energy (eV)`, showgrid: true, zeroline: false, color: axis_color },
       yaxis2: { title: is_orca ? `Max Gradient` : `Max Force (eV/Å)`, overlaying: `y`, side: `right`, showgrid: false, color: axis_color },

--- a/src/lib/workflow/NodeStatusPanel.svelte
+++ b/src/lib/workflow/NodeStatusPanel.svelte
@@ -1431,7 +1431,6 @@
                   points={convergence.points}
                   {is_orca}
                   running={status === `running` || status === `queued`}
-                  max_steps={Number(effective_node_params?.max_steps) || Number(effective_node_params?.NSW) || 0}
                 />
               {/if}
             </div>
@@ -1921,6 +1920,7 @@
               <ConvergencePlot
                 points={convergence?.points ?? []}
                 is_orca={true}
+                running={status === `running` || status === `queued`}
               />
             {:else}
               <div class="sp-ssh-hint">


### PR DESCRIPTION
Two related fixes for v1.0.x:

## 1. `fix(engine): prevent stale work_dir from blocking task resubmission` (`d9f041a1`)

Reproduced against a live workflow. A NEB-TS task had `/expanse/projects/...` (missing `/lustre/`) stickied to its `tasks.work_dir` from a prior attempt under a wrong `base_work_dir`. Every retry re-failed at `mkdir -p` with `Process exited with non-zero exit status 1` while the parent opts (with correct paths) re-ran fine. Only direct SQL could recover the workflow.

Root cause: `submitter.py` wrote `work_dir` to the DB *before* `mkdir` ran, and `resolve_work_dir` reused any stored value unconditionally, stickying failed-attempt paths across retries.

Three-part defense-in-depth:
- `submitter.py`: persist `work_dir` AFTER `mkdir -p` succeeds
- `hpc_utils.py`: only trust stored `work_dir` for UPLOADING/SUBMITTED/QUEUED/RUNNING/COMPLETED_REMOTE/COLLECTING/COMPLETED states; pre-submission states recompute from current run config (auto-heals existing stuck DBs)
- `service.py` + `error_handler.py`: `retry_task` and auto-retry paths clear `work_dir=None` on reset

## 2. `fix(ui): auto-scale ConvergencePlot x-axis for live monitoring` (`5565e993`)

`ConvergencePlot` was pinning its x-axis to `[0, max_steps]` (NSW / target steps), making early progress visually invisible on long jobs — a 57-of-500 step NEB filled only the leftmost 11% of the plot. Drop the `max_steps` prop and let Plotly auto-scale. Also wires the missing `running` flag to the second `ConvergencePlot` mount in `NodeStatusPanel` so live polling fires for queued/running tasks on that code path.

## Scope

No schema changes. Existing stuck workflows self-heal on next retry — no manual intervention needed for users