### PR TITLE
feat(catbot): persistent Gemini ACP process pool for cross-turn context

### DIFF
--- a/src/lib/chat/chat-state.svelte.ts
+++ b/src/lib/chat/chat-state.svelte.ts
@@ -460,6 +460,7 @@ export async function send_message(
         attachments,
         signal: slice.abort_controller.signal,
         tabId: tab_id,
+        chatId: tab_id,
       })
 
       let full_text = ``

--- a/src/lib/chat/sdk-stream.ts
+++ b/src/lib/chat/sdk-stream.ts
@@ -40,17 +40,24 @@ export interface StreamAgentParams {
    * "default" panel. Omit for legacy / popout contexts.
    */
   tabId?: string
+  /**
+   * Per-chat-thread key. Forwarded to the Gemini adapter's persistent ACP
+   * process pool so repeat prompts in the same chat tab reuse one
+   * `gemini --acp` process and keep cross-turn context. The Claude/Codex
+   * adapters ignore it (their SDKs persist the subprocess themselves).
+   */
+  chatId?: string
 }
 
 export async function* stream_sdk_agent(
   params: StreamAgentParams,
 ): AsyncGenerator<AgentEvent> {
-  const { agent, prompt, sessionId, model, systemPrompt, attachments, signal, tabId } = params
+  const { agent, prompt, sessionId, model, systemPrompt, attachments, signal, tabId, chatId } = params
 
   const response = await fetch(`${getAgentBase()}/api/agent/stream`, {
     method: `POST`,
     headers: { 'Content-Type': `application/json` },
-    body: JSON.stringify({ agent, prompt, sessionId, model, systemPrompt, attachments, tabId }),
+    body: JSON.stringify({ agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId }),
     signal,
   })
 

--- a/src/lib/server/agent-bridge/acp/__tests__/process-pool.test.ts
+++ b/src/lib/server/agent-bridge/acp/__tests__/process-pool.test.ts
@@ -1,0 +1,104 @@
+import { resolve } from 'node:path'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { GeminiProcessPool } from '../process-pool.js'
+
+const FAKE_CLI = resolve(__dirname, '../../../../../../tests/fixtures/fake-gemini-acp.mjs')
+
+beforeAll(() => {
+  process.env.CATGO_GEMINI_PATH = FAKE_CLI
+})
+
+function prompt(handle: { client: any; sessionId: string }, text: string) {
+  return handle.client.request('session/prompt', {
+    sessionId: handle.sessionId,
+    prompt: [{ type: 'text', text }],
+  })
+}
+
+describe('GeminiProcessPool', () => {
+  let pool: GeminiProcessPool
+
+  afterEach(async () => {
+    await pool.shutdown()
+  })
+
+  it('reuses one process for repeat chatId (cross-turn context)', async () => {
+    pool = new GeminiProcessPool()
+
+    const h1 = await pool.acquire('chat-A', {})
+    const pid1 = h1.child.pid
+    await prompt(h1, 'remember the number 7')
+    pool.release(h1)
+
+    const h2 = await pool.acquire('chat-A', {})
+    expect(h2.child.pid).toBe(pid1) // same process
+    expect(h2.sessionId).toBe(h1.sessionId) // same ACP session
+    const res = await prompt(h2, 'what number did I tell you?')
+    pool.release(h2)
+    expect(res.stopReason).toBe('end_turn')
+    expect(pool.size).toBe(1)
+  })
+
+  it('serializes concurrent acquires for one chatId FIFO', async () => {
+    pool = new GeminiProcessPool()
+
+    const order: number[] = []
+    const h1 = await pool.acquire('chat-B', {})
+
+    // Two more acquires while h1 is still held — must queue.
+    const p2 = pool.acquire('chat-B', {}).then((h) => { order.push(2); return h })
+    const p3 = pool.acquire('chat-B', {}).then((h) => { order.push(3); return h })
+
+    // Neither resolves until h1 is released.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(order).toEqual([])
+
+    pool.release(h1)
+    const h2 = await p2
+    order.push(-1) // marker: h2 settled before we release it
+    pool.release(h2)
+    const h3 = await p3
+    pool.release(h3)
+
+    expect(order).toEqual([2, -1, 3])
+    expect(h2.child.pid).toBe(h1.child.pid)
+    expect(h3.child.pid).toBe(h1.child.pid)
+  })
+
+  it('respawns + flags crashedBefore after an unexpected exit', async () => {
+    pool = new GeminiProcessPool()
+
+    const h1 = await pool.acquire('chat-C', {})
+    expect(h1.crashedBefore).toBe(false)
+    const pid1 = h1.child.pid
+
+    await expect(prompt(h1, 'CRASH now')).rejects.toThrow()
+    pool.release(h1)
+
+    // Give the exit listener a tick to record the crash + drop the entry.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(pool.size).toBe(0)
+
+    const h2 = await pool.acquire('chat-C', {})
+    expect(h2.child.pid).not.toBe(pid1) // fresh process
+    expect(h2.crashedBefore).toBe(true) // banner cue for the adapter
+    pool.release(h2)
+  })
+
+  it('idle sweep evicts after the configured timeout', async () => {
+    pool = new GeminiProcessPool(80 /* idleMs */, 20 /* sweepMs */)
+
+    const h1 = await pool.acquire('chat-D', {})
+    pool.release(h1)
+    expect(pool.size).toBe(1)
+
+    await new Promise((r) => setTimeout(r, 200))
+    expect(pool.size).toBe(0)
+
+    // A busy process is never swept.
+    const h2 = await pool.acquire('chat-D', {})
+    await new Promise((r) => setTimeout(r, 200))
+    expect(pool.size).toBe(1)
+    pool.release(h2)
+  })
+})

--- a/src/lib/server/agent-bridge/acp/client.ts
+++ b/src/lib/server/agent-bridge/acp/client.ts
@@ -1,0 +1,251 @@
+/**
+ * Minimal Agent Client Protocol (ACP) JSON-RPC client over a child process'
+ * stdio, plus the `gemini --acp` spawn + `initialize` handshake.
+ *
+ * Extracted from the one-shot Gemini adapter so the persistent process pool
+ * (`process-pool.ts`) and the adapter glue (`adapters/gemini.ts`) can share
+ * one implementation. ACP is the official IPC mode Gemini CLI 0.41+ exposes
+ * for IDE / SDK embedding: newline-delimited JSON-RPC 2.0 over stdin/stdout.
+ */
+
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
+import type { EventEmitter } from 'node:events'
+import { createInterface } from 'node:readline'
+
+// ────────────────────────────────────────────────────────────────────────────
+// CLI lookup
+// ────────────────────────────────────────────────────────────────────────────
+
+let _gemini_cli_path: string | null | undefined
+export function find_gemini_cli(): string | null {
+  // Explicit override (also the test seam — points at a fake ACP CLI).
+  // Bypasses the cache so tests can swap it between runs.
+  const override = process.env.CATGO_GEMINI_PATH
+  if (override) return override
+  if (_gemini_cli_path !== undefined) return _gemini_cli_path
+  const cmd = process.platform === 'win32' ? 'where' : 'which'
+  try {
+    const out = spawnSync(cmd, ['gemini'], { encoding: 'utf-8' })
+    if (out.status === 0) {
+      const first = out.stdout.split(/\r?\n/).find(Boolean)
+      _gemini_cli_path = first?.trim() || null
+      return _gemini_cli_path
+    }
+  } catch { /* fall through */ }
+  _gemini_cli_path = null
+  return null
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// JSON-RPC wire types
+// ────────────────────────────────────────────────────────────────────────────
+
+interface RpcRequest {
+  jsonrpc: '2.0'
+  id: number
+  method: string
+  params?: unknown
+}
+
+interface RpcResponse {
+  jsonrpc: '2.0'
+  id: number
+  result?: any
+  error?: { code: number; message: string; data?: unknown }
+}
+
+interface RpcNotification {
+  jsonrpc: '2.0'
+  method: string
+  params?: any
+}
+
+interface RpcIncomingRequest {
+  jsonrpc: '2.0'
+  id: number
+  method: string
+  params?: any
+}
+
+type RpcIncoming = RpcResponse | RpcNotification | RpcIncomingRequest
+
+// ────────────────────────────────────────────────────────────────────────────
+// Client
+// ────────────────────────────────────────────────────────────────────────────
+
+export class AcpClient {
+  private nextId = 1
+  private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>()
+  private notificationHandlers = new Map<string, (params: any) => void>()
+  private requestHandlers = new Map<
+    string,
+    (params: any) => Promise<unknown> | unknown
+  >()
+  private closed = false
+
+  constructor(private child: ChildProcessWithoutNullStreams) {
+    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity })
+    ;(rl as unknown as EventEmitter).on('line', (line: string) => {
+      const trimmed = line.trim()
+      if (!trimmed) return
+      let msg: RpcIncoming
+      try {
+        msg = JSON.parse(trimmed) as RpcIncoming
+      } catch {
+        // Non-JSON line (debug log etc.) — ignore.
+        return
+      }
+      this.dispatch(msg)
+    })
+
+    child.stderr?.on('data', () => {
+      // Discard CLI debug noise — surfaced via the agent's status notifications.
+    })
+
+    ;(child as unknown as EventEmitter).on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+      this.closed = true
+      const err = new Error(`gemini --acp exited (code=${code} signal=${signal})`)
+      for (const { reject } of this.pending.values()) reject(err)
+      this.pending.clear()
+    })
+  }
+
+  /** True once the child has exited or shutdown() was called. */
+  get isClosed(): boolean {
+    return this.closed
+  }
+
+  private dispatch(msg: RpcIncoming): void {
+    if ('id' in msg && 'method' in msg) {
+      // Server → client RPC request (e.g. session/request_permission).
+      const handler = this.requestHandlers.get(msg.method)
+      if (!handler) {
+        this.write({
+          jsonrpc: '2.0',
+          id: msg.id,
+          error: { code: -32601, message: `Method not found: ${msg.method}` },
+        })
+        return
+      }
+      Promise.resolve(handler(msg.params))
+        .then((result) => this.write({ jsonrpc: '2.0', id: msg.id, result }))
+        .catch((e) =>
+          this.write({
+            jsonrpc: '2.0',
+            id: msg.id,
+            error: { code: -32603, message: e?.message ?? String(e) },
+          }),
+        )
+      return
+    }
+    if ('id' in msg && ('result' in msg || 'error' in msg)) {
+      const entry = this.pending.get(msg.id)
+      if (!entry) return
+      this.pending.delete(msg.id)
+      if (msg.error) entry.reject(new Error(msg.error.message))
+      else entry.resolve(msg.result)
+      return
+    }
+    if ('method' in msg) {
+      const handler = this.notificationHandlers.get(msg.method)
+      if (handler) handler(msg.params)
+    }
+  }
+
+  private write(obj: unknown): void {
+    if (this.closed) return
+    try {
+      this.child.stdin.write(`${JSON.stringify(obj)}\n`)
+    } catch {
+      // Pipe broken — child exited mid-write. The 'exit' handler will
+      // reject any pending promises.
+    }
+  }
+
+  onNotification(method: string, handler: (params: any) => void): void {
+    this.notificationHandlers.set(method, handler)
+  }
+
+  onRequest(method: string, handler: (params: any) => Promise<unknown> | unknown): void {
+    this.requestHandlers.set(method, handler)
+  }
+
+  request<T = any>(method: string, params?: unknown): Promise<T> {
+    if (this.closed) {
+      return Promise.reject(new Error('gemini --acp client is closed'))
+    }
+    const id = this.nextId++
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      this.write({ jsonrpc: '2.0', id, method, params } satisfies RpcRequest)
+    })
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.write({ jsonrpc: '2.0', method, params } satisfies RpcNotification)
+  }
+
+  shutdown(): void {
+    if (this.closed) return
+    this.closed = true
+    try {
+      this.child.stdin.end()
+    } catch { /* already closed */ }
+    if (!this.child.killed) this.child.kill('SIGTERM')
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Spawn + handshake
+// ────────────────────────────────────────────────────────────────────────────
+
+export class GeminiCliNotFoundError extends Error {
+  constructor() {
+    super('Gemini CLI not found on PATH. Install with: npm install -g @google/gemini-cli')
+    this.name = 'GeminiCliNotFoundError'
+  }
+}
+
+export interface SpawnedAcp {
+  child: ChildProcessWithoutNullStreams
+  client: AcpClient
+}
+
+/**
+ * Spawn `gemini --acp`, attach an {@link AcpClient}, and run the protocol
+ * `initialize` handshake. Throws {@link GeminiCliNotFoundError} if the CLI
+ * is not on PATH. The caller still owns `session/new` + `session/prompt`.
+ */
+export async function spawn_gemini_acp(opts: {
+  cwd?: string
+  model?: string
+}): Promise<SpawnedAcp> {
+  const cliPath = find_gemini_cli()
+  if (!cliPath) throw new GeminiCliNotFoundError()
+
+  const args = ['--acp']
+  if (opts.model) args.push('--model', opts.model)
+
+  const child = spawn(cliPath, args, {
+    cwd: opts.cwd ?? process.cwd(),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      // GEMINI_API_KEY required by the CLI; OAuth users have a real one in
+      // their env, otherwise the CLI falls back to ~/.gemini/oauth_creds.json.
+      GEMINI_API_KEY:
+        process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || 'oauth',
+    },
+  }) as ChildProcessWithoutNullStreams
+
+  const client = new AcpClient(child)
+
+  await client.request('initialize', {
+    protocolVersion: 1,
+    clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+    clientInfo: { name: 'catgo-agent-bridge', title: 'CatGo', version: '1.0.2' },
+  })
+
+  return { child, client }
+}

