### PR TITLE
ci: wrangler.toml for Cloudflare Workers Static Assets

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,8 @@
+name = "catgo-docs"
+compatibility_date = "2026-05-13"
+
+# Static-assets-only Worker for the VitePress documentation site.
+# Cloudflare auto-serves files from `directory`; no Worker script needed.
+[assets]
+directory = "./docs/.vitepress/dist"
+not_found_handling = "404-page"


### PR DESCRIPTION
## Summary

Adds `wrangler.toml` at repo root so the `catgo-docs` Cloudflare Worker can serve the built VitePress site as static assets.

- \`name = catgo-docs\` matches the existing Worker project.
- \`[assets].directory = ./docs/.vitepress/dist\` points at the VitePress build output.
- \`not_found_handling = 404-page\` falls back to VitePress's generated 404 page.

No Worker script; Cloudflare serves files directly from the assets binding.

## Dash side

Build command: \`pnpm install && pnpm docs:build\`
Deploy command: \`npx wrangler deploy\`
Path: \`/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)