### PR TITLE
fix(water-layer): correct bundled spc216.gro path resolution

### DIFF
--- a/server/catgo/routers/water_layer.py
+++ b/server/catgo/routers/water_layer.py
@@ -70,7 +70,9 @@ def _find_spc216() -> str:
     3. GROMACS gmx binary auto-detection
     """
     # 1. Bundled copy (shipped with CatGO — works everywhere)
-    bundled = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "spc216.gro")
+    # __file__ = server/catgo/routers/water_layer.py → up 3 dirs to server/
+    server_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    bundled = os.path.join(server_dir, "data", "spc216.gro")
     if os.path.exists(bundled):
         return bundled
 


### PR DESCRIPTION
## Problem

`_find_spc216()` in `server/catgo/routers/water_layer.py` resolves the bundled water-box path as:

```python
os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "spc216.gro")
```

`__file__` is `server/catgo/routers/water_layer.py`, so two `dirname` calls reach `server/catgo/`, giving **`server/catgo/data/spc216.gro`**. But the bundled, git-tracked file lives at **`server/data/spc216.gro`** — exactly what the function's own docstring states ("Bundled copy in `server/data/spc216.gro`"). The path is one directory level too shallow.

Every water-layer generation therefore fails with:

```
Cannot find spc216.gro water box. The bundled file at
.../server/catgo/data/spc216.gro is missing. Reinstall CatGO or set GMXDATA env var.
```

This has been broken in **every install since the initial release** (`4d4495d`, v1.0.1), unless GROMACS happened to be installed locally and auto-detected via fallback #3.

## Fix

Add the missing third `os.path.dirname` (up to `server/`) so it resolves to the real `server/data/spc216.gro`, matching the docstring and the actual bundled file. Added a comment documenting the path math.

## Verification

```
resolved: .../server/data/spc216.gro
exists  : True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)