--- a/src/lib/server/agent-bridge/acp/process-pool.ts
+++ b/src/lib/server/agent-bridge/acp/process-pool.ts
@@ -1,0 +1,225 @@
+/**
+ * Persistent `gemini --acp` process pool — one long-lived process + ACP
+ * session per chat tab, so Gemini remembers prior turns (matching the
+ * Claude / Codex adapters, whose official SDKs already keep a subprocess
+ * alive across turns).
+ *
+ * Lifecycle:
+ *   • First acquire(chatId)  → spawn, `initialize`, `session/new`, store.
+ *   • Repeat acquire(chatId) → same handle, same ACP sessionId reused.
+ *   • Acquisitions for one chatId are serialized FIFO (one prompt in flight
+ *     per tab) via a per-chat promise chain — the section is held until
+ *     release(handle).
+ *   • Idle > idleMs        → swept + killed.
+ *   • Child crash          → entry dropped, chatId flagged; the next acquire
+ *     respawns and sets `crashedBefore` so the adapter can surface a
+ *     one-line "context reset" notice.
+ *
+ * The pool is the sole owner of every ManagedAcpProcess; direct refs (no
+ * WeakRef) — eviction is explicit.
+ */
+
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { EventEmitter } from 'node:events'
+import { AcpClient, spawn_gemini_acp } from './client.js'
+import { mapPermissionRequest, type PermissionOutcome } from './translate.js'
+
+export interface PoolInit {
+  cwd?: string
+  mcpServerUrl?: string
+  /** Per-tab id → X-CatGo-Tab-Id header on the session's MCP server. */
+  tabId?: string
+  model?: string
+}
+
+export interface ManagedAcpProcess {
+  chatId: string
+  client: AcpClient
+  sessionId: string
+  child: ChildProcessWithoutNullStreams
+  lastActivityMs: number
+  busy: boolean
+  /**
+   * True when this process was respawned after the previous one for the
+   * same chatId exited unexpectedly — the adapter shows a context-reset
+   * banner exactly once, then clears it.
+   */
+  crashedBefore: boolean
+  /**
+   * Swapped by the adapter before each `stream()` so the long-lived
+   * client's notifications/permission requests reach the live consumer.
+   */
+  onNotification: ((params: any) => void) | null
+  onPermission: (params: any) => Promise<PermissionOutcome>
+  /** @internal release the per-chat FIFO section. */
+  _release?: () => void
+  /** @internal set when the pool kills the process on purpose. */
+  _intentionalStop?: boolean
+}
+
+const DEFAULT_IDLE_MS = 10 * 60 * 1000
+const DEFAULT_SWEEP_MS = 15 * 1000
+
+function defaultPermissionHandler(): Promise<PermissionOutcome> {
+  // No adapter attached yet — cancel rather than hang the agent's turn.
+  return Promise.resolve({ outcome: { outcome: 'cancelled' } })
+}
+
+export class GeminiProcessPool {
+  private map = new Map<string, ManagedAcpProcess>()
+  private chains = new Map<string, Promise<void>>()
+  private crashed = new Set<string>()
+  private sweeper: ReturnType<typeof setInterval> | null = null
+  private shuttingDown = false
+
+  constructor(
+    private idleMs: number = DEFAULT_IDLE_MS,
+    private sweepMs: number = DEFAULT_SWEEP_MS,
+  ) {}
+
+  private ensureSweeper(): void {
+    if (this.sweeper || this.shuttingDown) return
+    this.sweeper = setInterval(() => this.sweep(), this.sweepMs)
+    // Don't keep the event loop alive just for the sweeper.
+    this.sweeper.unref?.()
+  }
+
+  private sweep(): void {
+    const now = Date.now()
+    for (const [chatId, entry] of this.map) {
+      if (!entry.busy && now - entry.lastActivityMs > this.idleMs) {
+        this.drop(chatId, 'idle')
+      }
+    }
+  }
+
+  /**
+   * Get the process for `chatId`, spawning + ACP-initializing one if none
+   * exists or the previous one died. Blocks (FIFO) while another prompt for
+   * the same chatId is in flight. Caller MUST call {@link release} when its
+   * `session/prompt` settles.
+   */
+  async acquire(chatId: string, init: PoolInit): Promise<ManagedAcpProcess> {
+    if (this.shuttingDown) throw new Error('GeminiProcessPool is shutting down')
+    this.ensureSweeper()
+
+    const prev = this.chains.get(chatId) ?? Promise.resolve()
+    let releaseSection!: () => void
+    const mine = new Promise<void>((r) => { releaseSection = r })
+    // The chain advances only once this section is released.
+    this.chains.set(chatId, prev.then(() => mine))
+
+    await prev // wait our turn — FIFO across concurrent acquires
+
+    try {
+      let entry = this.map.get(chatId)
+      if (!entry || entry.client.isClosed) {
+        if (entry) this.map.delete(chatId)
+        entry = await this.spawn(chatId, init)
+        this.map.set(chatId, entry)
+      }
+      entry.busy = true
+      entry.lastActivityMs = Date.now()
+      entry._release = releaseSection
+      return entry
+    } catch (e) {
+      // Spawn failed — free the section so we don't wedge the chain.
+      releaseSection()
+      throw e
+    }
+  }
+
+  /** End the in-flight section; keeps the process alive for the next turn. */
+  release(handle: ManagedAcpProcess): void {
+    handle.busy = false
+    handle.lastActivityMs = Date.now()
+    handle.onNotification = null
+    const r = handle._release
+    handle._release = undefined
+    if (r) r()
+  }
+
+  /** Kill + forget the process for `chatId` (idle sweep or explicit). */
+  drop(chatId: string, _reason: string): void {
+    const entry = this.map.get(chatId)
+    if (!entry) return
+    entry._intentionalStop = true
+    this.map.delete(chatId)
+    entry.client.shutdown()
+    const r = entry._release
+    entry._release = undefined
+    if (r) r()
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    if (this.sweeper) {
+      clearInterval(this.sweeper)
+      this.sweeper = null
+    }
+    for (const entry of this.map.values()) {
+      entry._intentionalStop = true
+      entry.client.shutdown()
+      const r = entry._release
+      entry._release = undefined
+      if (r) r()
+    }
+    this.map.clear()
+    this.chains.clear()
+  }
+
+  /** Test/diagnostic: number of live processes. */
+  get size(): number {
+    return this.map.size
+  }
+
+  private async spawn(chatId: string, init: PoolInit): Promise<ManagedAcpProcess> {
+    const { child, client } = await spawn_gemini_acp({ cwd: init.cwd, model: init.model })
+
+    const mcpServers: any[] = []
+    if (init.mcpServerUrl) {
+      const headers: { name: string; value: string }[] = []
+      if (init.tabId) headers.push({ name: 'X-CatGo-Tab-Id', value: init.tabId })
+      mcpServers.push({ type: 'http', name: 'catgo', url: init.mcpServerUrl, headers })
+    }
+    const newSession = await client.request<{ sessionId: string }>('session/new', {
+      cwd: init.cwd ?? process.cwd(),
+      mcpServers,
+    })
+
+    const handle: ManagedAcpProcess = {
+      chatId,
+      client,
+      sessionId: newSession?.sessionId ?? '',
+      child,
+      lastActivityMs: Date.now(),
+      busy: false,
+      crashedBefore: this.crashed.delete(chatId),
+      onNotification: null,
+      onPermission: defaultPermissionHandler,
+    }
+
+    // Long-lived handlers delegate to whatever the current stream installed.
+    client.onNotification('session/update', (p: any) => {
+      handle.onNotification?.(p)
+    })
+    client.onRequest('session/request_permission', (p: any) => handle.onPermission(p))
+
+    ;(child as unknown as EventEmitter).on('exit', () => {
+      // Only an *unexpected* exit flags a crash. Pool-initiated kills
+      // (idle/shutdown) set _intentionalStop first.
+      if (this.map.get(chatId) === handle && !handle._intentionalStop) {
+        this.crashed.add(chatId)
+        this.map.delete(chatId)
+        const r = handle._release
+        handle._release = undefined
+        if (r) r()
+      }
+    })
+
+    return handle
+  }
+}
+
+/** Re-export so the adapter has one import site for the mapping helper. */
+export { mapPermissionRequest }

