### PR TITLE
fix(trajectory): unify edit write path + 3-state edit mode (closes #51)

### DIFF
--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -806,6 +806,7 @@
     trajectory_frame_positions = null,
     trajectory_frame_forces = null as Float32Array | null,
     trajectory_step_idx = -1,
+    trajectory_positions_version = 0,
     get_trajectory_frame_positions = null as ((i: number) => Float32Array | null) | null,
     initial_traj_b64 = ``,
     initial_traj_format = ``,
@@ -940,6 +941,9 @@
       trajectory_frame_forces?: Float32Array | null
       // Active trajectory frame index (for per-frame bond cache).
       trajectory_step_idx?: number
+      // Bumps when the current trajectory frame's positions change in place
+      // (atom edit). Drives a bond recompute the step-idx guard would skip.
+      trajectory_positions_version?: number
       // Random-access lookup into the trajectory's position cache. When provided,
       // the bond cache can prefetch ±N neighbour frames and recompute connectivity
       // off the main thread.
@@ -1695,6 +1699,7 @@
     get_structure: () => structure,
     get_base: () => supercell_structure ?? structure,
     get_step_idx: () => trajectory_step_idx,
+    get_positions_version: () => trajectory_positions_version,
     get_trajectory_active: () => trajectory_active,
     get_positions: () => get_trajectory_frame_positions,
     get_strategy: () => (scene_props?.bonding_strategy ?? `electroneg_ratio`) as BondingStrategy,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -806,7 +806,7 @@
     trajectory_frame_positions = null,
     trajectory_frame_forces = null as Float32Array | null,
     trajectory_step_idx = -1,
-    trajectory_positions_version = 0,
+    trajectory_positions_version = { v: 0, all: false },
     get_trajectory_frame_positions = null as ((i: number) => Float32Array | null) | null,
     initial_traj_b64 = ``,
     initial_traj_format = ``,
@@ -943,7 +943,7 @@
       trajectory_step_idx?: number
       // Bumps when the current trajectory frame's positions change in place
       // (atom edit). Drives a bond recompute the step-idx guard would skip.
-      trajectory_positions_version?: number
+      trajectory_positions_version?: { v: number; all: boolean }
       // Random-access lookup into the trajectory's position cache. When provided,
       // the bond cache can prefetch ±N neighbour frames and recompute connectivity
       // off the main thread.
@@ -1699,7 +1699,8 @@
     get_structure: () => structure,
     get_base: () => supercell_structure ?? structure,
     get_step_idx: () => trajectory_step_idx,
-    get_positions_version: () => trajectory_positions_version,
+    get_positions_version: () => trajectory_positions_version.v,
+    get_positions_invalidate_all: () => trajectory_positions_version.all,
     get_trajectory_active: () => trajectory_active,
     get_positions: () => get_trajectory_frame_positions,
     get_strategy: () => (scene_props?.bonding_strategy ?? `electroneg_ratio`) as BondingStrategy,

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -446,10 +446,16 @@ export function create_interaction_controller(deps: InteractionDeps) {
     }
 
     deps.set_structure(new_structure)
+    // Fire the trajectory write path FIRST while the overrides still mask
+    // the edited atoms in Structure.svelte's Phase-2 loop. handle_atoms_-
+    // manipulated synchronously mirrors the edit into position_cache[idx];
+    // only after that is it safe to clear the overrides — otherwise Phase-2
+    // re-asserts the pre-edit cache slice for one frame (issue #51 defect C
+    // snap-back). For non-trajectory structures the callback is undefined
+    // and this is a no-op, so set_structure already covers it.
+    if (displacements.size > 0) deps.get_on_atoms_manipulated()?.({ displacements })
     // 安全: StructureScene 的位置快速路径同步更新 last_bond_structure
     realtime_position_overrides = new Map()
-
-    if (displacements.size > 0) deps.get_on_atoms_manipulated()?.({ displacements })
   }
 
   // ═══════════════════════════════════════════════════════════════════

--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -209,6 +209,10 @@ export function wire_trajectory_bond_cache(
     get_options: () => Record<string, number>
     set_connectivity: (v: BondConnectivity[] | null) => void
     get_connectivity: () => BondConnectivity[] | null
+    /** Optional. Bumps when the CURRENT frame's positions change in place
+     *  (atom edit) without step_idx moving — forces a recompute the
+     *  last_idx guard would otherwise skip. */
+    get_positions_version?: () => number
   },
 ): void {
   // Reset cache on actual value changes (not parent-render proxy churn).
@@ -287,16 +291,29 @@ export function wire_trajectory_bond_cache(
   // scene_props / structure and refires this effect, which kicks another
   // bond-worker request, which spreads again, and Svelte 5's flush
   // overflow guard kicks in.
+  let last_pos_version = -1
   $effect(() => {
     const idx = deps.get_step_idx()
+    const pv = deps.get_positions_version?.() ?? 0
     if (idx < 0) return
-    if (idx === last_idx) return
+    const idx_moved = idx !== last_idx
+    const pos_changed = pv !== last_pos_version
+    if (!idx_moved && !pos_changed) return
     untrack(() => {
       const getter = deps.get_positions()
       const base = deps.get_base()
       if (!getter || !base) return
       last_idx = idx
-      cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())
+      last_pos_version = pv
+      // A same-frame in-place edit must recompute THIS frame even though
+      // idx didn't move — invalidate then request (on_frame_change's cache
+      // hit-check would otherwise early-return).
+      if (pos_changed && !idx_moved) {
+        cache.invalidate(idx)
+        cache.request(idx, getter, base, deps.get_strategy(), deps.get_options())
+      } else {
+        cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())
+      }
     })
   })
 

--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -170,6 +170,25 @@ export class TrajectoryBondCache {
     this.generation++
     this.version++
   }
+
+  /** Drop one frame's cached connectivity (position-aware invalidation —
+   *  use after an in-place atom edit on that frame). Voids any inflight
+   *  compute for it and bumps `version` so consumers re-pull. */
+  invalidate(frame_idx: number): void {
+    this.cache.delete(frame_idx)
+    this.inflight.delete(frame_idx)
+    this.generation++
+    this.version++
+  }
+
+  /** Drop every frame (edit-all scope). Cheaper than `clear()`-then-rebuild
+   *  semantically identical here, but named for intent at call sites. */
+  invalidate_all(): void {
+    this.cache.clear()
+    this.inflight.clear()
+    this.generation++
+    this.version++
+  }
 }
 
 /** Create a reactive instance of the bond cache. */

--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -172,8 +172,10 @@ export class TrajectoryBondCache {
   }
 
   /** Drop one frame's cached connectivity (position-aware invalidation —
-   *  use after an in-place atom edit on that frame). Voids any inflight
-   *  compute for it and bumps `version` so consumers re-pull. */
+   *  use after an in-place atom edit on that frame). The `generation++` is
+   *  global: it voids ALL in-flight computes (any frame), not just this one
+   *  — matches `clear()`'s coarse model and is acceptable for the edit case.
+   *  `version++` drives consumers to re-pull. */
   invalidate(frame_idx: number): void {
     this.cache.delete(frame_idx)
     this.inflight.delete(frame_idx)
@@ -181,13 +183,11 @@ export class TrajectoryBondCache {
     this.version++
   }
 
-  /** Drop every frame (edit-all scope). Cheaper than `clear()`-then-rebuild
-   *  semantically identical here, but named for intent at call sites. */
+  /** Drop every frame (edit-all scope). Delegates to `clear()` — named
+   *  separately for intent at call sites; do not inline (keeps the
+   *  invalidation invariant single-sourced in `clear()`). */
   invalidate_all(): void {
-    this.cache.clear()
-    this.inflight.clear()
-    this.generation++
-    this.version++
+    this.clear()
   }
 }
 

