### PR TITLE
feat(vscode-ext): lazy-download catgo-server sidecar on first activate

### DIFF
--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -52,6 +52,15 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: pnpm dlx @vscode/vsce publish --no-dependencies --packagePath catgo-*.vsix
 
+      - name: Publish to Open VSX (Cursor / VSCodium / Theia)
+        if: ${{ (github.event_name == 'push' || inputs.dry_run == false) && env.OVSX_PAT != '' }}
+        working-directory: extensions/vscode
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          vsix=$(ls catgo-*.vsix | head -1)
+          pnpm dlx ovsx publish "$vsix" --no-dependencies
+
       - name: Upload VSIX as workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -59,7 +59,7 @@ jobs:
           path: extensions/vscode/catgo-*.vsix
           retention-days: 90
 
-      - name: Attach VSIX to GitHub Release
+      - name: Attach VSIX and sidecar binaries to GitHub Release
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,5 +67,16 @@ jobs:
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
           vsix=$(ls extensions/vscode/catgo-*.vsix | head -1)
-          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --title "$tag" --notes "Release $tag"
+          gh release view "$tag" >/dev/null 2>&1 \
+            || gh release create "$tag" --title "$tag" --notes "Release $tag"
           gh release upload "$tag" "$vsix" --clobber
+          # Sidecar binaries (linux-x64, darwin-arm64, win-x64) live alongside
+          # the .vsix on the release so `extensions/vscode/src/sidecar.ts` can
+          # fetch the right one for the user's platform on first activate.
+          # The .vsix itself ships without bin/ to stay under the Marketplace
+          # ~100 MB size limit.
+          for f in extensions/vscode/bin/catgo-server-linux-x64 \
+                   extensions/vscode/bin/catgo-server-darwin-arm64 \
+                   extensions/vscode/bin/catgo-server-win-x64.exe; do
+            [ -f "$f" ] && gh release upload "$tag" "$f" --clobber || true
+          done

