### PR TITLE
fix(ui): restore View Output Structure for ORCA NEB-TS

### DIFF
--- a/src/lib/workflow/EngineTaskEditor.svelte
+++ b/src/lib/workflow/EngineTaskEditor.svelte
@@ -13,6 +13,7 @@
   import StructureEditModal from './components/StructureEditModal.svelte'
   import { NODE_DEFINITIONS } from './node-defs'
   import type { NodeDefinition, ParamDef } from './workflow-types'
+  import { parse_xyz, parse_poscar } from '$lib/structure/parse'
 
   // ── Eagerly load StructurePreview (avoids async rendering issues with Threlte Canvas) ──
   let StructurePreviewComponent = $state<typeof import('$lib/structure/StructurePreview.svelte').default | null>(null)
@@ -126,13 +127,37 @@
   // ── Parse structure from JSON string safely + normalize lattice ──
   function try_parse_structure(raw: unknown): PymatgenStructure | null {
     if (!raw) return null
-    try {
-      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw
-      if (parsed && typeof parsed === 'object' && 'sites' in parsed) {
-        normalize_structure(parsed)
-        return parsed as PymatgenStructure
+    // Object input: must already be in pymatgen shape
+    if (typeof raw !== 'string') {
+      if (raw && typeof raw === 'object' && 'sites' in (raw as object)) {
+        normalize_structure(raw)
+        return raw as PymatgenStructure
       }
-    } catch { /* ignore */ }
+      return null
+    }
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    // pymatgen-serialized JSON (e.g. {"@module": ..., "sites": [...]})
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        if (parsed && typeof parsed === 'object' && 'sites' in parsed) {
+          normalize_structure(parsed)
+          return parsed as PymatgenStructure
+        }
+      } catch { /* fall through to text-format parsers */ }
+    }
+    // Plain-text formats produced by V2 engine output collectors:
+    //   ORCA NEB-TS → XYZ (first line is an atom count integer)
+    //   VASP/MLP    → POSCAR (line 2 is a numeric scale factor)
+    const first_line = trimmed.split(/\r?\n/, 1)[0]?.trim() ?? ''
+    const is_xyz = /^\d+$/.test(first_line)
+    const parsed = is_xyz ? parse_xyz(trimmed) : parse_poscar(trimmed)
+    if (parsed && parsed.sites?.length) {
+      // ParsedStructure has optional lattice; PymatgenStructure requires it
+      // but downstream renderers handle lattice-less molecules conditionally.
+      return parsed as unknown as PymatgenStructure
+    }
     return null
   }
 
@@ -185,8 +210,12 @@
         params = {}
       }
 