--- a/src/lib/server/agent-bridge/acp/translate.ts
+++ b/src/lib/server/agent-bridge/acp/translate.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure ACP ⇄ AgentEvent translation helpers, extracted from the Gemini
+ * adapter so the one-shot path and the persistent pool path share one
+ * implementation (and so they're unit-testable without spawning a CLI).
+ */
+
+import type { AgentEvent } from '../types.js'
+
+function extractText(content: any): string {
+  if (!content) return ''
+  if (typeof content === 'string') return content
+  if (content.type === 'text' && typeof content.text === 'string') return content.text
+  if (Array.isArray(content)) return content.map(extractText).join('')
+  return ''
+}
+
+/** Translate one ACP `session/update` payload into zero or more AgentEvents. */
+export function translateUpdate(update: any): AgentEvent[] {
+  const events: AgentEvent[] = []
+  if (!update?.sessionUpdate) return events
+  switch (update.sessionUpdate) {
+    case 'agent_message_chunk': {
+      const text = extractText(update.content)
+      if (text) events.push({ type: 'text', text })
+      break
+    }
+    case 'agent_thought_chunk': {
+      const text = extractText(update.content)
+      if (text) events.push({ type: 'thinking', text })
+      break
+    }
+    case 'tool_call':
+      events.push({
+        type: 'tool_start',
+        toolId: String(update.toolCallId ?? ''),
+        toolName: String(update.title ?? update.kind ?? ''),
+        input: update.input ?? {},
+      })
+      break
+    case 'tool_call_update': {
+      const status = String(update.status ?? '')
+      if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+        const resultText = Array.isArray(update.content)
+          ? update.content.map((c: any) => extractText(c.content ?? c)).join('\n')
+          : extractText(update.content)
+        events.push({
+          type: 'tool_end',
+          toolId: String(update.toolCallId ?? ''),
+          toolName: String(update.title ?? ''),
+          result: resultText,
+          isError: status === 'failed',
+        })
+      }
+      break
+    }
+    // plan / mode / command updates: not surfaced — UI doesn't render them.
+    default:
+      break
+  }
+  return events
+}
+
+/** The shape ACP expects back from a `session/request_permission` handler. */
+export type PermissionOutcome =
+  | { outcome: { outcome: 'selected'; optionId: string } }
+  | { outcome: { outcome: 'cancelled' } }
+
+/**
+ * Map a user allow/deny decision onto an ACP `optionId`.
+ *
+ * `optionId` is a server-defined string (e.g. `proceed_once`, `allow-once`)
+ * that varies between ACP agents — so we never hard-code it. Instead we pick
+ * from the `options` array the agent sent with the request, matching by
+ * standardized `kind`. Falls back to the first option (allow) or last option
+ * (deny) when the agent uses non-standard kinds, and cancels the turn if the
+ * agent sent no options at all (rather than hanging).
+ */
+export function mapPermissionRequest(
+  rpcParams: any,
+  behavior: 'allow' | 'deny',
+): PermissionOutcome {
+  const options: Array<{ optionId: string; kind?: string }> = Array.isArray(rpcParams?.options)
+    ? rpcParams.options
+    : []
+  const wantKinds = behavior === 'allow'
+    ? ['allow_once', 'allow_always']
+    : ['reject_once', 'reject_always']
+  const match = options.find((o) => wantKinds.includes(String(o.kind ?? '')))
+  if (match) {
+    return { outcome: { outcome: 'selected', optionId: match.optionId } }
+  }
+  if (options.length > 0) {
+    const fallback = behavior === 'allow' ? options[0] : options[options.length - 1]
+    return { outcome: { outcome: 'selected', optionId: fallback.optionId } }
+  }
+  return { outcome: { outcome: 'cancelled' } }
+}