--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -213,6 +213,9 @@ export function wire_trajectory_bond_cache(
      *  (atom edit) without step_idx moving — forces a recompute the
      *  last_idx guard would otherwise skip. */
     get_positions_version?: () => number
+    /** Optional. When the positions-version bump represents an edit-all
+     *  fan-out, drop EVERY frame's bond cache rather than just `idx`. */
+    get_positions_invalidate_all?: () => boolean
   },
 ): void {
   // Reset cache on actual value changes (not parent-render proxy churn).
@@ -309,7 +312,8 @@ export function wire_trajectory_bond_cache(
       // idx didn't move — invalidate then request (on_frame_change's cache
       // hit-check would otherwise early-return).
       if (pos_changed && !idx_moved) {
-        cache.invalidate(idx)
+        if (deps.get_positions_invalidate_all?.()) cache.invalidate_all()
+        else cache.invalidate(idx)
         cache.request(idx, getter, base, deps.get_strategy(), deps.get_options())
       } else {
         cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1277,16 +1277,25 @@
       }
       case 'manipulate': {
         if (!structure?.sites) return structure
-        const disps = op.displacements
-        const new_sites = structure.sites.map((site, idx) => {
-          const d = disps.get(idx)
-          if (!d) return site
-          return {
-            ...site,
-            xyz: [site.xyz[0] + d[0], site.xyz[1] + d[1], site.xyz[2] + d[2]] as Vec3,
-          }
-        })
-        return { ...structure, sites: new_sites }
+        // Same xyz+abc delta-add primitive as the directly-committed current
+        // frame, so fanned-out frames stay consistent for fractional export.
+        let inv_flat:
+          | [number, number, number, number, number, number, number, number, number]
+          | null = null
+        if (`lattice` in structure && (structure as PymatgenStructure).lattice) {
+          const li = matrix_inverse_3x3(
+            transpose_3x3_matrix((structure as PymatgenStructure).lattice.matrix),
+          )
+          inv_flat = [
+            li[0][0], li[0][1], li[0][2],
+            li[1][0], li[1][1], li[1][2],
+            li[2][0], li[2][1], li[2][2],
+          ]
+        }
+        return {
+          ...structure,
+          sites: apply_displacements(structure.sites, op.displacements, inv_flat),
+        }
       }
     }
   }
@@ -1443,7 +1452,9 @@
       const new_sites = apply_displacements(cur.structure.sites, displacements, inv_flat)
       frames[idx] = { ...cur, structure: { ...cur.structure, sites: new_sites } }
       // Mirror straight into the render source so Phase-2 GPU + bond getter
-      // see the edit synchronously (no snap-back window).
+      // see the edit. The snap-back window is fully closed once Task 6
+      // reorders interaction.svelte.ts to fire this BEFORE clearing
+      // realtime_position_overrides.
       const slice = position_cache?.[idx]
       if (slice) write_sites_to_cache_slice(slice, new_sites)
     }

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1200,7 +1200,8 @@
   let fullscreen = $state(false)
 
   // Cross-frame editing: apply atom manipulations to all frames
-  let cross_frame_edit = $state(true)
+  type EditMode = 'view' | 'edit-current' | 'edit-all'
+  let edit_mode = $state<EditMode>('edit-current')
   let cross_frame_busy = $state(false)
 
   // ─── Pending cross-frame ops (lazy materialization) ───
@@ -1377,11 +1378,16 @@
     process_chunk()
   }
 
