### PR TITLE
fix(trajectory): make export canvas detection reactive

### DIFF
--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -65,7 +65,25 @@
   let start_frame = $state(0)
   let end_frame = $state(0)
 
-  let canvas = $derived(wrapper?.querySelector(`canvas`) as HTMLCanvasElement)
+  // The WebGL <canvas> mounts asynchronously — after the trajectory parses and
+  // StructureScene initializes — which is AFTER `wrapper` is already bound. A
+  // one-shot `wrapper.querySelector('canvas')` in $derived runs too early (canvas
+  // doesn't exist yet) and never re-checks, since querySelector isn't reactive
+  // and the wrapper reference never changes. Mirror the working pattern in
+  // ExportPane.svelte: observe the subtree and update reactive $state.
+  let canvas = $state<HTMLCanvasElement | null>(null)
+  $effect(() => {
+    if (!wrapper) {
+      canvas = null
+      return
+    }
+    const check = () =>
+      (canvas = wrapper.querySelector(`canvas`) as HTMLCanvasElement | null)
+    check()
+    const observer = new MutationObserver(check)
+    observer.observe(wrapper, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  })
 
   // Estimated file size in MB
   let file_size_mb = $derived.by(() => {


### PR DESCRIPTION
## Problem

`TrajectoryExportPane.svelte` resolved the WebGL canvas with:

```js
let canvas = $derived(wrapper?.querySelector(`canvas`) as HTMLCanvasElement)
```

A `$derived` only recomputes when its tracked reactive dependencies change. The only dependency here is `wrapper`; `querySelector` is **not** reactive. The WebGL `<canvas>` mounts asynchronously — after the trajectory parses and `StructureScene` initializes — which is **after** `wrapper` is already bound. So the derived evaluated once (canvas absent → `null`) and never refreshed.

Effect: the export click handlers and `file_size_mb` saw `!canvas` → `export_error = "Canvas not ready"` (and 0 MB size / wrong resolution label) even though the canvas was present and the structure was visibly rendered.

## Fix

Mirror the pattern already used correctly for `has_canvas` in this same file (and in `ExportPane.svelte`): a `$state` holding the canvas, updated by an `$effect` + `MutationObserver` observing the wrapper subtree, so it reacts when the canvas is inserted later.

Bug present since the initial release (`4d4495d`, v1.0.1).

## Verification

With a trajectory loaded and structure rendered: the "Canvas not ready" box clears, the resolution label shows real pixel dimensions, estimated file size is non-zero, and the export buttons proceed instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)