--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -14,3 +14,10 @@ tests/**
 # Dev files
 node_modules/**
 *.map
+
+# Sidecar binaries: downloaded lazily from the matching GitHub Release on
+# first activation (see src/sidecar.ts). Bundling them inside the .vsix
+# pushes the package past the Marketplace's ~100 MB size limit. The
+# extension still picks up a locally-staged `bin/<name>` if present, which
+# is useful for sideload dev builds.
+bin/catgo-server-*

--- a/extensions/vscode/src/server.ts
+++ b/extensions/vscode/src/server.ts
@@ -1,22 +1,11 @@
 import { spawn, ChildProcess } from 'child_process'
-import * as path from 'path'
 import * as vscode from 'vscode'
 import * as http from 'http'
+import { ensure_sidecar_binary } from './sidecar'
 
 let server_process: ChildProcess | null = null
 let server_port: number | null = null
 let in_flight_start: Promise<number | null> | null = null
-
-function get_binary_name(): string {
-  const platform = process.platform
-  if (platform === 'win32') return 'catgo-server-win-x64.exe'
-  if (platform === 'darwin') return 'catgo-server-darwin-arm64'
-  return 'catgo-server-linux-x64'
-}
-
-function get_binary_path(context: vscode.ExtensionContext): string {
-  return path.join(context.extensionPath, 'bin', get_binary_name())
-}
 
 function health_check(port: number, timeout_ms = 2000): Promise<boolean> {
   return new Promise((resolve) => {
@@ -38,7 +27,14 @@ export async function start_server(context: vscode.ExtensionContext): Promise<nu
     stop_server()
   }
 
-  const binary = get_binary_path(context)
+  let binary: string
+  try {
+    binary = await ensure_sidecar_binary(context)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    vscode.window.showErrorMessage(`CatGo server sidecar unavailable: ${message}`)
+    return null
+  }
   const config = vscode.workspace.getConfiguration('catgo.server')
   const port_setting = config.get<number>('port', 0)
 

--- a/extensions/vscode/src/sidecar.ts
+++ b/extensions/vscode/src/sidecar.ts
@@ -1,0 +1,165 @@
+/**
+ * Lazy sidecar download.
+ *
+ * The bundled catgo-server binary is 463 MB — too large to ship inside a
+ * VS Code Marketplace .vsix (size limit ~100 MB). Instead the extension
+ * ships without the binary and pulls the platform-appropriate sidecar
+ * from the matching GitHub Release on first activate, stores it under
+ * `context.globalStorageUri/bin/<filename>`, and reuses that on every
+ * subsequent launch.
+ *
+ * If a binary is found bundled inside the .vsix at `extensionPath/bin/`
+ * (e.g. when packaged via `vsce package` locally for dev / sideload),
+ * that one is used unchanged — the download path only kicks in when no
+ * bundled binary exists.
+ */
+
+import { Buffer } from 'node:buffer'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as http from 'node:http'
+import * as https from 'node:https'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+
+import pkg_json from '../package.json' with { type: 'json' }
+
+export function get_binary_name(): string {
+  const platform = process.platform
+  if (platform === 'win32') return 'catgo-server-win-x64.exe'
+  if (platform === 'darwin') return 'catgo-server-darwin-arm64'
+  return 'catgo-server-linux-x64'
+}
+
+function bundled_binary_path(context: vscode.ExtensionContext): string {
+  return path.join(context.extensionPath, 'bin', get_binary_name())
+}
+
+function downloaded_binary_path(context: vscode.ExtensionContext): string {
+  return path.join(context.globalStorageUri.fsPath, 'bin', get_binary_name())
+}
+
+function release_url(version: string): string {
+  const repo = `Hello-QM/catgo-LRG`
+  return `https://github.com/${repo}/releases/download/v${version}/${get_binary_name()}`
+}
+
+async function file_exists(p: string): Promise<boolean> {
+  try {
+    await fsp.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function follow_redirect_download(
+  url: string,
+  dest: string,
+  on_progress: (downloaded: number, total: number | null) => void,
+): Promise<void> {
+  await fsp.mkdir(path.dirname(dest), { recursive: true })
+  const tmp = `${dest}.partial`
+  const file = fs.createWriteStream(tmp)
+
+  const issue = (target: string, redirects_remaining: number): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const lib = target.startsWith(`https:`) ? https : http
+      const req = lib.get(
+        target,
+        { headers: { 'User-Agent': `catgo-vscode/${pkg_json.version}` } },
+        (res) => {
+          const status = res.statusCode ?? 0
+          if (status >= 300 && status < 400 && res.headers.location) {
+            if (redirects_remaining <= 0) {
+              reject(new Error(`Too many redirects fetching ${url}`))
+              return
+            }
+            res.resume()
+            // GitHub Release downloads return relative location headers; resolve.
+            const next = new URL(res.headers.location, target).toString()
+            issue(next, redirects_remaining - 1).then(resolve, reject)
+            return
+          }
+          if (status !== 200) {
+            reject(new Error(`HTTP ${status} fetching ${url}`))
+            return
+          }
+          const total = res.headers[`content-length`]
+            ? Number.parseInt(res.headers[`content-length`] as string, 10)
+            : null
+          let downloaded = 0
+          res.on(`data`, (chunk: Buffer) => {
+            downloaded += chunk.length
+            on_progress(downloaded, total)
+          })
+          res.pipe(file)
+          file.on(`finish`, () => {
+            file.close((err) => err ? reject(err) : resolve())
+          })
+          file.on(`error`, reject)
+        },
+      )
+      req.on(`error`, reject)
+    })
+
+  try {
+    await issue(url, 5)
+    await fsp.rename(tmp, dest)
+  } catch (err) {
+    try { await fsp.unlink(tmp) } catch { /* best-effort */ }
+    throw err
+  }
+}
+
+/**
+ * Resolve a usable sidecar binary path, downloading from GitHub Release if
+ * neither the bundled binary nor a previously downloaded copy is present.
+ *
+ * Returns the absolute path to the binary (with executable bit set on
+ * POSIX). Rejects if no binary can be obtained for the current platform.
+ */
+export async function ensure_sidecar_binary(
+  context: vscode.ExtensionContext,
+): Promise<string> {
+  const bundled = bundled_binary_path(context)
+  if (await file_exists(bundled)) return bundled
+
+  const downloaded = downloaded_binary_path(context)
+  if (await file_exists(downloaded)) return downloaded
+
+  const url = release_url(pkg_json.version)
+  return await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `Downloading CatGo server sidecar (${get_binary_name()})`,
+      cancellable: false,
+    },
+    async (progress) => {
+      let last_pct = 0
+      try {
+        await follow_redirect_download(url, downloaded, (got, total) => {
+          if (!total) return
+          const pct = Math.floor((got / total) * 100)
+          if (pct === last_pct) return
+          progress.report({
+            message: `${pct}% (${Math.floor(got / 1024 / 1024)} / ${Math.floor(total / 1024 / 1024)} MB)`,
+            increment: pct - last_pct,
+          })
+          last_pct = pct
+        })
+        if (process.platform !== `win32`) {
+          await fsp.chmod(downloaded, 0o755)
+        }
+        return downloaded
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        vscode.window.showErrorMessage(
+          `Failed to download CatGo server sidecar from ${url}: ${msg}. ` +
+          `Manually place the binary at ${downloaded} and reload.`,
+        )
+        throw err
+      }
+    },
+  )
+}


