### PR TITLE
fix(trajectory): cart↔frac handedness for non-orthogonal cells

### DIFF
--- a/src/lib/trajectory/parsers/common.ts
+++ b/src/lib/trajectory/parsers/common.ts
@@ -47,7 +47,10 @@ export const create_structure = (
   force_data?: number[][],
   move_mask?: boolean[],
 ): AnyStructure => {
-  const inv_matrix = lattice_matrix ? get_inverse_matrix(lattice_matrix) : null
+  // extxyz/pymatgen lattice rows = a,b,c ⇒ cart = Mᵀ·frac ⇒ frac = inv(Mᵀ)·cart.
+  // inv(M) here silently breaks only non-orthogonal cells (M ≠ Mᵀ); matches pbc.ts.
+  const lattice_T = lattice_matrix ? math.transpose_3x3_matrix(lattice_matrix) : null
+  const inv_matrix = lattice_T ? math.matrix_inverse_3x3(lattice_T) : null
   // Pre-compute fractional coords for all atoms so the wrap-decision pass
   // can do a near-neighbor check in raw Cartesian without re-deriving abc.
   const initial_abcs: Vec3[] = positions.map((pos) =>
@@ -118,7 +121,9 @@ export const create_structure = (
         abc[2] - Math.floor(abc[2]),
       ]
       abc = new_abc
-      xyz = math.mat3x3_vec3_multiply(lattice_matrix, new_abc)
+      // frac→cart for rows=a,b,c is Mᵀ·frac (same as the inline near-neighbor
+      // check above and pbc.ts:219).
+      xyz = math.mat3x3_vec3_multiply(lattice_T as Matrix3x3, new_abc)
     }
     const properties: Record<string, unknown> = force_data?.[idx]
       ? { force: force_data[idx] as Vec3 }

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -1,3 +1,4 @@
+import { create_structure } from '$lib/trajectory/parsers/common'
 import {
   get_unsupported_format_message,
   is_trajectory_file,
@@ -907,4 +908,63 @@ describe(`Comprehensive File Coverage`, () => {
       })
     },
   )
+})
+
+describe(`create_structure non-orthogonal lattice (cart↔frac handedness)`, () => {
+  const M: [
+    [number, number, number],
+    [number, number, number],
+    [number, number, number],
+  ] = [
+    [-4.039723298286767, 4.039723298286767, 4.039723298286767],
+    [4.039723298286767, -4.039723298286767, 4.039723298286767],
+    [14.812318760384814, 14.812318760384814, -14.812318760384814],
+  ]
+  const Mt = [
+    [M[0][0], M[1][0], M[2][0]],
+    [M[0][1], M[1][1], M[2][1]],
+    [M[0][2], M[1][2], M[2][2]],
+  ]
+  function inv3(m: number[][]): number[][] {
+    const d =
+      m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1]) -
+      m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+      m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+    return [
+      [(m[1][1] * m[2][2] - m[1][2] * m[2][1]) / d, (m[0][2] * m[2][1] - m[0][1] * m[2][2]) / d, (m[0][1] * m[1][2] - m[0][2] * m[1][1]) / d],
+      [(m[1][2] * m[2][0] - m[1][0] * m[2][2]) / d, (m[0][0] * m[2][2] - m[0][2] * m[2][0]) / d, (m[0][2] * m[1][0] - m[0][0] * m[1][2]) / d],
+      [(m[1][0] * m[2][1] - m[1][1] * m[2][0]) / d, (m[0][1] * m[2][0] - m[0][0] * m[2][1]) / d, (m[0][0] * m[1][1] - m[0][1] * m[1][0]) / d],
+    ]
+  }
+  const invMt = inv3(Mt)
+  const expected_frac = (c: number[]) => [
+    invMt[0][0] * c[0] + invMt[0][1] * c[1] + invMt[0][2] * c[2],
+    invMt[1][0] * c[0] + invMt[1][1] * c[1] + invMt[1][2] * c[2],
+    invMt[2][0] * c[0] + invMt[2][1] * c[1] + invMt[2][2] * c[2],
+  ]
+
+  it(`keeps an in-cell atom's xyz and derives correct fractional abc`, () => {
+    const pos = [1.357, 1.36, -1.358]
+    const ef = expected_frac(pos)
+    const s = create_structure([pos], [`W`] as never, M as never, [true, true, true] as never)
+    const site = (s as { sites: { xyz: number[]; abc: number[] }[] }).sites[0]
+    expect(site.xyz[0]).toBeCloseTo(pos[0], 6)
+    expect(site.xyz[1]).toBeCloseTo(pos[1], 6)
+    expect(site.xyz[2]).toBeCloseTo(pos[2], 6)
+    expect(site.abc[0]).toBeCloseTo(ef[0], 5)
+    expect(site.abc[1]).toBeCloseTo(ef[1], 5)
+    expect(site.abc[2]).toBeCloseTo(ef[2], 5)
+  })
+
+  it(`round-trips: Mᵀ·abc reproduces xyz for the non-orthogonal cell`, () => {
+    const pos = [2.728, 2.694, -2.71]
+    const s = create_structure([pos], [`W`] as never, M as never, [true, true, true] as never)
+    const site = (s as { sites: { xyz: number[]; abc: number[] }[] }).sites[0]
+    const rx = Mt[0][0] * site.abc[0] + Mt[0][1] * site.abc[1] + Mt[0][2] * site.abc[2]
+    const ry = Mt[1][0] * site.abc[0] + Mt[1][1] * site.abc[1] + Mt[1][2] * site.abc[2]
+    const rz = Mt[2][0] * site.abc[0] + Mt[2][1] * site.abc[1] + Mt[2][2] * site.abc[2]
+    expect(rx).toBeCloseTo(site.xyz[0], 4)
+    expect(ry).toBeCloseTo(site.xyz[1], 4)
+    expect(rz).toBeCloseTo(site.xyz[2], 4)
+  })
 })


