### PR TITLE
fix(atoms): skip try_add fast-path when pencil sid collides with image atom

### DIFF
--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -3054,6 +3054,24 @@
         if (!USE_NEW_ATOM_SYSTEM) return false
         if (added.length === 0) return false
         if (!structure) return false
+        // Bail out if any incoming site_id collides with an existing slot in
+        // the manager. Pencil/fragment adds compute site_id from the
+        // **un-imaged** structure length, but the manager mirrors the
+        // **imaged** structure — so PBC image atoms already occupy sids in
+        // the [num_original, num_original + n_images) range that collides
+        // with the next pencil sid. add_atoms would overwrite the existing
+        // map entry, shadow sync would then remove the new slot during its
+        // diff (consuming the desired entry first, leaving the tail slot
+        // unmatched), and the final remove_atoms .delete(sid) call would
+        // wipe the surviving slot's map entry — leaving the buffer with the
+        // sid but find_slot_by_site_id returning -1. Caller falls back to
+        // canonical set_structure → shadow sync path which handles this
+        // correctly. See issue #33.
+        for (let i = 0; i < added.length; i++) {
+          if (atom_manager.find_slot_by_site_id(added[i].site_id) >= 0) {
+            return false
+          }
+        }
         const t0 = import.meta.env?.DEV ? performance.now() : 0
         // AtomManager: bulk-add the new slots, then set initial colors in a
         // batch. Typed-array construction per-call is fine for the small


### PR DESCRIPTION
Closes #33.

## Symptom

After adding a pencil or fragment atom to a structure with PBC image atoms, the new atom never followed selection drag or rotation — only the highlight ring moved. Keyboard arrow moves of a selection containing the pencil atom left it pinned.

## Root cause

`pencil-mode.svelte.ts:371` computes \`new_site_id = next_structure.sites.length - 1\` from the **un-imaged** structure. But \`atom_manager\` mirrors the **imaged** displayed structure (via the X2 shadow sync at \`StructureScene.svelte:2837-2945\`). The collision:

1. Pre-pencil, manager has \`N_orig + N_images\` slots; image atoms occupy sids in \`[N_orig, N_orig + N_images)\`.
2. \`try_add\` appends pencil with sid \`N_orig\` — already used by an image atom.
3. \`add_atoms\` does \`site_id_to_slot.set(N_orig, tail_slot)\`, overwriting the image atom's map entry. Buffer now has two slots with sid \`N_orig\`; map only references the tail.
4. \`set_structure(next)\` fires the shadow sync against the re-imaged 51-atom structure.
5. Scan-live-slots: the middle slot (old image, sid 36) hits the KEEP path because \`desired.get(36)\` finds the new pencil's row; the slot's xyz is overwritten to pencil-position and \`desired.delete(36)\`.
6. The tail slot (try_add's pencil, sid 36) then falls into \`slots_to_remove\` because \`desired.get(36)\` is now undefined.
7. \`remove_atoms([tail])\` does \`site_id_to_slot.delete(36)\` — wiping the only map entry for sid 36 even though buffer slot 36 still holds the pencil's geometry.

End state: \`site_ids_buffer[36] === 36\` but \`find_slot_by_site_id(36) === -1\`. The drag fast-path in \`AtomManagerInstances.svelte\` looks up slot via the map and silently skips on miss, so the renderer never repositions the pencil atom.

Confirmed in DevTools: \`globalThis.__catgo_drag_misses\` reported \`misses: [36, 37]\` with buffer \`[0..50]\` contiguous and \`manager_count: 51\` — exactly matches the trace above.

## Fix

Reject \`try_add\` when any incoming site_id is already in the manager. Callers fall back to the canonical \`set_structure\` → shadow sync mirror, which handles the add as a clean \`add_atoms(new_sids)\` against a freshly post-image manager state.

Fast path is preserved for the common case (fresh non-PBC structure, no image atoms yet).

## Test plan

- [x] Reproduce on \`pnpm desktop:serve\` with a CIF + show_image_atoms ON, add 2 pencil atoms, Shift+Alt-drag → with patch, both atoms follow drag; no \`[drag-fast-path] slot lookup miss\` warnings.
- [ ] Regression check on context-menu Add Atom (same try_add caller).
- [ ] Regression check on a non-PBC molecule (fast path should still fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)