### PR TITLE
fix(trajectory): stop atom move/rotate snapping back on multi-frame trajectories

### DIFF
--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -236,6 +236,16 @@
       trigger_atoms_manipulated: () => handle_atoms_manipulated({
         displacements: new Map([[0, [0.01, 0, 0]]]),
       } as AtomManipulationEvent),
+      // Snap-back regression probes: atom-0 x for the *current* frame, read
+      // from the two sources the bug left stale — the frame structure and
+      // the Architecture-P position cache slice that feeds the GPU.
+      get_current_frame_x0(): number | null {
+        return trajectory?.frames?.[current_step_idx]?.structure?.sites?.[0]?.xyz?.[0] ?? null
+      },
+      get_cache_x0(): number | null {
+        const slice = position_cache?.[current_step_idx]
+        return slice ? slice[0] : null
+      },
     }
     ;(globalThis as { __catgo_traj_test?: typeof api }).__catgo_traj_test = api
     return () => {
@@ -1401,6 +1411,17 @@
 
     // Fast path: in-place mutation with inline position cache update.
     // Avoids all object allocation — just mutates xyz/abc arrays directly.
+    //
+    // The current frame is NOT skipped. Under the Architecture-P fast-path
+    // the displayed atom positions come from `position_cache[current_step_idx]`
+    // (fed to the GPU by Structure.svelte's Phase-2 write loop), NOT from the
+    // eager `current_structure` the drag-commit path mutates. Skipping the
+    // current frame here leaves its cache slice stale, so once
+    // `realtime_position_overrides` clears at pointer-up, Phase-2 re-asserts
+    // the pre-drag coords → the dragged atom snaps back. The eager path only
+    // ever wrote `current_structure` (a separate object), never `frames[]`
+    // or `position_cache`, so applying the displacement to the current frame
+    // here is a single net move, not a double-apply.
     const frames = trajectory.frames
     const skip = current_step_idx
     const cache = position_cache
@@ -1427,7 +1448,6 @@
     function process_chunk() {
       const end = Math.min(pos + CHUNK, frames.length)
       for (let fi = pos; fi < end; fi++) {
-        if (fi === skip) continue
         const sites = frames[fi].structure.sites
         const cache_arr = cache?.[fi]
 

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -260,6 +260,38 @@ test.describe(`Trajectory Component`, () => {
     }
   })
 
+  test(`atom manipulation persists on the current frame (no snap-back)`, async ({ page }) => {
+    // Regression for issue #11: dragging/rotating an atom on a trajectory
+    // snapped back because handle_atoms_manipulated skipped the current
+    // frame, leaving position_cache[current_step_idx] (the source the
+    // Architecture-P GPU path reads) stale.
+    await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+
+    const before = await page.evaluate(
+      () => (globalThis as unknown as { __catgo_traj_test?: { get_current_frame_x0(): number | null } })
+        .__catgo_traj_test?.get_current_frame_x0() ?? null,
+    )
+    expect(before, `DEV test API present + atom 0 readable`).not.toBeNull()
+
+    await page.evaluate(
+      () => (globalThis as unknown as { __catgo_traj_test?: { trigger_atoms_manipulated(): void } })
+        .__catgo_traj_test?.trigger_atoms_manipulated(),
+    )
+    // chunked apply ends with a trajectory spread; allow a tick.
+    await page.waitForTimeout(150)
+
+    const after = await page.evaluate(
+      () => (globalThis as unknown as { __catgo_traj_test?: { get_current_frame_x0(): number | null } })
+        .__catgo_traj_test?.get_current_frame_x0() ?? null,
+    )
+    // Displacement applied to atom 0 is [0.01, 0, 0]; the current frame must
+    // reflect it rather than retaining the pre-edit coordinate.
+    expect(after, `current-frame atom 0 x moved by +0.01`).toBeCloseTo(
+      (before as number) + 0.01,
+      6,
+    )
+  })
+
   test.describe(`layout and configuration options`, () => {
     test(`layout classes are correct based on viewport and props`, async ({ page }) => {
       // Auto layout should be horizontal when container is wide


### PR DESCRIPTION
## Summary

- Dragging/rotating an atom on a loaded trajectory had no effect — it snapped back and playback kept showing the original frames.
- **Root cause:** `handle_atoms_manipulated()` (Trajectory.svelte) applies the displacement across all frames in an in-place chunked loop but **skipped the current frame** (`if (fi === skip) continue`). That skip was valid pre-Architecture-P, when the displayed frame's positions came from the eager `current_structure` the drag-commit path mutates. Under the Architecture-P fast-path the display reads `position_cache[current_step_idx]` (GPU-fed by Structure.svelte's Phase-2 loop). Skipping the current frame left that cache slice stale; once `realtime_position_overrides` clears at pointer-up, Phase-2 re-asserted the pre-drag coords → snap-back.
- **Fix:** apply the displacement to the current frame too. Single net move, not a double-apply — the eager commit path only ever wrote `current_structure` (a separate object), never `frames[]`/`position_cache`, and the on-screen atom is cache-sourced.

## Verification

- `pnpm check`: no new errors in `Trajectory.svelte` (6 pre-existing, unrelated).
- `pnpm vitest run trajectory`: 374 passed (no regression in parse/extract/streaming).
- Added Playwright regression `atom manipulation persists on the current frame (no snap-back)` + two DEV-only read probes on the existing `__catgo_traj_test` API. **The Playwright e2e harness isn't bootable in my sandbox** (no `src/routes`/`/test/trajectory` served by the bare `vite dev` webServer — every existing `trajectory.test.ts` case fails identically at `beforeEach`). The new test is written to run in the CI `e2e` job.

## Manual check (live DEV app)

On `pnpm desktop:serve`, with a multi-frame trajectory loaded, drag an atom: it should stay where dropped and survive scrubbing. Or via console: `__catgo_traj_test.get_current_frame_x0()` → `__catgo_traj_test.trigger_atoms_manipulated()` → re-read; x0 must increase by 0.01 (was unchanged before this fix).

## Test plan

- [ ] CI `e2e` runs the new regression green
- [ ] Manual: drag atom on a trajectory, confirm no snap-back + persists across frame scrub
- [ ] Manual: rotate-atom path (Shift-drag) also persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)