### PR TITLE
ci: build wasm-pack crates before SPA bundle in deploy-app

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -90,7 +90,31 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            extensions/rust -> target
+            extensions/chgdiff-wasm -> target
+
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
+
       - run: pnpm install --frozen-lockfile
+
+      - name: Build ferrox WASM (extensions/rust → extensions/rust-wasm/pkg)
+        working-directory: extensions/rust
+        run: |
+          wasm-pack build --target web --features wasm --no-default-features
+          rm -rf ../rust-wasm/pkg
+          cp -r pkg ../rust-wasm/pkg
+
+      - name: Build chgdiff WASM (extensions/chgdiff-wasm → src/lib/electronic/chgdiff-wasm-pkg)
+        working-directory: extensions/chgdiff-wasm
+        run: |
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
 
       - name: Build static SPA (VITE_STATIC_ONLY=true)
         run: pnpm deploy:build


### PR DESCRIPTION
Follow-up to #30. The first run failed (https://github.com/Hello-QM/catgo-LRG/actions/runs/25889006372) at the Vite stage:

\`\`\`
Could not resolve "./chgdiff-wasm-pkg/chgdiff_wasm.js" from "src/lib/electronic/chgdiff-wasm.ts"
\`\`\`

Both \`extensions/rust-wasm/pkg/\` and \`src/lib/electronic/chgdiff-wasm-pkg/\` are wasm-pack output, gitignored, and need to be regenerated on the runner.

## Changes

- \`deploy-app\` job: add Rust toolchain (\`dtolnay/rust-toolchain\`), Cargo cache (\`Swatinem/rust-cache\`), and \`wasm-pack\` (\`jetli/wasm-pack-action\`); build ferrox + chgdiff WASM packages right before \`pnpm deploy:build\`.
- \`deploy-docs\` unchanged.

## Test plan

- [ ] Merge and let main re-trigger the workflow
- [ ] Verify both jobs complete; visit \`app.catgo-ucsd.org\` and confirm fresh content