### PR TITLE
fix(trajectory): close edit-all bond-render races (closes #59, #60)

### DIFF
--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -308,15 +308,25 @@ export function wire_trajectory_bond_cache(
       if (!getter || !base) return
       last_idx = idx
       last_pos_version = pv
-      // A same-frame in-place edit must recompute THIS frame even though
-      // idx didn't move — invalidate then request (on_frame_change's cache
-      // hit-check would otherwise early-return).
-      if (pos_changed && !idx_moved) {
+      // An in-place edit (positions-version bumped) must invalidate BEFORE
+      // any request, independent of whether `idx` also moved in the same
+      // flush. When a scrub coalesces with an edit-all version bump,
+      // `idx_moved && pos_changed` are both true; without this the cache
+      // hit-check in on_frame_change/request early-returns stale bonds for
+      // the destination frame. edit-all → drop every frame; edit-current →
+      // drop just this one.
+      if (pos_changed) {
         if (deps.get_positions_invalidate_all?.()) cache.invalidate_all()
         else cache.invalidate(idx)
-        cache.request(idx, getter, base, deps.get_strategy(), deps.get_options())
-      } else {
+      }
+      if (idx_moved) {
+        // Frame changed (with or without a coalesced edit): on_frame_change
+        // recomputes idx (cache now clean if pos_changed) and primes
+        // neighbors.
         cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())
+      } else {
+        // Same-frame in-place edit only: recompute just this frame.
+        cache.request(idx, getter, base, deps.get_strategy(), deps.get_options())
       }
     })
   })

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -56,7 +56,7 @@
     clamp_fps,
     get_keyboard_action,
   } from './trajectory-controls'
