### PR TITLE
Revert "fix(trajectory): normalize pymatgen JSON frame shape (#34)"

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -18,18 +18,6 @@ import { stream_file_to_buffer } from './node-io'
 import { search_optimade_structures_backend, type OptimadeSearchOptions } from './optimade-backend'
 import { search_pubchem_compounds_backend } from './pubchem-backend'
 
-// Suppress Node 22 `punycode` DEP0040 deprecation warning surfaced by one of
-// our transitive deps. VS Code routes process warnings through the extension
-// host as ERR-level logs even though they're informational; the warning
-// leaks into the user-visible error channel and is non-actionable. All
-// other warnings pass through unchanged.
-process.on(`warning`, (warning: Error & { code?: string }) => {
-  if (warning.name === `DeprecationWarning` && warning.code === `DEP0040`) {
-    return
-  }
-  console.warn(`[node-warning]`, warning.name, warning.code ?? ``, warning.message)
-})
-
 interface FrameLoaderData {
   loader: FrameLoader
   file_data: ArrayBuffer

--- a/extensions/vscode/src/server.ts
+++ b/extensions/vscode/src/server.ts
@@ -98,25 +98,14 @@ export async function start_server(context: vscode.ExtensionContext): Promise<nu
 
     proc.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString()
-      // Drop verbose workflow.engine.scanner INFO records — the bundled
-      // sidecar logs full HPC job_defaults (account, paths, env_setup,
-      // module_loads) on every config read, which leaks user info into the
-      // VS Code extension-host console.  These are useful only with DEBUG
-      // logging on the sidecar; from the extension side, scrub them out
-      // before they hit `console.log`.
-      const filtered = text
-        .split(/\r?\n/)
-        .filter((line) => !/INFO:catgo\.workflow\.engine\.scanner/.test(line))
-        .join('\n')
-      if (!filtered.trim()) return
       // Python logging writes INFO/WARNING/ERROR records to stderr. Classify by
       // level so benign backend info logs don't spam VSCode's error channel.
-      if (/^\s*(ERROR|CRITICAL):/m.test(filtered) || /Traceback \(most recent call last\)/.test(filtered)) {
-        console.error('[catgo-server]', filtered)
-      } else if (/^\s*WARNING:/m.test(filtered) || /UserWarning/.test(filtered)) {
-        console.warn('[catgo-server]', filtered)
+      if (/^\s*(ERROR|CRITICAL):/m.test(text) || /Traceback \(most recent call last\)/.test(text)) {
+        console.error('[catgo-server]', text)
+      } else if (/^\s*WARNING:/m.test(text) || /UserWarning/.test(text)) {
+        console.warn('[catgo-server]', text)
       } else {
-        console.log('[catgo-server]', filtered)
+        console.log('[catgo-server]', text)
       }
     })
 

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -760,11 +760,6 @@ async function initialize() {
       const buffer = base64_to_array_buffer(wasm_binary)
       const wasm_uint8 = new Uint8Array(buffer)
       console.log(`[CatGO Webview] Decoded to Uint8Array (${wasm_uint8.length} bytes)`)
-      // Stash the ArrayBuffer on globalThis so compile_wasm_module
-      // (used by the bond Worker for WebAssembly.compile) avoids the
-      // vscode-webview://.../assets/ferrox_bg-*.wasm fetch which 403s
-      // against the sandboxed webview origin.
-      ;(globalThis as unknown as { __catgo_ferrox_wasm?: ArrayBuffer }).__catgo_ferrox_wasm = buffer
       console.log(`[CatGO Webview] Initializing ferrox-wasm...`)
       await ensure_ferrox_wasm_ready(wasm_uint8)
       console.log(`[CatGO Webview] Successfully initialized ferrox-wasm from extension binary!`)

--- a/src/lib/structure/DopingPTPanel.svelte
+++ b/src/lib/structure/DopingPTPanel.svelte
@@ -54,24 +54,6 @@
     if (tauri_win_label) return
     const url = `${window.location.origin}${window.location.pathname}#doping-pt`
 
-    // VS Code extension webview: window.open is sandboxed (warning) and
-    // `@tauri-apps/api`'s IPC bridge is absent (throws transformCallback
-    // undefined). The inline periodic table in DopingPane covers the picker
-    // UX, so just no-op here.
-    const is_vscode_webview = typeof globalThis !== `undefined` &&
-      typeof (globalThis as { acquireVsCodeApi?: unknown }).acquireVsCodeApi === `function`
-    if (is_vscode_webview) return
-
-    // Outside Tauri (plain web), bypass the Tauri path entirely — its IPC
-    // bridge is absent so post-construction calls (`.once(...)`) throw
-    // `Cannot read properties of undefined (reading 'transformCallback')`.
-    const has_tauri = typeof window !== `undefined` &&
-      (`__TAURI_INTERNALS__` in window || `__TAURI__` in window)
-    if (!has_tauri) {
-      open_browser_window(url)
-      return
-    }
-
     import(`@tauri-apps/api/webviewWindow`).then(({ WebviewWindow }) => {
       const label = `doping-pt-${Date.now()}`
       const win = new WebviewWindow(label, {

--- a/src/lib/structure/ferrox-wasm.ts
+++ b/src/lib/structure/ferrox-wasm.ts
@@ -366,20 +366,6 @@ export async function compile_wasm_module(): Promise<WebAssembly.Module> {
   if (!browser) throw new Error(`WASM only in browser`)
   if (cached_wasm_compiled_module) return cached_wasm_compiled_module
 
-  // VS Code extension preloads the binary on globalThis (see
-  // extensions/vscode/src/webview/main.ts) — fetching the URL there resolves
-  // to vscode-webview://.../assets/ferrox_bg-*.wasm and returns 403 against
-  // the webview's sandbox. Use the buffer directly when present.
-  const preloaded = (globalThis as unknown as {
-    __catgo_ferrox_wasm?: ArrayBuffer | Uint8Array
-  }).__catgo_ferrox_wasm
-  if (preloaded) {
-    const bytes = preloaded instanceof Uint8Array ? preloaded.buffer : preloaded
-    cached_wasm_compiled_module = await WebAssembly.compile(bytes as ArrayBuffer)
-    console.log(`[ferrox-wasm] compile_wasm_module: compiled from preloaded binary`)
-    return cached_wasm_compiled_module
-  }
-
   const wasm_url_module = await import(
     /* @vite-ignore */ `@catgo/ferrox-wasm/ferrox_bg.wasm?url`
   )

--- a/src/lib/trajectory/parsers/json.ts
+++ b/src/lib/trajectory/parsers/json.ts
@@ -1,41 +1,9 @@
 // JSON-based trajectory parsers (Pymatgen, generic JSON arrays, etc.)
-import type { AnyStructure, ElementSymbol, Pbc, Vec3 } from '$lib'
+import type { AnyStructure, ElementSymbol, Vec3 } from '$lib'
 import type { Matrix3x3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { TrajectoryFrame, TrajectoryType } from '../index'
-import { create_structure, create_trajectory_frame } from './common'
-
-// Normalize a pymatgen-format structure dict to the shape produced by
-// `create_structure` (used by extxyz / VASP / LAMMPS parsers). Without this,
-// Trajectory.svelte's bond/position-cache pipeline trips Svelte 5's
-// `effect_update_depth_exceeded` under the VS Code webview runtime: pymatgen
-// dicts carry `@class`, `@module`, `charge`, `oxidation_state: null` and may
-// omit `lattice.pbc`, and the resulting deep-proxy reads inside
-// `position_cache` + `trajectory_bond_cache.wire` race the topology gate.
-function normalize_pymatgen_frame_structure(
-  s: Record<string, unknown> | AnyStructure | undefined,
-): AnyStructure | null {
-  if (!s || typeof s !== `object` || !(`sites` in s)) return null
-  const sites = (s as { sites?: unknown[] }).sites
-  if (!Array.isArray(sites) || sites.length === 0) return null
-  const positions: Vec3[] = []
-  const elements: ElementSymbol[] = []
-  for (const site of sites as Record<string, unknown>[]) {
-    const xyz = site.xyz as Vec3 | undefined
-    if (!xyz || xyz.length < 3) return null
-    positions.push([xyz[0], xyz[1], xyz[2]])
-    const species = site.species as Array<{ element?: string }> | undefined
-    const element = (species?.[0]?.element ?? (site.label as string | undefined)) as
-      | ElementSymbol
-      | undefined
-    if (!element) return null
-    elements.push(element)
-  }
-  const lattice = (s as { lattice?: { matrix?: number[][]; pbc?: Pbc } }).lattice
-  const matrix = (lattice?.matrix as Matrix3x3 | undefined) ?? undefined
-  const pbc = lattice?.pbc
-  return create_structure(positions, elements, matrix, pbc) as AnyStructure
-}
+import { create_trajectory_frame } from './common'
 
 // Parse a JSON object into a trajectory (handles multiple JSON formats)
 export function parse_json_trajectory(
@@ -46,11 +14,9 @@ export function parse_json_trajectory(
   if (Array.isArray(data)) {
     const frames = data.map((frame_data, idx) => {
       const frame_obj = frame_data as Record<string, unknown>
-      const raw_structure = (frame_obj.structure ?? frame_obj) as Record<string, unknown>
-      const normalized = normalize_pymatgen_frame_structure(raw_structure)
       return {
-        structure: (normalized ?? raw_structure) as AnyStructure,
-        step: (frame_obj.step as number) ?? idx,
+        structure: (frame_obj.structure || frame_obj) as AnyStructure,
+        step: (frame_obj.step as number) || idx,
         metadata: (frame_obj.metadata as Record<string, unknown>) || {},
       }
     })
@@ -66,18 +32,8 @@ export function parse_json_trajectory(
 
   // Object with frames
   if (obj.frames && Array.isArray(obj.frames)) {
-    const frames = (obj.frames as TrajectoryFrame[]).map((f, idx) => {
-      const normalized = normalize_pymatgen_frame_structure(
-        f.structure as unknown as Record<string, unknown>,
-      )
-      return {
-        ...f,
-        step: f.step ?? idx,
-        structure: (normalized ?? f.structure) as AnyStructure,
-      }
-    })
     return {
-      frames,
+      frames: obj.frames as TrajectoryFrame[],
       metadata: {
         ...obj.metadata as Record<string, unknown>,
         source_format: `object_with_frames`,
@@ -87,9 +43,8 @@ export function parse_json_trajectory(
 
   // Single structure
   if (obj.sites) {
-    const normalized = normalize_pymatgen_frame_structure(obj)
     return {
-      frames: [{ structure: (normalized ?? obj) as AnyStructure, step: 0, metadata: {} }],
+      frames: [{ structure: obj as AnyStructure, step: 0, metadata: {} }],
       metadata: { source_format: `single_structure`, frame_count: 1 },
     }
   }


### PR DESCRIPTION
Reverts #34. The normalization shipped in #34 did **not** fix the doping-trajectory `effect_update_depth_exceeded` (re-confirmed locally on `pnpm desktop:serve` after pulling main). Reverting to clear the noise from the diff while the real cause is investigated under issue #33 / #35 follow-up.