### PR TITLE
fix(viewer): convert CHGCAR/CHGDIFF in-browser via wasm (issue #19 part A)

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -743,21 +743,34 @@
     }
     const text = typeof content === `string` ? content : new TextDecoder().decode(content)
 
-    // CHGCAR/AECCAR/LOCPOT 等 VASP 体积数据文件 → 后端转换为 cube 格式
+    // CHGCAR / CHGDIFF / LOCPOT etc. → convert to Gaussian cube via wasm.
+    // chgdiff-wasm exposes `chgcar_to_cube(text)` and the package is already
+    // bundled with the desktop frontend, so we don't hit the backend's
+    // `/api/chgcar/convert-to-cube` endpoint (which shells out to the
+    // Rust cube-processor binary that may not be present in a fresh
+    // PyInstaller bundle).  Backend HTTP path is kept as a fallback so
+    // dev setups with the binary present keep working unchanged.
     if (is_chgcar_file(filename)) {
       try {
-        const blob = new Blob([text], { type: `application/octet-stream` })
-        const form_data = new FormData()
-        form_data.append(`file`, new File([blob], filename))
-        const resp = await fetch(`${API_BASE}/chgcar/convert-to-cube`, {
-          method: `POST`,
-          body: form_data,
-        })
-        if (!resp.ok) {
-          const err = await resp.json().catch(() => ({ detail: resp.statusText }))
-          throw new Error(err.detail || `CHGCAR conversion failed: ${resp.statusText}`)
+        let cube_text: string
+        try {
+          const { chgcar_to_cube } = await import('$lib/electronic/chgdiff-wasm')
+          cube_text = await chgcar_to_cube(text)
+        } catch (wasm_err) {
+          console.warn(`[CHGCAR] wasm path failed, falling back to backend:`, wasm_err)
+          const blob = new Blob([text], { type: `application/octet-stream` })
+          const form_data = new FormData()
+          form_data.append(`file`, new File([blob], filename))
+          const resp = await fetch(`${API_BASE}/chgcar/convert-to-cube`, {
+            method: `POST`,
+            body: form_data,
+          })
+          if (!resp.ok) {
+            const err = await resp.json().catch(() => ({ detail: resp.statusText }))
+            throw new Error(err.detail || `CHGCAR conversion failed: ${resp.statusText}`)
+          }
+          cube_text = await resp.text()
         }
-        const cube_text = await resp.text()
         const cube_filename = filename.replace(/\.(gz|bz2|xz|zst)$/i, ``) + `.cube`
         try {
           const header = parse_cube_header(cube_text)

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -166,14 +166,15 @@ export interface SampleStructure {
 // ========== File Detection ==========
 
 /** CHGCAR/AECCAR/LOCPOT etc. VASP volumetric data file name detection */
-const CHGCAR_PATTERNS = /^(CHGCAR|AECCAR0|AECCAR1|AECCAR2|LOCPOT|ELFCAR|PARCHG)$/i
+const CHGCAR_PATTERNS = /^(CHGCAR|CHGDIFF|DIFFCHG|AECCAR0|AECCAR1|AECCAR2|LOCPOT|ELFCAR|PARCHG)(\.vasp)?$/i
 
 export function is_chgcar_file(filename: string): boolean {
   // Files with .cube/.cub extension are NOT CHGCAR, even if name contains "CHGCAR"
   if (/\.(cube|cub)$/i.test(filename)) return false
   const basename = filename.replace(/\.(gz|bz2|xz|zst)$/i, ``)
   if (CHGCAR_PATTERNS.test(basename)) return true
-  if (/CHGCAR|AECCAR|LOCPOT|ELFCAR|PARCHG/i.test(basename)) return true
+  // Loose match — catches "CHGCAR_diff_HCO2", "DIFFCHG_HCO2" etc.
+  if (/CHGCAR|CHGDIFF|DIFFCHG|AECCAR|LOCPOT|ELFCAR|PARCHG/i.test(basename)) return true
   return false
 }
 

--- a/extensions/chgdiff-wasm/src/lib.rs
+++ b/extensions/chgdiff-wasm/src/lib.rs
@@ -347,7 +347,80 @@ fn chgdiff_to_cube(
     Ok(out)
 }
 
+/// Write a single ParsedChgcar to a Gaussian cube string (e/Bohr³).
+/// Same coordinate / unit conventions as `chgdiff_to_cube`; just the
+/// volumetric values are the raw ρ from the CHGCAR rather than a diff.
+fn chgcar_to_cube_string(chg: &ParsedChgcar) -> Result<String, String> {
+    let lat = &chg.lattice;
+    let volume_ang3 = det3(lat).abs();
+    let volume_bohr3 = volume_ang3 * ANGSTROM_TO_BOHR.powi(3);
+
+    let (ngx, ngy, ngz) = (chg.ngx, chg.ngy, chg.ngz);
+    let n_atoms = chg.atomic_numbers.len();
+
+    let vx = lat[0].map(|x| x / ngx as f64 * ANGSTROM_TO_BOHR);
+    let vy = lat[1].map(|x| x / ngy as f64 * ANGSTROM_TO_BOHR);
+    let vz = lat[2].map(|x| x / ngz as f64 * ANGSTROM_TO_BOHR);
+
+    let total = ngx * ngy * ngz;
+    let cap = 300 + n_atoms * 65 + (total / 6 + 1) * 80;
+    let mut out = String::with_capacity(cap);
+
+    out.push_str(&format!("CHGCAR: {}\n", chg.comment));
+    out.push_str("Single-file conversion produced by CatGO chgdiff-wasm\n");
+    out.push_str(&format!("{:5}  {:12.6}  {:12.6}  {:12.6}\n", n_atoms, 0.0f64, 0.0f64, 0.0f64));
+    out.push_str(&format!("{:5}  {:12.6}  {:12.6}  {:12.6}\n", ngx, vx[0], vx[1], vx[2]));
+    out.push_str(&format!("{:5}  {:12.6}  {:12.6}  {:12.6}\n", ngy, vy[0], vy[1], vy[2]));
+    out.push_str(&format!("{:5}  {:12.6}  {:12.6}  {:12.6}\n", ngz, vz[0], vz[1], vz[2]));
+
+    for i in 0..n_atoms {
+        let z = chg.atomic_numbers[i];
+        let pos = chg.positions_cart[i];
+        out.push_str(&format!(
+            "{:5}  {:12.6}  {:12.6}  {:12.6}  {:12.6}\n",
+            z,
+            z as f64,
+            pos[0] * ANGSTROM_TO_BOHR,
+            pos[1] * ANGSTROM_TO_BOHR,
+            pos[2] * ANGSTROM_TO_BOHR,
+        ));
+    }
+
+    let mut col = 0usize;
+    for ix in 0..ngx {
+        for iy in 0..ngy {
+            for iz in 0..ngz {
+                let chg_idx = iz * ngy * ngx + iy * ngx + ix;
+                let v = chg.data[chg_idx] / volume_bohr3;
+                out.push_str(&fmt_e(v));
+                col += 1;
+                if col == 6 {
+                    out.push('\n');
+                    col = 0;
+                }
+            }
+        }
+    }
+    if col > 0 {
+        out.push('\n');
+    }
+    Ok(out)
+}
+
 // ── Public WASM API ──────────────────────────────────────────────────────────
+
+/// Convert a single CHGCAR-format file (CHGCAR, CHGDIFF, CHGCAR_diff, LOCPOT,
+/// ELFCAR, PARCHG, etc.) to a Gaussian cube string in e/Bohr³.
+///
+/// Lets the desktop app and the VS Code extension skip the
+/// `/api/chgcar/convert-to-cube` round-trip when the bundled
+/// `cube-processor` binary isn't available (and reduces overall latency
+/// since the file stays in the webview memory the whole time).
+#[wasm_bindgen]
+pub fn chgcar_to_cube(content: &str) -> Result<String, JsError> {
+    let chg = parse_chgcar(content).map_err(|e| JsError::new(&e))?;
+    chgcar_to_cube_string(&chg).map_err(|e| JsError::new(&e))
+}
 
 /// Compute difference charge density from three CHGCAR file contents.
 ///

--- a/server/catgo_server.spec
+++ b/server/catgo_server.spec
@@ -54,6 +54,15 @@ a = Analysis(
         ('catgo/tool_schema/*.json', 'catgo/tool_schema'),
         # HPC job script templates
         ('templates/*.sh', 'templates'),
+        # Rust cube-processor binary — used by /api/cube/{compute,slice,export-glb,
+        # export-obj} for mesh extraction and isosurface ops. Without it the
+        # bundled backend returns 503 "cube-processor binary not found" the
+        # moment a user clicks Export GLB / Export OBJ. Path inside the bundle
+        # must match the layout `server/catgo/routers/{chgcar,cube}.py` use,
+        # which is `<MEIPASS>/tools/cube-processor/target/release/cube-processor`
+        # (from Path(__file__).parent.parent.parent / "tools" / ...).
+        ('../tools/cube-processor/target/release/cube-processor',
+         'tools/cube-processor/target/release'),
     ] + pymatgen_datas + tblite_datas + ase_datas + rfc3987_syntax_datas,
     hiddenimports=catgo_submodules + workflow_submodules + [
         # ---------------------------------------------------------------

--- a/src/lib/electronic/chgdiff-wasm.ts
+++ b/src/lib/electronic/chgdiff-wasm.ts
@@ -12,6 +12,8 @@ type ChgdiffWasmModule = {
   default: (input: string | { module_or_path: string }) => Promise<void>
   /** Compute ρ_AB − ρ_A − ρ_B and return Gaussian cube text */
   compute_chgdiff: (ab: string, a: string, b: string) => string
+  /** Convert a single CHGCAR-format file (CHGCAR, CHGDIFF, LOCPOT, …) to cube */
+  chgcar_to_cube: (content: string) => string
 }
 
 let _module: ChgdiffWasmModule | null = null
@@ -54,4 +56,17 @@ export async function compute_chgdiff(
 ): Promise<string> {
   const mod = await ensure_ready()
   return mod.compute_chgdiff(content_ab, content_a, content_b)
+}
+
+/**
+ * Convert a single VASP grid file (CHGCAR / CHGDIFF / CHGCAR_diff / LOCPOT
+ * / ELFCAR / PARCHG) to a Gaussian cube string in e/Bohr³.  Pure-WASM —
+ * avoids the desktop backend's `/api/chgcar/convert-to-cube` round-trip
+ * and the cube-processor binary that's missing from the PyInstaller
+ * bundle, and gives the VS Code extension a path that doesn't depend on
+ * the bundled sidecar at all.
+ */
+export async function chgcar_to_cube(content: string): Promise<string> {
+  const mod = await ensure_ready()
+  return mod.chgcar_to_cube(content)
 }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3051,18 +3051,36 @@
                     // same backend cube-conversion endpoint.
                     const is_chgcar = !is_cube && /CHGCAR|CHGDIFF|DIFFCHG|AECCAR|LOCPOT|ELFCAR|PARCHG/i.test(file.name)
                     if (is_chgcar) {
-                      // CHGCAR needs backend conversion to cube format first
+                      // Convert CHGCAR-family files (CHGCAR, CHGDIFF, LOCPOT,
+                      // ELFCAR, PARCHG, …) to Gaussian cube text in the
+                      // browser via chgdiff-wasm.  Was a `/api/chgcar/convert-to-cube`
+                      // round-trip to the Python backend; that endpoint
+                      // shells out to a Rust `cube-processor` binary which
+                      // isn't bundled in the PyInstaller image, so a fresh
+                      // .deb / .AppImage couldn't render CHGDIFF at all.
+                      // The WASM path also makes the VS Code extension
+                      // independent of the bundled sidecar for this feature.
+                      // Falls back to the HTTP endpoint if WASM init fails
+                      // (older browsers, broken pkg) so existing dev setups
+                      // keep working.
                       try {
-                        const form = new FormData()
-                        form.append(`file`, file)
-                        const resp = await fetch(`${API_BASE}/chgcar/convert-to-cube`, {
-                          method: `POST`,
-                          body: form,
-                        })
-                        if (!resp.ok) throw new Error(`Conversion failed: ${resp.statusText}`)
-                        const cube_text = await resp.text()
+                        const text = await file.text()
+                        let cube_text: string
+                        try {
+                          const { chgcar_to_cube } = await import('$lib/electronic/chgdiff-wasm')
+                          cube_text = await chgcar_to_cube(text)
+                        } catch (wasm_err) {
+                          console.warn(`[CHGCAR] WASM path failed, falling back to backend:`, wasm_err)
+                          const form = new FormData()
+                          form.append(`file`, file)
+                          const resp = await fetch(`${API_BASE}/chgcar/convert-to-cube`, {
+                            method: `POST`,
+                            body: form,
+                          })
+                          if (!resp.ok) throw new Error(`Conversion failed: ${resp.statusText}`)
+                          cube_text = await resp.text()
+                        }
                         const cube_filename = file.name + `.cube`
-                        // Update structure from cube atoms
                         const { parse_cube_header, cube_atoms_to_molecule } = await import('$lib/cube/parse-cube')
                         const header = parse_cube_header(cube_text)
                         const molecule = cube_atoms_to_molecule(header)
@@ -3070,7 +3088,6 @@
                           structure = { ...molecule, _aligned: true } as any
                           center_camera_trigger++
                         }
-                        // Set cube file for CubePanel
                         const blob = new Blob([cube_text], { type: `chemical/x-cube` })
                         cube_file = new File([blob], cube_filename)
                         cube_pane_open = true


### PR DESCRIPTION
Adds a single-file `chgcar_to_cube` export to chgdiff-wasm and switches the viewer's CHGCAR branch to call it.  Removes the dependency on the Rust `cube-processor` binary that wasn't bundled into the PyInstaller image, which is why CHGCAR_diff_HCO2 (and any other VASP grid file) failed to render silently on a fresh desktop install.  Falls back to the HTTP endpoint when WASM is unavailable.

Refs #19 (bug A).  Bugs B + C (VSCode worker cross-origin) are tracked separately.