### PR TITLE
fix(trajectory): blank PNG export (attach scene/camera to canvas); clarify MP4 button

### DIFF
--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -804,14 +804,20 @@ export async function export_trajectory_png_sequence(
     on_step,
     png_dpi = 150,
     crop_region,
-    scene,
-    camera,
   } = options
 
   if (!canvas) throw new Error(`Canvas not available for PNG sequence export`)
   if (frame_indices.length === 0) return
 
   const renderer = (canvas as { __renderer?: WebGLRenderer }).__renderer
+  // Fall back to scene/camera attached to the canvas by StructureScene when a
+  // caller doesn't pass them explicitly (e.g. the trajectory export pane).
+  // Required for the reliable gl.readPixels path; without it the fallback
+  // canvas.toBlob() yields blank/transparent frames on a WebGL canvas.
+  const scene =
+    options.scene ?? (canvas as { __scene?: THREE.Scene }).__scene ?? null
+  const camera =
+    options.camera ?? (canvas as { __camera?: THREE.Camera }).__camera ?? null
   const resolution_multiplier = Math.min(png_dpi / 72, 10)
 
   const files: Record<string, Uint8Array> = {}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -911,7 +911,17 @@
       threlte.scene.background = null
     }
     if (threlte.renderer) {
-      Object.assign(threlte.renderer.domElement, { __renderer: threlte.renderer })
+      // Also expose scene/camera on the canvas (alongside __renderer) so
+      // export helpers can take the reliable gl.readPixels render path even
+      // when a caller doesn't thread scene/camera through props (e.g. the
+      // trajectory export pane). Without these, exports fall back to
+      // canvas.toBlob() on a non-preserveDrawingBuffer WebGL canvas and
+      // produce blank/transparent output.
+      Object.assign(threlte.renderer.domElement, {
+        __renderer: threlte.renderer,
+        __scene: threlte.scene,
+        __camera: threlte.camera.current,
+      })
     }
   })
 

--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -363,7 +363,13 @@
       {#if is_video_supported}
         {#each [
           { label: `WebM`, format: `webm`, hint: `Export as WebM video` },
-          { label: `MP4`, format: `mp4`, hint: `WebM + ffmpeg command` },
+          {
+            label: `MP4*`,
+            format: `mp4`,
+            hint:
+              `Browsers can't record MP4 — downloads a WebM and copies an ` +
+              `ffmpeg command to your clipboard to convert it to MP4`,
+          },
         ] as const as
           { label, format, hint }
           (format)


### PR DESCRIPTION
## Problem

**1. Trajectory image export was blank/transparent.**
`export_trajectory_png_sequence` only takes the reliable `gl.readPixels` render path when `renderer && scene && camera` are all present (`use_readpixels`). `TrajectoryExportPane` never passed `scene`/`camera` (and `Trajectory.svelte` never obtained them from its `<Structure>` child), unlike the working `ExportPane.svelte` which passes `scene ?? null, camera ?? null`. So the trajectory path fell back to `canvas.toBlob()` on a WebGL canvas with `preserveDrawingBuffer: false` — the compositor had already cleared the drawing buffer, yielding fully transparent frames.

**2. "MP4" export produced a WebM.**
Browsers can't `MediaRecorder` → MP4. The MP4 button always downloads `.webm` and copies an ffmpeg conversion command to the clipboard. The label/tooltip didn't make this obvious.

## Fix (Plan B — canvas attachment)

- `StructureScene.svelte` already attaches `__renderer` to the canvas DOM element; also attach `__scene` / `__camera` there (using the same `threlte.scene` / `threlte.camera.current` already in scope two lines above).
- `export.ts`: `export_trajectory_png_sequence` falls back to `canvas.__scene` / `canvas.__camera` when a caller doesn't pass them, so the reliable readPixels path is always reachable. `ExportPane` keeps passing them explicitly → **zero regression**, single source of truth lives on the canvas (consistent with the existing `__renderer` pattern).
- `TrajectoryExportPane.svelte`: relabel `MP4` → `MP4*` with an explicit tooltip stating it downloads WebM + copies an ffmpeg command.

## Scope

3 files, +26/-4. No behavior change to the working single-image `ExportPane` path.

## Verification

Hard-reload, load a trajectory, Export Trajectory → PNG Sequence: frames now contain the rendered structure instead of a transparent checkerboard. (`use_readpixels` is true because DPI 150 → resolution_multiplier ≈ 2.08 > 1.1 and scene/camera now resolve from the canvas.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)