### PR TITLE
ci(tauri-build): build cube-processor before PyInstaller

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -69,6 +69,12 @@ jobs:
           pip install -r reqs_no_ob.txt
           rm reqs_no_ob.txt
 
+      - name: Install Rust (cube-processor)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build cube-processor
+        run: cargo build --release --manifest-path tools/cube-processor/Cargo.toml
+
       - name: Build backend (Unix)
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
The v1.0.3 **Build Desktop App** (win/mac) run failed in `Build backend`:

\`\`\`
ERROR: Unable to find '.../tools/cube-processor/target/release/cube-processor' when adding binary and data files
\`\`\`

`server/catgo_server.spec:64` bundles `../tools/cube-processor/target/release/cube-processor`, but `tauri-build.yml` never built it (the `Install Rust` step ran *after* `Build backend`). Adds a Rust toolchain + `cargo build --release --manifest-path tools/cube-processor/Cargo.toml` before the backend step.

Pre-existing CI gap, unrelated to the v1.0.3 version bump. After merge, re-run the `v1.0.3` tag's Build Desktop App to produce win/mac artifacts. (vsix is being built locally per separate decision; this PR only fixes win/mac.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)