### PR TITLE
fix(ferrox-wasm): gate /@fs prefix on dev mode

### DIFF
--- a/src/lib/structure/ferrox-wasm.ts
+++ b/src/lib/structure/ferrox-wasm.ts
@@ -371,9 +371,11 @@ export async function compile_wasm_module(): Promise<WebAssembly.Module> {
   )
   let url = wasm_url_module.default as string
 
-  // vite-plugin-ferrox-wasm replaces the import with an absolute path like
-  // "/home/user/.../ferrox_bg.wasm". Prepend /@fs to make it a valid Vite dev URL.
-  if (url.startsWith(`/`) && !url.startsWith(`/@`)) {
+  // Dev only: vite-plugin-ferrox-wasm rewrites the import to an absolute
+  // filesystem path like "/home/user/.../ferrox_bg.wasm". Prepend /@fs so the
+  // Vite dev server can serve it. In production the same plugin emits a hashed
+  // asset URL (/assets/ferrox_bg-XXX.wasm) which must be left untouched.
+  if (import.meta.env.DEV && url.startsWith(`/`) && !url.startsWith(`/@`)) {
     url = `/@fs${url}`
   }
 


### PR DESCRIPTION
Closes #16.

## Summary

In production builds, the runtime in `src/lib/structure/ferrox-wasm.ts` prepended `/@fs/` to any absolute-path WASM URL — including the hashed production URL that `vite-plugin-ferrox-wasm` already emits (`/assets/ferrox_bg-XXX.wasm`). That made the request 404 onto the SPA fallback, served `index.html`, and tripped \`WebAssembly.compile()\`. Bond computation silently fell back to the single-threaded main path and froze the browser whenever an atom was dragged.

Fix: gate the dev-only \`/@fs/\` prepend on \`import.meta.env.DEV\`.

```diff
- if (url.startsWith(\`/\`) && !url.startsWith(\`/@\`)) {
+ if (import.meta.env.DEV && url.startsWith(\`/\`) && !url.startsWith(\`/@\`)) {
    url = \`/@fs\${url}\`
  }
```

## Test plan

- [x] \`pnpm deploy:build\` succeeds
- [x] \`grep -c '/@fs' build-desktop/assets/index-*.js\` -> 0 in every chunk
- [x] Redeploy to \`https://app.catgo-ucsd.org\` — fresh bundle live (\`index-DXoY2nE1.js\`)
- [ ] Hard-refresh, load a structure, rotate atoms — no main-thread fallback in DevTools console

🤖 Generated with [Claude Code](https://claude.com/claude-code)