### PR TITLE
feat(desktop): multi-file / folder import + structure-library sidebar

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -5,11 +5,11 @@
   import type { AnyStructure } from '$lib'
   import { parse_cube_header, cube_atoms_to_molecule } from '$lib/cube'
   import { API_BASE, STATIC_ONLY } from '$lib/api/config'
-  import { check_tauri, init_tauri, open_file as tauri_open_file } from '$lib/io/tauri'
+  import { check_tauri, init_tauri, open_files as tauri_open_files, open_folder as tauri_open_folder, read_dropped_paths as tauri_read_dropped_paths } from '$lib/io/tauri'
   import { decompress_file } from '$lib/io/decompress'
   import { is_trajectory_file, parse_trajectory_data } from '$lib/trajectory/parse'
   import type { TrajectoryType } from '$lib/trajectory'
-  import { parse_structure_file } from '$lib/structure/parse'
+  import { parse_structure_file, is_structure_file } from '$lib/structure/parse'
   import '$lib/theme/themes.js'
   import StatusPopout from '$lib/workflow/StatusPopout.svelte'
   import { apply_theme_to_dom, get_theme_preference } from '$lib/theme'
@@ -24,6 +24,7 @@
   import { show_toast } from '$lib/toast-state.svelte'
   import TabBar from './TabBar.svelte'
   import Sidebar from './Sidebar.svelte'
+  import StructureLibrary from './StructureLibrary.svelte'
   import type { AppTab } from './TabBar.svelte'
   import OptimadeSearchModal from '$lib/structure/OptimadeSearchModal.svelte'
   import OptimadePreviewModal from '$lib/structure/OptimadePreviewModal.svelte'
