### PR TITLE
fix(agent): force IPv4-first DNS so CatBot doesn't stall on dual-stack

### DIFF
--- a/scripts/agent-dev.mjs
+++ b/scripts/agent-dev.mjs
@@ -61,9 +61,18 @@ binary, so end users don't need Bun.)
   console.log(`[agent:dev] Bun installed at ${bun}. Continuing...`)
 }
 
+// Some lab / corp networks hang Node.js fetch (undici) when the DNS
+// resolver hands back AAAA first and the IPv6 path is broken. Forcing
+// IPv4-first on the runtime + Bun avoids the silent stall that
+// otherwise makes CatBot's workflow generation "freeze ~50% of the
+// time" on those hosts. Harmless on healthy networks.
 const child = spawn(bun, [`run`, ENTRY], {
   stdio: 'inherit',
-  env: process.env,
+  env: {
+    ...process.env,
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ``} --dns-result-order=ipv4first`.trim(),
+    BUN_DNS_ORDER: `ipv4first`,
+  },
 })
 child.on('exit', (code, signal) => {
   if (signal) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,7 +332,14 @@ pub fn run() {
                         let cmd = cmd
                             .env("CATGO_AGENT_PORT", &agent_port)
                             .env("CATGO_BACKEND_PORT", &port)
-                            .env("PATH", &augmented_path);
+                            .env("PATH", &augmented_path)
+                            // Force IPv4-first DNS so Node's `fetch` (undici)
+                            // doesn't stall on hosts whose IPv6 path is broken
+                            // — symptom: CatBot workflow generation freezes
+                            // ~50% of the time on certain lab / corp networks.
+                            // Harmless on healthy networks.
+                            .env("NODE_OPTIONS", "--dns-result-order=ipv4first")
+                            .env("BUN_DNS_ORDER", "ipv4first");
                         match cmd.spawn() {
                             Ok((mut rx, child)) => {
                                 log::info!("[CatGo] Agent bridge started (sidecar) on port {}", agent_port);


### PR DESCRIPTION
## Summary

User reported CatBot workflow generation freezes ~50% of the time on one specific lab machine but works on every other machine. Symptom matches the earlier Cloudflare-API stall on the same host — Node.js \`fetch\` (undici) and Bun's runtime both wait on AAAA records that resolve but never connect, while plain \`curl\` (which falls through to A immediately) is fine.

## Fix

Force IPv4-first DNS for the agent-bridge runtime in both code paths:

- \`scripts/agent-dev.mjs\` (dev) — set \`NODE_OPTIONS=--dns-result-order=ipv4first\` and \`BUN_DNS_ORDER=ipv4first\` before spawning the Bun TypeScript entrypoint.
- \`src-tauri/src/lib.rs\` (Tauri sidecar in production builds) — same two env vars passed into the spawned \`catgo-agent\` sidecar.

## Side effects on healthy networks

None. The flags only re-order the DNS family preference; they don't disable IPv6 connectivity, so dual-stack hosts that work today keep working.

## Test plan

- [ ] Tauri dev on the affected lab machine: drive a long CatBot workflow generation prompt 10× — none should hang.
- [ ] Tauri production build on a clean machine: behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)