### PR TITLE
fix(vscode-ext): externalize all Node builtins so the sidecar download works

### DIFF
--- a/extensions/vscode/vite.webview.config.ts
+++ b/extensions/vscode/vite.webview.config.ts
@@ -1,9 +1,21 @@
-import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { builtinModules } from 'node:module'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineConfig } from 'vite'
 
 const __dirname = fileURLToPath(new URL(`.`, import.meta.url))
+
+// The extension runs in VS Code's Node host — every Node builtin must be
+// externalized, NOT bundled. Rollup can't bundle a builtin (no JS source);
+// a missed one resolves to an empty namespace and the first call on it
+// throws "(void 0) is not a function" at runtime (issue #48: node:https +
+// node:fs/promises were absent from a hand-maintained list, killing the
+// sidecar download). Derive the list from Node so it can't drift again.
+const node_builtins = [
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]
 
 export default defineConfig({
   build: {
@@ -13,7 +25,7 @@ export default defineConfig({
       fileName: () => `extension.cjs`,
     },
     rollupOptions: {
-      external: [`vscode`, `fs`, `node:fs`, `path`, `node:path`, `node:buffer`, `node:http`, `http`, `child_process`, `ws`],
+      external: [`vscode`, `ws`, ...node_builtins],
     },
     minify: false,
   },


### PR DESCRIPTION
Fixes #48.

## Summary

- The extension bundle (`extension.cjs`) runs in VS Code's Node host — every Node builtin must stay a runtime `require`, not be bundled. Rollup can't bundle a builtin; a missed one resolves to an empty namespace and the first call on it throws **`(void 0) is not a function`**.
- The `external` list in `vite.webview.config.ts` was hand-maintained and had drifted: **`node:https`** and **`node:fs/promises`** were missing, but `sidecar.ts` imports both. On a fresh install (no bundled binary) the GitHub-release sidecar download died → extension had no backend.
- Fix: derive `external` from Node's own `builtinModules` (bare + `node:`-prefixed) so no future builtin import can reintroduce this.

## Verification

- Rebuilt `extension.cjs` via `vite build --config vite.webview.config.ts`.
- Before: `grep node:https|node:fs/promises` in the chunk → **0 matches** (swallowed).
- After: chunk emits `require("node:https")`, `require("node:fs/promises")`, `require("node:http")` — proper externals. Build green (28.6s).

## Test plan

- [ ] Package v-next `.vsix` without bundled binary, install on a clean machine (empty globalStorage), open a folder → sidecar downloads, no "(void 0) is not a function"
- [ ] Existing bundled-binary / already-downloaded paths still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)