### PR TITLE
fix(vscode-ext): wire on_file_load + guard Tauri popup outside Tauri

### DIFF
--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -631,9 +631,21 @@ const create_display = (
   const on_file_load = (payload: { trajectory?: unknown; filename?: string }) => {
     if (!payload?.trajectory) return
     const next_filename = payload.filename ?? filename
+    // Detach Svelte 5 $state proxies before handing the trajectory off to a
+    // freshly-mounted component. DopingPane / PathwayPane / SubstitutionPane
+    // build their frames from `$state` arrays, and re-reading those proxies
+    // inside the new Trajectory component's effects triggers
+    // `effect_update_depth_exceeded` (the bond-recompute effect writes to a
+    // signal it transitively depends on through the proxy).
+    let detached: unknown = payload.trajectory
+    try {
+      detached = structuredClone(payload.trajectory)
+    } catch (err) {
+      console.warn(`[CatGO Webview] structuredClone failed on trajectory payload, using raw reference:`, err)
+    }
     const next_result: ParseResult = {
       type: `trajectory`,
-      data: payload.trajectory,
+      data: detached,
       filename: next_filename,
     }
     // Defer the swap to the next macrotask so the originating click handler

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -636,13 +636,18 @@ const create_display = (
       data: payload.trajectory,
       filename: next_filename,
     }
-    // Tear down the current Structure mount and re-render as Trajectory.
-    cleanup_catgo().then(() => {
-      const next_app = create_display(container, next_result, next_filename)
-      current_app = next_app
-    }).catch((err) => {
-      console.error(`[CatGO Webview] Failed to swap to trajectory view:`, err)
-    })
+    // Defer the swap to the next macrotask so the originating click handler
+    // (and any synchronous Svelte reactivity it triggered) can settle before
+    // we unmount the Structure component out from under it. Unmounting mid
+    // event-handler under Svelte 5 wedges the UI on Trajectory remount.
+    setTimeout(() => {
+      cleanup_catgo().then(() => {
+        const next_app = create_display(container, next_result, next_filename)
+        current_app = next_app
+      }).catch((err) => {
+        console.error(`[CatGO Webview] Failed to swap to trajectory view:`, err)
+      })
+    }, 0)
   }
 
   // Create component props by mapping defaults to component props

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -624,6 +624,27 @@ const create_display = (
     }
   }
 
+  // `on_file_load` is how children (DopingPane / PathwayPane / SubstitutionPane)
+  // ask the host to re-mount in a different viewer.  Without this prop the
+  // Structure component's "Open as Trajectory" button is a no-op under the
+  // VS Code webview because there's no App.svelte router to route through.
+  const on_file_load = (payload: { trajectory?: unknown; filename?: string }) => {
+    if (!payload?.trajectory) return
+    const next_filename = payload.filename ?? filename
+    const next_result: ParseResult = {
+      type: `trajectory`,
+      data: payload.trajectory,
+      filename: next_filename,
+    }
+    // Tear down the current Structure mount and re-render as Trajectory.
+    cleanup_catgo().then(() => {
+      const next_app = create_display(container, next_result, next_filename)
+      current_app = next_app
+    }).catch((err) => {
+      console.error(`[CatGO Webview] Failed to swap to trajectory view:`, err)
+    })
+  }
+
   // Create component props by mapping defaults to component props
   const props = {
     ...(is_trajectory
@@ -639,6 +660,7 @@ const create_display = (
         fullscreen_toggle: false,
         hidden_toolbar_items: ['terminal', 'chat', 'plugin_hub', 'gesture', 'workflow'],
         ...(result.cube_file ? { cube_file: result.cube_file } : {}),
+        on_file_load,
       }),
     allow_file_drop: false,
     style: `height: 100%; border-radius: 0`,

--- a/src/lib/structure/DopingPTPanel.svelte
+++ b/src/lib/structure/DopingPTPanel.svelte
@@ -54,6 +54,17 @@
     if (tauri_win_label) return
     const url = `${window.location.origin}${window.location.pathname}#doping-pt`
 
+    // Skip the Tauri WebviewWindow path entirely outside Tauri.  In the VS
+    // Code webview the @tauri-apps module resolves but its IPC bridge is
+    // absent, so constructing a WebviewWindow throws
+    // "Cannot read properties of undefined (reading 'transformCallback')".
+    const has_tauri = typeof window !== `undefined` &&
+      (`__TAURI__` in window || `__TAURI_INTERNALS__` in window)
+    if (!has_tauri) {
+      open_browser_window(url)
+      return
+    }
+
     import(`@tauri-apps/api/webviewWindow`).then(({ WebviewWindow }) => {
       const label = `doping-pt-${Date.now()}`
       const win = new WebviewWindow(label, {


### PR DESCRIPTION
## Summary

Two regressions surfaced in the Doping pane inside the VS Code extension:

1. **\`Open as Trajectory\` was a no-op.** \`DopingPane.svelte\` raises a \`{ trajectory, filename }\` payload through \`Structure.svelte\`'s \`on_file_load\` prop, but the VS Code webview's \`create_display\` (in \`extensions/vscode/src/webview/main.ts\`) never attached a handler. There is no App.svelte router under the webview, so the event hit a \`?.\` and silently dropped. The fix adds an \`on_file_load\` callback that tears down the current Structure mount and re-renders \`create_display\` with a freshly-built \`type: 'trajectory'\` \`ParseResult\`, swapping \`current_app\` so file-change listeners stay attached.

2. **The DopingPTPanel popout path crashed the webview console** with \`TypeError: Cannot read properties of undefined (reading 'transformCallback')\`. \`@tauri-apps/api/webviewWindow\` resolves under the bundler but the Tauri IPC bridge is absent in VS Code, so \`new WebviewWindow(...)\` blew up before the existing \`.catch\` fallback could route to \`open_browser_window\`. Gate the Tauri import on \`window.__TAURI__ || __TAURI_INTERNALS__\` and route directly to the browser-window fallback otherwise (which the VS Code sandbox silently no-ops via \`window.open\` returning \`null\`).

## Files

- \`extensions/vscode/src/webview/main.ts\` — \`create_display\` now constructs an \`on_file_load\` closure that unmounts and re-mounts to switch from Structure → Trajectory.
- \`src/lib/structure/DopingPTPanel.svelte\` — skip the Tauri WebviewWindow path when no Tauri runtime is detected.

## Test plan

- [x] \`pnpm --filter ./extensions/vscode build\` succeeds.
- [ ] Reload the VS Code extension, open a structure, drive the Doping pane, click **Open as Trajectory** — Trajectory viewer mounts with the doped frames.
- [ ] Click the periodic-table popout — no \`transformCallback\` exception in the webview console; the inline periodic table stays usable.
- [ ] Web app smoke test (\`pnpm dev\` → Doping pane → Open as Trajectory) still routes through App.svelte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)