-      // Parse input structure from params
-      if (!cached) {
+      // Parse input/output structures. Re-fetch on cache miss OR when the cached
+      // entry has no output_structure but the task is now COMPLETED — this
+      // recovers from earlier loads where the result hadn't arrived yet or the
+      // parser couldn't handle the format (pre-XYZ-support cache entries).
+      const needs_refetch = !cached || (cached.output == null && t.status === 'COMPLETED')
+      if (needs_refetch) {
         const inp = try_parse_structure(params.structure) ?? try_parse_structure(params.structure_json)
         input_structure = inp
 

--- a/src/lib/workflow/NodeStatusPanel.svelte
+++ b/src/lib/workflow/NodeStatusPanel.svelte
@@ -33,6 +33,10 @@
   import { normalize_status } from '$lib/api/task-adapter'
   import { get_v2_task, get_v2_task_result, type V2Task } from '$lib/api/workflow-v2'
   import ResultsPlot from './ResultsPlot.svelte'
+  // Static imports for the View Structure click handler — using a dynamic
+  // import here would code-split the parsers into a chunk that can fail to
+  // load on production builds with strict CSP, silently swallowing clicks.
+  import { parse_poscar, parse_xyz } from '$lib/structure/parse'
 
   let {
     // ========== EXISTING STEP-BASED PROPS ==========
@@ -590,15 +594,22 @@
   }
   /** Parse outputs_json from a V2 task_results row and merge into base object */
   function _merge_outputs_json(base: Record<string, any>): Record<string, any> {
+    let merged: Record<string, any> = base
     if (typeof base.outputs_json === 'string' && base.outputs_json !== '{}') {
       try {
         const outputs = JSON.parse(base.outputs_json)
         if (outputs && typeof outputs === 'object') {
-          return { ...base, ...outputs }
+          merged = { ...base, ...outputs }
         }
       } catch { /* ignore malformed outputs_json */ }
     }
-    return base
+    // V2 engine writes output geometries (e.g. NEB-TS converged XYZ) to the
+    // `structure_json` column rather than embedding them in outputs_json.
+    // Surface it under the `structure` key the UI consults.
+    if (!merged.structure && typeof merged.structure_json === 'string' && merged.structure_json.trim().length > 0) {
+      merged = { ...merged, structure: merged.structure_json }
+    }
+    return merged
   }
 
   const cached_summary = $derived.by<CachedSummary>(() => {
@@ -2028,8 +2039,10 @@
           {/if}
         </div>
 
-        <!-- Output files for MLP (local: contcar key, HPC: structure key) -->
+        <!-- Output files: MLP / VASP write CONTCAR (POSCAR); ORCA writes XYZ -->
         {@const mlp_contcar = cached_summary.contcar || cached_summary.structure}
+        {@const mlp_contcar_is_xyz = !!mlp_contcar && /^\s*\d+\s*$/.test(mlp_contcar.split(/\r?\n/, 1)[0] ?? '')}
+        {@const mlp_contcar_filename = mlp_contcar_is_xyz ? 'output.xyz' : 'CONTCAR'}
         {#if mlp_contcar || cached_summary.work_dir}
           <div class="sp-section">
             <div class="sp-section-title">Output Files</div>
@@ -2039,11 +2052,11 @@
                   const blob = new Blob([mlp_contcar!], { type: 'text/plain' })
                   const url = URL.createObjectURL(blob)
                   const a = document.createElement('a')
-                  a.href = url; a.download = 'CONTCAR'; a.click()
+                  a.href = url; a.download = mlp_contcar_filename; a.click()
                   URL.revokeObjectURL(url)
                 }}>
                   <span class="sp-file-icon">📄</span>
-                  <span class="sp-file-name">CONTCAR</span>
+                  <span class="sp-file-name">{mlp_contcar_filename}</span>
                   <span class="sp-file-desc">Optimized structure</span>
                 </button>
               {/if}
@@ -2061,20 +2074,27 @@
                 </button>
               {/if}
               {#if mlp_contcar}
-                <button class="sp-file-btn sp-file-load" onclick={async () => {
+                <button class="sp-file-btn sp-file-load" onclick={() => {
+                  view_structure_error = null
                   try {
-                    const { parse_poscar } = await import('$lib/structure/parse')
-                    const parsed = parse_poscar(mlp_contcar!)
-                    if (parsed) {
-                      pending_open_structure.structure = parsed
-                      pending_open_structure.label = node_label
-                      pending_open_structure.seq++
-                    } else {
-                      view_structure_error = `Could not parse output structure (invalid CONTCAR format)`
+                    if (!mlp_contcar || mlp_contcar.trim().length === 0) {
+                      view_structure_error = `Output structure is empty — backend did not extract a geometry for this task.`
+                      return
                     }
+                    const parsed = mlp_contcar_is_xyz ? parse_xyz(mlp_contcar) : parse_poscar(mlp_contcar)
+                    if (!parsed) {
+                      const preview = mlp_contcar.slice(0, 80).replace(/\n/g, '\\n')
+                      view_structure_error = `Could not parse ${mlp_contcar_is_xyz ? 'XYZ' : 'POSCAR'} (first 80 chars: "${preview}")`
+                      console.error(`[NodeStatusPanel] parser returned null for ${mlp_contcar_is_xyz ? 'XYZ' : 'POSCAR'} payload of ${mlp_contcar.length} bytes`)
+                      return
+                    }
+                    pending_open_structure.structure = parsed
+                    pending_open_structure.label = node_label
+                    pending_open_structure.seq++
+                    console.info(`[NodeStatusPanel] View Structure: opened ${parsed.sites?.length ?? 0} sites in new tab`)
                   } catch (err) {
-                    console.error(`[NodeStatusPanel] Failed to parse structure:`, err)
-                    view_structure_error = `Failed to load structure: ${err instanceof Error ? err.message : err}`
+                    console.error(`[NodeStatusPanel] View Structure failed:`, err)
+                    view_structure_error = `Failed to load structure: ${err instanceof Error ? err.message : String(err)}`
                   }
                 }}>
                   <span class="sp-file-icon">🔬</span>
@@ -2082,7 +2102,7 @@
                   <span class="sp-file-desc">Open structure in another tab</span>
                 </button>
                 {#if view_structure_error}
-                  <div class="sp-error-box" style="margin-top: 4px; font-size: 11px;">{view_structure_error}</div>
+                  <div class="sp-error-box" style="margin-top: 6px; padding: 8px; font-size: 13px; line-height: 1.4; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.4); border-radius: 4px; color: #ef4444;" role="alert">{view_structure_error}</div>
                 {/if}
               {/if}
             </div>

--- a/src/lib/workflow/WorkflowEditor.svelte
+++ b/src/lib/workflow/WorkflowEditor.svelte
@@ -884,9 +884,32 @@
       label += ` — Input`
       is_readonly = true
     } else if (source === `output`) {
-      if (!workflow_id) return
-      // Try 1: Check step result_json for embedded structure (local nodes like doping_gen)
-      // Always fetch from Python backend since execution results live there
+      if (!workflow_id) {
+        alert(`View Output Structure: workflow not yet saved — cannot fetch results.`)
+        return
+      }
+      console.info(`[view-output] resolving output structure for node ${node_id}`)
+
+      // Helper: parse text payload (pymatgen JSON / XYZ / POSCAR) into structure_json
+      const parse_text_to_struct_json = async (raw: string): Promise<string | null> => {
+        const trimmed = raw.trim()
+        if (!trimmed) return null
+        // Already pymatgen JSON
+        if (trimmed.startsWith(`{`) || trimmed.startsWith(`[`)) {
+          try {
+            const obj = JSON.parse(trimmed)
+            if (obj && typeof obj === `object` && `sites` in obj) return trimmed
+          } catch { /* fall through to text parsers */ }
+        }
+        // XYZ if first line is just an atom count; otherwise treat as POSCAR
+        const first_line = trimmed.split(/\r?\n/, 1)[0]?.trim() ?? ``
+        const is_xyz = /^\d+$/.test(first_line)
+        const { parse_xyz, parse_poscar } = await import(`$lib/structure/parse`)
+        const parsed = is_xyz ? parse_xyz(trimmed) : parse_poscar(trimmed)
+        return parsed ? JSON.stringify(parsed) : null
+      }
+
+      // Try 1: V1 step result_json (local nodes like doping_gen)
       try {
         const resp = await fetch(`${API_BASE}/workflow/${encodeURIComponent(workflow_id)}/steps`)
         if (resp.ok) {
@@ -895,32 +918,70 @@
           if (step?.result_json) {
             const result = typeof step.result_json === `string` ? JSON.parse(step.result_json) : step.result_json
             if (result?.structure) {
-              structure_json = typeof result.structure === `string` ? result.structure : JSON.stringify(result.structure)
+              structure_json = typeof result.structure === `string`
+                ? (await parse_text_to_struct_json(result.structure)) ?? result.structure
+                : JSON.stringify(result.structure)
             } else if (result?.contcar) {
-              // MLP/local engines store optimized structure as CONTCAR (POSCAR format)
-              const { parse_poscar } = await import(`$lib/structure/parse`)
-              const parsed = parse_poscar(result.contcar)
-              if (parsed) structure_json = JSON.stringify(parsed)
+              structure_json = await parse_text_to_struct_json(result.contcar)
             }
           }
         }
-      } catch (err) { console.error(`[view-output] step fetch error:`, err) }
-      // Try 2: Load CONTCAR from HPC work directory (remote compute nodes)
+      } catch (err) { console.error(`[view-output] V1 step fetch error:`, err) }
+
+      // Try 2: V2 engine task result (NEB-TS converged XYZ lands in structure_json column).
+      // V2 engine never writes to workflow_steps so Try 1 returns nothing for V2 tasks.
+      if (!structure_json) {
+        try {
+          const resp = await fetch(`${API_BASE}/engine/tasks/${encodeURIComponent(node_id)}/result`)
+          if (resp.ok) {
+            const row: any = await resp.json()
+            const raw = row?.structure_json
+            if (typeof raw === `string` && raw.trim().length > 0) {
+              structure_json = await parse_text_to_struct_json(raw)
+              if (!structure_json) {
+                console.error(`[view-output] V2 structure_json present (${raw.length} bytes) but parsers returned null`,
+                  { preview: raw.slice(0, 200) })
+              } else {
+                console.info(`[view-output] resolved from V2 engine task result`)
+              }
+            }
+            // Also check outputs_json for an inlined `structure` (forward-compat with future ORCA collectors)
+            if (!structure_json && typeof row?.outputs_json === `string`) {
+              try {
+                const outputs = JSON.parse(row.outputs_json)
+                if (outputs?.structure) {
+                  structure_json = typeof outputs.structure === `string`
+                    ? (await parse_text_to_struct_json(outputs.structure)) ?? outputs.structure
+                    : JSON.stringify(outputs.structure)
+                }
+              } catch { /* malformed outputs_json */ }
+            }
+          }
+        } catch (err) { console.error(`[view-output] V2 engine task result fetch error:`, err) }
+      }
+
+      // Try 3: Load CONTCAR from HPC work directory (VASP/MLP remote nodes)
       if (!structure_json) {
         try {
           const data = await api.get_step_output(workflow_id, node_id, `CONTCAR`)
           if (data?.content) {
-            const { parse_poscar } = await import(`$lib/structure/parse`)
-            const parsed = parse_poscar(data.content)
-            if (parsed) structure_json = JSON.stringify(parsed)
+            structure_json = await parse_text_to_struct_json(data.content)
           }
         } catch { /* CONTCAR not available */ }
       }
+
       label += ` — Output`
       is_readonly = true
     }
 
-    if (!structure_json) return
+    if (!structure_json) {
+      const msg = source === `output`
+        ? `View Output Structure: no geometry available for this task.\n\nLikely cause: the calculation completed but the backend did not extract an output geometry (HPC connection may have dropped, or the converged file was not produced).\n\nCheck the task's work directory or rerun the task.`
+        : `View Structure: no geometry data found for this node.`
+      console.error(`[view-output] all resolution paths failed for node ${node_id} (source=${source})`)
+      alert(msg)
+      return
+    }
 
     try {
       edit_3d_node_id = node_id
@@ -952,8 +1013,9 @@
 
       // Show modal AFTER all state is ready
       show_structure_edit_3d = true
-    } catch {
-      // invalid JSON
+    } catch (err) {
+      console.error(`[view-output] failed to open 3D editor:`, err, { structure_json_preview: structure_json?.slice(0, 200) })
+      alert(`View Output Structure: failed to open the 3D editor — ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 

--- a/tests/vitest/structure/view_output_structure_click.test.ts
+++ b/tests/vitest/structure/view_output_structure_click.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { parse_xyz, parse_poscar } from '$lib/structure/parse'
+import cyclohexane from '$site/molecules/cyclohexane.xyz?raw'
+
+// Simulate what NodeStatusPanel.svelte does at click time.
+function sniff_and_parse(mlp_contcar: string) {
+  const first_line = mlp_contcar.split(/\r?\n/, 1)[0] ?? ''
+  const is_xyz = /^\s*\d+\s*$/.test(first_line)
+  return { is_xyz, parsed: is_xyz ? parse_xyz(mlp_contcar) : parse_poscar(mlp_contcar) }
+}
+
+describe('NodeStatusPanel View Structure click handler', () => {
+  it('parses cyclohexane.xyz (mimics ORCA NEB-TS converged.xyz)', () => {
+    const { is_xyz, parsed } = sniff_and_parse(cyclohexane)
+    expect(is_xyz).toBe(true)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.sites?.length).toBe(18)
+  })
+
+  it('handles leading whitespace on atom count', () => {
+    const padded = '   18\n' + cyclohexane.split('\n').slice(1).join('\n')
+    const { is_xyz, parsed } = sniff_and_parse(padded)
+    expect(is_xyz).toBe(true)
+    expect(parsed).not.toBeNull()
+  })
+
+  it('handles CRLF line endings', () => {
+    const crlf = cyclohexane.replace(/\n/g, '\r\n')
+    const { is_xyz, parsed } = sniff_and_parse(crlf)
+    expect(is_xyz).toBe(true)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.sites?.length).toBe(18)
+  })
+
+  it('handles trailing newline', () => {
+    const { is_xyz, parsed } = sniff_and_parse(cyclohexane + '\n')
+    expect(is_xyz).toBe(true)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.sites?.length).toBe(18)
+  })
+
+  it('still parses POSCAR via parse_poscar branch', () => {
+    const poscar = `Cu test\n1.0\n3.6 0 0\n0 3.6 0\n0 0 3.6\nCu\n4\nDirect\n0 0 0\n0.5 0.5 0\n0.5 0 0.5\n0 0.5 0.5\n`
+    const { is_xyz, parsed } = sniff_and_parse(poscar)
+    expect(is_xyz).toBe(false)
+    expect(parsed).not.toBeNull()
+  })
+})


### PR DESCRIPTION
The "View Output Structure" button on completed ORCA NEB-TS nodes did nothing because every resolution path silently returned null:

- V1 step API (workflow_steps.result_json) — V2 engine never writes here.
- HPC CONTCAR fetch — ORCA writes XYZ, not CONTCAR.
- Final guard `if (!structure_json) return` — no error, no log.

For V2 engine ORCA tasks the converged geometry is persisted in the task_results.structure_json column (as raw XYZ from ORCA_NEB-TS_converged.xyz). The frontend was never reading it, and even when it did the only parser invoked was parse_poscar, which throws on XYZ input.

Changes:

* WorkflowEditor.open_structure_edit_3d(_, 'output'): add a V2 engine task-result fetch (/engine/tasks/{id}/result), a parse_text_to_struct_json helper that sniffs pymatgen-JSON / XYZ / POSCAR, and surfaces every failure path via alert() + console.error (no more silent return).
* NodeStatusPanel: lift structure_json -> structure in _merge_outputs_json so cached_summary.structure is populated for V2 ORCA tasks. View Structure click handler now uses static parse_xyz/parse_poscar imports (no dynamic chunk loading risk), sniffs format, and renders parser failures in a visible red error box instead of 11px text.
* EngineTaskEditor.try_parse_structure: handle XYZ/POSCAR text payloads in addition to pymatgen JSON. Cache invalidation re-fetches when a cached null output coincides with a COMPLETED task (recovers existing sessions that loaded the task before parser support landed).

Regression test added (cyclohexane.xyz against the exact click-handler sniff+parse logic).