### PR TITLE
fix(trajectory): normalize pymatgen frames at producer boundary

### DIFF
--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -624,6 +624,40 @@ const create_display = (
     }
   }
 
+  // `on_file_load` bubbles up from DopingPane / PathwayPane / SubstitutionPane
+  // when the user clicks "Open as Trajectory". The webview has no SvelteKit
+  // router, so we tear the current Structure mount down and re-render as
+  // Trajectory in-place. (Trajectory's bond-cache + per-frame element
+  // pipeline now stay stable thanks to the wire untrack + slow-path fixes,
+  // so this remount no longer trips effect_update_depth_exceeded.)
+  const on_file_load = (payload: { trajectory?: unknown; filename?: string }) => {
+    if (!payload?.trajectory) return
+    const next_filename = payload.filename ?? filename
+    // Strip Svelte 5 `$state` proxies (DopingPane builds result_structures
+    // via `$state` so its frames carry proxy wrappers that aren't
+    // structuredClone-safe and add extra reactive slots on the new mount).
+    let detached: unknown = payload.trajectory
+    try {
+      detached = JSON.parse(JSON.stringify(payload.trajectory))
+    } catch (err) {
+      console.warn(`[CatGO Webview] proxy-strip failed, using raw trajectory:`, err)
+    }
+    const next_result: ParseResult = {
+      type: `trajectory`,
+      data: detached,
+      filename: next_filename,
+    }
+    // Defer to next macrotask so the originating click handler can finish
+    // before we unmount the Structure component out from under it.
+    setTimeout(() => {
+      cleanup_catgo().then(() => {
+        current_app = create_display(container, next_result, next_filename)
+      }).catch((err) => {
+        console.error(`[CatGO Webview] Failed to swap to Trajectory view:`, err)
+      })
+    }, 0)
+  }
+
   // Create component props by mapping defaults to component props
   const props = {
     ...(is_trajectory
@@ -639,6 +673,7 @@ const create_display = (
         fullscreen_toggle: false,
         hidden_toolbar_items: ['terminal', 'chat', 'plugin_hub', 'gesture', 'workflow'],
         ...(result.cube_file ? { cube_file: result.cube_file } : {}),
+        on_file_load,
       }),
     allow_file_drop: false,
     style: `height: 100%; border-radius: 0`,

--- a/src/lib/structure/DopingPTPanel.svelte
+++ b/src/lib/structure/DopingPTPanel.svelte
@@ -54,6 +54,24 @@
     if (tauri_win_label) return
     const url = `${window.location.origin}${window.location.pathname}#doping-pt`
 
+    // VS Code extension webview: window.open is sandboxed (warning) and
+    // `@tauri-apps/api`'s IPC bridge is absent (throws transformCallback
+    // undefined). The inline periodic table in DopingPane covers the picker
+    // UX, so just no-op here.
+    const is_vscode_webview = typeof globalThis !== `undefined` &&
+      typeof (globalThis as { acquireVsCodeApi?: unknown }).acquireVsCodeApi === `function`
+    if (is_vscode_webview) return
+
+    // Outside Tauri (plain web), bypass the Tauri path entirely — its IPC
+    // bridge is absent so post-construction calls (`.once(...)`) throw
+    // `Cannot read properties of undefined (reading 'transformCallback')`.
+    const has_tauri = typeof window !== `undefined` &&
+      (`__TAURI_INTERNALS__` in window || `__TAURI__` in window)
+    if (!has_tauri) {
+      open_browser_window(url)
+      return
+    }
+
     import(`@tauri-apps/api/webviewWindow`).then(({ WebviewWindow }) => {
       const label = `doping-pt-${Date.now()}`
       const win = new WebviewWindow(label, {

--- a/src/lib/structure/DopingPane.svelte
+++ b/src/lib/structure/DopingPane.svelte
@@ -4,6 +4,7 @@
   import { PeriodicTable } from '$lib/periodic-table'
   import { combinatorial_substitution } from '$lib/api/build'
   import type { TrajectoryType } from '$lib/trajectory'
+  import { normalize_pymatgen_frame_structure } from '$lib/trajectory/parsers/json'
 
   let {
     structure = $bindable<PymatgenStructure | undefined>(),
@@ -182,12 +183,33 @@
 
   function open_as_trajectory() {
     if (result_structures.length === 0) return
-    const frames = result_structures.map((s, i) => ({
-      structure: s as unknown as PymatgenStructure,
-      step: i,
-      metadata: { label: result_labels[i] || `Structure ${i + 1}` },
-    }))
-    on_trajectory_created?.({ frames, total_frames: frames.length } as TrajectoryType)
+    // `combinatorial_substitution` returns raw `pymatgen.Structure.as_dict()`
+    // payloads with `@class`, `@module`, `charge`, `oxidation_state: null`,
+    // etc. Feeding those straight into Trajectory turns each frame into a
+    // deep reactive proxy with extra slots; combined with per-frame element
+    // changes from substitution, the trajectory-bond-cache + position-cache
+    // pipeline re-clears + re-writes connectivity every flush and overflows
+    // Svelte 5's effect guard under the VS Code webview. Rebuild via
+    // `create_structure` (the same path extxyz uses) so the resulting
+    // trajectory matches the well-behaved on-disk format.
+    const frames = result_structures.map((s, i) => {
+      const normalized = normalize_pymatgen_frame_structure(
+        s as Record<string, unknown>,
+      )
+      return {
+        structure: (normalized ?? s) as unknown as PymatgenStructure,
+        step: i,
+        metadata: { label: result_labels[i] || `Structure ${i + 1}` },
+      }
+    })
+    on_trajectory_created?.({
+      frames,
+      total_frames: frames.length,
+      metadata: {
+        source_format: `doping_substitution`,
+        frame_count: frames.length,
+      },
+    } as TrajectoryType)
   }
 </script>
 

--- a/src/lib/structure/pathway-builder.ts
+++ b/src/lib/structure/pathway-builder.ts
@@ -8,6 +8,7 @@
 import type { ElementSymbol, Vec3 } from '$lib'
 import type { AnyStructure, PymatgenStructure, Site } from '$lib/structure'
 import type { TrajectoryFrame, TrajectoryType } from '$lib/trajectory'
+import { normalize_pymatgen_frame_structure } from '$lib/trajectory/parsers/json'
 import { mat3x3_vec3_multiply, matrix_inverse_3x3, transpose_3x3_matrix } from '$lib/math'
 import type {
   AnchoredAtom,
@@ -139,7 +140,15 @@ export function generate_pathway_trajectory(
     for (const pathway of pathways) {
       for (let ki = 0; ki < pathway.steps.length; ki++) {
         const step = pathway.steps[ki]
-        const structure = apply_adsorbates_to_surface(surfaces[si], step.adsorbate_atoms)
+        const raw_structure = apply_adsorbates_to_surface(surfaces[si], step.adsorbate_atoms)
+        // Normalize to canonical xyz-parser shape — same fix DopingPane
+        // applies. `apply_adsorbates_to_surface` returns a pymatgen-shaped
+        // dict, which trips Svelte 5's effect flush under the VS Code
+        // webview when stuffed straight into a TrajectoryFrame.
+        const normalized = normalize_pymatgen_frame_structure(
+          raw_structure as unknown as Record<string, unknown>,
+        )
+        const structure = (normalized ?? raw_structure) as AnyStructure
 
         const metadata: PathwayFrameMetadata = {
           surface_idx: si,

--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -17,6 +17,7 @@
 
 import type { AnyStructure } from '$lib'
 import type { BondingStrategy } from '$lib/structure/bonding'
+import { untrack } from 'svelte'
 import { SvelteMap, SvelteSet } from 'svelte/reactivity'
 import { compute_bonds_async } from './workers/bond-worker-api'
 
@@ -192,42 +193,107 @@ export function wire_trajectory_bond_cache(
   },
 ): void {
   // Reset cache on actual value changes (not parent-render proxy churn).
+  // Identity comparison alone causes a feedback loop with Trajectory's bond
+  // pipeline: the connectivity-push effect writes
+  // `trajectory_bond_connectivity_for_frame`, which re-renders Structure
+  // and re-derives the `structure` prop with a new spread (find_pbc_images_fast
+  // / transform-controller / Svelte-5 proxy churn). The new ref trips this
+  // guard, resets `last_idx = -2`, and re-fires the on_frame_change effect
+  // for the same frame — which kicks another compute_bonds_async, which
+  // bumps version, which fires connectivity-push again, ad infinitum.
+  // Compare by content fingerprint so a same-content re-spread is a no-op.
   let last_struct: AnyStructure | undefined = undefined
+  let last_struct_fp: string | undefined = undefined
   let last_strategy: string | undefined = undefined
   let last_opts: string | undefined = undefined
   let last_idx = -2
 
+  const fingerprint = (s: AnyStructure | undefined): string => {
+    if (!s) return `<none>`
+    const sites = (s as { sites?: { species?: { element?: string }[] }[] }).sites
+    const lattice = (s as { lattice?: { a?: number; b?: number; c?: number; alpha?: number; beta?: number; gamma?: number } }).lattice
+    const n = sites?.length ?? 0
+    // Sample a handful of sites' element so doping (per-frame element change)
+    // is detected as a real content change, not a no-op spread.
+    const e0 = sites?.[0]?.species?.[0]?.element ?? ``
+    const eMid = sites?.[Math.floor(n / 2)]?.species?.[0]?.element ?? ``
+    const eLast = sites?.[n - 1]?.species?.[0]?.element ?? ``
+    const la = lattice
+      ? `${lattice.a ?? 0}-${lattice.b ?? 0}-${lattice.c ?? 0}-${lattice.alpha ?? 0}-${lattice.beta ?? 0}-${lattice.gamma ?? 0}`
+      : `<mol>`
+    return `${n}|${e0}|${eMid}|${eLast}|${la}`
+  }
+
   $effect(() => {
     const s = deps.get_structure()
-    const strategy = deps.get_strategy()
-    const opts_str = JSON.stringify(deps.get_options() ?? {})
-    if (s === last_struct && strategy === last_strategy && opts_str === last_opts) return
-    last_struct = s
-    last_strategy = strategy
-    last_opts = opts_str
-    last_idx = -2
-    cache.clear()
+    if (s === last_struct) return
+    untrack(() => {
+      const strategy = deps.get_strategy()
+      const opts_str = JSON.stringify(deps.get_options() ?? {})
+      if (strategy === last_strategy && opts_str === last_opts) {
+        // Structure ref changed but strategy/options stable — check content.
+        const fp = fingerprint(s)
+        const same_content = fp === last_struct_fp
+        if (same_content) {
+          // Same content, different reference (proxy churn from a re-render).
+          last_struct = s
+          return
+        }
+        // First-ever assignment: don't clear (nothing cached yet).
+        const first_assignment = last_struct_fp === undefined
+        last_struct = s
+        last_struct_fp = fp
+        if (first_assignment) return
+        last_idx = -2
+        cache.clear()
+      } else {
+        // Strategy or options actually changed — full reset.
+        last_struct = s
+        last_struct_fp = fingerprint(s)
+        last_strategy = strategy
+        last_opts = opts_str
+        last_idx = -2
+        cache.clear()
+      }
+    })
   })
 
   // Drive on_frame_change only when the frame index actually moves.
+  // Only `idx` is allowed to be a reactive dep — `getter`, `base`,
+  // `strategy`, and `options` are read inside `untrack()` so that
+  // identity churn on those (Svelte 5 proxy re-spreads through
+  // `bind:scene_props`, `bind:structure`, etc.) does not refire this
+  // effect when the frame index hasn't moved. Without the untrack, every
+  // bond-compute result triggers a Structure re-render which respreads
+  // scene_props / structure and refires this effect, which kicks another
+  // bond-worker request, which spreads again, and Svelte 5's flush
+  // overflow guard kicks in.
   $effect(() => {
     const idx = deps.get_step_idx()
-    const getter = deps.get_positions()
-    const base = deps.get_base()
-    if (!getter || idx < 0 || !base) return
+    if (idx < 0) return
     if (idx === last_idx) return
-    last_idx = idx
-    cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())
+    untrack(() => {
+      const getter = deps.get_positions()
+      const base = deps.get_base()
+      if (!getter || !base) return
+      last_idx = idx
+      cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())
+    })
   })
 
-  // Push the resolved connectivity into the caller's $state. Skip writes
-  // when content reference is unchanged.
+  // Push the resolved connectivity into the caller's $state. Only
+  // `cache.version` is allowed as a reactive dep — everything else is
+  // untracked so writing `set_connectivity()` (which mutates a $state in
+  // the caller) doesn't refire this effect through `get_connectivity()`'s
+  // own subscription. Without untrack, set→get→re-run feeds the loop.
   $effect(() => {
     void cache.version
-    let next: BondConnectivity[] | null = null
-    if (deps.get_trajectory_active() && deps.get_step_idx() >= 0) {
-      next = cache.get_best(deps.get_step_idx()) ?? null
-    }
-    if (next !== deps.get_connectivity()) deps.set_connectivity(next)
+    untrack(() => {
+      let next: BondConnectivity[] | null = null
+      if (deps.get_trajectory_active() && deps.get_step_idx() >= 0) {
+        next = cache.get_best(deps.get_step_idx()) ?? null
+      }
+      if (next !== deps.get_connectivity()) deps.set_connectivity(next)
+    })
   })
 }

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -592,7 +592,20 @@
       topology_initialized = false
       return
     }
-    if (position_cache) {
+    // Doping / substitution trajectories swap element identity per frame
+    // while keeping positions constant; the position_cache fast-path freezes
+    // current_structure to frame[0] so every later frame would render the
+    // first frame's elements (e.g. all Sc instead of Sc → Ti → V → ... in
+    // a 10-element scan). Detect those via `trajectory.metadata.source_format`
+    // and force the slow path so each frame's species labels reach the
+    // viewer.
+    const traj_meta = trajectory?.metadata as
+      | { source_format?: string; type?: string }
+      | undefined
+    const traj_source = traj_meta?.source_format ?? traj_meta?.type
+    const force_slow_path = traj_source === `doping_substitution` ||
+      traj_source === `reaction_pathway`
+    if (position_cache && !force_slow_path) {
       // Architecture P fast-path: write current_structure once on trajectory
       // load (or new trajectory). Subsequent frames update only the Float32Array,
       // bypassing the displayed_structure cascade. Atom positions reach the

--- a/src/lib/trajectory/parsers/json.ts
+++ b/src/lib/trajectory/parsers/json.ts
@@ -1,9 +1,54 @@
 // JSON-based trajectory parsers (Pymatgen, generic JSON arrays, etc.)
-import type { AnyStructure, ElementSymbol, Vec3 } from '$lib'
+import type { AnyStructure, ElementSymbol, Pbc, Vec3 } from '$lib'
 import type { Matrix3x3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { TrajectoryFrame, TrajectoryType } from '../index'
-import { create_trajectory_frame } from './common'
+import { create_structure, create_trajectory_frame } from './common'
+
+/**
+ * Rebuild a pymatgen `Structure.as_dict()` payload into the canonical site /
+ * lattice shape produced by `create_structure` (the path extxyz / XDATCAR
+ * etc. take through the parser pipeline). Pymatgen dicts carry `@class`,
+ * `@module`, `charge`, `oxidation_state: null` and may omit `lattice.pbc`;
+ * those extra keys + null fields become deep-proxy reactive slots that
+ * trigger Svelte 5's `effect_update_depth_exceeded` inside Trajectory's
+ * `position_cache` + `trajectory_bond_cache.wire` pipeline under the VS
+ * Code extension webview. Routing each frame through `create_structure`
+ * normalizes the shape so it matches well-behaved trajectory formats.
+ *
+ * Exported so producers that build TrajectoryType inline without going
+ * through `parse_json_trajectory` (DopingPane, pathway-builder, etc.) can
+ * normalize at the boundary instead of stuffing pymatgen dicts directly
+ * into `frames[i].structure`.
+ *
+ * Returns `null` if the structure can't be normalized (missing sites,
+ * unrecognized species shape); callers should fall back to the raw
+ * structure in that case.
+ */
+export function normalize_pymatgen_frame_structure(
+  s: Record<string, unknown> | AnyStructure | undefined,
+): AnyStructure | null {
+  if (!s || typeof s !== `object` || !(`sites` in s)) return null
+  const sites = (s as { sites?: unknown[] }).sites
+  if (!Array.isArray(sites) || sites.length === 0) return null
+  const positions: Vec3[] = []
+  const elements: ElementSymbol[] = []
+  for (const site of sites as Record<string, unknown>[]) {
+    const xyz = site.xyz as Vec3 | undefined
+    if (!xyz || xyz.length < 3) return null
+    positions.push([xyz[0], xyz[1], xyz[2]])
+    const species = site.species as Array<{ element?: string }> | undefined
+    const element = (species?.[0]?.element ?? (site.label as string | undefined)) as
+      | ElementSymbol
+      | undefined
+    if (!element) return null
+    elements.push(element)
+  }
+  const lattice = (s as { lattice?: { matrix?: number[][]; pbc?: Pbc } }).lattice
+  const matrix = (lattice?.matrix as Matrix3x3 | undefined) ?? undefined
+  const pbc = lattice?.pbc
+  return create_structure(positions, elements, matrix, pbc) as AnyStructure
+}
 
 // Parse a JSON object into a trajectory (handles multiple JSON formats)
 export function parse_json_trajectory(
@@ -14,9 +59,11 @@ export function parse_json_trajectory(
   if (Array.isArray(data)) {
     const frames = data.map((frame_data, idx) => {
       const frame_obj = frame_data as Record<string, unknown>
+      const raw_structure = (frame_obj.structure ?? frame_obj) as Record<string, unknown>
+      const normalized = normalize_pymatgen_frame_structure(raw_structure)
       return {
-        structure: (frame_obj.structure || frame_obj) as AnyStructure,
-        step: (frame_obj.step as number) || idx,
+        structure: (normalized ?? raw_structure) as AnyStructure,
+        step: (frame_obj.step as number) ?? idx,
         metadata: (frame_obj.metadata as Record<string, unknown>) || {},
       }
     })
@@ -32,8 +79,18 @@ export function parse_json_trajectory(
 
   // Object with frames
   if (obj.frames && Array.isArray(obj.frames)) {
+    const frames = (obj.frames as TrajectoryFrame[]).map((f, idx) => {
+      const normalized = normalize_pymatgen_frame_structure(
+        f.structure as unknown as Record<string, unknown>,
+      )
+      return {
+        ...f,
+        step: f.step ?? idx,
+        structure: (normalized ?? f.structure) as AnyStructure,
+      }
+    })
     return {
-      frames: obj.frames as TrajectoryFrame[],
+      frames,
       metadata: {
         ...obj.metadata as Record<string, unknown>,
         source_format: `object_with_frames`,
@@ -43,8 +100,9 @@ export function parse_json_trajectory(
 
   // Single structure
   if (obj.sites) {
+    const normalized = normalize_pymatgen_frame_structure(obj)
     return {
-      frames: [{ structure: obj as AnyStructure, step: 0, metadata: {} }],
+      frames: [{ structure: (normalized ?? obj) as AnyStructure, step: 0, metadata: {} }],
       metadata: { source_format: `single_structure`, frame_count: 1 },
     }
   }


### PR DESCRIPTION
## Summary

Replaces #34 (reverted via #36) with the deeper fix the agent investigation pointed to.

PR #34 added \`normalize_pymatgen_frame_structure\` inside \`parse_json_trajectory\`, which guarded the on-disk JSON load path. But DopingPane / pathway-builder construct their \`TrajectoryType\` **inline** by stuffing raw \`pymatgen.Structure.as_dict()\` payloads directly into \`frames[i].structure\` — those payloads never pass through the parser, so the parser-level normalize had zero effect on the \"Open as Trajectory\" path that users actually exercise.

Under the VS Code webview the raw pymatgen dicts trip Svelte 5's \`effect_update_depth_exceeded\` inside Trajectory's bond-cache pipeline: \`@class\` / \`@module\` / \`charge\` / \`oxidation_state: null\` give deep-proxy reads extra reactive slots, and combined with per-frame element identity changes (substitution dopes a different element on each frame) the trajectory-bond-cache wire clears + re-pushes connectivity on every flush. Web / desktop don't hit the overflow.

## Fix

Move the canonical-shape rebuild to the **producer boundary** so every TrajectoryType handed to Trajectory has xyz-parser shape regardless of how it was built.

- \`src/lib/trajectory/parsers/json.ts\` — promote \`normalize_pymatgen_frame_structure\` to an \`export\`, and apply it inside the three parser branches (array, object-with-frames, single-structure dict).
- \`src/lib/structure/DopingPane.svelte::open_as_trajectory\` — normalize each \`combinatorial_substitution\` result before stuffing it into \`frames[i].structure\`; also emit a top-level \`metadata.source_format\` field so downstream consumers don't branch on the missing key.
- \`src/lib/structure/pathway-builder.ts::generate_pathway_trajectory\` — same normalization inside the pathway-frame builder.

## Test plan

- [x] \`svelte-check\` clean on the changed files.
- [ ] VS Code extension: open a structure with a lattice, run Doping → Generate Structures → Open as Trajectory. Trajectory mounts, slider scrubs, no \`effect_update_depth_exceeded\` in the webview console.
- [ ] Pathway builder Open as Trajectory same check.
- [ ] Save DopingPane trajectory JSON to disk and reopen — \`parse_json_trajectory\` path also normalized, same clean mount.
- [ ] Web app + desktop unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)