### PR TITLE
fix(wasm): build ferrox with --features wasm --no-default-features

### DIFF
--- a/extensions/rust-wasm/package.json
+++ b/extensions/rust-wasm/package.json
@@ -20,6 +20,6 @@
     "pkg"
   ],
   "scripts": {
-    "build": "cd ../rust && wasm-pack build --target web --out-dir ../rust-wasm/pkg"
+    "build": "cd ../rust && wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm --no-default-features"
   }
 }


### PR DESCRIPTION
## Problem

The `extensions/rust-wasm` `build` script omitted the WASM feature flags:

```
cd ../rust && wasm-pack build --target web --out-dir ../rust-wasm/pkg
```

In `extensions/rust/Cargo.toml`, `wasm-bindgen` is an **optional** dependency gated behind the `wasm` feature, and the default feature set (`rayon`) does **not** include it. Building without `--features wasm` succeeds silently but produces a module with **zero `#[wasm_bindgen]` exports** (~23KB `ferrox_bg.wasm`, only `initSync`/`__wbg_init`/`memory`).

Every WASM call then fails at runtime:

```
mod.generate_slab_layers is not a function
mod.make_supercell_diag is not a function
mod.detect_bonds_solid_angle is not a function
wasm.find_pbc_image_sites is not a function
...
```

This script is invoked by CI (`test.yml` → `cd extensions/rust-wasm && pnpm build`) and is also the natural command for local WASM rebuilds, so both paths hit the empty-module trap.

## Fix

Add `--features wasm --no-default-features`, aligning with the already-correct command in `deploy-cloudflare.yml` and the in-repo dev docs.

## Verification

| | before | after |
|---|---|---|
| `ferrox_bg.wasm` | 23.5 KB | 4.2 MB |
| exported functions | 0 | ~160 |
| `generate_slab_layers` / `make_supercell_diag` / `detect_bonds_solid_angle` / `find_pbc_image_sites` | missing | present |

🤖 Generated with [Claude Code](https://claude.com/claude-code)