### PR TITLE
Fix/orca convergence detection

### DIFF
--- a/server/catgo/utils/job_parser.py
+++ b/server/catgo/utils/job_parser.py
@@ -1308,8 +1308,10 @@ async def parse_orca_neb_progress(
     # Parse .interp file for per-image energy data (optional, may not exist yet)
     image_energies = await parse_neb_image_energies(conn, orca_interp)
 
-    # Check if NEB converged
-    converged = "THE NEB OPTIMIZATION HAS CONVERGED" in content
+    # NEB-TS only reports true convergence after the TS optimization stage.
+    # The earlier "THE NEB OPTIMIZATION HAS CONVERGED" marker fires when the
+    # CI-NEB stage finishes but before the TS opt — don't treat that as done.
+    converged = "THE TS OPTIMIZATION HAS CONVERGED" in content
 
     # Count how many PATH SUMMARY table headers appear.
     # Each NEB iteration produces one PATH SUMMARY block in the output.

--- a/server/catgo/utils/job_parser.py
+++ b/server/catgo/utils/job_parser.py
@@ -1311,7 +1311,16 @@ async def parse_orca_neb_progress(
     # NEB-TS only reports true convergence after the TS optimization stage.
     # The earlier "THE NEB OPTIMIZATION HAS CONVERGED" marker fires when the
     # CI-NEB stage finishes but before the TS opt — don't treat that as done.
-    converged = "THE TS OPTIMIZATION HAS CONVERGED" in content
+    #
+    # The marker can sit several MB from EOF when ORCA appends a Hessian /
+    # frequency block after the TS opt, so the 2 MB tail in `content` may
+    # not contain it. grep -q short-circuits at the first match, so it
+    # only reads up through the marker (not the trailing Hessian output).
+    marker_result = await conn.run(
+        f"grep -q 'THE TS OPTIMIZATION HAS CONVERGED' {orca_out}",
+        check=False,
+    )
+    converged = marker_result.exit_status == 0
 
     # Count how many PATH SUMMARY table headers appear.
     # Each NEB iteration produces one PATH SUMMARY block in the output.

--- a/src/lib/workflow/NodeStatusPanel.svelte
+++ b/src/lib/workflow/NodeStatusPanel.svelte
@@ -1447,7 +1447,11 @@
           {/if}
 
           <!-- Convergence flag (client-side validated) -->
-          {#if is_actually_converged}
+          <!-- Freq nodes compute a Hessian, not an iterative optimization, so a
+               convergence verdict is meaningless — suppress the flag entirely. -->
+          {#if node_type === `freq` || node_type === `orca_freq`}
+            {''}
+          {:else if is_actually_converged}
             <div class="sp-conv-flag converged">Converged</div>
           {:else if status === `completed` || status === `not_converged` || status === `failed`}
             <div class="sp-conv-flag not-converged">Not converged</div>


### PR DESCRIPTION
Removes convergence tag from frequency calculations. Greps entire .out file for NEB-TS files so convergence won't be missed.