### PR TITLE
fix(adsorbate): Quick Optimize crashes viewer; soften site markers

### DIFF
--- a/src/lib/structure/AdsorbatePlacementPane.svelte
+++ b/src/lib/structure/AdsorbatePlacementPane.svelte
@@ -301,7 +301,7 @@
 
         if (is_ok(result)) {
           on_push_undo?.()
-          on_structure_change?.(result as unknown as AnyStructure)
+          on_structure_change?.(result.ok.structure as unknown as AnyStructure)
           success_message = `UFF optimization complete`
         } else {
           error_message = `UFF optimization failed`

--- a/src/lib/structure/AdsorptionSiteMarkers.svelte
+++ b/src/lib/structure/AdsorptionSiteMarkers.svelte
@@ -98,7 +98,7 @@
       }}
     >
       <T.SphereGeometry args={[radius, 16, 16]} />
-      <T.MeshBasicMaterial color={site_color} />
+      <T.MeshBasicMaterial color={site_color} transparent opacity={0.6} depthWrite={false} />
     </T.Mesh>
   {/each}
 {/if}


### PR DESCRIPTION
## Summary

Two small, related changes in the Adsorbate Placement pane:

- **Bug fix — Quick Optimize wipes the loaded structure.** The UFF branch of `quick_optimize` was passing the entire `WasmResult` wrapper to `on_structure_change` instead of `result.ok.structure`. The viewer received an object with no `lattice` / `sites` and crashed, removing the structure from screen. The server-side branch a few lines below already does the right thing (`result.structure`); this aligns the local UFF path with it.
- **UX — adsorption site markers are now semi-transparent.** Solid colored spheres fully occlude each other and the underlying atoms, which makes it hard to see overlapping / hollow-site geometry. Switched the material to `transparent opacity={0.6}` with `depthWrite={false}` so markers alpha-blend back-to-front without z-fighting. `depthTest` stays enabled so opaque atoms in front still correctly occlude markers.

## Repro for the crash

1. Load a slab structure (e.g. a Pt(111) slab).
2. Open Build → Adsorbate, place an adsorbate (Find Sites → pick a site → Place).
3. Click **Quick Optimize** in the placement-success block with `ForceField = uff`.
4. Before: the 3D viewer goes blank and the structure disappears. After: the structure stays, just with relaxed adsorbate atoms.

## Files

- `src/lib/structure/AdsorbatePlacementPane.svelte` — one-line fix (`result.ok.structure`).
- `src/lib/structure/AdsorptionSiteMarkers.svelte` — one-line material tweak.

## Test plan

- [ ] Load a slab, place adsorbate, click Quick Optimize with `uff`, confirm the structure is preserved and the adsorbate atoms relax.
- [ ] Same flow with `Full Optimize...` to confirm no regression on the server path.
- [ ] Visual check that adsorption site markers from Find Sites render as semi-transparent colored spheres, with opaque atoms in front correctly occluding them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)