-  import { apply_displacements, write_sites_to_cache_slice } from './edit-apply'
+  import { apply_displacements, sites_to_float32, write_sites_to_cache_slice } from './edit-apply'
 
   type EventHandlers = {
     on_play?: (data: TrajHandlerData) => void
@@ -1867,7 +1867,19 @@
           {trajectory_frame_forces}
           trajectory_step_idx={current_step_idx}
           trajectory_positions_version={trajectory_positions_version}
-          get_trajectory_frame_positions={(i: number) => position_cache?.[i] ?? null}
+          get_trajectory_frame_positions={(i: number) => {
+            const c = position_cache?.[i]
+            if (c) return c
+            // position_cache transiently null (an edit-all enqueued a
+            // pending op in the same flush that nulled it): fall back to
+            // the already-committed frame sites so the bond pipeline never
+            // reads null mid-edit (issue #60). Indexed/streaming frames
+            // have no in-memory structure → null (slow path handles it).
+            const sites = (
+              trajectory?.frames?.[i]?.structure as { sites?: { xyz: [number, number, number] }[] } | undefined
+            )?.sites
+            return sites ? sites_to_float32(sites) : null
+          }}
           allow_file_drop={false}
           style="height: 100%; min-height: 0; z-index: 3; border-radius: 0"
           {...{

--- a/src/lib/trajectory/edit-apply.ts
+++ b/src/lib/trajectory/edit-apply.ts
@@ -54,6 +54,22 @@ export function apply_displacements<T extends EditSite>(
   })
 }
 
+/** Build a fresh xyz-flat (3·n) Float32Array from sites. Renderer/bond
+ *  fallback for when the `position_cache` is transiently null — e.g. an
+ *  edit-all enqueues a pending op (which nulls the cache) in the same flush
+ *  the bond pipeline reads positions. Reads the already-committed frame
+ *  sites so the getter never returns null mid-edit. */
+export function sites_to_float32(sites: readonly { xyz: Vec3 }[]): Float32Array {
+  const out = new Float32Array(sites.length * 3)
+  for (let i = 0; i < sites.length; i++) {
+    const xyz = sites[i].xyz
+    out[i * 3] = xyz[0]
+    out[i * 3 + 1] = xyz[1]
+    out[i * 3 + 2] = xyz[2]
+  }
+  return out
+}
+
 /** Mirror sites' xyz into a position-cache Float32Array slice, in place. */
 export function write_sites_to_cache_slice(
   slice: Float32Array,

--- a/tests/vitest/trajectory/edit-apply.test.ts
+++ b/tests/vitest/trajectory/edit-apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { apply_displacements, write_sites_to_cache_slice } from '$lib/trajectory/edit-apply'
+import { apply_displacements, sites_to_float32, write_sites_to_cache_slice } from '$lib/trajectory/edit-apply'
 
 type Site = { xyz: [number, number, number]; abc: [number, number, number]; species: unknown }
 
@@ -68,5 +68,24 @@ describe('write_sites_to_cache_slice', () => {
     const arr = new Float32Array(3)
     write_sites_to_cache_slice(arr, sites)
     expect(Array.from(arr)).toEqual([1, 2, 3])
+  })
+})
+
+describe('sites_to_float32', () => {
+  it('builds a fresh xyz-flat (3·n) Float32Array from sites', () => {
+    const out = sites_to_float32([site(1, 2, 3), site(4, 5, 6)])
+    expect(out).toBeInstanceOf(Float32Array)
+    expect(out.length).toBe(6)
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('returns an empty Float32Array for no sites', () => {
+    const out = sites_to_float32([])
+    expect(out.length).toBe(0)
+  })
+
+  it('reads xyz only (ignores abc) so the bond fallback matches the cache slice layout', () => {
+    const s = { xyz: [7, 8, 9] as [number, number, number], abc: [0.1, 0.2, 0.3] as [number, number, number] }
+    expect(Array.from(sites_to_float32([s]))).toEqual([7, 8, 9])
   })
 })


### PR DESCRIPTION
Closes #59, closes #60. Follow-up to PR #56 review (the two non-blocking edit-all bond-render race observations).

## A — stale bond cylinders when scrub coalesces with positions-version bump (#59)

The bond-cache driver `$effect` only invalidated on `pos_changed && !idx_moved`. When an `edit-all` `trajectory_positions_version` bump coalesces with a scrub into one Svelte flush, `idx_moved && pos_changed` are both true → control fell to `cache.on_frame_change(idx, ...)` with **no invalidation**; an already-cached destination frame's bonds early-returned at the `has()` guard → stale connectivity rendered.

Fix: invalidate whenever `pos_changed` (`invalidate_all()` / `invalidate(idx)` per `get_positions_invalidate_all`), independent of `idx_moved`. `on_frame_change` (idx moved → recompute + prime neighbors) vs `request` (same-frame in-place edit) still keyed on `idx_moved`. The three prior cases are unchanged; only the both-true case is fixed.

## E — position_cache nulled by pending-ops effect races the bond slice (#60)

`edit-all` calls `enqueue_pending_op(...)`, making `pending_ops.length > 0`, whose `$effect` nulls `position_cache` in the same flush the bond getter (`get_trajectory_frame_positions`) reads it. Svelte-5 in-batch effect order is undocumented; if the null-effect runs first the getter returns `null` and bonds early-return (transient disappear/no-update).

Fix: when `position_cache?.[i]` is transiently null, the bond getter falls back to the **already-committed** `frames[i].structure.sites` (the edit-all path commits `frames[idx]` before the enqueue) via a new pure `sites_to_float32()`. Indexed/streaming frames (no in-memory structure) → `null`, slow path unchanged.

## Verification

- `sites_to_float32` unit-tested (`edit-apply.test.ts`, 10 passed incl. 3 new).
- A is a pure branch rewrite, no new imports; `svelte-check` shows zero new errors/warnings in the three touched files (the 2 remaining `check` errors are the pre-existing water-layer #3/#4 #57 deliberately deferred).
- The worktree lacks the local `@catgo/ferrox-wasm` build, so the full `pnpm vitest run trajectory` set is deferred to CI (complete env, with the ferrox build + the #51 / issue-B e2e regression — must stay green).

Both are timing-sensitive transient render bugs; atom positions/topology were always correct, `edit-current` / `view` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