@@ -42,7 +43,7 @@
   import { terminal } from './state/terminal-state.svelte'
   // Extracted pure utilities
   import {
-    type PaneState, type LayoutType, type StructureTabState, type SampleStructure,
+    type PaneState, type LayoutType, type StructureTabState, type SampleStructure, type LibraryEntry,
     layout_panel_count, get_pane_label, create_empty_pane, pane_has_content,
     content_to_base64, create_tab_state, auto_name as _auto_name,
     find_import_target_pane, get_visible_panes, get_grid_style, get_pane_position,
@@ -166,6 +167,7 @@
     get_active_tab_type: () => tm.active_tab_type,
     get_active_tab_id: () => tm.active_tab_id,
     process_file_content,
+    import_many,
     get_drag_target_pane: () => drag_target_pane,
     set_drag_target_pane: (v) => { drag_target_pane = v },
     set_is_loading: (v) => { is_loading = v },
@@ -583,6 +585,7 @@
 
   // ========== File Handling ==========
   let file_input_ref = $state<HTMLInputElement | undefined>()
+  let folder_input_ref = $state<HTMLInputElement | undefined>()
   let file_input_target_tab = ``
   let file_input_target_pane = 0
 
@@ -591,16 +594,13 @@
     if (!ts) return
     ts.active_pane = pane_idx
     if (is_tauri) {
-      is_loading = true
       try {
-        const result = await tauri_open_file()
-        if (result) {
-          await process_file_content(tab_id, result.content, result.filename, pane_idx)
+        const results = await tauri_open_files()
+        if (results && results.length > 0) {
+          await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
         }
       } catch (err) {
         console.error(err)
-      } finally {
-        is_loading = false
       }
     } else {
       file_input_target_tab = tab_id
@@ -609,18 +609,60 @@
     }
   }
 
+  /** Open a folder and import every recognizable structure file inside it. */
+  async function handle_open_folder(tab_id: string, pane_idx: number) {
+    const ts = tab_states[tab_id]
+    if (!ts) return
+    ts.active_pane = pane_idx
+    const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
+    if (is_tauri) {
+      try {
+        const results = await tauri_open_folder(accept)
+        if (results && results.length > 0) {
+          await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    } else {
+      file_input_target_tab = tab_id
+      file_input_target_pane = pane_idx
+      folder_input_ref?.click()
+    }
+  }
+
   async function handle_file_input(event: Event) {
     const input = event.target as HTMLInputElement
-    const file = input.files?.[0]
-    if (!file) return
-    is_loading = true
+    const files = Array.from(input.files ?? [])
+    if (files.length === 0) return
     try {
-      const { content, filename } = await decompress_file(file)
-      await process_file_content(file_input_target_tab, content, filename, file_input_target_pane)
+      await import_many(
+        file_input_target_tab,
+        files.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
+        file_input_target_pane,
+      )
     } catch (err) {
       console.error(err)
     } finally {
-      is_loading = false
+      input.value = ``
+    }
+  }
+
+  /** Browser folder picker (webkitdirectory) — filters to structure files. */
+  async function handle_folder_input(event: Event) {
+    const input = event.target as HTMLInputElement
+    const all = Array.from(input.files ?? [])
+    const files = all.filter(f => is_structure_file(f.name) || is_trajectory_file(f.name) || is_chgcar_file(f.name))
+    if (files.length === 0) { input.value = ``; return }
+    try {
+      await import_many(
+        file_input_target_tab,
+        files.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
+        file_input_target_pane,
+      )
+    } catch (err) {
+      console.error(err)
+    } finally {
       input.value = ``
     }
   }
@@ -737,18 +779,21 @@
     modal.db_preview_lattice = null
   }
 
-  async function process_file_content(tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) {
-    const ts = tab_states[tab_id]
-    if (!ts) return
-    let target = find_import_target_pane(ts, pane_idx)
-    if (target === -1) {
-      // All panes full — open a new tab and load there
-      open_tab(`structure`)
-      const new_ts = tab_states[tm.active_tab_id]
-      if (!new_ts) return
-      return process_file_content(tm.active_tab_id, content, filename, 0, remote_origin, local_file_path)
-    }
+  // Result of parsing one file. 'skip' = ignore silently; 'editor' = not a
+  // structure, open raw text in the editor; 'entry' = a library entry payload.
+  type IngestOutcome =
+    | { kind: 'entry'; entry: Omit<LibraryEntry, 'id'> }
+    | { kind: 'skip' }
+    | { kind: 'editor'; text: string }
+
+  /**
+   * Parse a single file into a LibraryEntry payload WITHOUT touching any pane.
+   * Shared by the single-file path (process_file_content) and the batch path
+   * (import_many) so the CIF / cube / CHGCAR / trajectory branching lives once.
+   */
+  async function ingest_one(content: string | ArrayBuffer, filename: string): Promise<IngestOutcome> {
     const text = typeof content === `string` ? content : new TextDecoder().decode(content)
+    const ext = filename.replace(/\.(gz|bz2|xz|zst)$/i, ``).split(`.`).pop()?.toLowerCase() || ``
 
     // CHGCAR / CHGDIFF / LOCPOT etc. → convert to Gaussian cube via wasm.
     // chgdiff-wasm exposes `chgcar_to_cube(text)` and the package is already
@@ -779,99 +824,207 @@
           cube_text = await resp.text()
         }
         const cube_filename = filename.replace(/\.(gz|bz2|xz|zst)$/i, ``) + `.cube`
+        let structure: AnyStructure | undefined
         try {
-          const header = parse_cube_header(cube_text)
-          const molecule = cube_atoms_to_molecule(header)
-          if (molecule.sites.length > 0) {
-            ts.panes[target].structure = { ...molecule, _aligned: true } as AnyStructure
-            ts.panes[target].initial_site_count = molecule.sites.length
-            ts.panes[target].initial_structure_ref = ts.panes[target].structure
-          }
+          const molecule = cube_atoms_to_molecule(parse_cube_header(cube_text))
+          if (molecule.sites.length > 0) structure = { ...molecule, _aligned: true } as AnyStructure
         } catch (err) {
           console.error(`Failed to parse converted cube atoms:`, err)
         }
-        const cube_blob = new Blob([cube_text], { type: `chemical/x-cube` })
-        ts.panes[target].cube_file = new File([cube_blob], cube_filename)
-        ts.panes[target].is_trajectory_mode = false
-        ts.panes[target].trajectory = null
-        ts.panes[target].selected_sites = []
-        ts.panes[target].current_step_idx = 0
-        ts.panes[target].modified = false
-        ts.panes[target].remote_origin = remote_origin ?? null
-        ts.panes[target].local_file_path = local_file_path ?? null
-        ts.panes[target].source_filename = filename
-        ts.active_pane = target
-        update_tab_label(tab_id)
+        const cube_file = new File([new Blob([cube_text], { type: `chemical/x-cube` })], cube_filename)
+        return { kind: 'entry', entry: { filename, source_path: null, format: `cube`, structure, trajectory: undefined, is_trajectory: false, cube_file } }
       } catch (err) {
         console.error(`Failed to convert CHGCAR to cube:`, err)
+        return { kind: 'skip' }
       }
-      return
     }
 
     if (/\.(cube|cub)$/i.test(filename)) {
+      let structure: AnyStructure | undefined
       try {
-        const header = parse_cube_header(text)
-        const molecule = cube_atoms_to_molecule(header)
-        if (molecule.sites.length > 0) {
-          ts.panes[target].structure = { ...molecule, _aligned: true } as AnyStructure
-          ts.panes[target].initial_site_count = molecule.sites.length
-          ts.panes[target].initial_structure_ref = ts.panes[target].structure
-        }
+        const molecule = cube_atoms_to_molecule(parse_cube_header(text))
+        if (molecule.sites.length > 0) structure = { ...molecule, _aligned: true } as AnyStructure
       } catch (err) {
         console.error(`Failed to parse cube file atoms:`, err)
       }
-      const blob = new Blob([text], { type: `chemical/x-cube` })
-      ts.panes[target].cube_file = new File([blob], filename)
-      ts.panes[target].is_trajectory_mode = false
-      ts.panes[target].trajectory = null
-      ts.panes[target].selected_sites = []
-      ts.panes[target].current_step_idx = 0
-      ts.panes[target].modified = false
-      ts.panes[target].remote_origin = remote_origin ?? null
-      ts.panes[target].local_file_path = local_file_path ?? null
-      ts.panes[target].source_filename = filename
-      ts.active_pane = target
-      update_tab_label(tab_id)
-      return
+      const cube_file = new File([new Blob([text], { type: `chemical/x-cube` })], filename)
+      return { kind: 'entry', entry: { filename, source_path: null, format: `cube`, structure, trajectory: undefined, is_trajectory: false, cube_file } }
     }
 
     // Skip non-structure files (images, PDFs, spreadsheets, media, archives, binaries)
     if (NON_STRUCTURE_EXTS.test(filename)) {
-      console.warn(`[process_file_content] Skipping non-structure file: ${filename}`)
-      return
+      console.warn(`[ingest_one] Skipping non-structure file: ${filename}`)
+      return { kind: 'skip' }
     }
 
     if (is_trajectory_file(filename, text)) {
-      ts.panes[target].is_trajectory_mode = true
-      ts.panes[target].structure = undefined
-      ts.panes[target].trajectory = await parse_trajectory_data(content, filename)
-      ts.panes[target].initial_site_count = 0
-      ts.panes[target].raw_traj_b64 = content_to_base64(content)
-      ts.panes[target].raw_traj_format = filename.split('.').pop()?.toLowerCase() || ''
-    } else {
-      ts.panes[target].is_trajectory_mode = false
-      ts.panes[target].trajectory = null
-      const parsed = parse_structure_file(text, filename)
-      if (parsed?.sites?.length) {
-        ts.panes[target].structure = parsed
-        ts.panes[target].initial_site_count = parsed.sites.length
-        ts.panes[target].initial_structure_ref = parsed
-      } else {
-        // Can't parse as structure — open in text editor as fallback
-        const session = remote_origin?.session_id || ``
-        const fp = remote_origin?.file_path || local_file_path || ``
-        handle_sidebar_open_editor(text, filename, fp, session)
-        return
+      const trajectory = await parse_trajectory_data(content, filename)
+      return {
+        kind: 'entry',
+        entry: {
+          filename, source_path: null, format: ext, structure: undefined, trajectory,
+          is_trajectory: true, cube_file: null,
+          raw_traj_b64: content_to_base64(content),
+          raw_traj_format: filename.split('.').pop()?.toLowerCase() || '',
+        },
       }
     }
-    ts.panes[target].selected_sites = []
-    ts.panes[target].current_step_idx = 0
-    ts.panes[target].modified = false
-    ts.panes[target].remote_origin = remote_origin ?? null
-    ts.panes[target].local_file_path = local_file_path ?? null
-    ts.panes[target].source_filename = filename
+
+    const parsed = parse_structure_file(text, filename)
+    if (parsed?.sites?.length) {
+      return { kind: 'entry', entry: { filename, source_path: null, format: ext, structure: parsed, trajectory: undefined, is_trajectory: false, cube_file: null } }
+    }
+    // Can't parse as structure — fall back to the text editor
+    return { kind: 'editor', text }
+  }
+
+  /** Write a library entry's parsed content into a pane (in-place — Svelte 5 deep proxy). */
+  function apply_entry_to_pane(
+    tab_id: string,
+    ts: StructureTabState,
+    target: number,
+    e: LibraryEntry,
+    remote_origin: { session_id: string; file_path: string } | null = null,
+    local_file_path: string | null = null,
+  ) {
+    const p = ts.panes[target]
+    if (e.cube_file) {
+      p.structure = e.structure
+      p.initial_site_count = e.structure?.sites?.length ?? 0
+      p.initial_structure_ref = e.structure ?? null
+      p.cube_file = e.cube_file
+      p.is_trajectory_mode = false
+      p.trajectory = null
+    } else if (e.is_trajectory) {
+      p.is_trajectory_mode = true
+      p.structure = undefined
+      p.trajectory = e.trajectory
+      p.initial_site_count = 0
+      p.initial_structure_ref = null
+      p.cube_file = null
+      p.raw_traj_b64 = e.raw_traj_b64 ?? ''
+      p.raw_traj_format = e.raw_traj_format ?? ''
+    } else {
+      p.is_trajectory_mode = false
+      p.trajectory = null
+      p.structure = e.structure
+      p.initial_site_count = e.structure?.sites?.length ?? 0
+      p.initial_structure_ref = e.structure ?? null
+      p.cube_file = null
+    }
+    p.selected_sites = []
+    p.current_step_idx = 0
+    p.modified = false
+    p.remote_origin = remote_origin
+    p.local_file_path = local_file_path
+    p.source_filename = e.filename
     ts.active_pane = target
     update_tab_label(tab_id)
+  }
+
+  async function process_file_content(tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) {
+    const ts = tab_states[tab_id]
+    if (!ts) return
+    let target = find_import_target_pane(ts, pane_idx)
+    if (target === -1) {
+      // All panes full — open a new tab and load there
+      open_tab(`structure`)
+      const new_ts = tab_states[tm.active_tab_id]
+      if (!new_ts) return
+      return process_file_content(tm.active_tab_id, content, filename, 0, remote_origin, local_file_path)
+    }
+    const outcome = await ingest_one(content, filename)
+    if (outcome.kind === 'skip') return
+    if (outcome.kind === 'editor') {
+      const session = remote_origin?.session_id || ``
+      const fp = remote_origin?.file_path || local_file_path || ``
+      handle_sidebar_open_editor(outcome.text, filename, fp, session)
+      return
+    }
+    const entry: LibraryEntry = { id: crypto.randomUUID(), ...outcome.entry, source_path: local_file_path ?? outcome.entry.source_path ?? null }
+    ts.library.push(entry)
+    ts.active_library_id = entry.id
+    apply_entry_to_pane(tab_id, ts, target, entry, remote_origin ?? null, local_file_path ?? null)
+  }
+
+  /**
+   * Import many files into a tab's structure library. Each file is parsed in
+   * isolation (one bad file never aborts the batch); entries are appended to
+   * the library and the first newly-added one is shown in the active pane.
+   * `items` carry either pre-read `content` (Tauri) or a `File` (browser).
+   */
+  async function import_many(
+    tab_id: string,
+    items: Array<{ content?: string | ArrayBuffer; filename: string; file?: File; path?: string | null }>,
+    pane_idx: number,
+  ) {
+    const ts = tab_states[tab_id]
+    if (!ts) return
+    ts.active_pane = pane_idx
+    is_loading = true
+    const start = ts.library.length
+    let failures = 0
+    try {
+      for (const it of items) {
+        try {
+          let content = it.content
+          let filename = it.filename
+          if (it.file) {
+            const d = await decompress_file(it.file)
+            content = d.content
+            filename = d.filename
+          }
+          if (content == null) { failures++; continue }
+          const outcome = await ingest_one(content, filename)
+          if (outcome.kind !== 'entry') { failures++; continue }
+          ts.library.push({ id: crypto.randomUUID(), ...outcome.entry, source_path: it.path ?? outcome.entry.source_path ?? null })
+        } catch (err) {
+          failures++
+          console.warn(`[import_many] failed to import ${it.filename}:`, err)
+        }
+      }
+      if (ts.library.length > start) {
+        select_library_entry(tab_id, ts.library[start].id)
+      }
+    } finally {
+      is_loading = false
+    }
+    if (failures > 0) console.warn(`[import_many] ${failures} file(s) skipped or failed`)
+  }
+
+  /** Show a library entry in the tab's active pane. */
+  function select_library_entry(tab_id: string, id: string) {
+    const ts = tab_states[tab_id]
+    if (!ts) return
+    const entry = ts.library.find(e => e.id === id)
+    if (!entry) return
+    apply_entry_to_pane(tab_id, ts, ts.active_pane, entry)
+    ts.active_library_id = id
+    tick().then(() => window.dispatchEvent(new Event('resize')))
+  }
+
+  /** Remove one entry; if it was active, fall back to the first remaining (or clear the pane). */
+  function remove_library_entry(tab_id: string, id: string) {
+    const ts = tab_states[tab_id]
+    if (!ts) return
+    const was_active = ts.active_library_id === id
+    ts.library = ts.library.filter(e => e.id !== id)
+    if (!was_active) return
+    if (ts.library.length > 0) {
+      select_library_entry(tab_id, ts.library[0].id)
+    } else {
+      ts.active_library_id = null
+      ts.panes[ts.active_pane] = create_empty_pane()
+      update_tab_label(tab_id)
+    }
+  }
+
+  /** Empty the library list (does not clear what's currently shown in the pane). */
+  function clear_library(tab_id: string) {
+    const ts = tab_states[tab_id]
+    if (!ts) return
+    ts.library = []
+    ts.active_library_id = null
   }
 
   function create_on_file_drop(tab_id: string, pane_idx: number) {
@@ -968,47 +1121,54 @@
         if (event.payload.type === `drop`) {
           const paths = event.payload.paths
           if (paths && paths.length > 0) {
-            const file_path = paths[0]
             const now = Date.now()
-            if (file_path === last_drop_path && now - last_drop_time < 500) return
+            // Dedupe on the whole batch (key off first path) so a single
+            // multi-file drop doesn't double-fire.
+            const batch_key = paths[0]
+            if (batch_key === last_drop_path && now - last_drop_time < 500) return
             last_drop_time = now
-            last_drop_path = file_path
-            const filename = file_path.split(/[/\\]/).pop() || `unknown`
+            last_drop_path = batch_key
 
             // If a modal dialog with a drop zone is open, skip — let DOM handlers process it
             if (document.querySelector(`.dialog-backdrop`)) return
 
-            // PDFs are never valid structure files — always route to paper import.
+            // PDFs are never valid structure files — route each to paper import.
             // App-level drop (not scoped to a specific tab) — route to the
             // currently-active tab's chat slice so the loading spinner and
             // any error message surface there.
-            if (/\.pdf$/i.test(filename)) {
+            const pdf_paths = paths.filter(p => /\.pdf$/i.test(p))
+            const other_paths = paths.filter(p => !/\.pdf$/i.test(p))
+
+            for (const pdf_path of pdf_paths) {
+              const pdf_name = pdf_path.split(/[/\\]/).pop() || `unknown.pdf`
               const target_tab_id = tm.active_tab_id
               const chat_slice = get_chat_slice(target_tab_id)
               try {
                 chat_slice.loading.value = true
                 chat_slice.error.value = ``
-                const content = await readFile(file_path)
-                const file = new File([content], filename, { type: `application/pdf` })
+                const content = await readFile(pdf_path)
+                const file = new File([content], pdf_name, { type: `application/pdf` })
                 await import_paper(file, target_tab_id)
               } catch (err) {
                 chat_slice.error.value = err instanceof Error ? err.message : `Paper import failed`
               } finally {
                 chat_slice.loading.value = false
               }
-              return
             }
+
+            if (other_paths.length === 0) return
 
             const ts = get_active_ts()
             if (!ts) return
             is_loading = true
             try {
-              const content = await readFile(file_path)
-              const text_content = new TextDecoder().decode(content)
+              const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
+              const files = await tauri_read_dropped_paths(other_paths, accept)
               const target_pane = ts.panes.findIndex(p => !pane_has_content(p))
               const pane_idx = target_pane >= 0 ? target_pane : ts.active_pane
-              await process_file_content(tm.active_tab_id, text_content, filename, pane_idx, null, file_path)
-              ts.active_pane = pane_idx
+              if (files.length > 0) {
+                await import_many(tm.active_tab_id, files.map(f => ({ content: f.content, filename: f.filename, path: f.path })), pane_idx)
+              }
             } catch (err) {
               console.error(`[Tauri Drop] Error reading file:`, err)
             } finally {
@@ -1263,12 +1423,22 @@
   <ThemeControl style="position: static; box-shadow: none; backdrop-filter: none;" />
 </TabBar>
 
-<!-- Hidden file input (shared) -->
+<!-- Hidden file input (shared, multi-select) -->
 <input
   bind:this={file_input_ref}
   type="file"
+  multiple
   accept=".cif,.poscar,.vasp,.xyz,.json,.extxyz,.traj,.h5,.hdf5,.gz,.bz2,.xz,.zst,.cube,.cub,.xml,.data,.lammps,*"
   onchange={handle_file_input}
+  hidden
+/>
+<!-- Hidden folder input (browser webkitdirectory) -->
+<input
+  bind:this={folder_input_ref}
+  type="file"
+  multiple
+  webkitdirectory
+  onchange={handle_folder_input}
   hidden
 />
 
@@ -1317,6 +1487,16 @@
         {@const visible = get_visible_panes(ts)}
         {@const panel_count = layout_panel_count(ts.layout)}
 
+        <div class="structure-workspace">
+        {#if ts.library.length >= 2}
+          <StructureLibrary
+            entries={ts.library}
+            active_id={ts.active_library_id}
+            on_select={(id) => select_library_entry(tab.id, id)}
+            on_remove={(id) => remove_library_entry(tab.id, id)}
+            on_clear={() => clear_library(tab.id)}
+          />
+        {/if}
         <div class="grid-container" class:resizing={is_panel_resizing} style={get_grid_style(ts)}>
           {#each visible as idx (idx)}
             {@const pane = ts.panes[idx]}
@@ -1519,7 +1699,18 @@
                       </svg>
                       <div class="import-text">
                         <span class="import-title">Open File</span>
-                        <span class="import-desc">or drop here</span>
+                        <span class="import-desc">multi-select or drop</span>
+                      </div>
+                    </button>
+
+                    <button class="import-card add-own-card" onclick={() => handle_open_folder(tab.id, idx)}>
+                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+                        <path d="M2 10h20"/>
+                      </svg>
+                      <div class="import-text">
+                        <span class="import-title">Open Folder</span>
+                        <span class="import-desc">load all structures</span>
                       </div>
                     </button>
 
@@ -1738,6 +1929,7 @@
             ></div>
           {/if}
         </div>
+        </div><!-- end structure-workspace -->
       {/if}
 
     {:else if tab.type === `workflow`}
@@ -2043,6 +2235,16 @@
     visibility: hidden;
     pointer-events: none;
     z-index: -1;
+  }
+
+  .structure-workspace {
+    display: flex;
+    width: 100%;
+    height: 100%;
+  }
+  .structure-workspace > .grid-container {
+    flex: 1;
+    min-width: 0;
   }
 
   .grid-container {

--- a/desktop/StructureLibrary.svelte
+++ b/desktop/StructureLibrary.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import type { LibraryEntry } from './pane-utils'
+
+  let {
+    entries,
+    active_id,
+    on_select,
+    on_remove,
+    on_clear,
+  }: {
+    entries: LibraryEntry[]
+    active_id: string | null
+    on_select: (id: string) => void
+    on_remove: (id: string) => void
+    on_clear: () => void
+  } = $props()
+
+  const FORMAT_COLORS: Record<string, string> = {
+    cif: `rgba(100, 149, 237, 0.9)`,
+    xyz: `rgba(50, 205, 50, 0.9)`,
+    extxyz: `rgba(50, 205, 50, 0.9)`,
+    poscar: `rgba(255, 140, 0, 0.9)`,
+    vasp: `rgba(255, 140, 0, 0.9)`,
+    json: `rgba(138, 43, 226, 0.9)`,
+    traj: `rgba(255, 105, 180, 0.9)`,
+    h5: `rgba(255, 69, 0, 0.9)`,
+    hdf5: `rgba(255, 69, 0, 0.9)`,
+    cube: `rgba(0, 206, 209, 0.9)`,
+    xml: `rgba(176, 124, 60, 0.9)`,
+    data: `rgba(120, 144, 156, 0.9)`,
+  }
+  const dot_color = (fmt: string) => FORMAT_COLORS[fmt?.toLowerCase()] ?? `rgba(150, 150, 150, 0.9)`
+</script>
+
+<div class="structure-library">
+  <div class="lib-header">
+    <span class="lib-count">{entries.length} file{entries.length === 1 ? `` : `s`}</span>
+    <button
+      class="lib-clear"
+      title="Clear list (keeps the open structure)"
+      onclick={on_clear}
+    >Clear all</button>
+  </div>
+  <div class="lib-list">
+    {#each entries as entry (entry.id)}
+      <div
+        class="lib-item"
+        class:active={entry.id === active_id}
+        role="button"
+        tabindex="0"
+        title={entry.source_path || entry.filename}
+        onclick={() => on_select(entry.id)}
+        onkeydown={(e) => (e.key === `Enter` || e.key === ` `) && (e.preventDefault(), on_select(entry.id))}
+      >
+        <span class="lib-dot" style:background-color={dot_color(entry.format)}></span>
+        <span class="lib-name">{entry.filename}</span>
+        {#if entry.is_trajectory}<span class="lib-tag">traj</span>{/if}
+        <button
+          class="lib-remove"
+          title="Remove from list"
+          onclick={(e) => { e.stopPropagation(); on_remove(entry.id) }}
+        >
+          <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .structure-library {
+    width: 210px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.14));
+    background: light-dark(rgba(0, 0, 0, 0.02), rgba(255, 255, 255, 0.03));
+    overflow: hidden;
+  }
+  .lib-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 8px;
+    border-bottom: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.12));
+    font-size: 0.7em;
+  }
+  .lib-count {
+    opacity: 0.7;
+    font-variant-numeric: tabular-nums;
+  }
+  .lib-clear {
+    background: transparent;
+    border: 1px solid light-dark(rgba(0, 0, 0, 0.18), rgba(255, 255, 255, 0.24));
+    border-radius: 4px;
+    color: var(--text-color-muted, #6b7280);
+    font-size: 0.95em;
+    padding: 2px 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .lib-clear:hover {
+    color: var(--text-color, inherit);
+    background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1));
+  }
+  .lib-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .lib-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 6px;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .lib-item:hover {
+    border-color: var(--accent-color, #007acc);
+    background: rgba(0, 122, 204, 0.14);
+  }
+  .lib-item.active {
+    border-color: var(--success-color, #00c853);
+    background: rgba(0, 200, 83, 0.16);
+    box-shadow: 0 0 6px rgba(0, 200, 83, 0.25);
+  }
+  .lib-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .lib-name {
+    flex: 1;
+    font-size: 0.72em;
+    line-height: 1.15;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .lib-tag {
+    font-size: 0.58em;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    opacity: 0.6;
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    padding: 0 3px;
+    flex-shrink: 0;
+  }
+  .lib-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    color: var(--text-color-muted, #6b7280);
+    cursor: pointer;
+    opacity: 0;
+    flex-shrink: 0;
+    transition: opacity 0.15s ease, background 0.15s ease;
+  }
+  .lib-item:hover .lib-remove {
+    opacity: 0.7;
+  }
+  .lib-remove:hover {
+    opacity: 1;
+    background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
+  }
+</style>

--- a/desktop/lib/drag-drop-handlers.ts
+++ b/desktop/lib/drag-drop-handlers.ts
@@ -6,16 +6,54 @@
 
 import type { StructureTabState } from '../pane-utils'
 import { pane_has_content } from '../pane-utils'
-import { decompress_file } from '$lib/io/decompress'
+
+export interface ImportItem {
+  content?: string | ArrayBuffer
+  filename: string
+  file?: File
+  path?: string | null
+}
 
 export interface DragDropDeps {
   get_active_ts: () => StructureTabState | null
   get_active_tab_type: () => string
   get_active_tab_id: () => string
   process_file_content: (tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number) => Promise<void>
+  import_many: (tab_id: string, items: ImportItem[], pane_idx: number) => Promise<void>
   get_drag_target_pane: () => number | null
   set_drag_target_pane: (v: number | null) => void
   set_is_loading: (v: boolean) => void
+}
+
+/* Minimal File System Entry typings (non-standard webkit API). */
+interface FsEntry {
+  isFile: boolean
+  isDirectory: boolean
+  fullPath?: string
+  file?: (cb: (f: File) => void, err?: (e: unknown) => void) => void
+  createReader?: () => { readEntries: (cb: (e: FsEntry[]) => void, err?: (e: unknown) => void) => void }
+}
+
+/** Recursively collect File objects from a dropped FileSystemEntry (depth/count guarded). */
+async function read_entry_files(entry: FsEntry | null, out: Array<{ file: File; path: string | null }>, depth: number): Promise<void> {
+  if (!entry || depth > 3 || out.length >= 500) return
+  if (entry.isFile && entry.file) {
+    await new Promise<void>((resolve) => {
+      entry.file!((f) => { out.push({ file: f, path: entry.fullPath || null }); resolve() }, () => resolve())
+    })
+  } else if (entry.isDirectory && entry.createReader) {
+    const reader = entry.createReader()
+    const read_batch = (): Promise<FsEntry[]> =>
+      new Promise((resolve) => reader.readEntries((e) => resolve(e), () => resolve([])))
+    let batch = await read_batch()
+    while (batch.length > 0 && out.length < 500) {
+      for (const e of batch) {
+        if (out.length >= 500) break
+        await read_entry_files(e, out, depth + 1)
+      }
+      batch = await read_batch()
+    }
+  }
 }
 
 export function get_pane_from_event(deps: DragDropDeps, event: DragEvent): number {
@@ -89,22 +127,37 @@ export async function handle_drop(deps: DragDropDeps, event: DragEvent) {
     return
   }
 
-  const file = event.dataTransfer?.files[0]
-  if (!file) {
-    return
+  // Capture entries/files synchronously — the DataTransfer list is invalidated
+  // once the event handler yields (first await), so snapshot before any await.
+  const dt = event.dataTransfer
+  const entry_roots: FsEntry[] = []
+  const items = dt?.items
+  if (items && items.length && typeof (items[0] as unknown as { webkitGetAsEntry?: unknown }).webkitGetAsEntry === `function`) {
+    for (let i = 0; i < items.length; i++) {
+      const ent = (items[i] as unknown as { webkitGetAsEntry: () => FsEntry | null }).webkitGetAsEntry()
+      if (ent) entry_roots.push(ent)
+    }
   }
+  const flat_files = Array.from(dt?.files ?? [])
 
-  // Skip non-structure files in drag-and-drop
-  const drop_name = file.name.toLowerCase()
-  if (/\.(png|jpg|jpeg|gif|bmp|webp|svg|ico|tiff?|pdf|xlsx?|xlsm|xlsb|ods|mp[34]|wav|ogg|avi|mov|mkv|zip|gz|tar|rar|7z|exe|dll|so|dylib)$/i.test(drop_name)) {
-    console.warn(`[Drop] Skipping non-structure file: ${file.name}`)
-    return
-  }
+  if (entry_roots.length === 0 && flat_files.length === 0) return
 
   deps.set_is_loading(true)
   try {
-    const { content, filename } = await decompress_file(file)
-    await deps.process_file_content(deps.get_active_tab_id(), content, filename, pane_idx)
+    const collected: Array<{ file: File; path: string | null }> = []
+    if (entry_roots.length > 0) {
+      for (const root of entry_roots) await read_entry_files(root, collected, 0)
+    }
+    // Fallback / supplement: any plain files not surfaced via the entry API.
+    if (collected.length === 0) {
+      for (const f of flat_files) collected.push({ file: f, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })
+    }
+    if (collected.length === 0) return
+    await deps.import_many(
+      deps.get_active_tab_id(),
+      collected.map(c => ({ file: c.file, filename: c.file.name, path: c.path })),
+      pane_idx,
+    )
     ts.active_pane = pane_idx
   } catch (err) {
     console.error(`[Drop] Error:`, err)

--- a/desktop/lib/tab-manager.svelte.ts
+++ b/desktop/lib/tab-manager.svelte.ts
@@ -141,6 +141,8 @@ export function create_tab_manager() {
           ts.active_pane = 0
           ts.col_split = 50
           ts.row_split = 50
+          ts.library = []
+          ts.active_library_id = null
           tab.label = `Structure`
         }
       }
@@ -165,6 +167,8 @@ export function create_tab_manager() {
         ts.col_split = 50
         ts.row_split = 50
         ts.close_confirm_pane = null
+        ts.library = []
+        ts.active_library_id = null
         tab.label = `Structure`
       }
       return

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -36,6 +36,27 @@ export interface PaneState {
 
 export type LayoutType = 'single' | 'splitH' | 'splitV' | 'quad'
 
+/**
+ * One imported structure held in a tab's structure-library sidebar.
+ * Parsed eagerly (see desktop/App.svelte ingest_one): a multi-frame file
+ * (vasprun/.traj/.extxyz/.h5) becomes a SINGLE entry with is_trajectory:true.
+ */
+export interface LibraryEntry {
+  id: string
+  /** Display name (post-decompression basename) */
+  filename: string
+  /** Tauri abs path or webkitRelativePath, for tooltip / re-resolve */
+  source_path?: string | null
+  /** Lowercased extension / detected format */
+  format: string
+  structure: AnyStructure | undefined
+  trajectory?: unknown
+  is_trajectory: boolean
+  cube_file?: File | null
+  raw_traj_b64?: string
+  raw_traj_format?: string
+}
+
 export interface StructureTabState {
   panes: PaneState[]
   layout: LayoutType
@@ -43,6 +64,9 @@ export interface StructureTabState {
   close_confirm_pane: number | null
   col_split: number
   row_split: number
+  /** Per-tab structure library (sidebar). Cleared automatically on tab close. */
+  library: LibraryEntry[]
+  active_library_id: string | null
 }
 
 // ========== Pure Functions ==========
@@ -93,6 +117,8 @@ export function create_tab_state(): StructureTabState {
     close_confirm_pane: null,
     col_split: 50,
     row_split: 50,
+    library: [],
+    active_library_id: null,
   }
 }
 

--- a/src/lib/io/tauri.ts
+++ b/src/lib/io/tauri.ts
@@ -89,7 +89,34 @@ export async function init_tauri(): Promise<void> {
   }
 }
 
-// Open file dialog and read file content
+const STRUCTURE_DIALOG_FILTERS = [
+  {
+    name: 'Structure Files',
+    extensions: ['cif', 'poscar', 'vasp', 'xyz', 'json', 'extxyz', 'cube', 'cub', 'xml'],
+  },
+  { name: 'All Files', extensions: ['*'] },
+]
+
+export interface OpenedFile {
+  content: string | ArrayBuffer
+  filename: string
+  path: string
+}
+
+/** Read a single absolute path as text, falling back to binary. */
+async function read_one(path: string): Promise<OpenedFile> {
+  const { readFile, readTextFile } = await import('@tauri-apps/plugin-fs')
+  const filename = path.split(/[/\\]/).pop() || 'unknown'
+  try {
+    const content = await readTextFile(path)
+    return { content, filename, path }
+  } catch {
+    const content = await readFile(path)
+    return { content: content.buffer as ArrayBuffer, filename, path }
+  }
+}
+
+// Open file dialog and read file content (single file — kept for legacy callers)
 export async function open_file(): Promise<
   { content: string | ArrayBuffer; filename: string } | null
 > {
@@ -97,34 +124,134 @@ export async function open_file(): Promise<
 
   try {
     const { open } = await import('@tauri-apps/plugin-dialog')
-    const { readFile, readTextFile } = await import('@tauri-apps/plugin-fs')
-
-    const path = await open({
-      multiple: false,
-      filters: [
-        {
-          name: 'Structure Files',
-          extensions: ['cif', 'poscar', 'vasp', 'xyz', 'json', 'extxyz', 'cube', 'cub', 'xml'],
-        },
-        { name: 'All Files', extensions: ['*'] },
-      ],
-    })
-
+    const path = await open({ multiple: false, filters: STRUCTURE_DIALOG_FILTERS })
     if (!path || Array.isArray(path)) return null
-
-    // Extract filename from path
-    const filename = path.split(/[/\\]/).pop() || 'unknown'
-
-    // Try to read as text first, fall back to binary
-    try {
-      const content = await readTextFile(path)
-      return { content, filename }
-    } catch {
-      const content = await readFile(path)
-      return { content: content.buffer as ArrayBuffer, filename }
-    }
+    const { content, filename } = await read_one(path)
+    return { content, filename }
   } catch (error) {
     console.error('Tauri file open error:', error)
     return null
   }
+}
+
+/** Open a multi-select file dialog; returns all chosen files (text or binary). */
+export async function open_files(): Promise<OpenedFile[] | null> {
+  if (!check_tauri()) return null
+
+  try {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const picked = await open({ multiple: true, filters: STRUCTURE_DIALOG_FILTERS })
+    if (!picked) return null
+    const paths = Array.isArray(picked) ? picked : [picked]
+    const out: OpenedFile[] = []
+    for (const p of paths) {
+      try {
+        out.push(await read_one(p))
+      } catch (err) {
+        console.error('Tauri read error for', p, err)
+      }
+    }
+    return out.length ? out : null
+  } catch (error) {
+    console.error('Tauri multi-file open error:', error)
+    return null
+  }
+}
+
+/** Recursively collect accepted file paths under `base` (depth/symlink/count guarded). */
+async function walk_dir(
+  base: string,
+  accept: (filename: string) => boolean,
+  collected: string[],
+  depth: number,
+  max_depth: number,
+  max_files: number,
+): Promise<void> {
+  if (depth > max_depth || collected.length >= max_files) return
+  const { readDir } = await import('@tauri-apps/plugin-fs')
+  const { join } = await import('@tauri-apps/api/path')
+  let entries
+  try {
+    entries = await readDir(base)
+  } catch {
+    return
+  }
+  for (const e of entries) {
+    if (collected.length >= max_files) return
+    if (e.isSymlink) continue
+    const full = await join(base, e.name)
+    if (e.isDirectory) {
+      await walk_dir(full, accept, collected, depth + 1, max_depth, max_files)
+    } else if (e.isFile && accept(e.name)) {
+      collected.push(full)
+    }
+  }
+}
+
+async function read_paths(paths: string[]): Promise<OpenedFile[]> {
+  const out: OpenedFile[] = []
+  for (const p of paths) {
+    try {
+      out.push(await read_one(p))
+    } catch (err) {
+      console.error('Tauri read error for', p, err)
+    }
+  }
+  return out
+}
+
+/**
+ * Open a directory picker and return every recognizable structure file inside,
+ * recursing up to `max_depth` levels (default 3). Symlinks are skipped and the
+ * total is hard-capped to avoid pathological traversals.
+ */
+export async function open_folder(
+  accept: (filename: string) => boolean,
+  max_depth = 3,
+  max_files = 500,
+): Promise<OpenedFile[] | null> {
+  if (!check_tauri()) return null
+
+  try {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const dir = await open({ directory: true, multiple: false })
+    if (!dir || Array.isArray(dir)) return null
+
+    const collected: string[] = []
+    await walk_dir(dir, accept, collected, 0, max_depth, max_files)
+    const out = await read_paths(collected)
+    return out.length ? out : null
+  } catch (error) {
+    console.error('Tauri folder open error:', error)
+    return null
+  }
+}
+
+/**
+ * Expand a list of dropped paths (files and/or directories) into readable
+ * files, filtering by `accept`. Directories are walked like open_folder.
+ */
+export async function read_dropped_paths(
+  paths: string[],
+  accept: (filename: string) => boolean,
+  max_depth = 3,
+  max_files = 500,
+): Promise<OpenedFile[]> {
+  if (!check_tauri()) return []
+  const { stat } = await import('@tauri-apps/plugin-fs')
+  const collected: string[] = []
+  for (const p of paths) {
+    if (collected.length >= max_files) break
+    try {
+      const info = await stat(p)
+      if (info.isDirectory) {
+        await walk_dir(p, accept, collected, 0, max_depth, max_files)
+      } else if (info.isFile && accept(p.split(/[/\\]/).pop() || p)) {
+        collected.push(p)
+      }
+    } catch (err) {
+      console.error('Tauri stat error for', p, err)
+    }
+  }
+  return read_paths(collected)
 }


### PR DESCRIPTION
## What

Adds **batch structure import** to the desktop shell, surfaced via a per-tab **structure-library sidebar**. Importing many files (multi-select dialog, multi-file drag-drop, or a whole folder) lists them in a left sidebar; clicking an entry shows it in the single active pane.

Single-file UX is **unchanged** — the sidebar only appears at ≥2 entries.

## Changes

- **`pane-utils.ts`** — `LibraryEntry` type + per-tab `library[]` / `active_library_id`; freed automatically on tab close (last-tab-reset blocks in `tab-manager` too).
- **`App.svelte`** — refactor `process_file_content` into pure `ingest_one()` + `apply_entry_to_pane()` (zero parser duplication across CIF / cube / CHGCAR / trajectory; **preserves the existing wasm CHGCAR path + backend fallback**); add `import_many()` with per-file error isolation; `select`/`remove`/`clear_library`; multi-select dialog + browser `<input multiple>` + `webkitdirectory` folder input; "Open Folder" landing card.
- **`io/tauri.ts`** — `open_files()`, `open_folder()` (readDir recursion, depth 3, symlink-skip, 500-file cap), `read_dropped_paths()`; shared `read_one` / `read_paths` helpers.
- **`drag-drop-handlers.ts`** — multi-file drop + `webkitGetAsEntry()` directory traversal, routed through `import_many`.
- **`StructureLibrary.svelte`** (new) — sidebar: id-keyed list, active highlight, per-row remove, clear-all.

## Behavior notes

- Multi-frame files (vasprun / `.traj` / `.extxyz` / `.h5`) become a **single** trajectory library entry; selecting one enters trajectory mode unchanged.
- Per-tab libraries are independent and cleaned up with the tab (no cross-tab leakage).
- Svelte-5: all mutations in-place on the deep `$state` proxy; library `{#each}` keyed by `entry.id` (per `desktop/CLAUDE.md`).

## Verification

- `pnpm check` (svelte-check): **0 errors** (warnings are pre-existing repo-wide patterns).
- Branched off current `origin/main`; merged cleanly except 3 localized hunks in `App.svelte` (imports + the `process_file_content`/CHGCAR region), resolved keeping trunk's wasm-CHGCAR improvement on top of the new `ingest_one` structure.

Not included: automated tests (the repo's vitest setup has the known `@rollup/rollup-linux-x64-gnu` issue) — recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)