--- a/src/lib/server/agent-bridge/adapters/__tests__/gemini.test.ts
+++ b/src/lib/server/agent-bridge/adapters/__tests__/gemini.test.ts
@@ -1,0 +1,97 @@
+import { resolve } from 'node:path'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import type { AgentEvent, PermissionResult, StreamParams } from '../../types.js'
+import { createGeminiAdapter, resetGeminiPoolForTests } from '../gemini.js'
+
+const FAKE_CLI = resolve(__dirname, '../../../../../../tests/fixtures/fake-gemini-acp.mjs')
+
+beforeAll(() => {
+  process.env.CATGO_GEMINI_PATH = FAKE_CLI
+})
+
+afterEach(async () => {
+  await resetGeminiPoolForTests()
+})
+
+function baseParams(over: Partial<StreamParams>): StreamParams {
+  return {
+    prompt: '',
+    permissionCallback: async (): Promise<PermissionResult> => ({ behavior: 'allow' }),
+    ...over,
+  }
+}
+
+async function collect(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = []
+  for await (const e of gen) out.push(e)
+  return out
+}
+
+function textOf(events: AgentEvent[]): string {
+  return events
+    .filter((e): e is Extract<AgentEvent, { type: 'text' }> => e.type === 'text')
+    .map((e) => e.text)
+    .join(' ')
+}
+
+describe('gemini adapter — persistent chatId', () => {
+  it('keeps context across 3 sequential stream() calls with one chatId', async () => {
+    const adapter = createGeminiAdapter()
+
+    const turn1 = await collect(
+      adapter.stream(baseParams({ chatId: 'tab-1', prompt: 'remember the number 7' })),
+    )
+    expect(turn1.at(-1)).toEqual({ type: 'done' })
+    expect(turn1.some((e) => e.type === 'result' && e.isError)).toBe(false)
+
+    const turn2 = await collect(
+      adapter.stream(baseParams({ chatId: 'tab-1', prompt: 'what number did I tell you?' })),
+    )
+    expect(textOf(turn2)).toContain('7')
+
+    const turn3 = await collect(
+      adapter.stream(baseParams({ chatId: 'tab-1', prompt: 'remind me what number that was' })),
+    )
+    expect(textOf(turn3)).toContain('7')
+  })
+
+  it('one-shot path (no chatId) does NOT retain context', async () => {
+    const adapter = createGeminiAdapter()
+
+    await collect(adapter.stream(baseParams({ prompt: 'remember the number 9' })))
+    const turn2 = await collect(adapter.stream(baseParams({ prompt: 'what number did I tell you?' })))
+    // Fresh process per call → memory gone.
+    expect(textOf(turn2)).not.toContain('9')
+    expect(textOf(turn2).toLowerCase()).toContain('not told')
+  })
+})
+
+describe('gemini adapter — permission optionId picked by kind', () => {
+  it('allow → the option whose kind is allow_once', async () => {
+    const adapter = createGeminiAdapter()
+    const events = await collect(
+      adapter.stream(
+        baseParams({
+          chatId: 'tab-perm-allow',
+          prompt: 'PERMISSION test',
+          permissionCallback: async () => ({ behavior: 'allow' }),
+        }),
+      ),
+    )
+    expect(textOf(events)).toContain('opt-allow')
+  })
+
+  it('deny → the option whose kind is reject_once', async () => {
+    const adapter = createGeminiAdapter()
+    const events = await collect(
+      adapter.stream(
+        baseParams({
+          chatId: 'tab-perm-deny',
+          prompt: 'PERMISSION test',
+          permissionCallback: async () => ({ behavior: 'deny' }),
+        }),
+      ),
+    )
+    expect(textOf(events)).toContain('opt-deny')
+  })
+})

--- a/src/lib/server/agent-bridge/adapters/gemini.ts
+++ b/src/lib/server/agent-bridge/adapters/gemini.ts
@@ -1,256 +1,95 @@
 /**
  * Gemini CLI adapter — talks to `gemini --acp` over JSON-RPC stdio.
  *
- * Replaces the deprecated `@ketd/gemini-cli-sdk` (third-party, unmaintained,
- * one-shot spawn per prompt) with a direct ACP (Agent Client Protocol)
- * integration. ACP is the official IPC mode Gemini CLI 0.41+ exposes for
- * IDE / SDK embedding:
+ * Two modes, selected by whether `StreamParams.chatId` is present:
  *
- *   1. Spawn `gemini --acp` once per `stream()` call.
- *   2. JSON-RPC 2.0 messages over stdin/stdout (\n-delimited).
- *   3. `initialize` → `session/new` (carries the CatGo MCP server URL +
- *      `X-CatGo-Tab-Id` header so structure pushes land in the originating
- *      tab) → `session/prompt`.
- *   4. Agent streams `session/update` notifications (text deltas, tool
- *      calls, plans, thoughts).
- *   5. Agent calls `session/request_permission` for tool approvals; we
- *      bridge to the StreamParams.permissionCallback.
- *   6. `session/prompt` resolves with `{ stopReason }` — emit `result` +
- *      `done` and tear the subprocess down.
+ *  • Persistent (chatId set): a {@link GeminiProcessPool} keeps one
+ *    `gemini --acp` process + ACP session alive per chat tab, so the model
+ *    remembers prior turns and tool results — matching the Claude / Codex
+ *    adapters whose SDKs persist their subprocess. Idle tabs evict; crashed
+ *    processes respawn with a one-line context-reset notice.
  *
- * Tested against gemini-cli 0.41.x. Drops the @ketd/gemini-cli-sdk dep.
+ *  • One-shot (chatId absent): spawn a fresh process, run the single prompt,
+ *    tear it down. Legacy behaviour — keeps non-pooled callers and tests
+ *    cheap and unaffected.
+ *
+ * ACP is the official IPC mode Gemini CLI 0.41+ exposes for IDE / SDK
+ * embedding: newline-delimited JSON-RPC 2.0 over stdin/stdout. The JSON-RPC
+ * client + spawn handshake live in `../acp/client.ts`; the ACP⇄AgentEvent
+ * translation in `../acp/translate.ts`; the pool in `../acp/process-pool.ts`.
  */
 
-import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { spawn, spawnSync } from 'node:child_process'
-import type { EventEmitter } from 'node:events'
-import { createInterface } from 'node:readline'
 import type { AgentAdapter } from '../adapter.js'
 import { registerAdapter } from '../adapter.js'
 import type { AgentEvent, SessionInfo, StreamParams } from '../types.js'