### PR DESCRIPTION
Trajectory atoms rendered outside the unit-cell box for **non-orthogonal** lattices (e.g. `V8Ta12W71Re8-mace-omat.xyz`, `ase-images-Ag-0-to-97.xyz.gz`).

## Root cause
`create_structure` (`src/lib/trajectory/parsers/common.ts`) computed fractional coords as `inv(M)·pos` and wrapped atoms back as `M·abc`. extxyz/pymatgen store the lattice matrix with **rows = a,b,c**, so the correct conversions are `inv(Mᵀ)·pos` and `Mᵀ·abc` (the convention already used correctly in `src/lib/structure/pbc.ts:219`). For orthogonal/diagonal cells `M = Mᵀ` so the bug was invisible; every existing `parse.test` lattice fixture is diagonal, which is why it was never caught. Wrong `abc` also misfired the wrap heuristic and corrupted `xyz` for wrapped atoms → a chunk of the structure rendered outside the (correctly drawn) box.

## Fix
`common.ts` `create_structure`: derive `lattice_T = transpose(M)`, use `inv(Mᵀ)` for cart→frac and `Mᵀ` for the wrap-back frac→cart. `src/lib/structure/Lattice.svelte` (cell-box `makeBasis` with a,b,c as columns) was already correct and is intentionally **untouched** (it maps cube coords by the same `Mᵀ·frac`, consistent with corrected atoms; changing it would re-break rendering). The inline near-neighbor block in `common.ts` already used `Mᵀ·w` and is unchanged.

## Verification
- New `create_structure` non-orthogonal unit tests (V8Ta12W71Re8 lattice): xyz preserved + `abc == inv(Mᵀ)·pos` + `Mᵀ·abc` round-trips. Fail on old code, pass on fix.
- Full trajectory suite green (376 passed / 1 skipped); diagonal fixtures unaffected (transpose of diagonal = no-op → structurally no regression).
- Headless parse-check of both repro trajectories: every atom of frame 0 satisfies `xyz == Mᵀ·abc` (<1e-3) and stays within the cell-scale bound.
- `pnpm check` unchanged (6 pre-existing unrelated errors, none in touched files).

## Scope
Independent of #56 (edit architecture) and PR #53. Overlaps the concern #53 named ("cart↔frac for non-orthogonal cells") but is a minimal targeted fix in `common.ts` only (2 files incl. test). Follow-up (non-blocking): `get_inverse_matrix`/`matrix_cache` in `common.ts` are now dead — left in place to avoid an out-of-scope barrel-API change.

## Periodic full-wrap (partial-wrap tear)
**Root cause:** even with correct `abc`, periodic *trajectory* frames still tore into two clusters. `create_structure` applied a static near-neighbor `should_wrap` heuristic designed for isolated-molecule straddle: it wrapped only the **subset** of atoms it judged "split across a boundary," leaving the rest unwrapped. For a periodic crystal whose frame happens to span a cell boundary, partial wrapping splits one lattice into two displaced clusters (the visible "tear").

