### PR TITLE
ci: regenerate docs-chunks.json before SPA bundle

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -116,6 +116,9 @@ jobs:
         run: |
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
 
+      - name: Generate docs-chunks.json for CatBot RAG
+        run: pnpm build:doc-chunks
+
       - name: Build static SPA (VITE_STATIC_ONLY=true)
         run: pnpm deploy:build
 


### PR DESCRIPTION
Third follow-up. After #31 the WASM crates were available but the SPA bundle still failed on:

\`\`\`
Could not resolve "./docs-chunks.json" from "src/lib/chat/rag.ts"
\`\`\`

\`src/lib/chat/docs-chunks.json\` is the RAG index for CatBot — gitignored, regenerated by \`pnpm build:doc-chunks\` (\`scripts/build-doc-chunks.js\`). Adds that step to \`deploy-app\` right before the Vite bundle.