-  /** Guard: cross-frame edit enabled and trajectory is in-memory */
-  function _can_cross_frame_edit(): boolean {
-    if (!trajectory || !cross_frame_edit) return false
+  /** True when this trajectory is in-memory (frames mutable, position_cache
+   *  usable). Indexed/streaming trajectories have a frame_loader. */
+  function _is_in_memory(): boolean {
+    if (!trajectory) return false
     // @ts-expect-error - frame_loader is added dynamically for indexed/streaming trajectories
     return !trajectory.frame_loader
+  }
+  /** Back-compat alias kept for any other callers; edit-all == old ON. */
+  function _can_cross_frame_edit(): boolean {
+    return edit_mode === 'edit-all' && _is_in_memory()
   }
 
   function handle_atoms_manipulated(event: AtomManipulationEvent) {
@@ -1729,21 +1735,29 @@
                 {/if}
               </button>
             {/if}
-            <!-- Cross-frame editing toggle -->
+            <!-- Edit-scope mode: view → edit-current → edit-all -->
             <button
               type="button"
-              onclick={() => (cross_frame_edit = !cross_frame_edit)}
-              title={cross_frame_edit
-                ? `Cross-frame editing ON: atom manipulations apply to all frames`
-                : `Cross-frame editing OFF: atom manipulations apply to current frame only`}
+              onclick={() => {
+                edit_mode = edit_mode === `view`
+                  ? `edit-current`
+                  : edit_mode === `edit-current`
+                  ? `edit-all`
+                  : `view`
+              }}
+              title={edit_mode === `view`
+                ? `View only — scrubbing fast, atom edits disabled`
+                : edit_mode === `edit-current`
+                ? `Edit current frame only`
+                : `Edit all frames (sync) — applies to every frame`}
               class="cross-frame-toggle"
-              class:active={cross_frame_edit}
+              class:active={edit_mode !== `view`}
               disabled={cross_frame_busy}
             >
               {#if cross_frame_busy}
                 <Spinner style="width: 14px; height: 14px;" />
               {:else}
-                <Icon icon="Link" />
+                {edit_mode === `view` ? `👁` : edit_mode === `edit-current` ? `✏️1` : `✏️∀`}
               {/if}
             </button>
             {#if trajectory}

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -10,7 +10,7 @@
   import { add_atom, delete_atoms, replace_atom } from '$lib/structure'
   import type { AtomManipulationEvent } from '$lib/structure'
   import type { AnyStructure, PymatgenStructure } from '$lib/structure'
-  import { type Matrix3x3, mat3x3_vec3_multiply, matrix_inverse_3x3, transpose_3x3_matrix } from '$lib/math'
+  import { type Matrix3x3, matrix_inverse_3x3, transpose_3x3_matrix } from '$lib/math'
   import { writeRemoteFile } from '$lib/api/hpc'
   import { structure_to_poscar_str } from '$lib/structure/export'
   import { handle_url_drop, load_from_url } from '$lib/io'
@@ -57,6 +57,7 @@
     clamp_fps,
     get_keyboard_action,
   } from './trajectory-controls'
+  import { apply_displacements, write_sites_to_cache_slice } from './edit-apply'
 
   type EventHandlers = {
     on_play?: (data: TrajHandlerData) => void
@@ -236,6 +237,15 @@
       trigger_atoms_manipulated: () => handle_atoms_manipulated({
         displacements: new Map([[0, [0.01, 0, 0]]]),
       } as AtomManipulationEvent),
+      get edit_mode(): string { return edit_mode },
+      set_edit_mode(m: 'view' | 'edit-current' | 'edit-all') { edit_mode = m },
+      get_frame_x0(frame_idx: number): number | null {
+        return trajectory?.frames?.[frame_idx]?.structure?.sites?.[0]?.xyz?.[0] ?? null
+      },
+      get_current_idx(): number { return current_step_idx },
+      get_current_frame_x0(): number | null {
+        return trajectory?.frames?.[current_step_idx]?.structure?.sites?.[0]?.xyz?.[0] ?? null
+      },
     }
     ;(globalThis as { __catgo_traj_test?: typeof api }).__catgo_traj_test = api
     return () => {
@@ -1232,6 +1242,12 @@
   let pending_ops     = $state<PendingOp[]>([])
   let frame_op_cursor = $state<number[]>([])
 
+  // Bumped whenever the CURRENT frame's positions change in place (atom
+  // edit). Passed to <Structure> → bond-cache driver so bonds recompute
+  // even though current_step_idx didn't move (issue #51 bond defect).
+  // `all` = drop every frame's bond cache (edit-all fan-out), else just idx.
+  let trajectory_positions_version = $state<{ v: number; all: boolean }>({ v: 0, all: false })
+
   // Keep `frame_op_cursor` length in sync with `trajectory.frames.length`.
   // The only way the frame count changes in steady state is a brand-new
   // trajectory being loaded — in that case the old queue is stale and we
@@ -1395,82 +1411,63 @@
     const { displacements } = event
     if (displacements.size === 0) return
 
-    if (!_can_cross_frame_edit()) {
+    // view mode: edits disabled. (Edits shouldn't fire, but guard anyway —
+    // never silently mutate while the user is in inspect mode.)
+    if (edit_mode === `view`) return
+    if (!_is_in_memory()) {
+      // Indexed/streaming: positions live in frame.structure already (slow
+      // path writes current_structure = frame.structure each frame). Just
+      // refresh so the change is observed.
       trajectory = { ...trajectory }
       return
     }
 
-    // Drag is still the eager in-place path — make sure any pending queue
-    // ops are applied first so we mutate fresh structures. No-op while the
-    // queue is empty (Phases A–G).
-    flush_pending_ops()
-
-    // Fast path: in-place mutation with inline position cache update.
-    // Avoids all object allocation — just mutates xyz/abc arrays directly.
     const frames = trajectory.frames
-    const skip = current_step_idx
-    const cache = position_cache
+    const idx = current_step_idx
 
-    // Precompute inverse lattice matrix once (shared across all frames with same lattice)
-    let inv_matrix: Matrix3x3 | null = null
-    const sample_idx = skip === 0 ? 1 : 0
-    const sample = materialize_frame(sample_idx) ?? frames[sample_idx]?.structure
-    if (sample && `lattice` in sample && sample.lattice) {
-      const lat = (sample as PymatgenStructure).lattice
-      inv_matrix = matrix_inverse_3x3(transpose_3x3_matrix(lat.matrix))
+    // Build inverse-lattice once (cartesian Δ → fractional Δ for abc).
+    let inv: Matrix3x3 | null = null
+    const ref = frames[idx]?.structure
+    if (ref && `lattice` in ref && (ref as PymatgenStructure).lattice) {
+      const lat = (ref as PymatgenStructure).lattice
+      inv = matrix_inverse_3x3(transpose_3x3_matrix(lat.matrix))
+    }
+    const inv_flat = inv
+      ? [inv[0][0], inv[0][1], inv[0][2], inv[1][0], inv[1][1], inv[1][2], inv[2][0], inv[2][1], inv[2][2]] as
+        [number, number, number, number, number, number, number, number, number]
+      : null
+
+    // ── Single write path: always commit the CURRENT frame first ──────────
+    const cur = frames[idx]
+    if (cur?.structure?.sites) {
+      const new_sites = apply_displacements(cur.structure.sites, displacements, inv_flat)
+      frames[idx] = { ...cur, structure: { ...cur.structure, sites: new_sites } }
+      // Mirror straight into the render source so Phase-2 GPU + bond getter
+      // see the edit synchronously (no snap-back window).
+      const slice = position_cache?.[idx]
+      if (slice) write_sites_to_cache_slice(slice, new_sites)
     }
 
-    // Precompute per-atom displacement entries and their fractional equivalents (computed once, reused for every frame)
-    const disp_entries: [number, Vec3][] = [...displacements.entries()]
-    const frac_disps: Vec3[] = disp_entries.map(([, d]) =>
-      inv_matrix ? mat3x3_vec3_multiply(inv_matrix, d) : d,
-    )
-
-    const CHUNK = 2000 // large chunks — each frame is just a few additions
-    let pos = 0
-    cross_frame_busy = true
-
-    function process_chunk() {
-      const end = Math.min(pos + CHUNK, frames.length)
-      for (let fi = pos; fi < end; fi++) {
-        if (fi === skip) continue
-        const sites = frames[fi].structure.sites
-        const cache_arr = cache?.[fi]
-
-        for (let di = 0; di < disp_entries.length; di++) {
-          const [atom_idx] = disp_entries[di]
-          const site = sites[atom_idx]
-          if (!site) continue
-          const disp = disp_entries[di][1]
-          const frac = frac_disps[di]
-
-          // In-place xyz mutation
-          site.xyz[0] += disp[0]
-          site.xyz[1] += disp[1]
-          site.xyz[2] += disp[2]
-
-          // In-place abc mutation
-          site.abc[0] += frac[0]
-          site.abc[1] += frac[1]
-          site.abc[2] += frac[2]
-
-          // Inline position cache update — skip the $effect rebuild
-          if (cache_arr) {
-            cache_arr[atom_idx * 3] = site.xyz[0]
-            cache_arr[atom_idx * 3 + 1] = site.xyz[1]
-            cache_arr[atom_idx * 3 + 2] = site.xyz[2]
-          }
-        }
-      }
-      pos = end
-      if (pos < frames.length) {
-        setTimeout(process_chunk, 0)
-      } else {
-        if (trajectory) trajectory = { ...trajectory }
-        cross_frame_busy = false
-      }
+    if (edit_mode === `edit-current`) {
+      // Signal bond pipeline THIS frame changed (drop only idx's cache).
+      trajectory_positions_version = { v: trajectory_positions_version.v + 1, all: false }
+      // Other frames stay independent (use-case 2).
+      trajectory = { ...trajectory }
+      return
     }
-    process_chunk()
+
+    // ── edit-all: fan out lazily via the pending-ops machinery ────────────
+    // (use-case 3: many frames, must not freeze). Other frames materialize
+    // their copy of this displacement on next read (scrub / export / flush)
+    // exactly like the proven `delete` path. The current frame is already
+    // committed above, so record the op with its cursor pre-advanced past
+    // the current frame.
+    enqueue_pending_op({ kind: `manipulate`, displacements: new Map(displacements) })
+    frame_op_cursor[idx] = pending_ops.length // current frame already applied
+    // Drop EVERY frame's bond cache (lazy recompute via keyframe/prefetch
+    // scheduler keeps long trajectories smooth).
+    trajectory_positions_version = { v: trajectory_positions_version.v + 1, all: true }
+    trajectory = { ...trajectory }
   }
 
   function handle_atom_added(event: { element: ElementSymbol; position: Vec3 }) {
@@ -1881,6 +1878,7 @@
           {trajectory_frame_positions}
           {trajectory_frame_forces}
           trajectory_step_idx={current_step_idx}
+          trajectory_positions_version={trajectory_positions_version}
           get_trajectory_frame_positions={(i: number) => position_cache?.[i] ?? null}
           allow_file_drop={false}
           style="height: 100%; min-height: 0; z-index: 3; border-radius: 0"

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1410,7 +1410,10 @@
     // @ts-expect-error - frame_loader is added dynamically for indexed/streaming trajectories
     return !trajectory.frame_loader
   }
-  /** Back-compat alias kept for any other callers; edit-all == old ON. */
+  /** Gate for cross-frame propagation of add/delete/replace edits: true only
+   *  in edit-all on an in-memory trajectory. In the default `edit-current`
+   *  mode these edits stay current-frame-scoped (intentional per the 3-state
+   *  model — issue #51). */
   function _can_cross_frame_edit(): boolean {
     return edit_mode === 'edit-all' && _is_in_memory()
   }

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -51,7 +51,6 @@
     compute_step_label_positions,
     get_view_mode_label,
     read_file_content,
-    structures_compatible,
   } from './trajectory-utils'
   import {
     clamp_fps,
@@ -243,6 +242,9 @@
         return trajectory?.frames?.[frame_idx]?.structure?.sites?.[0]?.xyz?.[0] ?? null
       },
       get_current_idx(): number { return current_step_idx },
+      get_frame_natoms(frame_idx: number): number | null {
+        return trajectory?.frames?.[frame_idx]?.structure?.sites?.length ?? null
+      },
       get_current_frame_x0(): number | null {
         return trajectory?.frames?.[current_step_idx]?.structure?.sites?.[0]?.xyz?.[0] ?? null
       },
@@ -1340,69 +1342,6 @@
     pending_ops = [...pending_ops, op]
   }
 
-  // structures_compatible imported from trajectory-utils.ts
-
-  /** Get first non-current frame as compatibility reference (for add/delete/replace where current frame already changed) */
-  function _get_ref_structure(): AnyStructure | null {
-    if (!trajectory) return null
-    for (let i = 0; i < trajectory.frames.length; i++) {
-      if (i !== current_step_idx) return materialize_frame(i) ?? trajectory.frames[i].structure
-    }
-    return null
-  }
-
-  /** Apply edit_fn to all compatible non-current frames in chunks to avoid blocking the UI.
-   *  Used for add/delete/replace — less frequent than move, so object allocation is acceptable. */
-  function _chunked_cross_frame_edit(
-    edit_fn: (structure: AnyStructure) => AnyStructure,
-    ref_structure: AnyStructure,
-  ) {
-    if (!trajectory) return
-    // Catch all frames up to the current pending queue before an eager edit,
-    // so edit_fn sees the latest state and pending ops don't get lost.
-    // No-op while the queue is empty (Phases A–C).
-    flush_pending_ops()
-    const frames = trajectory.frames
-    const skip = current_step_idx
-
-    // Pre-check compatibility once: if the first non-current frame is incompatible, bail early.
-    // Trajectory frames almost always share the same atom count and element sequence.
-    const probe_idx = skip === 0 ? 1 : 0
-    if (probe_idx >= frames.length) return
-    const probe_struct = materialize_frame(probe_idx) ?? frames[probe_idx].structure
-    if (!structures_compatible(ref_structure, probe_struct)) return
-
-    // Chunks sized to stay close to one 60fps frame budget (~16 ms). At
-    // ~1.5–2 ms per frame edit on an 878-site proxy-wrapped structure,
-    // CHUNK=8 keeps each macrotask under ~16 ms so the scheduler rarely
-    // drops a frame. FIRST_CHUNK=4 makes the kick-off task tiny so the user
-    // sees no perceivable hitch right after the delete.
-    const FIRST_CHUNK = 4
-    const CHUNK = 8
-    let pos = 0
-    let first_pass = true
-    cross_frame_busy = true
-
-    function process_chunk() {
-      const size = first_pass ? FIRST_CHUNK : CHUNK
-      first_pass = false
-      const end = Math.min(pos + size, frames.length)
-      for (let i = pos; i < end; i++) {
-        if (i === skip) continue
-        const frame = frames[i]
-        frames[i] = { ...frame, structure: edit_fn(frame.structure) }
-      }
-      pos = end
-      if (pos < frames.length) {
-        setTimeout(process_chunk, 0)
-      } else {
-        if (trajectory) trajectory = { ...trajectory }
-        cross_frame_busy = false
-      }
-    }
-    process_chunk()
-  }
-
   /** True when this trajectory is in-memory (frames mutable, position_cache
    *  usable). Indexed/streaming trajectories have a frame_loader. */
   function _is_in_memory(): boolean {
@@ -1484,51 +1423,71 @@
     trajectory = { ...trajectory }
   }
 
-  function handle_atom_added(event: { element: ElementSymbol; position: Vec3 }) {
-    // W5: topology-altering edit during pause disables resume. Must come
-    // BEFORE _can_cross_frame_edit guard — even for indexed trajectories
-    // where cross-frame propagation doesn't run, the topology is altered
-    // locally and position_cache becomes invalid.
+  /**
+   * Unified topology-edit write path (add / delete / replace), mirroring the
+   * #51 manipulate path. Always commits the CURRENT frame (the fast-path
+   * renders position_cache / slow-path renders frames[idx].structure — NOT
+   * the bound current_structure — so the current frame must be committed
+   * here, never skipped). Topology changes atom count → drop position_cache
+   * (slow-path renders the edited frame; bond cache invalidated via the
+   * {all:true} positions-version). edit-current stops; edit-all fans the op
+   * out lazily via the existing pending-ops machinery.
+   */
+  function _apply_topology_op(op: PendingOp) {
+    // W5: a topology-altering edit while paused disables resume (even in the
+    // not-in-memory case the local topology / position_cache is now invalid).
     if (!is_playing) resume_disabled = true
-    if (!_can_cross_frame_edit()) return
-    // Current frame already has the atom — use non-current frame as ref
-    const ref = _get_ref_structure()
-    if (!ref) return
-    _chunked_cross_frame_edit((s) => add_atom(s, event.element, event.position), ref)
+    if (!trajectory) return
+    if (edit_mode === `view`) return
+    if (!_is_in_memory()) {
+      // Indexed/streaming slow path already renders frame.structure each
+      // frame; the editing UI mutated the current structure via bind. Just
+      // refresh so the change is observed.
+      trajectory = { ...trajectory }
+      return
+    }
+
+    const frames = trajectory.frames
+    const idx = current_step_idx
+    const cur = frames[idx]
+    if (!cur?.structure) return
+
+    // Commit the CURRENT frame.
+    frames[idx] = { ...cur, structure: apply_op(cur.structure, op) }
+
+    // Topology changed: the Float32 position cache (fixed per-frame length)
+    // is invalid. Dropping it makes the render fall back to the slow path
+    // (current_structure = frames[idx].structure) so the edit is visible on
+    // the current frame; the {all:true} bump invalidates every bond frame.
+    position_cache = null
+    force_cache = null
+    trajectory_positions_version = { v: trajectory_positions_version.v + 1, all: true }
+
+    if (edit_mode === `edit-current`) {
+      // Other frames stay independent (use-case 2).
+      trajectory = { ...trajectory }
+      return
+    }
+
+    // edit-all: fan out lazily (use-case 3 — many frames, must not freeze).
+    // Other frames materialize this op on next read (scrub / export / flush)
+    // exactly like the proven delete path. Current frame already applied →
+    // pre-advance its cursor so materialize_frame won't re-apply it.
+    enqueue_pending_op(op)
+    frame_op_cursor[idx] = pending_ops.length
+    trajectory = { ...trajectory }
+  }
+
+  function handle_atom_added(event: { element: ElementSymbol; position: Vec3 }) {
+    _apply_topology_op({ kind: `add`, element: event.element, position: event.position })
   }
 
   function handle_atoms_deleted(event: { site_indices: number[] }) {
-    if (!is_playing) resume_disabled = true
-    // Phase D: lazy delete. O(1) at the edit site. Record the op once; each
-    // frame applies it in `materialize_frame()` the next time that frame is
-    // read (navigation, flush, save). Current frame's view is already
-    // post-delete via Structure.svelte's `bind:structure`, so nothing to do
-    // for it here — if the user scrubs away and comes back, materialize
-    // catches it up from its stale baseline using the same pending op.
-    //
-    // Compared to the previous eager chunked-edit model, this eliminates:
-    //   - 200+ proxy reads per frame per delete
-    //   - setTimeout chunk storm (N_frames / CHUNK tasks)
-    //   - `trajectory = { ...trajectory }` spread → plot_series re-derive
-    //   - cross_frame_busy flag dance
-    if (!_can_cross_frame_edit()) return
-    if (!_get_ref_structure()) return // no other frames to edit
-    enqueue_pending_op({ kind: 'delete', site_indices: event.site_indices })
+    _apply_topology_op({ kind: `delete`, site_indices: event.site_indices })
   }
 
   function handle_atom_replaced(event: { site_indices: number[]; new_element: ElementSymbol }) {
-    if (!is_playing) resume_disabled = true
-    if (!_can_cross_frame_edit()) return
-    // Current frame already has atoms replaced — use non-current frame as ref
-    const ref = _get_ref_structure()
-    if (!ref) return
-    _chunked_cross_frame_edit((s) => {
-      let result = s
-      for (const idx of event.site_indices) {
-        result = replace_atom(result, idx, event.new_element)
-      }
-      return result
-    }, ref)
+    _apply_topology_op({ kind: `replace`, site_indices: event.site_indices, new_element: event.new_element })
   }
 </script>
 

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1373,6 +1373,14 @@
       return
     }
 
+    // Catch every frame (incl. the current one) up to the pending queue
+    // before this eager in-place edit, so we commit on top of the latest
+    // materialized state and a prior lazy op can't be skipped on the
+    // current frame (its cursor is pre-advanced below). No-op when the
+    // queue is empty. Restores the guard the old `_chunked_cross_frame_edit`
+    // ran before every eager edit.
+    flush_pending_ops()
+
     const frames = trajectory.frames
     const idx = current_step_idx
 
@@ -1446,6 +1454,13 @@
       trajectory = { ...trajectory }
       return
     }
+
+    // Catch every frame up to the pending queue before this eager topology
+    // edit, so the current frame is committed on top of the latest
+    // materialized state and a prior lazy op can't be skipped on it (its
+    // cursor is pre-advanced below). No-op when the queue is empty.
+    // Restores the guard the old `_chunked_cross_frame_edit` ran first.
+    flush_pending_ops()
 
     const frames = trajectory.frames
     const idx = current_step_idx

--- a/src/lib/trajectory/edit-apply.ts
+++ b/src/lib/trajectory/edit-apply.ts
@@ -1,9 +1,9 @@
 /**
  * Pure trajectory-edit primitives. No Svelte, no side effects — unit-testable.
  *
- * `applyDisplacements` is the single position-edit operation both the
+ * `apply_displacements` is the single position-edit operation both the
  * edit-current and edit-all scopes use (issue #51 "single write path").
- * `writeSitesToCacheSlice` mirrors a frame's sites into its `position_cache`
+ * `write_sites_to_cache_slice` mirrors a frame's sites into its `position_cache`
  * Float32Array so the renderer + bond pipeline see the edit synchronously.
  */
 
@@ -32,7 +32,7 @@ function mat3_vec3(m: Mat3Flat, v: Vec3): Vec3 {
  * row-major flat 9) converts the cartesian Δ to a fractional Δ; pass `null`
  * for non-periodic / when abc should track the cartesian Δ directly.
  */
-export function applyDisplacements<T extends EditSite>(
+export function apply_displacements<T extends EditSite>(
   sites: readonly T[],
   displacements: ReadonlyMap<number, Vec3>,
   inv_lattice: Mat3Flat | null,
@@ -42,6 +42,10 @@ export function applyDisplacements<T extends EditSite>(
     const d = displacements.get(i)
     if (!d) return s
     const fd = inv_lattice ? mat3_vec3(inv_lattice, d) : d
+    // Delta-add (abc + inv·Δ) is intentional, NOT a full recompute like
+    // `apply_per_atom_displacements` (new_abc = inv·new_xyz): it preserves the
+    // user's wrapped/unwrapped fractional coords and avoids re-wrap surprises
+    // during trajectory edits — do not "align" this to the full-recompute form.
     return {
       ...s,
       xyz: [s.xyz[0] + d[0], s.xyz[1] + d[1], s.xyz[2] + d[2]] as Vec3,
@@ -51,7 +55,7 @@ export function applyDisplacements<T extends EditSite>(
 }
 
 /** Mirror sites' xyz into a position-cache Float32Array slice, in place. */
-export function writeSitesToCacheSlice(
+export function write_sites_to_cache_slice(
   slice: Float32Array,
   sites: readonly { xyz: Vec3 }[],
 ): void {

--- a/src/lib/trajectory/edit-apply.ts
+++ b/src/lib/trajectory/edit-apply.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure trajectory-edit primitives. No Svelte, no side effects — unit-testable.
+ *
+ * `applyDisplacements` is the single position-edit operation both the
+ * edit-current and edit-all scopes use (issue #51 "single write path").
+ * `writeSitesToCacheSlice` mirrors a frame's sites into its `position_cache`
+ * Float32Array so the renderer + bond pipeline see the edit synchronously.
+ */
+
+export type Vec3 = [number, number, number]
+export type Mat3Flat = [number, number, number, number, number, number, number, number, number]
+
+interface EditSite {
+  xyz: Vec3
+  abc: Vec3
+  // other fields preserved via spread
+  [k: string]: unknown
+}
+
+function mat3_vec3(m: Mat3Flat, v: Vec3): Vec3 {
+  return [
+    m[0] * v[0] + m[1] * v[1] + m[2] * v[2],
+    m[3] * v[0] + m[4] * v[1] + m[5] * v[2],
+    m[6] * v[0] + m[7] * v[1] + m[8] * v[2],
+  ]
+}
+
+/**
+ * Return a new sites array with `displacements` (atom index → cartesian Δ)
+ * applied to xyz and abc. Untouched sites are kept by reference. Input is
+ * never mutated. `inv_lattice` (inverse of the transposed lattice matrix,
+ * row-major flat 9) converts the cartesian Δ to a fractional Δ; pass `null`
+ * for non-periodic / when abc should track the cartesian Δ directly.
+ */
+export function applyDisplacements<T extends EditSite>(
+  sites: readonly T[],
+  displacements: ReadonlyMap<number, Vec3>,
+  inv_lattice: Mat3Flat | null,
+): T[] {
+  if (displacements.size === 0) return sites.slice()
+  return sites.map((s, i) => {
+    const d = displacements.get(i)
+    if (!d) return s
+    const fd = inv_lattice ? mat3_vec3(inv_lattice, d) : d
+    return {
+      ...s,
+      xyz: [s.xyz[0] + d[0], s.xyz[1] + d[1], s.xyz[2] + d[2]] as Vec3,
+      abc: [s.abc[0] + fd[0], s.abc[1] + fd[1], s.abc[2] + fd[2]] as Vec3,
+    }
+  })
+}
+
+/** Mirror sites' xyz into a position-cache Float32Array slice, in place. */
+export function writeSitesToCacheSlice(
+  slice: Float32Array,
+  sites: readonly { xyz: Vec3 }[],
+): void {
+  const n = Math.min(sites.length, Math.floor(slice.length / 3))
+  for (let i = 0; i < n; i++) {
+    const xyz = sites[i].xyz
+    slice[i * 3] = xyz[0]
+    slice[i * 3 + 1] = xyz[1]
+    slice[i * 3 + 2] = xyz[2]
+  }
+}

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -985,6 +985,78 @@ test.describe(`Trajectory Component`, () => {
       check_ratios(vertical_dims, `width`)
     })
   })
+
+  test.describe(`edit architecture (issue #51)`, () => {
+    const api = `(globalThis).__catgo_traj_test`
+
+    test(`edit-current persists on the current frame and does NOT touch others`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-current`), api)
+
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const before_cur = await page.evaluate((a) => eval(a).get_frame_x0(eval(a).get_current_idx()), api)
+      const other = idx === 0 ? 1 : 0
+      const before_other = await page.evaluate(([a, o]) => eval(a).get_frame_x0(o), [api, other] as const)
+
+      await page.evaluate((a) => eval(a).trigger_atoms_manipulated(), api) // Δ = [0.01,0,0] on atom 0
+      await page.waitForTimeout(120)
+
+      const after_cur = await page.evaluate((a) => eval(a).get_frame_x0(eval(a).get_current_idx()), api)
+      const after_other = await page.evaluate(([a, o]) => eval(a).get_frame_x0(o), [api, other] as const)
+
+      expect(after_cur, `current frame moved`).toBeCloseTo((before_cur as number) + 0.01, 6)
+      expect(after_other, `other frame untouched`).toBeCloseTo(before_other as number, 6)
+    })
+
+    test(`edit-current survives scrub away and back`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-current`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const before = await page.evaluate(([a, i]) => eval(a).get_frame_x0(i), [api, idx] as const)
+
+      await page.evaluate((a) => eval(a).trigger_atoms_manipulated(), api)
+      await page.waitForTimeout(120)
+      // scrub away and back via keyboard (existing arrow-key nav)
+      await page.keyboard.press(`ArrowRight`)
+      await page.waitForTimeout(80)
+      await page.keyboard.press(`ArrowLeft`)
+      await page.waitForTimeout(80)
+
+      const after = await page.evaluate(([a, i]) => eval(a).get_frame_x0(i), [api, idx] as const)
+      expect(after, `edit retained after scrub round-trip`).toBeCloseTo((before as number) + 0.01, 6)
+    })
+
+    test(`edit-all fans the displacement out to every frame`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-all`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const other = idx === 0 ? 1 : 0
+      const before_other = await page.evaluate(([a, o]) => eval(a).get_frame_x0(o), [api, other] as const)
+
+      await page.evaluate((a) => eval(a).trigger_atoms_manipulated(), api)
+      await page.waitForTimeout(120)
+      // Force the lazy pending-op to materialize on `other` by navigating to it.
+      await page.evaluate(([a, o]) => eval(a).set_edit_mode(`edit-all`) , [api, other] as const)
+      await page.keyboard.press(idx < other ? `ArrowRight` : `ArrowLeft`)
+      await page.waitForTimeout(120)
+
+      const after_other = await page.evaluate(([a, o]) => eval(a).get_frame_x0(o), [api, other] as const)
+      expect(after_other, `other frame received the displacement lazily`).toBeCloseTo(
+        (before_other as number) + 0.01, 6,
+      )
+    })
+
+    test(`view mode blocks edits`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`view`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const before = await page.evaluate(([a, i]) => eval(a).get_frame_x0(i), [api, idx] as const)
+      await page.evaluate((a) => eval(a).trigger_atoms_manipulated(), api)
+      await page.waitForTimeout(120)
+      const after = await page.evaluate(([a, i]) => eval(a).get_frame_x0(i), [api, idx] as const)
+      expect(after, `view mode = no mutation`).toBeCloseTo(before as number, 6)
+    })
+  })
 })
 
 test.describe(`Trajectory Demo Page - Unit-Aware Plotting`, () => {

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -1123,6 +1123,50 @@ test.describe(`Trajectory Component`, () => {
       const n1 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
       expect(n1, `view mode = no topology change`).toBe(n0 as number)
     })
+
+    // issue B regression: two consecutive edit-all edits WITHOUT scrubbing
+    // between them. The current frame must commit on top of the prior op
+    // (not a stale baseline) so neither op is skipped on it, and the lazy
+    // fan-out must land BOTH ops on other frames identically. Pre-fix, the
+    // missing flush_pending_ops() let the second edit commit on a stale
+    // baseline / pre-advance the cursor past the first op → current frame
+    // diverged from every other frame.
+    test(`edit-all: consecutive manipulate+add (no scrub) keeps both ops on current frame and fans out consistently`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-all`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const other = idx === 0 ? 1 : 0
+      const cur_x0 = await page.evaluate(([a, i]) => eval(a).get_frame_x0(i), [api, idx] as const)
+      const cur_n0 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      const oth_x0 = await page.evaluate(([a, o]) => eval(a).get_frame_x0(o), [api, other] as const)
+      const oth_n0 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+
+      // op1: manipulate atom 0 by Δ=[0.01,0,0]; op2: add an H. No scrub between.
+      await page.evaluate((a) => eval(a).trigger_atoms_manipulated(), api)
+      await page.waitForTimeout(120)
+      await page.evaluate((a) => eval(a).trigger_atom_added(), api)
+      await page.waitForTimeout(150)
+
+      // Current frame must reflect BOTH ops (manipulate not skipped by the
+      // subsequent topology edit committing on a stale baseline).
+      const cur_x1 = await page.evaluate(([a, i]) => eval(a).get_frame_x0(i), [api, idx] as const)
+      const cur_n1 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      expect(cur_x1, `current frame kept the manipulate displacement`).toBeCloseTo(
+        (cur_x0 as number) + 0.01, 6,
+      )
+      expect(cur_n1, `current frame kept the add`).toBe((cur_n0 as number) + 1)
+
+      // Force the lazy fan-out to materialize on `other`, then assert it
+      // received the SAME two ops — no divergence from the current frame.
+      await page.keyboard.press(idx < other ? `ArrowRight` : `ArrowLeft`)
+      await page.waitForTimeout(150)
+      const oth_x1 = await page.evaluate(([a, o]) => eval(a).get_frame_x0(o), [api, other] as const)
+      const oth_n1 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+      expect(oth_x1, `other frame received the manipulate op lazily`).toBeCloseTo(
+        (oth_x0 as number) + 0.01, 6,
+      )
+      expect(oth_n1, `other frame received the add op lazily`).toBe((oth_n0 as number) + 1)
+    })
   })
 })
 

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -1057,6 +1057,73 @@ test.describe(`Trajectory Component`, () => {
       expect(after, `view mode = no mutation`).toBeCloseTo(before as number, 6)
     })
   })
+
+  test.describe(`add/delete/replace edit scope (issue #51 follow-up)`, () => {
+    const api = `(globalThis).__catgo_traj_test`
+
+    test(`edit-current add: only the current frame gains an atom`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-current`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const other = idx === 0 ? 1 : 0
+      const cur0 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      const oth0 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+
+      await page.evaluate((a) => eval(a).trigger_atom_added(), api)
+      await page.waitForTimeout(150)
+
+      const cur1 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      const oth1 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+      expect(cur1, `current frame +1 atom`).toBe((cur0 as number) + 1)
+      expect(oth1, `other frame unchanged`).toBe(oth0 as number)
+    })
+
+    test(`edit-all add: every frame gains the atom (current + lazily others)`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-all`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const other = idx === 0 ? 1 : 0
+      const cur0 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      const oth0 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+
+      await page.evaluate((a) => eval(a).trigger_atom_added(), api)
+      await page.waitForTimeout(150)
+      const cur1 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      expect(cur1, `current frame +1`).toBe((cur0 as number) + 1)
+      await page.keyboard.press(idx < other ? `ArrowRight` : `ArrowLeft`)
+      await page.waitForTimeout(150)
+      const oth1 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+      expect(oth1, `other frame +1 lazily`).toBe((oth0 as number) + 1)
+    })
+
+    test(`edit-current delete: only current frame loses an atom`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`edit-current`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const other = idx === 0 ? 1 : 0
+      const cur0 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      const oth0 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+
+      await page.evaluate((a) => eval(a).trigger_atoms_deleted(), api)
+      await page.waitForTimeout(150)
+
+      const cur1 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      const oth1 = await page.evaluate(([a, o]) => eval(a).get_frame_natoms(o), [api, other] as const)
+      expect(cur1, `current frame -1 atom`).toBe((cur0 as number) - 1)
+      expect(oth1, `other frame unchanged`).toBe(oth0 as number)
+    })
+
+    test(`view mode blocks topology edits`, async ({ page }) => {
+      await expect(trajectory_viewer).toBeVisible({ timeout: 10000 })
+      await page.evaluate((a) => eval(a).set_edit_mode(`view`), api)
+      const idx = await page.evaluate((a) => eval(a).get_current_idx(), api)
+      const n0 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      await page.evaluate((a) => eval(a).trigger_atom_added(), api)
+      await page.waitForTimeout(150)
+      const n1 = await page.evaluate(([a, i]) => eval(a).get_frame_natoms(i), [api, idx] as const)
+      expect(n1, `view mode = no topology change`).toBe(n0 as number)
+    })
+  })
 })
 
 test.describe(`Trajectory Demo Page - Unit-Aware Plotting`, () => {

--- a/tests/vitest/trajectory/bond-cache-invalidate.test.ts
+++ b/tests/vitest/trajectory/bond-cache-invalidate.test.ts
@@ -10,24 +10,43 @@ function seed(cache: ReturnType<typeof create_trajectory_bond_cache>, idx: numbe
   cache.version++
 }
 
+function gen(cache: ReturnType<typeof create_trajectory_bond_cache>): number {
+  // @ts-expect-error private generation counter, focused unit test
+  return cache.generation as number
+}
+function mark_inflight(cache: ReturnType<typeof create_trajectory_bond_cache>, idx: number) {
+  // @ts-expect-error private inflight set, focused unit test
+  cache.inflight.add(idx)
+}
+function is_inflight(cache: ReturnType<typeof create_trajectory_bond_cache>, idx: number): boolean {
+  // @ts-expect-error private inflight set, focused unit test
+  return cache.inflight.has(idx)
+}
+
 describe('TrajectoryBondCache.invalidate', () => {
-  it('drops one frame and bumps version + generation so an inflight result is voided', () => {
+  it('drops one frame, clears its inflight flag, and bumps version + generation so an inflight result is voided', () => {
     const c = create_trajectory_bond_cache()
     seed(c, 3)
     seed(c, 4)
+    mark_inflight(c, 3)
     const v0 = c.version
+    const g0 = gen(c)
     c.invalidate(3)
     expect(c.get(3)).toBeNull()
     expect(c.get(4)).not.toBeNull()
+    expect(is_inflight(c, 3)).toBe(false)
     expect(c.version).toBeGreaterThan(v0)
+    expect(gen(c)).toBeGreaterThan(g0)
   })
 
-  it('invalidate_all drops every frame', () => {
+  it('invalidate_all drops every frame and bumps generation', () => {
     const c = create_trajectory_bond_cache()
     seed(c, 0)
     seed(c, 1)
+    const g0 = gen(c)
     c.invalidate_all()
     expect(c.get(0)).toBeNull()
     expect(c.get(1)).toBeNull()
+    expect(gen(c)).toBeGreaterThan(g0)
   })
 })

--- a/tests/vitest/trajectory/bond-cache-invalidate.test.ts
+++ b/tests/vitest/trajectory/bond-cache-invalidate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { create_trajectory_bond_cache } from '$lib/structure/trajectory-bond-cache.svelte'
+
+// Seed the private cache via the public surface: directly poke through a
+// minimal cast — the class stores Map<idx, conn[]>; we only test invalidate.
+function seed(cache: ReturnType<typeof create_trajectory_bond_cache>, idx: number) {
+  // @ts-expect-error reach into private cache for a focused unit test
+  cache.cache.set(idx, [{ site_idx_1: 0, site_idx_2: 1, strength: 1, jimage: [0, 0, 0] }])
+  // @ts-expect-error
+  cache.version++
+}
+
+describe('TrajectoryBondCache.invalidate', () => {
+  it('drops one frame and bumps version + generation so an inflight result is voided', () => {
+    const c = create_trajectory_bond_cache()
+    seed(c, 3)
+    seed(c, 4)
+    const v0 = c.version
+    c.invalidate(3)
+    expect(c.get(3)).toBeNull()
+    expect(c.get(4)).not.toBeNull()
+    expect(c.version).toBeGreaterThan(v0)
+  })
+
+  it('invalidate_all drops every frame', () => {
+    const c = create_trajectory_bond_cache()
+    seed(c, 0)
+    seed(c, 1)
+    c.invalidate_all()
+    expect(c.get(0)).toBeNull()
+    expect(c.get(1)).toBeNull()
+  })
+})

--- a/tests/vitest/trajectory/edit-apply.test.ts
+++ b/tests/vitest/trajectory/edit-apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyDisplacements, writeSitesToCacheSlice } from '$lib/trajectory/edit-apply'
+import { apply_displacements, write_sites_to_cache_slice } from '$lib/trajectory/edit-apply'
 
 type Site = { xyz: [number, number, number]; abc: [number, number, number]; species: unknown }
 
@@ -7,10 +7,10 @@ function site(x: number, y: number, z: number): Site {
   return { xyz: [x, y, z], abc: [x, y, z], species: [{ element: 'O', occu: 1 }] }
 }
 
-describe('applyDisplacements', () => {
+describe('apply_displacements', () => {
   it('returns a new sites array with xyz + abc displaced for matched indices (no lattice = abc==xyz delta)', () => {
     const sites = [site(0, 0, 0), site(1, 1, 1)]
-    const out = applyDisplacements(sites, new Map([[1, [0.5, 0, -0.5]]]), null)
+    const out = apply_displacements(sites, new Map([[1, [0.5, 0, -0.5]]]), null)
     expect(out).not.toBe(sites) // new array
     expect(out[0]).toBe(sites[0]) // untouched site kept by reference
     expect(out[1].xyz).toEqual([1.5, 1, 0.5])
@@ -23,30 +23,50 @@ describe('applyDisplacements', () => {
     const inv: [number, number, number, number, number, number, number, number, number] =
       [0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5]
     const sites = [site(0, 0, 0)]
-    const out = applyDisplacements(sites, new Map([[0, [2, 4, 6]]]), inv)
+    const out = apply_displacements(sites, new Map([[0, [2, 4, 6]]]), inv)
     expect(out[0].xyz).toEqual([2, 4, 6])
     expect(out[0].abc).toEqual([1, 2, 3])
   })
 
+  it('applies off-diagonal inv_lattice terms in row-major order (mat3_vec3 contract)', () => {
+    // inv row-major = [1,2,0, 0,1,0, 0,0,1], Δ = [1,1,0]
+    // abc delta = [1*1+2*1+0, 0+1+0, 0] = [3,1,0]; xyz delta = [1,1,0]
+    const inv: [number, number, number, number, number, number, number, number, number] =
+      [1, 2, 0, 0, 1, 0, 0, 0, 1]
+    const sites = [site(0, 0, 0)]
+    const out = apply_displacements(sites, new Map([[0, [1, 1, 0]]]), inv)
+    expect(out[0].xyz).toEqual([1, 1, 0])
+    expect(out[0].abc).toEqual([3, 1, 0])
+  })
+
+  it('delta-adds onto the existing abc rather than recomputing from xyz', () => {
+    // site whose abc != xyz: xyz=[5,0,0], abc=[0.5,0,0]; Δ=[1,0,0], null inv
+    // → xyz=[6,0,0], abc=[1.5,0,0] (proves abc + Δ, not inv·new_xyz recompute)
+    const s: Site = { xyz: [5, 0, 0], abc: [0.5, 0, 0], species: [{ element: 'O', occu: 1 }] }
+    const out = apply_displacements([s], new Map([[0, [1, 0, 0]]]), null)
+    expect(out[0].xyz).toEqual([6, 0, 0])
+    expect(out[0].abc).toEqual([1.5, 0, 0])
+  })
+
   it('is a no-op (same array contents, new array) when displacements is empty', () => {
     const sites = [site(0, 0, 0)]
-    const out = applyDisplacements(sites, new Map(), null)
+    const out = apply_displacements(sites, new Map(), null)
     expect(out[0]).toBe(sites[0])
   })
 })
 
-describe('writeSitesToCacheSlice', () => {
+describe('write_sites_to_cache_slice', () => {
   it('mirrors sites xyz into the Float32Array slice in place, up to min(len)', () => {
     const sites = [site(1, 2, 3), site(4, 5, 6)]
     const arr = new Float32Array(6)
-    writeSitesToCacheSlice(arr, sites)
+    write_sites_to_cache_slice(arr, sites)
     expect(Array.from(arr)).toEqual([1, 2, 3, 4, 5, 6])
   })
 
   it('does not overflow when the array is shorter than sites*3 (supercell-extra atoms)', () => {
     const sites = [site(1, 2, 3), site(4, 5, 6)]
     const arr = new Float32Array(3)
-    writeSitesToCacheSlice(arr, sites)
+    write_sites_to_cache_slice(arr, sites)
     expect(Array.from(arr)).toEqual([1, 2, 3])
   })
 })

--- a/tests/vitest/trajectory/edit-apply.test.ts
+++ b/tests/vitest/trajectory/edit-apply.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { applyDisplacements, writeSitesToCacheSlice } from '$lib/trajectory/edit-apply'
+
+type Site = { xyz: [number, number, number]; abc: [number, number, number]; species: unknown }
+
+function site(x: number, y: number, z: number): Site {
+  return { xyz: [x, y, z], abc: [x, y, z], species: [{ element: 'O', occu: 1 }] }
+}
+
+describe('applyDisplacements', () => {
+  it('returns a new sites array with xyz + abc displaced for matched indices (no lattice = abc==xyz delta)', () => {
+    const sites = [site(0, 0, 0), site(1, 1, 1)]
+    const out = applyDisplacements(sites, new Map([[1, [0.5, 0, -0.5]]]), null)
+    expect(out).not.toBe(sites) // new array
+    expect(out[0]).toBe(sites[0]) // untouched site kept by reference
+    expect(out[1].xyz).toEqual([1.5, 1, 0.5])
+    expect(out[1].abc).toEqual([1.5, 1, 0.5]) // no inv lattice → fractional delta == cartesian delta
+    expect(sites[1].xyz).toEqual([1, 1, 1]) // input not mutated
+  })
+
+  it('uses the inverse-lattice matrix to convert the cartesian delta to a fractional abc delta', () => {
+    // 2x identity lattice → inv = 0.5*I → frac delta = 0.5 * cartesian delta
+    const inv: [number, number, number, number, number, number, number, number, number] =
+      [0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5]
+    const sites = [site(0, 0, 0)]
+    const out = applyDisplacements(sites, new Map([[0, [2, 4, 6]]]), inv)
+    expect(out[0].xyz).toEqual([2, 4, 6])
+    expect(out[0].abc).toEqual([1, 2, 3])
+  })
+
+  it('is a no-op (same array contents, new array) when displacements is empty', () => {
+    const sites = [site(0, 0, 0)]
+    const out = applyDisplacements(sites, new Map(), null)
+    expect(out[0]).toBe(sites[0])
+  })
+})
+
+describe('writeSitesToCacheSlice', () => {
+  it('mirrors sites xyz into the Float32Array slice in place, up to min(len)', () => {
+    const sites = [site(1, 2, 3), site(4, 5, 6)]
+    const arr = new Float32Array(6)
+    writeSitesToCacheSlice(arr, sites)
+    expect(Array.from(arr)).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('does not overflow when the array is shorter than sites*3 (supercell-extra atoms)', () => {
+    const sites = [site(1, 2, 3), site(4, 5, 6)]
+    const arr = new Float32Array(3)
+    writeSitesToCacheSlice(arr, sites)
+    expect(Array.from(arr)).toEqual([1, 2, 3])
+  })
+})


### PR DESCRIPTION
Implements the architecture in #51. **Supersedes #50.**

## What this fixes

Atom move/rotate on a loaded trajectory was architecturally broken: rendered positions came from `position_cache` (a derived mirror of `frames[].sites.xyz`) while the edit commit only wrote the frozen `current_structure`, so edits snapped back and bonds drew against stale endpoints. See #51 for the full data-flow analysis + screenshots.

## Approach (single write path + 3-state mode)

- **`src/lib/trajectory/edit-apply.ts`** (new, pure, unit-tested): `apply_displacements` (xyz+abc delta-add, inverse-of-transposed-lattice, non-orthogonal-cell correct) + `write_sites_to_cache_slice`. One primitive used by the current-frame commit and the lazy fan-out.
- **`handle_atoms_manipulated` rewritten**: commits the current frame's structure, synchronously mirrors into `position_cache[idx]`, bumps a `{v,all}` positions-version. `edit-current` = current frame only; `edit-all` = enqueue a lazy `pending_ops` `manipulate` op (non-blocking on long trajectories); `apply_op`'s `manipulate` case routes through `apply_displacements` so fanned-out frames are xyz+abc consistent for fractional export.
- **add / delete / replace unified**: a shared `_apply_topology_op(op)` routes all three through the SAME write path — always commits the current frame via `apply_op`, nulls `position_cache`/`force_cache`, bumps the `{v,all:true}` positions-version (bond invalidate); `edit-current` isolates to the current frame, `edit-all` fans out lazily via `pending_ops` with the current frame's cursor pre-advanced. The pre-Architecture-P selective `_chunked_cross_frame_edit`/skip-current-frame logic (which tore structures / left the current frame stale) is removed.
- **Bond pipeline**: `TrajectoryBondCache.invalidate(idx)`/`invalidate_all()`; the driver gains a positions-version dep so a same-frame in-place edit forces a bond recompute (the `last_idx` guard would otherwise skip it). Bonds follow edited atoms.
- **3-state `edit_mode`** (`view` / `edit-current` / `edit-all`) replaces the `cross_frame_edit` boolean; toolbar cycles. Maps to the 3 trajectory use-cases (inspect / per-frame edit / sync-all).
- **Defect C**: `interaction.svelte.ts` fires `on_atoms_manipulated` *before* clearing `realtime_position_overrides`, so the synchronous cache mirror lands before Phase-2 can re-assert — no snap-back window.

## Behavioural change — read this

The default scope is `edit-current` (previously `cross_frame_edit` defaulted ON ≈ edit-all). Intentional, per the 3-state model and the maintainer's stated mental model ("OFF = current frame only; ON = all frames"). Consequence: **move/rotate AND add/delete/replace** edits are all current-frame-scoped by default; cross-frame propagation is opt-in via `edit-all`. All four edit kinds now go through the one `_apply_topology_op`/`handle_atoms_manipulated` write path (current-frame commit + cache mirror + bond invalidation), so the current frame is always correct in both scopes — no handler is left on the old selective path.

**Known follow-ups (not regressions introduced here):**
- Slow-path (indexed/streaming `frame_loader`) trajectories: edits are a no-op refresh (large-file workflow, accepted per #51); a topology-writeback path persisting the current-frame edit into `frames[idx].structure` on the slow path is pre-existing scope, tracked separately.

## Verification

- `pnpm vitest run trajectory` — green (incl. new `edit-apply` + `bond-cache-invalidate` unit suites): 383 passed / 1 skipped.
- `pnpm check` — 6 pre-existing errors, all in unrelated files (`water-layer-local.ts`, `WaterLayerPane.svelte`, `WorkflowView.svelte`); **zero in any file this PR touches**. (Fixed separately in #57.)
- Playwright e2e (CI; `/test/trajectory` not bootable in the dev sandbox): the `edit architecture (issue #51)` block (manipulate: edit-current persist+isolation, scrub round-trip, edit-all fan-out, view-block) **plus** the `add/delete/replace edit scope (issue #51 follow-up)` block (edit-current add isolation, edit-all add eager+lazy fan-out, edit-current delete isolation, view-mode block).
- Per-task spec + code-quality review on every commit (manipulate write path, defect-C reorder, add/delete/replace `_apply_topology_op`, e2e) + a final whole-branch review — all passed.

## Sequencing vs #53 / #58

The trajectory rendering fixes (cart↔frac handedness, variable-cell per-frame lattice, periodic full-wrap, bond per-frame lattice) landed separately in #58 (merged to `main`). This PR (#56, edit architecture) is independent; rebase onto current `main` before merge. #53's bond-cache + cart↔frac work is superseded (commented on #53); its water-layer part split out, the svelte-check errors fixed in #57.

Closes #51.