### PR TITLE
ci: auto-deploy docs + app to Cloudflare Workers on push to main

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,136 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "desktop/**"
+      - "extensions/rust-wasm/**"
+      - "static/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "vite.desktop.config.ts"
+      - "vite.shared.ts"
+      - "svelte.config.js"
+      - "wrangler.docs.toml"
+      - "wrangler.app.toml"
+      - ".github/workflows/deploy-cloudflare.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: cloudflare-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  WRANGLER_SEND_METRICS: "false"
+
+jobs:
+  deploy-docs:
+    name: Deploy docs.catgo-ucsd.org
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm docs:build
+
+      - name: Inject cache headers
+        run: |
+          cat > docs/.vitepress/dist/_headers <<'EOF'
+          /assets/*
+            Cache-Control: public, max-age=31536000, immutable
+
+          /*.woff2
+            Cache-Control: public, max-age=31536000, immutable
+
+          /*.woff
+            Cache-Control: public, max-age=31536000, immutable
+
+          /index.html
+            Cache-Control: public, max-age=0, must-revalidate
+
+          /
+            Cache-Control: public, max-age=0, must-revalidate
+          EOF
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config wrangler.docs.toml
+
+  deploy-app:
+    name: Deploy app.catgo-ucsd.org
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build static SPA (VITE_STATIC_ONLY=true)
+        run: pnpm deploy:build
+
+      - name: Inject cache + isolation headers
+        run: |
+          # Remove the dev-only _redirects shipped under build-desktop/;
+          # wrangler.app.toml uses not_found_handling = "single-page-application"
+          # which conflicts with a wildcard _redirects rule.
+          rm -f build-desktop/_redirects
+
+          cat > build-desktop/_headers <<'EOF'
+          /*
+            Cross-Origin-Opener-Policy: same-origin
+            Cross-Origin-Embedder-Policy: require-corp
+            Cross-Origin-Resource-Policy: same-origin
+
+          /assets/*
+            Cache-Control: public, max-age=31536000, immutable
+            Cross-Origin-Resource-Policy: same-origin
+
+          /*.wasm
+            Cache-Control: public, max-age=31536000, immutable
+            Cross-Origin-Resource-Policy: same-origin
+
+          /*.woff2
+            Cache-Control: public, max-age=31536000, immutable
+
+          /*.woff
+            Cache-Control: public, max-age=31536000, immutable
+
+          /index.html
+            Cache-Control: public, max-age=0, must-revalidate
+
+          /
+            Cache-Control: public, max-age=0, must-revalidate
+          EOF
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config wrangler.app.toml

--- a/wrangler.app.toml
+++ b/wrangler.app.toml
@@ -1,0 +1,14 @@
+# Cloudflare Worker — CatGo SPA at https://app.catgo-ucsd.org
+# Static-only build (no Python backend); user data + workflows live in the
+# desktop app. Deployed by .github/workflows/deploy-cloudflare.yml on push
+# to main:
+#     wrangler deploy -c wrangler.app.toml
+
+name = "catgo-app"
+compatibility_date = "2026-05-13"
+workers_dev = false
+preview_urls = false
+
+[assets]
+directory = "./build-desktop"
+not_found_handling = "single-page-application"

--- a/wrangler.docs.toml
+++ b/wrangler.docs.toml
@@ -1,0 +1,12 @@
+# Cloudflare Worker — VitePress docs site at https://docs.catgo-ucsd.org
+# Deployed by .github/workflows/deploy-cloudflare.yml on push to main:
+#     wrangler deploy -c wrangler.docs.toml
+
+name = "catgo-docs"
+compatibility_date = "2026-05-13"
+workers_dev = false
+preview_urls = false
+
+[assets]
+directory = "./docs/.vitepress/dist"
+not_found_handling = "404-page"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-builds and deploys both static sites every time `main` updates:

- \`https://docs.catgo-ucsd.org\` — \`pnpm docs:build\` → \`wrangler deploy -c wrangler.docs.toml\`
- \`https://app.catgo-ucsd.org\` — \`pnpm deploy:build\` (\`VITE_STATIC_ONLY=true\`) → \`wrangler deploy -c wrangler.app.toml\`

Cache + COOP/COEP headers are injected at deploy time (not committed under source) so multi-threaded WASM (ferrox bonding) works on the web build.

## Required setup (one-time)

Add two repo secrets at https://github.com/Hello-QM/catgo-LRG/settings/secrets/actions:

| Secret | Value |
|--------|-------|
| \`CLOUDFLARE_API_TOKEN\` | Token from the **Edit Cloudflare Workers** template, **Zone Resources** restricted to \`catgo-ucsd.org\` |
| \`CLOUDFLARE_ACCOUNT_ID\` | \`e801448c28ba95ef543cfc05094fb858\` (Guangshengliu2021@gmail.com's Account) |

After merge, the first push to main (or a manual **Run workflow** trigger) will deploy.

## Path filter

The workflow only fires when build-relevant paths change (\`docs/\`, \`src/\`, \`desktop/\`, the wrangler configs, \`package.json\`, lockfile, etc.). Doc-only commits or PR-only changes don't waste compute.

## Test plan

- [ ] Add the two secrets to the repo
- [ ] Merge this PR
- [ ] Trigger the workflow manually (\`gh workflow run deploy-cloudflare.yml\`) or push a small docs commit
- [ ] Verify both \`docs.catgo-ucsd.org\` and \`app.catgo-ucsd.org\` serve the new build

🤖 Generated with [Claude Code](https://claude.com/claude-code)