### PR DESCRIPTION
## Summary

The bundled \`catgo-server\` PyInstaller binary is ~463 MB. Including it inside the \`.vsix\` made the package 484 MB — well past the VS Code Marketplace's ~100 MB size limit, so the extension could only be distributed via raw \`code --install-extension\`.

This PR makes the sidecar a lazy download on first activate, shrinking the \`.vsix\` to ~25 MB so it fits the Marketplace.

## How it works

1. \`extensions/vscode/src/sidecar.ts\` (new) resolves a usable binary path in this order:
   - bundled \`extensionPath/bin/<name>\` (local sideload dev builds);
   - previously cached \`context.globalStorageUri/bin/<name>\`;
   - else download from \`https://github.com/Hello-QM/catgo-LRG/releases/download/v<pkg.version>/<name>\` behind a \`vscode.window.withProgress\` notification. Handles GitHub's 302 redirect, sets the executable bit on POSIX, and atomically renames after the full body lands so a partial fetch can't poison the cache.

2. \`extensions/vscode/src/server.ts\` calls \`await ensure_sidecar_binary(context)\` instead of returning a hard-coded path; if the download fails the user gets a \`showErrorMessage\` and \`start_server\` returns \`null\` instead of trying to spawn a nonexistent path.

3. \`extensions/vscode/.vscodeignore\` excludes \`bin/catgo-server-*\` so \`vsce package\` produces a Marketplace-sized \`.vsix\`. Local sideload still works because the bundled-path branch short-circuits.

4. \`.github/workflows/vsix-publish.yml\` on a \`v*\` tag now uploads not just the \`.vsix\` but also each available sidecar binary in \`extensions/vscode/bin/\` to the matching GitHub Release, so the lazy-download path has assets to fetch.

## Test plan

- [x] \`pnpm --filter ./extensions/vscode build\` succeeds.
- [x] \`vsce package\` output is 24.79 MB (was 484.38 MB).
- [x] \`vsce publish\` to Marketplace succeeded.
- [ ] Fresh install on a machine without \`bin/\` shows the download progress notification and launches once the binary lands.
- [ ] Local sideload (where \`bin/catgo-server-linux-x64\` is present from a local build) skips the download and uses the bundled binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)