+import { GeminiCliNotFoundError, spawn_gemini_acp } from '../acp/client.js'
+import { mapPermissionRequest, translateUpdate } from '../acp/translate.js'
+import { GeminiProcessPool } from '../acp/process-pool.js'
+
+// One pool per agent-bridge process. Shut down on SIGTERM by server.ts.
+let pool = new GeminiProcessPool()
+
+export function shutdownGeminiPool(): Promise<void> {
+  return pool.shutdown()
+}
+
+/** Test seam: tear the pool down and start a fresh one. */
+export async function resetGeminiPoolForTests(): Promise<void> {
+  await pool.shutdown()
+  pool = new GeminiProcessPool()
+}
 
 // ────────────────────────────────────────────────────────────────────────────
-// CLI lookup
+// Small queue that bridges async ACP notifications → an async generator.
 // ────────────────────────────────────────────────────────────────────────────
 
-let _gemini_cli_path: string | null | undefined
-function find_gemini_cli(): string | null {
-  if (_gemini_cli_path !== undefined) return _gemini_cli_path
-  const cmd = process.platform === 'win32' ? 'where' : 'which'
-  try {
-    const out = spawnSync(cmd, ['gemini'], { encoding: 'utf-8' })
-    if (out.status === 0) {
-      const first = out.stdout.split(/\r?\n/).find(Boolean)
-      _gemini_cli_path = first?.trim() || null
-      return _gemini_cli_path
+class EventPump {
+  private q: AgentEvent[] = []
+  private wake: (() => void) | null = null
+  private done = false
+
+  push(e: AgentEvent): void {
+    this.q.push(e)
+    this.fire()
+  }
+
+  finish(): void {
+    this.done = true
+    this.fire()
+  }
+
+  private fire(): void {
+    if (this.wake) {
+      const w = this.wake
+      this.wake = null
+      w()
     }
-  } catch { /* fall through */ }
-  _gemini_cli_path = null
-  return null
-}
+  }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Minimal JSON-RPC client over child stdio
-// ────────────────────────────────────────────────────────────────────────────
-
-interface RpcRequest {
-  jsonrpc: '2.0'
-  id: number
-  method: string
-  params?: unknown
-}
-
-interface RpcResponse {
-  jsonrpc: '2.0'
-  id: number
-  result?: any
-  error?: { code: number; message: string; data?: unknown }
-}
-
-interface RpcNotification {
-  jsonrpc: '2.0'
-  method: string
-  params?: any
-}
-
-interface RpcIncomingRequest {
-  jsonrpc: '2.0'
-  id: number
-  method: string
-  params?: any
-}
-
-type RpcIncoming = RpcResponse | RpcNotification | RpcIncomingRequest
-
-class AcpClient {
-  private nextId = 1
-  private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>()
-  private notificationHandlers = new Map<string, (params: any) => void>()
-  private requestHandlers = new Map<
-    string,
-    (params: any) => Promise<unknown> | unknown
-  >()
-  private closed = false
-
-  constructor(private child: ChildProcessWithoutNullStreams) {
-    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity })
-    ;(rl as unknown as EventEmitter).on('line', (line: string) => {
-      const trimmed = line.trim()
-      if (!trimmed) return
-      let msg: RpcIncoming
-      try {
-        msg = JSON.parse(trimmed) as RpcIncoming
-      } catch {
-        // Non-JSON line (debug log etc.) — ignore.
-        return
+  async *drain(): AsyncGenerator<AgentEvent> {
+    while (!this.done || this.q.length > 0) {
+      if (this.q.length > 0) {
+        yield this.q.shift()!
+        continue
       }
-      this.dispatch(msg)
-    })
-
-    child.stderr?.on('data', () => {
-      // Discard CLI debug noise — surfaced via the agent's status notifications.
-    })
-
-    ;(child as unknown as EventEmitter).on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
-      this.closed = true
-      const err = new Error(`gemini --acp exited (code=${code} signal=${signal})`)
-      for (const { reject } of this.pending.values()) reject(err)
-      this.pending.clear()
-    })
-  }
-
-  private dispatch(msg: RpcIncoming): void {
-    if ('id' in msg && 'method' in msg) {
-      // Server → client RPC request (e.g. session/request_permission).
-      const handler = this.requestHandlers.get(msg.method)
-      if (!handler) {
-        this.write({
-          jsonrpc: '2.0',
-          id: msg.id,
-          error: { code: -32601, message: `Method not found: ${msg.method}` },
-        })
-        return
-      }
-      Promise.resolve(handler(msg.params))
-        .then((result) => this.write({ jsonrpc: '2.0', id: msg.id, result }))
-        .catch((e) =>
-          this.write({
-            jsonrpc: '2.0',
-            id: msg.id,
-            error: { code: -32603, message: e?.message ?? String(e) },
-          }),
-        )
-      return
+      if (this.done) break
+      await new Promise<void>((r) => { this.wake = r })
     }
-    if ('id' in msg && ('result' in msg || 'error' in msg)) {
-      const entry = this.pending.get(msg.id)
-      if (!entry) return
-      this.pending.delete(msg.id)
-      if (msg.error) entry.reject(new Error(msg.error.message))
-      else entry.resolve(msg.result)
-      return
-    }
-    if ('method' in msg) {
-      const handler = this.notificationHandlers.get(msg.method)
-      if (handler) handler(msg.params)
-    }
-  }
-
-  private write(obj: unknown): void {
-    if (this.closed) return
-    try {
-      this.child.stdin.write(`${JSON.stringify(obj)}\n`)
-    } catch {
-      // Pipe broken — child exited mid-write. The 'exit' handler will
-      // reject any pending promises.
-    }
-  }
-
-  onNotification(method: string, handler: (params: any) => void): void {
-    this.notificationHandlers.set(method, handler)
-  }
-
-  onRequest(method: string, handler: (params: any) => Promise<unknown> | unknown): void {
-    this.requestHandlers.set(method, handler)
-  }
-
-  request<T = any>(method: string, params?: unknown): Promise<T> {
-    const id = this.nextId++
-    return new Promise<T>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject })
-      this.write({ jsonrpc: '2.0', id, method, params } satisfies RpcRequest)
-    })
-  }
-
-  notify(method: string, params?: unknown): void {
-    this.write({ jsonrpc: '2.0', method, params } satisfies RpcNotification)
-  }
-
-  shutdown(): void {
-    if (this.closed) return
-    this.closed = true
-    try {
-      this.child.stdin.end()
-    } catch { /* already closed */ }
-    if (!this.child.killed) this.child.kill('SIGTERM')
   }
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// ACP → AgentEvent translation
-// ────────────────────────────────────────────────────────────────────────────
-
-function extractText(content: any): string {
-  if (!content) return ''
-  if (typeof content === 'string') return content
-  if (content.type === 'text' && typeof content.text === 'string') return content.text
-  if (Array.isArray(content)) return content.map(extractText).join('')
-  return ''
-}
-
-function translateUpdate(update: any): AgentEvent[] {
-  const events: AgentEvent[] = []
-  if (!update?.sessionUpdate) return events
-  switch (update.sessionUpdate) {
-    case 'agent_message_chunk': {
-      const text = extractText(update.content)
-      if (text) events.push({ type: 'text', text })
-      break
-    }
-    case 'agent_thought_chunk': {
-      const text = extractText(update.content)
-      if (text) events.push({ type: 'thinking', text })
-      break
-    }
-    case 'tool_call':
-      events.push({
-        type: 'tool_start',
-        toolId: String(update.toolCallId ?? ''),
-        toolName: String(update.title ?? update.kind ?? ''),
-        input: update.input ?? {},
-      })
-      break
-    case 'tool_call_update': {
-      const status = String(update.status ?? '')
-      if (status === 'completed' || status === 'failed' || status === 'cancelled') {
-        const resultText = Array.isArray(update.content)
-          ? update.content.map((c: any) => extractText(c.content ?? c)).join('\n')
-          : extractText(update.content)
-        events.push({
-          type: 'tool_end',
-          toolId: String(update.toolCallId ?? ''),
-          toolName: String(update.title ?? ''),
-          result: resultText,
-          isError: status === 'failed',
-        })
-      }
-      break
-    }
-    // plan / mode / command updates: not surfaced — UI doesn't render them.
-    default:
-      break
-  }
-  return events
+function buildPermissionOutcome(
+  rpcParams: any,
+  permissionCallback: StreamParams['permissionCallback'],
+) {
+  const tc = rpcParams?.toolCall ?? rpcParams ?? {}
+  return permissionCallback({
+    id: String(tc.toolCallId ?? tc.id ?? ''),
+    toolName: String(tc.title ?? tc.kind ?? tc.toolName ?? ''),
+    input: tc.input ?? {},
+  }).then((result) =>
+    mapPermissionRequest(rpcParams, result.behavior === 'allow' ? 'allow' : 'deny'),
+  )
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -262,190 +101,11 @@ export function createGeminiAdapter(): AgentAdapter {
     agent: 'gemini',
 
     async *stream(params: StreamParams): AsyncGenerator<AgentEvent> {
-      const {
-        prompt,
-        sessionId,
-        model,
-        cwd,
-        mcpServerUrl,
-        permissionCallback,
-        abortSignal,
-        tabId,
-      } = params
-
-      const cliPath = find_gemini_cli()
-      if (!cliPath) {
-        yield {
-          type: 'result',
-          isError: true,
-          errorMessage:
-            'Gemini CLI not found on PATH. Install with: npm install -g @google/gemini-cli',
-        }
-        yield { type: 'done' }
-        return
-      }
-
-      const args = ['--acp']
-      if (model) args.push('--model', model)
-      const child = spawn(cliPath, args, {
-        cwd: cwd ?? process.cwd(),
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: {
-          ...process.env,
-          // GEMINI_API_KEY required by the CLI; OAuth users have a real one
-          // in their env, otherwise the CLI falls back to ~/.gemini/oauth_creds.json.
-          GEMINI_API_KEY:
-            process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || 'oauth',
-        },
-      })
-
-      const client = new AcpClient(child)
-      const eventQueue: AgentEvent[] = []
-      let queueResolve: (() => void) | null = null
-      let streamDone = false
-      let stopReason: string | undefined
-      const promptErrorBox: { value: Error | null } = { value: null }
-
-      const pushEvent = (e: AgentEvent) => {
-        eventQueue.push(e)
-        if (queueResolve) {
-          const r = queueResolve
-          queueResolve = null
-          r()
-        }
-      }
-
-      client.onNotification('session/update', (notifParams: any) => {
-        for (const ev of translateUpdate(notifParams?.update)) {
-          pushEvent(ev)
-        }
-      })
-
-      client.onRequest('session/request_permission', async (rpcParams: any) => {
-        const tc = rpcParams?.toolCall ?? rpcParams ?? {}
-        const result = await permissionCallback({
-          id: String(tc.toolCallId ?? tc.id ?? ''),
-          toolName: String(tc.title ?? tc.kind ?? tc.toolName ?? ''),
-          input: tc.input ?? {},
-        })
-        // ACP `optionId` is a server-defined string (e.g. `proceed_once` or
-        // `allow-once`, varies by agent). Pick from the `options` array the
-        // agent sent with the request by matching `kind`. Falls back to the
-        // first option of either category if the agent uses non-standard
-        // kinds.
-        const options: Array<{ optionId: string; kind?: string }> = Array.isArray(rpcParams?.options)
-          ? rpcParams.options
-          : []
-        const wantKinds = result.behavior === 'allow'
-          ? ['allow_once', 'allow_always']
-          : ['reject_once', 'reject_always']
-        const match = options.find((o) => wantKinds.includes(String(o.kind ?? '')))
-        if (match) {
-          return { outcome: { outcome: 'selected', optionId: match.optionId } }
-        }
-        // No kind match — fall back to first option (allow path) or last (deny).
-        if (options.length > 0) {
-          const fallback = result.behavior === 'allow' ? options[0] : options[options.length - 1]
-          return { outcome: { outcome: 'selected', optionId: fallback.optionId } }
-        }
-        // No options at all — cancel the turn rather than hang.
-        return { outcome: { outcome: 'cancelled' } }
-      })
-
-      // Forward an abort from the caller through cancel + child kill.
-      const onAbort = () => {
-        if (sessionId) client.notify('session/cancel', { sessionId })
-        client.shutdown()
-      }
-      if (abortSignal) {
-        if (abortSignal.aborted) onAbort()
-        else abortSignal.addEventListener('abort', onAbort, { once: true })
-      }
-
-      try {
-        // 1. initialize
-        await client.request('initialize', {
-          protocolVersion: 1,
-          clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
-          clientInfo: { name: 'catgo-agent-bridge', title: 'CatGo', version: '1.0.2' },
-        })
-
-        // 2. session/new — carry the CatGo MCP server + tabId header so
-        //    structure pushes from this gemini run land in the chat's
-        //    active panel.
-        const mcpServers: any[] = []
-        if (mcpServerUrl) {
-          const headers: { name: string; value: string }[] = []
-          if (tabId) headers.push({ name: 'X-CatGo-Tab-Id', value: tabId })
-          mcpServers.push({ type: 'http', name: 'catgo', url: mcpServerUrl, headers })
-        }
-        const newSession = await client.request<{ sessionId: string }>('session/new', {
-          cwd: cwd ?? process.cwd(),
-          mcpServers,
-        })
-        const effectiveSessionId = newSession?.sessionId ?? sessionId ?? ''
-
-        yield { type: 'status', sessionId: effectiveSessionId, model: model ?? undefined }
-
-        // 3. session/prompt — fire-and-forget, drain notifications until result.
-        const promptPromise = client
-          .request<{ stopReason?: string }>('session/prompt', {
-            sessionId: effectiveSessionId,
-            prompt: [{ type: 'text', text: prompt }],
-          })
-          .then((res) => {
-            stopReason = res?.stopReason
-            streamDone = true
-            if (queueResolve) {
-              const r = queueResolve
-              queueResolve = null
-              r()
-            }
-          })
-          .catch((e: Error) => {
-            promptErrorBox.value = e
-            streamDone = true
-            if (queueResolve) {
-              const r = queueResolve
-              queueResolve = null
-              r()
-            }
-          })
-
-        // 4. Drain event queue until prompt resolves.
-        while (!streamDone || eventQueue.length > 0) {
-          if (eventQueue.length > 0) {
-            yield eventQueue.shift()!
-            continue
-          }
-          if (streamDone) break
-          await new Promise<void>((resolve) => {
-            queueResolve = resolve
-          })
-        }
-        await promptPromise
-      } finally {
-        if (abortSignal) abortSignal.removeEventListener('abort', onAbort)
-        client.shutdown()
-      }
-
-      if (promptErrorBox.value) {
-        yield { type: 'result', isError: true, errorMessage: promptErrorBox.value.message }
+      if (params.chatId) {
+        yield* streamPersistent(params, params.chatId)
       } else {
-        yield {
-          type: 'result',
-          isError: stopReason === 'refusal',
-          errorMessage:
-            stopReason === 'max_tokens'
-              ? 'Reached model max_tokens'
-              : stopReason === 'max_turn_requests'
-              ? 'Reached max turn requests'
-              : stopReason === 'refusal'
-              ? 'Model refused to continue'
-              : undefined,
-        }
+        yield* streamOneShot(params)
       }
-      yield { type: 'done' }
     },
 
     async listSessions(): Promise<SessionInfo[]> {
@@ -453,6 +113,169 @@ export function createGeminiAdapter(): AgentAdapter {
       return []
     },
   }
+}
+
+// ── Persistent (pooled) path ────────────────────────────────────────────────
+
+async function* streamPersistent(
+  params: StreamParams,
+  chatId: string,
+): AsyncGenerator<AgentEvent> {
+  const { prompt, model, cwd, mcpServerUrl, permissionCallback, abortSignal, tabId } = params
+
+  let handle
+  try {
+    handle = await pool.acquire(chatId, { cwd, mcpServerUrl, tabId, model })
+  } catch (e) {
+    const msg = e instanceof GeminiCliNotFoundError
+      ? e.message
+      : `Failed to start Gemini: ${e instanceof Error ? e.message : String(e)}`
+    yield { type: 'result', isError: true, errorMessage: msg }
+    yield { type: 'done' }
+    return
+  }
+
+  const pump = new EventPump()
+  const stop = { reason: undefined as string | undefined, err: null as Error | null }
+
+  handle.onNotification = (notifParams: any) => {
+    for (const ev of translateUpdate(notifParams?.update)) pump.push(ev)
+  }
+  handle.onPermission = (rpcParams: any) => buildPermissionOutcome(rpcParams, permissionCallback)
+
+  const onAbort = () => {
+    handle.client.notify('session/cancel', { sessionId: handle.sessionId })
+    // Don't shutdown the process — abort cancels the turn, the pool keeps
+    // the process for the next prompt. The prompt request rejects, which
+    // ends this stream.
+  }
+  if (abortSignal) {
+    if (abortSignal.aborted) onAbort()
+    else abortSignal.addEventListener('abort', onAbort, { once: true })
+  }
+
+  try {
+    // One-time context-reset banner after an unexpected prior crash.
+    if (handle.crashedBefore) {
+      handle.crashedBefore = false
+      yield {
+        type: 'thinking',
+        text: '⚠️ Previous Gemini session ended unexpectedly — context reset.',
+      }
+    }
+
+    yield { type: 'status', sessionId: handle.sessionId, model: model ?? undefined }
+
+    const promptPromise = handle.client
+      .request<{ stopReason?: string }>('session/prompt', {
+        sessionId: handle.sessionId,
+        prompt: [{ type: 'text', text: prompt }],
+      })
+      .then((res) => { stop.reason = res?.stopReason })
+      .catch((e: Error) => { stop.err = e })
+      .finally(() => pump.finish())
+
+    for await (const ev of pump.drain()) yield ev
+    await promptPromise
+  } finally {
+    if (abortSignal) abortSignal.removeEventListener('abort', onAbort)
+    pool.release(handle)
+  }
+
+  yield* finalEvents(stop)
+}
+
+// ── One-shot (legacy) path ──────────────────────────────────────────────────
+
+async function* streamOneShot(params: StreamParams): AsyncGenerator<AgentEvent> {
+  const {
+    prompt, sessionId, model, cwd, mcpServerUrl, permissionCallback, abortSignal, tabId,
+  } = params
+
+  let spawned
+  try {
+    spawned = await spawn_gemini_acp({ cwd, model })
+  } catch (e) {
+    const msg = e instanceof GeminiCliNotFoundError
+      ? e.message
+      : `Failed to start Gemini: ${e instanceof Error ? e.message : String(e)}`
+    yield { type: 'result', isError: true, errorMessage: msg }
+    yield { type: 'done' }
+    return
+  }
+
+  const { client } = spawned
+  const pump = new EventPump()
+  const stop = { reason: undefined as string | undefined, err: null as Error | null }
+
+  client.onNotification('session/update', (notifParams: any) => {
+    for (const ev of translateUpdate(notifParams?.update)) pump.push(ev)
+  })
+  client.onRequest('session/request_permission', (rpcParams: any) =>
+    buildPermissionOutcome(rpcParams, permissionCallback),
+  )
+
+  const onAbort = () => {
+    if (sessionId) client.notify('session/cancel', { sessionId })
+    client.shutdown()
+  }
+  if (abortSignal) {
+    if (abortSignal.aborted) onAbort()
+    else abortSignal.addEventListener('abort', onAbort, { once: true })
+  }
+
+  try {
+    const mcpServers: any[] = []
+    if (mcpServerUrl) {
+      const headers: { name: string; value: string }[] = []
+      if (tabId) headers.push({ name: 'X-CatGo-Tab-Id', value: tabId })
+      mcpServers.push({ type: 'http', name: 'catgo', url: mcpServerUrl, headers })
+    }
+    const newSession = await client.request<{ sessionId: string }>('session/new', {
+      cwd: cwd ?? process.cwd(),
+      mcpServers,
+    })
+    const effectiveSessionId = newSession?.sessionId ?? sessionId ?? ''
+
+    yield { type: 'status', sessionId: effectiveSessionId, model: model ?? undefined }
+
+    const promptPromise = client
+      .request<{ stopReason?: string }>('session/prompt', {
+        sessionId: effectiveSessionId,
+        prompt: [{ type: 'text', text: prompt }],
+      })
+      .then((res) => { stop.reason = res?.stopReason })
+      .catch((e: Error) => { stop.err = e })
+      .finally(() => pump.finish())
+
+    for await (const ev of pump.drain()) yield ev
+    await promptPromise
+  } finally {
+    if (abortSignal) abortSignal.removeEventListener('abort', onAbort)
+    client.shutdown()
+  }
+
+  yield* finalEvents(stop)
+}
+
+function* finalEvents(stop: { reason?: string; err: Error | null }): Generator<AgentEvent> {
+  if (stop.err) {
+    yield { type: 'result', isError: true, errorMessage: stop.err.message }
+  } else {
+    yield {
+      type: 'result',
+      isError: stop.reason === 'refusal',
+      errorMessage:
+        stop.reason === 'max_tokens'
+          ? 'Reached model max_tokens'
+          : stop.reason === 'max_turn_requests'
+          ? 'Reached max turn requests'
+          : stop.reason === 'refusal'
+          ? 'Model refused to continue'
+          : undefined,
+    }
+  }
+  yield { type: 'done' }
 }
 
 registerAdapter('gemini', createGeminiAdapter)

--- a/src/lib/server/agent-bridge/server.ts
+++ b/src/lib/server/agent-bridge/server.ts
@@ -31,6 +31,7 @@ import type { AgentType } from './types.js'
 import './adapters/claude.js'
 import './adapters/codex.js'
 import './adapters/gemini.js'
+import { shutdownGeminiPool } from './adapters/gemini.js'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -93,7 +94,7 @@ function agentCwdFor(agent: AgentType): string {
 
 async function handleStream(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const body = JSON.parse(await readBody(req))
-  const { agent, prompt, sessionId, model, systemPrompt, attachments, tabId } = body
+  const { agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId } = body
 
   if (!VALID_AGENTS.includes(agent)) {
     jsonResponse(res, 400, { error: `Invalid agent: must be one of ${VALID_AGENTS.join(', ')}` })
@@ -141,6 +142,7 @@ async function handleStream(req: IncomingMessage, res: ServerResponse): Promise<
       permissionCallback,
       abortSignal: abortController.signal,
       tabId,
+      chatId,
     })) {
       writeEvent(event)
     }
@@ -237,6 +239,9 @@ server.listen(AGENT_PORT, HOST, () => {
 // Graceful shutdown — Tauri sidecar sends SIGTERM on app exit.
 for (const sig of ['SIGINT', 'SIGTERM'] as const) {
   process.on(sig, () => {
+    // Kill all persistent gemini --acp children so desktop:serve restarts
+    // don't leak processes.
+    void shutdownGeminiPool()
     server.close(() => process.exit(0))
     // Hard exit after 2s if close hangs (long-poll SSE connection)
     setTimeout(() => process.exit(1), 2000).unref()

--- a/src/lib/server/agent-bridge/types.ts
+++ b/src/lib/server/agent-bridge/types.ts
@@ -64,4 +64,12 @@ export interface StreamParams {
    * currently ignore this (their CLIs configure MCP elsewhere).
    */
   tabId?: string
+  /**
+   * Per-chat-thread key for the persistent Gemini ACP process pool. When
+   * set, repeat `stream()` calls with the same `chatId` reuse one
+   * `gemini --acp` process + ACP session, so the model remembers prior
+   * turns. Omit → fresh one-shot process per call (legacy behaviour;
+   * keeps non-pooled callers and the Claude/Codex adapters unaffected).
+   */
+  chatId?: string
 }

--- a/tests/fixtures/fake-gemini-acp.mjs
+++ b/tests/fixtures/fake-gemini-acp.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Fake `gemini --acp` CLI for tests. Speaks the minimal slice of the Agent
+ * Client Protocol our adapter/pool/client use: newline-delimited JSON-RPC 2.0
+ * over stdin/stdout.
+ *
+ * Behaviour is keyed off the prompt text so tests can drive scenarios:
+ *   • "remember the number N"  → stores N in this process' memory
+ *   • "what number ..."        → replies with the remembered N (proves the
+ *                                process is reused across turns)
+ *   • "PERMISSION"             → sends a server→client
+ *                                session/request_permission and echoes the
+ *                                picked optionId back as the reply text
+ *   • "CRASH"                  → process.exit(1) without replying (simulates
+ *                                an unexpected child crash mid-turn)
+ *   • anything else            → replies "ok: <prompt>"
+ *
+ * The remembered number lives in module scope, so it survives multiple
+ * session/prompt calls within one process but is gone if the process is
+ * respawned — exactly the property the persistence + crash-reset tests check.
+ */
+
+import { createInterface } from 'node:readline'
+
+let remembered = null
+let sessionCounter = 0
+let nextServerId = 10000
+const permissionWaiters = new Map()
+
+function send(obj) {
+  process.stdout.write(`${JSON.stringify(obj)}\n`)
+}
+
+function notifyText(sessionId, text) {
+  send({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: { sessionId, update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } } },
+  })
+}
+
+async function handlePrompt(id, params) {
+  const text = (params?.prompt ?? []).map((p) => p.text ?? '').join('')
+  const sessionId = params?.sessionId
+
+  const rememberMatch = text.match(/remember the number\s+(\d+)/i)
+  if (rememberMatch) {
+    remembered = rememberMatch[1]
+    notifyText(sessionId, `Got it — ${remembered}.`)
+    send({ jsonrpc: '2.0', id, result: { stopReason: 'end_turn' } })
+    return
+  }
+
+  if (/what number/i.test(text)) {
+    notifyText(sessionId, remembered === null ? 'You have not told me a number.' : `The number is ${remembered}.`)
+    send({ jsonrpc: '2.0', id, result: { stopReason: 'end_turn' } })
+    return
+  }
+
+  if (text.includes('PERMISSION')) {
+    const sid = nextServerId++
+    const picked = new Promise((resolve) => permissionWaiters.set(sid, resolve))
+    send({
+      jsonrpc: '2.0',
+      id: sid,
+      method: 'session/request_permission',
+      params: {
+        toolCall: { toolCallId: 'tc-1', title: 'danger_tool', input: {} },
+        options: [
+          { optionId: 'opt-allow', kind: 'allow_once' },
+          { optionId: 'opt-deny', kind: 'reject_once' },
+        ],
+      },
+    })
+    const outcome = await picked
+    const optionId = outcome?.outcome?.optionId ?? outcome?.outcome?.outcome ?? 'none'
+    notifyText(sessionId, `permission picked: ${optionId}`)
+    send({ jsonrpc: '2.0', id, result: { stopReason: 'end_turn' } })
+    return
+  }
+
+  if (text.includes('CRASH')) {
+    // Die mid-turn without replying — client should reject the pending
+    // session/prompt and the pool should flag a crash.
+    process.exit(1)
+  }
+
+  notifyText(sessionId, `ok: ${text}`)
+  send({ jsonrpc: '2.0', id, result: { stopReason: 'end_turn' } })
+}
+
+const rl = createInterface({ input: process.stdin })
+rl.on('line', (line) => {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  let msg
+  try {
+    msg = JSON.parse(trimmed)
+  } catch {
+    return
+  }
+
+  // Response to a server→client request (permission outcome).
+  if (msg.id !== undefined && msg.method === undefined && (msg.result !== undefined || msg.error !== undefined)) {
+    const w = permissionWaiters.get(msg.id)
+    if (w) {
+      permissionWaiters.delete(msg.id)
+      w(msg.result)
+    }
+    return
+  }
+
+  if (msg.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: 1 } })
+    return
+  }
+  if (msg.method === 'session/new') {
+    sessionCounter += 1
+    send({ jsonrpc: '2.0', id: msg.id, result: { sessionId: `sess-${sessionCounter}` } })
+    return
+  }
+  if (msg.method === 'session/prompt') {
+    void handlePrompt(msg.id, msg.params)
+    return
+  }
+  if (msg.method === 'session/cancel') {
+    // notification — no reply
+    return
+  }
+  if (msg.id !== undefined) {
+    send({ jsonrpc: '2.0', id: msg.id, error: { code: -32601, message: `Method not found: ${msg.method}` } })
+  }
+})

--- a/vite-plugin-agent-bridge.ts
+++ b/vite-plugin-agent-bridge.ts
@@ -80,7 +80,7 @@ export function agentBridgePlugin(serverPort: number): Plugin {
             await ensureAdapters()
 
             const body = JSON.parse(await readBody(req))
-            const { agent, prompt, sessionId, model, systemPrompt, attachments, tabId } = body
+            const { agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId } = body
 
             if (!VALID_AGENTS.includes(agent)) {
               jsonResponse(res, 400, { error: `Invalid agent: must be one of ${VALID_AGENTS.join(', ')}` })
@@ -144,6 +144,7 @@ export function agentBridgePlugin(serverPort: number): Plugin {
                 permissionCallback,
                 abortSignal: abortController.signal,
                 tabId,
+                chatId,
               })) {
                 writeEvent(event)
               }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    include: ['tests/vitest/**/*.test.ts'],
+    include: ['tests/vitest/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
     globals: false,
     // quickhull3d ships an ESM index.js that imports `./QuickHull` without
     // an extension. Node's ESM resolver rejects that — force Vite to


### PR DESCRIPTION
Replaces #47 (auto-closed when its stacked base `fix/gemini-acp-rewrite` merged via #46 and was deleted). Rebased `--onto main`, dropping the now-merged ACP-rewrite commit; this PR is purely the persistent-pool layer on top of #46.

## Summary

- Gemini provider spawned a fresh `gemini --acp` process + ACP session on every message — context lost between turns, ~500ms spawn cost per prompt. Now one long-lived process + session per chat tab, like the Claude/Codex adapters.
- New `acp/` modules: `client.ts` (JSON-RPC + spawn/initialize, `CATGO_GEMINI_PATH` override), `translate.ts` (pure ACP⇄AgentEvent + permission mapping), `process-pool.ts` (`GeminiProcessPool` — per-`chatId` reuse, FIFO serialization, idle eviction, crash respawn + one-line context-reset notice).
- `gemini.ts` thin glue: `chatId` present → pooled persistent path; absent → one-shot (legacy, regression-safe).
- `chatId` threaded `StreamParams` → sidecar `server.ts` + dev `vite-plugin-agent-bridge.ts` → `sdk-stream` → `chat-state` (reuses per-tab slice id; context survives reloads). Pool shutdown wired into the agent-bridge SIGTERM handler. `X-CatGo-Tab-Id` still rides into `session/new` mcpServers headers. Claude/Codex adapters untouched. No new top-level deps.

## Verification

- `pnpm vitest run agent-bridge` — 8/8 green post-rebase (pool reuse, FIFO queueing, crash respawn + `crashedBefore`, idle eviction; adapter 3-turn context retention, one-shot isolation, permission optionId-by-kind). Fake ACP CLI over real stdio.
- Full `pnpm vitest run` previously 3362 passed; `pnpm check` no new errors in touched files.
- Live: persistence + single-process-per-tab + crash→respawn+banner verified against real `gemini-cli 0.41.2` via `pnpm desktop:serve` (3100 vite-plugin path) earlier in development.

## Test plan

- [ ] `pnpm desktop:serve`: "remember the number 7" → "what number?" → 7
- [ ] 5 prompts/row → one `gemini` per tab; second tab → second process
- [ ] >10 min idle → process gone
- [ ] `kill -9 <pid>` → respawn + reset banner, conversation continues
- [ ] "add a lattice" with active OH2 tab → lands in OH2 tab (X-CatGo-Tab-Id)

(Unrelated trajectory edit architecture issues tracked separately in #51 / draft #50 — not in scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)