**Fix (commit `3a18e622`):** thread an `is_trajectory` flag into `create_structure`. When set **and** the lattice is fully periodic (`pbc` all-true, or undefined), apply an **unconditional `frac mod 1` wrap** to every atom (all atoms mapped into `[0,1)` consistently — no clustering). The static molecule-straddle heuristic path is **byte-unchanged** for non-trajectory / non-periodic inputs; the PFW gate explicitly requires pbc all-true so mixed/2D-periodic structures fall back to the old heuristic untouched.

**Headless verification** (real `parse_xyz_trajectory` → `create_structure(is_trajectory=true)`, LAST frame of each repro file):

| file | frame idx | pbc | nAtoms | out_of_cell | min dist (Å) | median NN (Å) |
|---|---|---|---|---|---|---|
| `V8Ta12W71Re8-mace-omat.xyz` | 6 (of 7) | `[true,true,true]` | 99 | **0** | 2.398778 | 2.658764 |
| `ase-images-Ag-0-to-97.xyz.gz` | 50 (of 51) | `[true,true,true]` | 119 | **0** | 1.775940 | 1.864569 |

Both repro files are **pbc-all-true** with `out_of_cell == 0` and physically sane minimum interatomic distances → **both fully fixed by the PFW path**. No partial-wrap tear remains.

## Bond per-frame lattice (over-coordination)
**Root cause:** trajectory bond connectivity (`build_frame_structure` → bonding worker) reconstructed bonds using the **frozen frame-0 lattice** while atoms were already per-frame positioned (and PFW-wrapped) per their own frame's cell. On a variable-cell trajectory, feeding the wrong (frame-0) lattice into the bond/PBC search produced **spurious periodic neighbours** — every atom acquired ~20+ bonds plus dangling cross-cell bond stubs, a dense over-coordinated hairball instead of the true ~12-neighbour metallic lattice.

**Fix (commits `180aecc6` BPL-T1, `6339b53f` BPL-T2):** thread a per-frame `lattice_getter` through the bond cache. `build_frame_structure` now applies the **frame's own matrix** when building the structure handed to the bonding worker, and the prefetched ±5 frames each use their own per-frame lattice. `bond_lattice_matrix` prefers the **current-frame lattice** for cross-cell render geometry. Verified closed loop: `position_cache` is built from the PFW-wrapped `frames[i].structure.sites.xyz`, so bonds now compute on the **PFW-wrapped positions + that frame's own cell** — fully consistent inputs.

**Headless verification** (real `parse_xyz_trajectory` → `create_structure(is_trajectory=true)`, LAST frame, minimum-image coordination over the 27 image translations using **that frame's** lattice, 3.2 Å metallic cutoff):

| file | frame idx | nAtoms | median coord | max coord | min interatomic dist (Å) |
|---|---|---|---|---|---|
| `V8Ta12W71Re8-mace-omat.xyz` | 6 (of 7) | 99 | **12** | **12** | 2.3988 |

Median **= max = 12** (textbook fcc/bcc-class close-packed metal coordination, expected ≈ 8–14), min interatomic distance **2.3988 Å** (sane). The pre-fix bug produced far higher counts. Over-coordination is gone.

## Combined scope — four root causes, one user report
PR #58 now bundles the **four** distinct root causes behind the single user report (atoms rendered outside the box / dense over-coordinated bonds for these trajectories):
1. **cart↔frac handedness** — `inv(M)`/`M` vs `inv(Mᵀ)`/`Mᵀ` for non-orthogonal lattices.
2. **frozen per-frame lattice (cell box)** — per-frame lattice threaded so each frame's cell box uses its own matrix.
3. **partial-wrap structure tear** — `is_trajectory` unconditional full-wrap for periodic trajectory frames.
4. **bond per-frame lattice (over-coordination)** — per-frame `lattice_getter` threaded through the bond cache so connectivity computes on the frame's own cell + PFW-wrapped positions (this section).

### Remaining follow-ups (separate tasks, not blocking #58)
- **Bond-cache invalidation on trajectory RELOAD** — optional. Reloading a *different* trajectory into the same component should fully drop the bond cache; the existing frames-ref clear covers the practical case (cache keyed by frame ref, so a new frames array already misses), so this is a defensive hardening follow-up rather than a correctness gap for the reported scenario.
- **Per-axis wrap for 2D-periodic slab trajectories** — **NOT needed for these repro files.** The Ag trajectory is pbc `[true,true,true]` (not a mixed-pbc slab) with `out_of_cell == 0`, so the all-true PFW path already handles it. A per-axis wrap would only matter for a future mixed-pbc (e.g. `[true,true,false]`) trajectory that the PFW gate intentionally skips; no such case is present here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
