### PR TITLE
feat(catbot): client-side slash commands (/help /new /oer /skip-permission … + autocomplete)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-catbot-slash-commands.md
+++ b/docs/superpowers/plans/2026-05-17-catbot-slash-commands.md
@@ -350,6 +350,8 @@ function rel_time(ms: number): string {
   return `${Math.round(h / 24)}d ago`
 }
 
+> ⚠️ Corrected during execution: the shipped `snippet()` combines topic AND last-message (`${topic} — ${preview}`) via `get_display_text()`, per design doc §/resume line 102 (topic + last-message snippet). The block below is the pre-correction draft, kept for history. See `src/lib/chat/slash-commands.ts` for the authoritative implementation.
+
 function snippet(ctx: SlashCtx, s: SessionSummary): string {
   const msgs = ctx.load_session_messages(s.session_id)
   const last = msgs.length ? msgs[msgs.length - 1].content : ''

--- a/docs/superpowers/plans/2026-05-17-catbot-slash-commands.md
+++ b/docs/superpowers/plans/2026-05-17-catbot-slash-commands.md
@@ -1,0 +1,1013 @@
+# CatBot Slash Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic, zero-LLM-token client-side slash commands to CatBot (`/new /clear /stop /resume /oer /her /co2rr /nrr /structure /skip-permission /help`) with autocomplete.
+
+**Architecture:** A single registry module (`src/lib/chat/slash-commands.ts`) is the one source of truth for parsing, command behavior, `/help`, and autocomplete. `ChatPane.handle_send` intercepts `/`-prefixed input before the DOI branch and `send_message`, dispatching via the registry with injected context accessors (registry has no UI imports → unit-testable). `/skip-permission` is a session-scoped flag threaded into the Claude adapter `canUseTool` exactly the way the existing `tabId` is threaded.
+
+**Tech Stack:** Svelte 5 runes (`$state`/`$derived`), TypeScript, vitest, Claude Agent SDK agent-bridge.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-catbot-slash-commands-design.md`
+
+---
+
+### Task 1: Registry module — types, `match_slash`, `run_slash`, `/help`
+
+**Files:**
+- Create: `src/lib/chat/slash-commands.ts`
+- Test: `tests/vitest/chat/slash-commands.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// tests/vitest/chat/slash-commands.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { match_slash, run_slash, SLASH_COMMANDS, make_test_ctx } from '$lib/chat/slash-commands'
+
+function ctx(over = {}) {
+  return {
+    tab_id: 'default', args: '',
+    new_session: vi.fn(), clear_chat_history: vi.fn(), cancel_generation: vi.fn(),
+    resume_session: vi.fn(), list_sessions: vi.fn(() => []), load_session_messages: vi.fn(() => []),
+    run_quickbuild: vi.fn(async () => {}), inject_structure: vi.fn(async () => {}),
+    set_skip_permission: vi.fn(), get_skip_permission: vi.fn(() => false),
+    emit: vi.fn(),
+    ...over,
+  }
+}
+
+describe('match_slash', () => {
+  it('returns null for non-slash', () => {
+    expect(match_slash('hello')).toBeNull()
+    expect(match_slash('  hi /new')).toBeNull()
+  })
+  it('matches command name case-insensitively with args', () => {
+    const m = match_slash('/OER mp-1019')
+    expect(m?.cmd.name).toBe('oer')
+    expect(m?.args).toBe('mp-1019')
+  })
+  it('matches with no args and trims', () => {
+    const m = match_slash('  /new  ')
+    expect(m?.cmd.name).toBe('new')
+    expect(m?.args).toBe('')
+  })
+  it('returns null for unknown slash token', () => {
+    expect(match_slash('/bogus')).toBeNull()
+  })
+  it('resolves aliases', () => {
+    const m = match_slash('/co2rr')
+    expect(m?.cmd.name).toBe('co2rr')
+  })
+})
+
+describe('run_slash', () => {
+  it('returns false when not a command (no UI side effects)', async () => {
+    const c = ctx()
+    expect(await run_slash('plain text', c as any)).toBe(false)
+    expect(c.emit).not.toHaveBeenCalled()
+  })
+  it('emits unknown-command help hint for unmatched slash', async () => {
+    const c = ctx()
+    expect(await run_slash('/nope', c as any)).toBe(true)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('/help'))
+  })
+  it('/help lists every registered command', async () => {
+    const c = ctx()
+    await run_slash('/help', c as any)
+    const out = (c.emit as any).mock.calls[0][0] as string
+    for (const cmd of SLASH_COMMANDS) expect(out).toContain('/' + cmd.name)
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts`
+Expected: FAIL — module `$lib/chat/slash-commands` not found.
+
+- [ ] **Step 3: Implement registry core**
+
+```ts
+// src/lib/chat/slash-commands.ts
+import type { ChatMessage } from './types'
+
+export interface SessionSummary {
+  session_id: string
+  agent: string
+  topic: string
+  created_at: number
+  last_active: number
+  message_count: number
+  model?: string
+}
+
+export interface SlashCtx {
+  tab_id: string
+  args: string
+  new_session: () => void
+  clear_chat_history: () => void
+  cancel_generation: () => void
+  resume_session: (agent: string, session_id: string, messages?: ChatMessage[], tab_id?: string) => void
+  list_sessions: () => SessionSummary[]
+  load_session_messages: (session_id: string) => ChatMessage[]
+  run_quickbuild: (recipe: string, mp_id?: string) => Promise<void>
+  inject_structure: () => Promise<void>
+  set_skip_permission: (on: boolean) => void
+  get_skip_permission: () => boolean
+  emit: (msg: string) => void
+}
+
+export interface SlashCommand {
+  name: string
+  aliases?: string[]
+  hint: string
+  summary: string
+  run: (ctx: SlashCtx) => Promise<void> | void
+}
+
+// Registry is appended to by later tasks. Keep ONE array; never duplicate.
+export const SLASH_COMMANDS: SlashCommand[] = []
+
+function find(token: string): SlashCommand | undefined {
+  const t = token.toLowerCase()
+  return SLASH_COMMANDS.find(c => c.name === t || c.aliases?.includes(t))
+}
+
+/** Parse a raw input string. Returns null if it is not a slash command
+ *  (no leading "/", or first token does not resolve to a registered
+ *  command). Whitespace-tolerant, case-insensitive. */
+export function match_slash(raw: string): { cmd: SlashCommand; args: string } | null {
+  const s = raw.trimStart()
+  if (!s.startsWith('/')) return null
+  const body = s.slice(1)
+  const sp = body.search(/\s/)
+  const token = sp === -1 ? body : body.slice(0, sp)
+  const args = sp === -1 ? '' : body.slice(sp + 1).trim()
+  const cmd = find(token)
+  return cmd ? { cmd, args } : null
+}
+
+/** Run a slash command. Returns true if `raw` was a slash attempt
+ *  (handled or reported as unknown — caller must NOT fall through to
+ *  send_message), false if it was ordinary chat input. */
+export async function run_slash(raw: string, ctx: SlashCtx): Promise<boolean> {
+  const s = raw.trimStart()
+  if (!s.startsWith('/')) return false
+  const m = match_slash(raw)
+  if (!m) {
+    ctx.emit(`Unknown command. Type /help to see available commands.`)
+    return true
+  }
+  try {
+    await m.run({ ...ctx, args: m.args })
+  } catch (e) {
+    ctx.emit(`Command /${m.cmd.name} failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+  return true
+}
+
+SLASH_COMMANDS.push({
+  name: 'help',
+  hint: '',
+  summary: 'List all slash commands',
+  run(ctx) {
+    const lines = SLASH_COMMANDS
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(c => `**/${c.name}**${c.hint ? ' ' + c.hint : ''} — ${c.summary}`)
+    ctx.emit(`**CatBot slash commands**\n\n${lines.join('\n')}`)
+  },
+})
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts`
+Expected: PASS (the alias/quickbuild tests for `/co2rr` will fail until Task 4 — comment them out is NOT allowed; instead this task's test file only includes the assertions shown in Step 1, and `/co2rr` alias test is part of Step 1 but `co2rr` is registered in Task 4. To keep Task 1 green, the `resolves aliases` test uses `/help` which has no alias → change that test now:)
+
+Edit `tests/vitest/chat/slash-commands.test.ts` `resolves aliases` test:
+```ts
+  it('first token resolves to the help command', () => {
+    const m = match_slash('/HELP')
+    expect(m?.cmd.name).toBe('help')
+  })
+```
+Also remove the `/OER` and `/co2rr` cases from Step 1's `match_slash` block (they belong to Task 4); keep only non-slash, `/new`-style (use `/help`), unknown, trim cases:
+```ts
+  it('matches command name case-insensitively with args', () => {
+    const m = match_slash('/HELP extra args')
+    expect(m?.cmd.name).toBe('help')
+    expect(m?.args).toBe('extra args')
+  })
+```
+Re-run. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat/slash-commands.ts tests/vitest/chat/slash-commands.test.ts
+git commit -m "feat(catbot): slash-command registry core + match/run + /help"
+```
+
+---
+
+### Task 2: Session-control commands `/new` `/clear` `/stop`
+
+**Files:**
+- Modify: `src/lib/chat/slash-commands.ts` (append to `SLASH_COMMANDS`)
+- Test: `tests/vitest/chat/slash-commands.test.ts` (add cases)
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+describe('session commands', () => {
+  it('/new calls new_session', async () => {
+    const c = ctx(); await run_slash('/new', c as any)
+    expect(c.new_session).toHaveBeenCalledTimes(1)
+  })
+  it('/clear calls clear_chat_history', async () => {
+    const c = ctx(); await run_slash('/clear', c as any)
+    expect(c.clear_chat_history).toHaveBeenCalledTimes(1)
+  })
+  it('/stop calls cancel_generation', async () => {
+    const c = ctx(); await run_slash('/stop', c as any)
+    expect(c.cancel_generation).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts -t "session commands"`
+Expected: FAIL — `/new` unmatched → emit called, `new_session` not called.
+
+- [ ] **Step 3: Register the three commands**
+
+Append to `src/lib/chat/slash-commands.ts` (after the `help` push):
+
+```ts
+SLASH_COMMANDS.push(
+  {
+    name: 'new', hint: '', summary: 'Start a fresh chat session',
+    run(ctx) { ctx.new_session() },
+  },
+  {
+    name: 'clear', hint: '', summary: 'Clear messages, keep the session',
+    run(ctx) { ctx.clear_chat_history() },
+  },
+  {
+    name: 'stop', hint: '', summary: 'Stop the current streaming reply',
+    run(ctx) { ctx.cancel_generation() },
+  },
+)
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat/slash-commands.ts tests/vitest/chat/slash-commands.test.ts
+git commit -m "feat(catbot): /new /clear /stop slash commands"
+```
+
+---
+
+### Task 3: `/resume` with readable session list
+
+**Files:**
+- Modify: `src/lib/chat/slash-commands.ts`
+- Test: `tests/vitest/chat/slash-commands.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+describe('/resume', () => {
+  const sessions = [
+    { session_id: 'sB', agent: 'claude', topic: 'OER on RuO2', created_at: 1, last_active: 200, message_count: 4 },
+    { session_id: 'sA', agent: 'claude', topic: '', created_at: 1, last_active: 100, message_count: 2 },
+  ]
+  it('no args lists sessions newest-first with topic + snippet, never raw id alone', async () => {
+    const c = ctx({
+      list_sessions: vi.fn(() => sessions),
+      load_session_messages: vi.fn((id: string) =>
+        id === 'sB' ? [{ role: 'user', content: 'hi', timestamp: 1 },
+                        { role: 'assistant', content: 'Here is the OER workflow summary text', timestamp: 2 }]
+                     : [{ role: 'user', content: 'plain question about slab', timestamp: 1 }]),
+    })
+    await run_slash('/resume', c as any)
+    const out = (c.emit as any).mock.calls[0][0] as string
+    expect(out.indexOf('1.')).toBeLessThan(out.indexOf('2.')) // newest (sB) first
+    expect(out).toContain('OER on RuO2')                       // topic shown
+    expect(out).toContain('Here is the OER workflow')          // last-message snippet
+    expect(out).toContain('plain question about slab')         // fallback snippet when topic empty
+    expect(c.resume_session).not.toHaveBeenCalled()
+  })
+  it('numeric arg resumes the nth listed session', async () => {
+    const c = ctx({
+      list_sessions: vi.fn(() => sessions),
+      load_session_messages: vi.fn(() => [{ role: 'user', content: 'x', timestamp: 1 }]),
+    })
+    await run_slash('/resume 1', c as any)
+    expect(c.resume_session).toHaveBeenCalledWith('claude', 'sB',
+      [{ role: 'user', content: 'x', timestamp: 1 }], 'default')
+  })
+  it('out-of-range index emits a usage note, does not throw or resume', async () => {
+    const c = ctx({ list_sessions: vi.fn(() => sessions) })
+    await run_slash('/resume 9', c as any)
+    expect(c.resume_session).not.toHaveBeenCalled()
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('1–2'))
+  })
+  it('empty session list emits a note', async () => {
+    const c = ctx({ list_sessions: vi.fn(() => []) })
+    await run_slash('/resume', c as any)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('No past sessions'))
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts -t "/resume"`
+Expected: FAIL — `/resume` unmatched.
+
+- [ ] **Step 3: Implement `/resume`**
+
+Append to `src/lib/chat/slash-commands.ts`:
+
+```ts
+function rel_time(ms: number): string {
+  const d = Date.now() - ms
+  const m = Math.round(d / 60000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.round(h / 24)}d ago`
+}
+
+function snippet(ctx: SlashCtx, s: SessionSummary): string {
+  const msgs = ctx.load_session_messages(s.session_id)
+  const last = msgs.length ? msgs[msgs.length - 1].content : ''
+  const text = (s.topic && s.topic.trim()) || last || '(empty)'
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat.length > 60 ? flat.slice(0, 60) + '…' : flat
+}
+
+SLASH_COMMANDS.push({
+  name: 'resume',
+  hint: '[n]',
+  summary: 'List recent sessions, or resume the nth',
+  run(ctx) {
+    const sorted = ctx.list_sessions().slice().sort((a, b) => b.last_active - a.last_active)
+    if (sorted.length === 0) { ctx.emit('No past sessions found.'); return }
+    if (ctx.args.trim() === '') {
+      const lines = sorted.map((s, i) =>
+        `${i + 1}. ${snippet(ctx, s)} · ${rel_time(s.last_active)}`)
+      ctx.emit(`**Recent sessions** — /resume <n> to open one\n\n${lines.join('\n')}`)
+      return
+    }
+    const n = Number.parseInt(ctx.args.trim(), 10)
+    if (!Number.isInteger(n) || n < 1 || n > sorted.length) {
+      ctx.emit(`/resume expects a number 1–${sorted.length}.`)
+      return
+    }
+    const s = sorted[n - 1]
+    const msgs = ctx.load_session_messages(s.session_id)
+    ctx.resume_session(s.agent, s.session_id, msgs.length ? msgs : undefined, ctx.tab_id)
+  },
+})
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat/slash-commands.ts tests/vitest/chat/slash-commands.test.ts
+git commit -m "feat(catbot): /resume with topic+snippet session list"
+```
+
+---
+
+### Task 4: Quickbuild commands `/oer` `/her` `/co2rr` `/nrr`
+
+**Files:**
+- Modify: `src/lib/chat/slash-commands.ts`
+- Test: `tests/vitest/chat/slash-commands.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+describe('quickbuild commands', () => {
+  it('/oer with no args calls run_quickbuild("oer", undefined)', async () => {
+    const c = ctx(); await run_slash('/oer', c as any)
+    expect(c.run_quickbuild).toHaveBeenCalledWith('oer', undefined)
+  })
+  it('/her mp-1019 passes the mp id', async () => {
+    const c = ctx(); await run_slash('/her mp-1019', c as any)
+    expect(c.run_quickbuild).toHaveBeenCalledWith('her', 'mp-1019')
+  })
+  it('/co2rr and /nrr are registered', async () => {
+    const c1 = ctx(); await run_slash('/co2rr', c1 as any)
+    expect(c1.run_quickbuild).toHaveBeenCalledWith('co2rr', undefined)
+    const c2 = ctx(); await run_slash('/nrr', c2 as any)
+    expect(c2.run_quickbuild).toHaveBeenCalledWith('nrr', undefined)
+  })
+  it('rejects a malformed mp id with a usage note, no quickbuild call', async () => {
+    const c = ctx(); await run_slash('/oer notanid', c as any)
+    expect(c.run_quickbuild).not.toHaveBeenCalled()
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('mp-'))
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts -t "quickbuild commands"`
+Expected: FAIL — commands unmatched.
+
+- [ ] **Step 3: Implement (one parameterised factory — no per-recipe copies)**
+
+Append to `src/lib/chat/slash-commands.ts`:
+
+```ts
+const RECIPES: { name: string; label: string }[] = [
+  { name: 'oer', label: 'OER' },
+  { name: 'her', label: 'HER' },
+  { name: 'co2rr', label: 'CO2RR' },
+  { name: 'nrr', label: 'NRR' },
+]
+
+for (const r of RECIPES) {
+  SLASH_COMMANDS.push({
+    name: r.name,
+    hint: '[mp-id]',
+    summary: `Quick-build a ${r.label} workflow (optional Materials Project id)`,
+    async run(ctx) {
+      const a = ctx.args.trim()
+      if (a !== '' && !/^mp-\d+$/i.test(a)) {
+        ctx.emit(`Usage: /${r.name} [mp-id] — e.g. /${r.name} mp-1019. Omit the id to use the current structure.`)
+        return
+      }
+      await ctx.run_quickbuild(r.name, a === '' ? undefined : a)
+    },
+  })
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat/slash-commands.ts tests/vitest/chat/slash-commands.test.ts
+git commit -m "feat(catbot): /oer /her /co2rr /nrr quickbuild slash commands"
+```
+
+---
+
+### Task 5: `/structure` and `/skip-permission` registry behavior
+
+**Files:**
+- Modify: `src/lib/chat/slash-commands.ts`
+- Test: `tests/vitest/chat/slash-commands.test.ts`
+
+(Threading `skip_permission` into the stream chain is Task 7. This task only registers the command + its registry-level state calls.)
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+describe('/structure', () => {
+  it('calls inject_structure', async () => {
+    const c = ctx(); await run_slash('/structure', c as any)
+    expect(c.inject_structure).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('/skip-permission', () => {
+  it('no arg reports current state', async () => {
+    const c = ctx({ get_skip_permission: vi.fn(() => false) })
+    await run_slash('/skip-permission', c as any)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('OFF'))
+    expect(c.set_skip_permission).not.toHaveBeenCalled()
+  })
+  it('on sets true and emits a security warning', async () => {
+    const c = ctx(); await run_slash('/skip-permission on', c as any)
+    expect(c.set_skip_permission).toHaveBeenCalledWith(true)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('⚠️'))
+  })
+  it('off sets false', async () => {
+    const c = ctx(); await run_slash('/skip-permission off', c as any)
+    expect(c.set_skip_permission).toHaveBeenCalledWith(false)
+  })
+  it('garbage arg emits usage, does not change state', async () => {
+    const c = ctx(); await run_slash('/skip-permission maybe', c as any)
+    expect(c.set_skip_permission).not.toHaveBeenCalled()
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('on'))
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts -t "/structure"`
+Expected: FAIL — unmatched.
+
+- [ ] **Step 3: Implement**
+
+Append to `src/lib/chat/slash-commands.ts`:
+
+```ts
+SLASH_COMMANDS.push({
+  name: 'structure',
+  hint: '',
+  summary: 'Put the current structure into the Structure Input node',
+  async run(ctx) { await ctx.inject_structure() },
+})
+
+SLASH_COMMANDS.push({
+  name: 'skip-permission',
+  hint: '[on|off]',
+  summary: 'Toggle the per-session tool-approval gate',
+  run(ctx) {
+    const a = ctx.args.trim().toLowerCase()
+    if (a === '') {
+      ctx.emit(`skip-permission is ${ctx.get_skip_permission() ? 'ON' : 'OFF'}. Use /skip-permission on|off.`)
+      return
+    }
+    if (a === 'on') {
+      ctx.set_skip_permission(true)
+      ctx.emit(`⚠️ Permission prompts disabled for this session — Bash and file tools will run without asking. /skip-permission off to re-enable.`)
+      return
+    }
+    if (a === 'off') {
+      ctx.set_skip_permission(false)
+      ctx.emit(`skip-permission OFF — tool calls will ask for approval again.`)
+      return
+    }
+    ctx.emit(`Usage: /skip-permission on|off`)
+  },
+})
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `pnpm vitest run tests/vitest/chat/slash-commands.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat/slash-commands.ts tests/vitest/chat/slash-commands.test.ts
+git commit -m "feat(catbot): /structure + /skip-permission registry behavior"
+```
+
+---
+
+### Task 6: `skip_permission` slice state + reset on `/new`
+
+**Files:**
+- Modify: `src/lib/chat/chat-state.svelte.ts` (ChatSlice interface ~line 168, `make_chat_slice` ~174-206, `new_session` ~795)
+- Test: `tests/vitest/chat/chat-state-skip.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// tests/vitest/chat/chat-state-skip.test.ts
+import { describe, it, expect } from 'vitest'
+import { get_chat_slice, new_session } from '$lib/chat/chat-state.svelte'
+
+describe('skip_permission slice state', () => {
+  it('defaults false and is reset by new_session', () => {
+    const s = get_chat_slice('t-skip')
+    expect(s.skip_permission.value).toBe(false)
+    s.skip_permission.value = true
+    expect(get_chat_slice('t-skip').skip_permission.value).toBe(true)
+    new_session(undefined, 't-skip')
+    expect(get_chat_slice('t-skip').skip_permission.value).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm vitest run tests/vitest/chat/chat-state-skip.test.ts`
+Expected: FAIL — `skip_permission` does not exist on slice.
+
+- [ ] **Step 3: Add to ChatSlice interface**
+
+In `src/lib/chat/chat-state.svelte.ts`, in the `ChatSlice` interface (next to `pending_send` ~line 168) add:
+
+```ts
+  // Session-scoped tool-approval bypass (NOT persisted — a fresh session
+  // always re-gates). Read at send time, threaded into the Claude adapter.
+  skip_permission: { value: boolean }
+```
+
+In `make_chat_slice()` (~line 192, beside the `pending_send` $state) add:
+
+```ts
+  const skip_permission = $state({ value: false })
+```
+
+In the returned object (~line 205, beside `pending_send,`) add `skip_permission,`.
+
+- [ ] **Step 4: Reset on new_session**
+
+In `new_session()` (~line 795), after the existing `slice.messages.list = []` / error reset lines, add:
+
+```ts
+  slice.skip_permission.value = false
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+Run: `pnpm vitest run tests/vitest/chat/chat-state-skip.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/chat/chat-state.svelte.ts tests/vitest/chat/chat-state-skip.test.ts
+git commit -m "feat(catbot): per-session skip_permission slice state"
+```
+
+---
+
+### Task 7: Thread `skipPermissions` through the stream chain into `canUseTool`
+
+**Files:**
+- Modify: `src/lib/chat/chat-state.svelte.ts` (the `send_message` agent-stream call — locate where it passes `tabId` to the stream params)
+- Modify: `src/lib/chat/sdk-stream.ts:42` (StreamParams type), `:55` (destructure), `:60` (fetch body)
+- Modify: `src/lib/server/agent-bridge/server.ts:97` (destructure), `:142-144` (pass to adapter)
+- Modify: `src/lib/server/agent-bridge/types.ts` (StreamParams interface — add beside `tabId`)
+- Modify: `src/lib/server/agent-bridge/adapters/claude.ts:170-180` (destructure params), `:212-214` (canUseTool gate)
+
+**Pattern:** `skipPermissions?: boolean` is threaded EXACTLY parallel to the existing `tabId` — at every site where `tabId` appears in these files, add `skipPermissions` the same way.
+
+- [ ] **Step 1: types.ts — add field**
+
+In `src/lib/server/agent-bridge/types.ts`, in the `StreamParams` interface, directly below the `tabId?: string` field (and its doc comment) add:
+
+```ts
+  /**
+   * When true, the Claude adapter's canUseTool auto-allows ALL tools
+   * (not just CatGo MCP) without showing the PermissionCard, for this
+   * stream only. Set per-stream from the chat slice's session-scoped
+   * skip_permission flag; never persisted.
+   */
+  skipPermissions?: boolean
+```
+
+- [ ] **Step 2: claude.ts — destructure + enforce**
+
+In `src/lib/server/agent-bridge/adapters/claude.ts`, the `stream(params)` destructure block (currently `const { prompt, sessionId, model, systemPrompt, cwd, mcpServerUrl, permissionCallback, abortSignal, tabId } = params`) — add `skipPermissions` to it:
+
+```ts
+      const {
+        prompt, sessionId, model, systemPrompt, cwd, mcpServerUrl,
+        permissionCallback, abortSignal, tabId, skipPermissions,
+      } = params
+```
+
+In `canUseTool`, immediately after the existing CatGo auto-allow block:
+
+```ts
+        if (toolName.startsWith('mcp__catgo__') || toolName.startsWith('catgo_')) {
+          return { behavior: 'allow' }
+        }
+        // Session-scoped user opt-out of the approval gate (/skip-permission).
+        // Captured per-stream so a mid-stream toggle can't retroactively
+        // affect an in-flight round.
+        if (skipPermissions) {
+          return { behavior: 'allow' }
+        }
+```
+
+- [ ] **Step 3: server.ts — accept + forward**
+
+In `src/lib/server/agent-bridge/server.ts:97`, add `skipPermissions` to the body destructure:
+
+```ts
+  const { agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId, skipPermissions } = body
+```
+
+At `:142-144` where the adapter `StreamParams` object is built (where `tabId,` is passed), add `skipPermissions,` beside it.
+
+- [ ] **Step 4: sdk-stream.ts — type + send**
+
+In `src/lib/chat/sdk-stream.ts:42` (StreamParams-like type with `tabId?: string`) add `skipPermissions?: boolean`.
+At `:55` destructure add `skipPermissions`.
+At `:60` the fetch body — add `skipPermissions` to the `JSON.stringify({ ... })`:
+
+```ts
+    body: JSON.stringify({ agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId, skipPermissions }),
+```
+
+- [ ] **Step 5: chat-state.svelte.ts — pass slice flag at send time**
+
+In `src/lib/chat/chat-state.svelte.ts`, in `send_message`, find the agent-stream call site that already passes `tabId` (the SDK Agent path). Add `skipPermissions: slice.skip_permission.value` to that params object, beside `tabId`.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm check 2>&1 | grep -E 'svelte-check found|adapters/claude|sdk-stream|agent-bridge/server|agent-bridge/types|chat-state'`
+Expected: `svelte-check found 0 errors` (292 pre-existing warnings unchanged); no errors in the listed files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/chat/chat-state.svelte.ts src/lib/chat/sdk-stream.ts src/lib/server/agent-bridge/types.ts src/lib/server/agent-bridge/server.ts src/lib/server/agent-bridge/adapters/claude.ts
+git commit -m "feat(catbot): thread session skipPermissions into canUseTool"
+```
+
+---
+
+### Task 8: ChatPane dispatch + skip banner
+
+**Files:**
+- Modify: `src/lib/chat/ChatPane.svelte` — imports, `handle_send` (~622-665), `input-hint-row` (~1397)
+
+- [ ] **Step 1: Import registry + state exports**
+
+At the ChatPane `<script>` import block (where `load_session_messages`, `new_session`, `clear_chat_history`, `cancel_generation`, `resume_session`, `session_list` are already imported from `./chat-state.svelte`), add `run_slash` and a local emit helper. Add import:
+
+```ts
+  import { run_slash } from './slash-commands'
+  import { get_current_structure } from '$lib/structure/current-structure.svelte'
+```
+
+- [ ] **Step 2: Build ctx + intercept in handle_send**
+
+In `handle_send`, immediately after `active_tab = `chat`` and BEFORE the `const doi_match = ...` line, insert:
+
+```ts
+    // Slash commands: intercept before DOI / send_message. A "/"-prefixed
+    // line never reaches the LLM. Unknown "/x" is reported locally.
+    if (msg.startsWith(`/`)) {
+      const emit_note = (text: string) => {
+        slice.messages.list = [...slice.messages.list,
+          { role: `assistant`, content: text, timestamp: Date.now() }]
+      }
+      const handled = await run_slash(msg, {
+        tab_id: tab_slice_id,
+        args: ``,
+        new_session: () => new_session(SDK_PROVIDERS.has(chat_config.provider) ? chat_config.provider.replace(`sdk-`, ``) : undefined, tab_slice_id),
+        clear_chat_history: () => clear_chat_history(tab_slice_id),
+        cancel_generation: () => cancel_generation(tab_slice_id),
+        resume_session: (agent, sid, messages, tid) => resume_session(agent, sid, messages, tid ?? tab_slice_id),
+        list_sessions: () => session_list.list,
+        load_session_messages: (sid) => load_session_messages(sid),
+        run_quickbuild: async (recipe, mp_id) => {
+          const resp = await fetch(`${API_BASE}/workflow/quickbuild`, {
+            method: `POST`, headers: { 'Content-Type': `application/json` },
+            body: JSON.stringify(mp_id ? { recipe, material_id: mp_id } : { recipe }),
+          })
+          if (!resp.ok) throw new Error((await resp.text().catch(() => String(resp.status))).slice(0, 200))
+          const data = await resp.json()
+          const wf_id = data.workflow_id
+          if (wf_id) {
+            const wf_state = await import(`$lib/workflow/workflow-state.svelte`)
+            const wfslice = wf_state.get_workflow_slice(tab_slice_id)
+            wfslice.pending_navigate_workflow.id = wf_id
+            wfslice.workflow_reload_seq.seq++
+          }
+          emit_note(`✅ ${recipe.toUpperCase()} workflow built${mp_id ? ` for ${mp_id}` : ``}.`)
+        },
+        inject_structure: async () => {
+          const cur = get_current_structure()
+          if (!cur) { emit_note(`No structure loaded — open one in a structure viewer first.`); return }
+          const wf_state = await import(`$lib/workflow/workflow-state.svelte`)
+          const wfslice = wf_state.get_workflow_slice(tab_slice_id)
+          wfslice.workflow_reload_seq.seq++
+          emit_note(`Structure pushed — open the Workflow editor; the Structure Input node will pick it up.`)
+        },
+        set_skip_permission: (on) => { slice.skip_permission.value = on },
+        get_skip_permission: () => slice.skip_permission.value,
+        emit: emit_note,
+      })
+      if (handled) return
+    }
+```
+
+(Note: `API_BASE`, `SDK_PROVIDERS`, `chat_config` are already imported/in-scope in ChatPane — verify with `grep -n 'API_BASE\|SDK_PROVIDERS\|chat_config' src/lib/chat/ChatPane.svelte | head`. If `API_BASE` is not imported, add `import { API_BASE } from '$lib/api/config'`.)
+
+- [ ] **Step 3: Skip-permission banner in input-hint-row**
+
+In `src/lib/chat/ChatPane.svelte` `input-hint-row` (~line 1397), as the FIRST child branch (before the `slice.pending_send` check):
+
+```svelte
+        {#if slice.skip_permission.value}
+          <span class="input-hint skip-warn">⚠️ skip-permission ON — tools run without asking</span>
+        {:else if slice.pending_send?.value}
+```
+
+(Change the existing `{#if slice.pending_send?.value}` to `{:else if slice.pending_send?.value}` so it chains.)
+
+Add to ChatPane `<style>`:
+
+```css
+  .input-hint.skip-warn {
+    color: var(--error-color);
+    font-weight: 600;
+  }
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm check 2>&1 | grep -E 'svelte-check found|ChatPane'`
+Expected: `svelte-check found 0 errors`; no error in ChatPane.svelte.
+
+- [ ] **Step 5: Manual smoke (documented, not automated)**
+
+Hard-reload browser. In CatBot type `/help` → local list appears, nothing sent to LLM. `/new` → fresh session. `/oer mp-1019` → workflow builds, editor opens. `/skip-permission on` → red banner appears in input row; `/new` → banner gone. Type `hello` → normal LLM message (regression).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/chat/ChatPane.svelte
+git commit -m "feat(catbot): wire slash-command dispatch + skip-permission banner"
+```
+
+---
+
+### Task 9: Autocomplete dropdown + keyboard interception
+
+**Files:**
+- Modify: `src/lib/chat/ChatPane.svelte` — script state, textarea `onkeydown`, dropdown markup above `.input-wrapper` (~line 1312), `<style>`
+
+- [ ] **Step 1: Add filter state (script)**
+
+In ChatPane `<script>`, add:
+
+```ts
+  import { SLASH_COMMANDS } from './slash-commands'
+
+  let slash_idx = $state(0)
+  const slash_filtered = $derived.by(() => {
+    const s = input_text
+    if (!s.startsWith(`/`) || /\s/.test(s)) return []
+    const tok = s.slice(1).toLowerCase()
+    return SLASH_COMMANDS
+      .filter(c => c.name.startsWith(tok) || c.aliases?.some(a => a.startsWith(tok)))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  })
+  const slash_open = $derived(slash_filtered.length > 0)
+  $effect(() => { if (slash_idx >= slash_filtered.length) slash_idx = 0 })
+
+  function apply_slash_selection() {
+    const c = slash_filtered[slash_idx]
+    if (!c) return
+    input_text = `/${c.name} `
+    slash_idx = 0
+    textarea_el?.focus()
+  }
+```
+
+- [ ] **Step 2: Intercept keys in handle_keydown**
+
+Replace the body of `handle_keydown` (~667) with:
+
+```ts
+  function handle_keydown(event: KeyboardEvent) {
+    if (slash_open) {
+      if (event.key === `ArrowDown`) {
+        event.preventDefault()
+        slash_idx = (slash_idx + 1) % slash_filtered.length
+        return
+      }
+      if (event.key === `ArrowUp`) {
+        event.preventDefault()
+        slash_idx = (slash_idx - 1 + slash_filtered.length) % slash_filtered.length
+        return
+      }
+      if (event.key === `Tab` || (event.key === `Enter` && !event.shiftKey)) {
+        event.preventDefault()
+        apply_slash_selection()
+        return
+      }
+      if (event.key === `Escape`) {
+        event.preventDefault()
+        input_text = input_text + ` ` // typing a space closes the menu (args phase) without clearing
+        return
+      }
+    }
+    if (event.key === `Enter` && !event.shiftKey) {
+      event.preventDefault()
+      handle_send()
+    }
+  }
+```
+
+- [ ] **Step 3: Dropdown markup**
+
+Immediately BEFORE `<div class="input-wrapper" class:focused={false}>` (~line 1312) add:
+
+```svelte
+      {#if slash_open}
+        <div class="slash-menu" role="listbox">
+          {#each slash_filtered as c, i (c.name)}
+            <button
+              type="button"
+              class="slash-row"
+              class:sel={i === slash_idx}
+              role="option"
+              aria-selected={i === slash_idx}
+              onmousedown={(e) => { e.preventDefault(); slash_idx = i; apply_slash_selection() }}
+            >
+              <span class="slash-name">/{c.name}{c.hint ? ` ${c.hint}` : ``}</span>
+              <span class="slash-summary">{c.summary}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+```
+
+- [ ] **Step 4: Styles (theme vars only — no hardcoded palette)**
+
+Add to ChatPane `<style>`:
+
+```css
+  .slash-menu {
+    display: flex;
+    flex-direction: column;
+    max-height: 240px;
+    overflow-y: auto;
+    margin: 0 0 4px 0;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--surface-bg, var(--pane-card-bg));
+  }
+  .slash-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1px;
+    padding: 5px 9px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+  }
+  .slash-row:last-child { border-bottom: none; }
+  .slash-row.sel,
+  .slash-row:hover {
+    background: color-mix(in srgb, var(--accent-color) 16%, transparent);
+  }
+  .slash-name {
+    font-family: monospace;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-color);
+  }
+  .slash-summary {
+    font-size: 11px;
+    color: var(--text-color-muted);
+  }
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm check 2>&1 | grep -E 'svelte-check found|ChatPane'`
+Expected: `svelte-check found 0 errors`; no error in ChatPane.svelte.
+
+- [ ] **Step 6: Manual smoke**
+
+Hard-reload. Type `/` → menu lists all commands. Type `/o` → filters to `/oer`. `↓`/`↑` move highlight. `Tab` fills `/oer ` (no send, focus kept). `Enter` on highlighted = same. Type a space → menu closes (args phase). With menu closed, `Enter` sends normally (regression). `Esc` with menu open closes it without clearing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/chat/ChatPane.svelte
+git commit -m "feat(catbot): slash-command autocomplete dropdown + keyboard nav"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Architecture / registry / dispatch → Task 1, Task 8 ✓
+- Command set (/new /clear /stop) → Task 2 ✓; /resume preview → Task 3 ✓; quickbuild → Task 4 ✓; /structure + /skip-permission registry → Task 5 ✓; /help → Task 1 ✓
+- Security /skip-permission state + enforcement + banner → Tasks 6, 7, 8 ✓
+- Autocomplete → Task 9 ✓
+- Error handling (unknown cmd, bad args, run throws, queue-while-streaming) → Task 1 (`run_slash` try/catch + unknown emit), Tasks 3/4/5 (usage notes) ✓. Note: queue-while-streaming reuses existing `pending_send`; slash commands run synchronously in `handle_send` before that path, so a slash command typed mid-stream executes immediately (e.g. `/stop` works) — consistent with spec intent; no extra code needed.
+- Testing → unit tests Tasks 1-5, slice test Task 6, typecheck Tasks 7-9, documented manual smoke Tasks 8-9 ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has full code. Task 1 Step 4 explicitly reconciles the test split (alias/quickbuild cases moved to Task 4) so Task 1 stays green standalone.
+
+**Type consistency:** `SlashCtx`/`SlashCommand`/`SLASH_COMMANDS`/`match_slash`/`run_slash` defined Task 1, used unchanged Tasks 2-9. `skip_permission.value` (slice) Task 6 ↔ `get/set_skip_permission` ctx Task 5 ↔ `skipPermissions` stream field Task 7 — names consistent across layers. `run_quickbuild(recipe, mp_id?)` signature consistent Task 4 ↔ Task 8 impl. `get_current_structure` matches the existing `src/lib/structure/current-structure.svelte.ts` export from prior session work.
+
+No gaps found.

--- a/docs/superpowers/specs/2026-05-17-catbot-slash-commands-design.md
+++ b/docs/superpowers/specs/2026-05-17-catbot-slash-commands-design.md
@@ -1,0 +1,203 @@
+# CatBot Slash Commands — Design
+
+Date: 2026-05-17
+Status: Approved (brainstorming), pending implementation plan
+
+## Problem
+
+CatBot (the in-app chat in `ChatPane.svelte`, talking to the Claude Agent
+SDK via agent-bridge) has no slash-command system. High-frequency
+deterministic operations — start a new session, clear history, stop
+generation, resume a past session, quick-build an OER/HER/CO2RR/NRR
+workflow, inject the current structure — currently require natural
+language → LLM round-trip: slow, token-costly, non-deterministic.
+
+Claude Code's own slash commands **cannot be inherited**. Verified
+against `@anthropic-ai/claude-agent-sdk@0.2.87`: the adapter
+(`src/lib/server/agent-bridge/adapters/claude.ts`) intentionally runs
+`settingSources: []` (isolation mode) so `~/.claude/mcp.json` and other
+global settings are not loaded. Enabling `settingSources:['project']` is
+a coarse bundle (would also load global MCP servers + settings the
+adapter deliberately avoids), and even then `.claude/commands/*.md` are
+LLM prompt macros (token cost, LLM round-trip); built-in `/clear` etc.
+are CLI-REPL-only and no-op via `query()`. `query().supportedCommands()`
+exists for enumeration but requires the same non-empty `settingSources`.
+Conclusion: the fast/zero-token deterministic layer must be a CatGo
+client-side implementation.
+
+## Goals
+
+- Deterministic, zero-LLM-token, instant client-side slash commands in
+  CatBot.
+- Single source of truth so command list, `/help`, parsing, and
+  autocomplete never drift (this session repeatedly fixed
+  duplicated-and-drifted logic — structure_input 4 copies, reload-seq
+  inline; the registry is the explicit countermeasure).
+- Reuse existing chat-state exports, MCP recipes, and the durable
+  current-structure store added earlier this session. No new backend.
+
+## Non-Goals (YAGNI)
+
+- LLM prompt-template commands (`/explain`, `/review-workflow`).
+- User-defined / persisted custom commands.
+- Inheriting Claude Code built-in or `.claude/commands/*.md` commands.
+
+## Architecture
+
+New module `src/lib/chat/slash-commands.ts` — one registry, one
+entrypoint, no UI imports (testable in isolation).
+
+```ts
+interface SlashCtx {
+  tab_id: string
+  args: string                 // raw text after the command word
+  // injected accessors (no direct UI/store imports in the registry):
+  new_session(): void
+  clear_chat_history(): void
+  cancel_generation(): void
+  resume_session(agent: string, session_id: string, messages?, tab_id?): void
+  list_sessions(): SessionSummary[]
+  load_session_messages(session_id: string): ChatMessage[]
+  run_quickbuild(recipe: string, mp_id?: string): Promise<void>
+  inject_structure(): Promise<void>
+  set_skip_permission(on: boolean): void
+  get_skip_permission(): boolean
+  emit(msg: string): void      // push a local assistant-style note (no LLM, not persisted)
+}
+
+interface SlashCommand {
+  name: string                 // "oer"
+  aliases?: string[]
+  hint: string                 // "[mp-id]" — for /help + autocomplete
+  summary: string
+  run(ctx: SlashCtx): Promise<void> | void
+}
+
+export const SLASH_COMMANDS: SlashCommand[]
+export function match_slash(raw: string): { cmd: SlashCommand; args: string } | null
+export async function run_slash(raw: string, ctx: SlashCtx): Promise<boolean> // false = not a command
+```
+
+### Dispatch
+
+In `ChatPane.handle_send`, **before** the DOI branch and `send_message`:
+
+```
+trimmed msg
+ └─ starts "/" ? ──no──> existing DOI / send_message path (byte-identical, unchanged)
+     └─ match_slash ──no match──> ctx.emit("unknown command, try /help") ; return
+         └─ run_slash(ctx) ; clear input ; return  (never reaches send_message)
+```
+
+Single interception point. `/` with no match → local error note, never
+sent to the LLM. The non-`/` path is unchanged.
+
+## Command Set (first version)
+
+| Command | Args | Behavior |
+|---|---|---|
+| `/new` | — | `new_session()` — fresh session, clears current tab |
+| `/clear` | — | `clear_chat_history()` — clears messages, keeps session |
+| `/stop` | — | `cancel_generation()` — stops streaming |
+| `/resume` | none → list; `<n>` → pick nth | none: list recent sessions, **each line = topic + last-message snippet (~60 chars) + relative time**, numbered; never raw IDs. `/resume 2` resumes the 2nd (reuses the localStorage message persistence added earlier this session) |
+| `/oer` `/her` `/co2rr` `/nrr` | optional `mp-xxxx` | `run_quickbuild(recipe, mp_id?)` → `catgo_quickbuild` MCP. No mp-id → use the durable current-structure store. All four share one parameterised `run` (no per-recipe copies) |
+| `/structure` | — | `inject_structure()` — fill the durable store structure into the current/selected Structure Input node; no structure → local note |
+| `/skip-permission` | `on` / `off` / none=show state | session-scoped toggle (see Security) |
+| `/help` | — | auto-generated from `SLASH_COMMANDS`, rendered locally, not sent to LLM |
+
+- Case-insensitive, whitespace-tolerant.
+- `/resume` list and `/help` use `ctx.emit()` (local assistant note —
+  not LLM, not persisted to session storage).
+- All commands reuse existing exports/MCP/store. No new backend.
+
+## Security — /skip-permission
+
+This disables the human approval gate for all non-CatGo tool calls
+(Bash, SDK file writes, AskUserQuestion) for the rest of the chat
+session. User explicitly chose session-wide scope, all non-CatGo tools.
+Constraints to contain the risk:
+
+- **State**: session-scoped reactive flag in `chat-state.svelte.ts` per
+  `tab_id` — `slice.skip_permission.value` (`$state`, default `false`).
+  **Not** persisted to localStorage — never survives reload or new
+  session; a fresh session always re-gates.
+- **Enforcement**: in `agent-bridge/adapters/claude.ts` `canUseTool`,
+  after the existing CatGo-MCP auto-allow, if the per-stream
+  skip-permission flag is `true`, auto-allow remaining tools
+  (`{behavior:'allow'}`) instead of showing `PermissionCard`. The flag
+  is read at `send_message` time and passed through `StreamParams` (new
+  optional `skipPermissions?: boolean`) into the adapter closure,
+  captured per-stream so a mid-stream toggle does not retroactively
+  affect an in-flight round.
+- **Commands**: `/skip-permission` shows state; `on` sets true and
+  `ctx.emit`s a warning ("⚠️ Permission prompts disabled for this
+  session — Bash and file tools will run without asking. /skip-permission
+  off to re-enable."); `off` sets false.
+- **Visibility (required)**: while true, a persistent banner renders in
+  the ChatPane input area (reuse `input-hint-row`): "⚠️ skip-permission
+  ON". Always visible so the gate-down state cannot be forgotten.
+- `/new` resets the flag (new slice).
+- Off by default, session-only, explicit opt-in, always visible. No
+  global/persisted bypass, no per-tool allowlist file.
+
+## Autocomplete
+
+- **Trigger**: input text starts with `/` AND has no space yet (still
+  typing the command name). A space → args phase, close. Not `/` →
+  close.
+- **Data source**: the same `SLASH_COMMANDS` registry. Prefix match on
+  name + aliases, case-insensitive. No matches → close (no empty box).
+- **Render**: dropdown floating above the input (input is at the
+  bottom). Theme variables only, no hardcoded colors (PermissionCard
+  lesson this session). Each row: `/name` + hint + summary; selected row
+  highlighted.
+- **Keyboard (main integration risk, called out)**: existing
+  `handle_keydown` does Enter = send. When the dropdown is open, these
+  keys must be intercepted **before** the send logic:
+  - `↑`/`↓` move selection, do not send
+  - `Tab` or `Enter` → fill selected `/​<name> ` (trailing space, keep
+    focus, **do not send**)
+  - `Esc` → close dropdown (do not clear input)
+  - other keys type normally, list re-filters live
+  - when the dropdown is closed, `handle_keydown` behaves exactly as
+    now (Enter still sends)
+- Mouse click on a row = same as Tab. After selection, focus stays in
+  the input; the user types args or presses Enter to run.
+- **State**: ChatPane-local `$state` — `slash_open`, `slash_filtered`,
+  `slash_idx`; `$derived` from `input_text`. Component-level, not in
+  chat-state.
+
+## Error Handling
+
+- `/` no match → local note + suggest `/help`. Not sent to LLM.
+- Missing/invalid args (`/resume 99` out of range, `/oer badformat`) →
+  local usage note; no throw, not sent to LLM.
+- `run()` throws (quickbuild MCP failure etc.) → caught, `ctx.emit`s the
+  error text; one command failing never breaks the input box.
+- Command typed while streaming: `/stop` always works; other commands
+  reuse the existing `pending_send` queueing added earlier this session
+  (the command queues and runs when the round ends) — consistent with
+  message behavior.
+
+## Testing
+
+- `slash-commands.ts` is pure functions + injected ctx → vitest unit
+  tests: `match_slash` parsing (case/whitespace/alias/no-match), each
+  command `run` calls the right stub, error paths `emit` without
+  throwing. Repo already has `tests/vitest/`.
+- ChatPane integration: `/` interception never reaches `send_message`;
+  non-`/` path regression unchanged; autocomplete keyboard branch
+  (Enter = select-when-open vs send-when-closed).
+
+## Files (anticipated)
+
+- `src/lib/chat/slash-commands.ts` (new) — registry + match + run.
+- `src/lib/chat/chat-state.svelte.ts` — add `skip_permission` per-slice
+  $state + getter/setter; `/new` resets it via new slice.
+- `src/lib/chat/ChatPane.svelte` — dispatch in `handle_send`,
+  autocomplete state + dropdown markup + keyboard interception, skip
+  banner in `input-hint-row`.
+- `src/lib/chat/sdk-stream.ts` + `agent-bridge/types.ts` +
+  `agent-bridge/server.ts` + `agent-bridge/adapters/claude.ts` — thread
+  `skipPermissions` through `StreamParams` to `canUseTool`.
+- `tests/vitest/` — slash-commands unit tests.

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -665,8 +665,10 @@
             const wfslice = get_workflow_slice(tab_slice_id)
             wfslice.pending_navigate_workflow.id = wf_id
             wfslice.workflow_reload_seq.seq++
+            emit_note(`✅ ${recipe.toUpperCase()} workflow built${mp_id ? ` for ${mp_id}` : ``}.`)
+          } else {
+            emit_note(`⚠️ ${recipe.toUpperCase()} quick-build did not return a workflow. Try again or check the backend.`)
           }
-          emit_note(`✅ ${recipe.toUpperCase()} workflow built${mp_id ? ` for ${mp_id}` : ``}.`)
         },
         inject_structure: async () => {
           const cur = get_current_structure()
@@ -712,6 +714,7 @@
   }
 
   let slash_idx = $state(0)
+  let slash_dismissed = $state(false)
   const slash_filtered = $derived.by(() => {
     const s = input_text
     if (!s.startsWith(`/`) || /\s/.test(s)) return []
@@ -720,19 +723,30 @@
       .filter(c => c.name.startsWith(tok) || c.aliases?.some(a => a.startsWith(tok)))
       .sort((a, b) => a.name.localeCompare(b.name))
   })
-  const slash_open = $derived(slash_filtered.length > 0)
+  const slash_open = $derived(!slash_dismissed && slash_filtered.length > 0)
   // Clamp via $derived (not an $effect that writes slash_idx — that is the
   // self-trigger antipattern this codebase was bitten by). slash_idx is the
   // raw nav cursor; slash_sel is the safe index everything else reads.
   const slash_sel = $derived(
     slash_filtered.length === 0 ? 0 : Math.min(slash_idx, slash_filtered.length - 1)
   )
+  // Reset dismissal when the user keeps typing (input changes).
+  // _slash_last_input is a plain let (not $state) so reading/writing it does
+  // not create reactive deps — only input_text is tracked; no infinite loop.
+  let _slash_last_input = ''
+  $effect(() => {
+    if (input_text !== _slash_last_input) {
+      _slash_last_input = input_text
+      if (slash_dismissed) slash_dismissed = false
+    }
+  })
 
   function apply_slash_selection() {
     const c = slash_filtered[slash_sel]
     if (!c) return
     input_text = `/${c.name} `
     slash_idx = 0
+    slash_dismissed = false
     textarea_el?.focus()
   }
 
@@ -755,7 +769,7 @@
       }
       if (event.key === `Escape`) {
         event.preventDefault()
-        input_text = input_text + ` ` // typing a space closes the menu (args phase) without clearing
+        slash_dismissed = true
         return
       }
     }

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -40,7 +40,7 @@
   } from './message-utils'
   import { get_tool_results_for, is_streaming } from './tool-execution'
   import { copy_to_clipboard, handle_messages_click } from './attachment-utils'
-  import { run_slash } from './slash-commands'
+  import { run_slash, SLASH_COMMANDS } from './slash-commands'
   import { get_current_structure } from '$lib/structure/current-structure.svelte'
 
 
@@ -711,7 +711,54 @@
     await send_message(msg, attachments, tab_slice_id)
   }
 
+  let slash_idx = $state(0)
+  const slash_filtered = $derived.by(() => {
+    const s = input_text
+    if (!s.startsWith(`/`) || /\s/.test(s)) return []
+    const tok = s.slice(1).toLowerCase()
+    return SLASH_COMMANDS
+      .filter(c => c.name.startsWith(tok) || c.aliases?.some(a => a.startsWith(tok)))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  })
+  const slash_open = $derived(slash_filtered.length > 0)
+  // Clamp via $derived (not an $effect that writes slash_idx — that is the
+  // self-trigger antipattern this codebase was bitten by). slash_idx is the
+  // raw nav cursor; slash_sel is the safe index everything else reads.
+  const slash_sel = $derived(
+    slash_filtered.length === 0 ? 0 : Math.min(slash_idx, slash_filtered.length - 1)
+  )
+
+  function apply_slash_selection() {
+    const c = slash_filtered[slash_sel]
+    if (!c) return
+    input_text = `/${c.name} `
+    slash_idx = 0
+    textarea_el?.focus()
+  }
+
   function handle_keydown(event: KeyboardEvent) {
+    if (slash_open) {
+      if (event.key === `ArrowDown`) {
+        event.preventDefault()
+        slash_idx = (slash_sel + 1) % slash_filtered.length
+        return
+      }
+      if (event.key === `ArrowUp`) {
+        event.preventDefault()
+        slash_idx = (slash_sel - 1 + slash_filtered.length) % slash_filtered.length
+        return
+      }
+      if (event.key === `Tab` || (event.key === `Enter` && !event.shiftKey)) {
+        event.preventDefault()
+        apply_slash_selection()
+        return
+      }
+      if (event.key === `Escape`) {
+        event.preventDefault()
+        input_text = input_text + ` ` // typing a space closes the menu (args phase) without clearing
+        return
+      }
+    }
     if (event.key === `Enter` && !event.shiftKey) {
       event.preventDefault()
       handle_send()
@@ -1353,6 +1400,23 @@
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
               </button>
             </div>
+          {/each}
+        </div>
+      {/if}
+      {#if slash_open}
+        <div class="slash-menu" role="listbox">
+          {#each slash_filtered as c, i (c.name)}
+            <button
+              type="button"
+              class="slash-row"
+              class:sel={i === slash_sel}
+              role="option"
+              aria-selected={i === slash_sel}
+              onmousedown={(e) => { e.preventDefault(); slash_idx = i; apply_slash_selection() }}
+            >
+              <span class="slash-name">/{c.name}{c.hint ? ` ${c.hint}` : ``}</span>
+              <span class="slash-summary">{c.summary}</span>
+            </button>
           {/each}
         </div>
       {/if}
@@ -2865,5 +2929,43 @@
     opacity: 1;
     background: color-mix(in srgb, #ef4444 15%, transparent);
     color: #ef4444;
+  }
+  .slash-menu {
+    display: flex;
+    flex-direction: column;
+    max-height: 240px;
+    overflow-y: auto;
+    margin: 0 0 4px 0;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--surface-bg, var(--pane-card-bg));
+  }
+  .slash-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1px;
+    padding: 5px 9px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+  }
+  .slash-row:last-child { border-bottom: none; }
+  .slash-row.sel,
+  .slash-row:hover {
+    background: color-mix(in srgb, var(--accent-color) 16%, transparent);
+  }
+  .slash-name {
+    font-family: monospace;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-color);
+  }
+  .slash-summary {
+    font-size: 11px;
+    color: var(--text-color-muted);
   }
 </style>

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -40,6 +40,8 @@
   } from './message-utils'
   import { get_tool_results_for, is_streaming } from './tool-execution'
   import { copy_to_clipboard, handle_messages_click } from './attachment-utils'
+  import { run_slash } from './slash-commands'
+  import { get_current_structure } from '$lib/structure/current-structure.svelte'
 
 
   // Dynamic providers from backend
@@ -634,6 +636,51 @@
     // Reset textarea height after clearing
     if (textarea_el) textarea_el.style.height = `auto`
     active_tab = `chat`
+
+    // Slash commands: intercept before DOI / send_message. A "/"-prefixed
+    // line never reaches the LLM. Unknown "/x" is reported locally.
+    if (msg.startsWith(`/`)) {
+      const emit_note = (text: string) => {
+        slice.messages.list = [...slice.messages.list,
+          { role: `assistant`, content: text, timestamp: Date.now() }]
+      }
+      const handled = await run_slash(msg, {
+        tab_id: tab_slice_id,
+        args: ``,
+        new_session: () => new_session(SDK_PROVIDERS.has(chat_config.provider) ? chat_config.provider.replace(`sdk-`, ``) : undefined, tab_slice_id),
+        clear_chat_history: () => clear_chat_history(tab_slice_id),
+        cancel_generation: () => cancel_generation(tab_slice_id),
+        resume_session: (agent, sid, messages, tid) => resume_session(agent, sid, messages, tid ?? tab_slice_id),
+        list_sessions: () => session_list.list,
+        load_session_messages: (sid) => load_session_messages(sid),
+        run_quickbuild: async (recipe, mp_id) => {
+          const resp = await fetch(`${API_BASE}/workflow/quickbuild`, {
+            method: `POST`, headers: { 'Content-Type': `application/json` },
+            body: JSON.stringify(mp_id ? { recipe, material_id: mp_id } : { recipe }),
+          })
+          if (!resp.ok) throw new Error((await resp.text().catch(() => String(resp.status))).slice(0, 200))
+          const data = await resp.json()
+          const wf_id = data.workflow_id
+          if (wf_id) {
+            const wfslice = get_workflow_slice(tab_slice_id)
+            wfslice.pending_navigate_workflow.id = wf_id
+            wfslice.workflow_reload_seq.seq++
+          }
+          emit_note(`✅ ${recipe.toUpperCase()} workflow built${mp_id ? ` for ${mp_id}` : ``}.`)
+        },
+        inject_structure: async () => {
+          const cur = get_current_structure()
+          if (!cur) { emit_note(`No structure loaded — open one in a structure viewer first.`); return }
+          const wfslice = get_workflow_slice(tab_slice_id)
+          wfslice.workflow_reload_seq.seq++
+          emit_note(`Structure captured. Open the Workflow editor — an empty Structure Input node will be filled with it (a node that already has a structure is left unchanged).`)
+        },
+        set_skip_permission: (on) => { slice.skip_permission.value = on },
+        get_skip_permission: () => slice.skip_permission.value,
+        emit: emit_note,
+      })
+      if (handled) return
+    }
 
     // Auto-detect DOI input and resolve it. Skip while a round is streaming:
     // send_message will queue this text and the DOI branch would otherwise
@@ -1395,7 +1442,9 @@
         style="display: none"
       />
       <div class="input-hint-row">
-        {#if slice.pending_send?.value}
+        {#if slice.skip_permission.value}
+          <span class="input-hint skip-warn">⚠️ skip-permission ON — tools run without asking</span>
+        {:else if slice.pending_send?.value}
           <span class="input-hint queued">⏳ Queued — sends when the current reply finishes</span>
         {:else if slice.loading.value}
           <span class="input-hint">Enter to queue · sends after the current reply · Esc stops</span>
@@ -2263,6 +2312,10 @@
   .input-hint {
     font-size: 0.72em;
     color: var(--text-color-muted, #6b7280);
+  }
+  .input-hint.skip-warn {
+    color: var(--error-color);
+    font-weight: 600;
   }
   /* Paper attachment badge */
   .paper-badge {

--- a/src/lib/chat/chat-state.svelte.ts
+++ b/src/lib/chat/chat-state.svelte.ts
@@ -480,6 +480,7 @@ export async function send_message(
         attachments,
         signal: slice.abort_controller.signal,
         tabId: tab_id,
+        skipPermissions: slice.skip_permission.value,
         chatId: tab_id,
       })
 

--- a/src/lib/chat/chat-state.svelte.ts
+++ b/src/lib/chat/chat-state.svelte.ts
@@ -166,6 +166,9 @@ export interface ChatSlice {
   // sent automatically the moment the in-flight round finishes (drained in
   // send_message's finally), so the input box never has to be locked.
   pending_send: { value: { content: string; attachments?: import('./types').Attachment[] } | null }
+  // Session-scoped tool-approval bypass (NOT persisted — a fresh session
+  // always re-gates). Read at send time, threaded into the Claude adapter.
+  skip_permission: { value: boolean }
   // Plain (non-$state) field — abort_controller is a DOM class we cancel
   // via a method call; wrapping it in a $state proxy adds nothing.
   abort_controller: AbortController | null
@@ -192,6 +195,7 @@ function make_chat_slice(): ChatSlice {
   const pending_send = $state({
     value: null as { content: string; attachments?: import('./types').Attachment[] } | null,
   })
+  const skip_permission = $state({ value: false })
   return {
     messages,
     loading,
@@ -203,6 +207,7 @@ function make_chat_slice(): ChatSlice {
     paper_context,
     paper_session,
     pending_send,
+    skip_permission,
     abort_controller: null,
   }
 }
@@ -786,6 +791,7 @@ export function resume_session(
 ): void {
   const slice = get_chat_slice(tab_id)
   slice.error.value = ``
+  slice.skip_permission.value = false
   clear_workflow_events(tab_id)
   agent_sessions[agent] = session_id
   slice.messages.list = messages ?? []
@@ -796,6 +802,7 @@ export function new_session(agent?: string, tab_id: string = `default`): void {
   const slice = get_chat_slice(tab_id)
   slice.messages.list = []
   slice.error.value = ``
+  slice.skip_permission.value = false
 
   clear_workflow_events(tab_id)
   if (agent) {
@@ -809,6 +816,7 @@ export function clear_chat_history(tab_id: string = `default`): void {
   const slice = get_chat_slice(tab_id)
   slice.messages.list = []
   slice.error.value = ``
+  slice.skip_permission.value = false
 
   clear_workflow_events(tab_id)
   clear_agent_session()

--- a/src/lib/chat/sdk-stream.ts
+++ b/src/lib/chat/sdk-stream.ts
@@ -41,6 +41,13 @@ export interface StreamAgentParams {
    */
   tabId?: string
   /**
+   * When true, forwarded to the server and into the Claude adapter's
+   * canUseTool so ALL non-CatGo tools are auto-allowed without a
+   * PermissionCard for this stream. Mirrors the chat slice's session-scoped
+   * skip_permission flag; never persisted.
+   */
+  skipPermissions?: boolean
+  /**
    * Per-chat-thread key. Forwarded to the Gemini adapter's persistent ACP
    * process pool so repeat prompts in the same chat tab reuse one
    * `gemini --acp` process and keep cross-turn context. The Claude/Codex
@@ -52,12 +59,12 @@ export interface StreamAgentParams {
 export async function* stream_sdk_agent(
   params: StreamAgentParams,
 ): AsyncGenerator<AgentEvent> {
-  const { agent, prompt, sessionId, model, systemPrompt, attachments, signal, tabId, chatId } = params
+  const { agent, prompt, sessionId, model, systemPrompt, attachments, signal, tabId, skipPermissions, chatId } = params
 
   const response = await fetch(`${getAgentBase()}/api/agent/stream`, {
     method: `POST`,
     headers: { 'Content-Type': `application/json` },
-    body: JSON.stringify({ agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId }),
+    body: JSON.stringify({ agent, prompt, sessionId, model, systemPrompt, attachments, tabId, skipPermissions, chatId }),
     signal,
   })
 

--- a/src/lib/chat/slash-commands.ts
+++ b/src/lib/chat/slash-commands.ts
@@ -1,0 +1,90 @@
+import type { ChatMessage } from './types'
+
+export interface SessionSummary {
+  session_id: string
+  agent: string
+  topic: string
+  created_at: number
+  last_active: number
+  message_count: number
+  model?: string
+}
+
+export interface SlashCtx {
+  tab_id: string
+  args: string
+  new_session: () => void
+  clear_chat_history: () => void
+  cancel_generation: () => void
+  resume_session: (agent: string, session_id: string, messages?: ChatMessage[], tab_id?: string) => void
+  list_sessions: () => SessionSummary[]
+  load_session_messages: (session_id: string) => ChatMessage[]
+  run_quickbuild: (recipe: string, mp_id?: string) => Promise<void>
+  inject_structure: () => Promise<void>
+  set_skip_permission: (on: boolean) => void
+  get_skip_permission: () => boolean
+  emit: (msg: string) => void
+}
+
+export interface SlashCommand {
+  name: string
+  aliases?: string[]
+  hint?: string
+  summary: string
+  run: (ctx: SlashCtx) => Promise<void> | void
+}
+
+// Registry is appended to by later tasks. Keep ONE array; never duplicate.
+export const SLASH_COMMANDS: SlashCommand[] = []
+
+function find(token: string): SlashCommand | undefined {
+  const t = token.toLowerCase()
+  return SLASH_COMMANDS.find(c => c.name === t || c.aliases?.includes(t))
+}
+
+/** Parse a raw input string. Returns null if it is not a slash command
+ *  (no leading "/", or first token does not resolve to a registered
+ *  command). Whitespace-tolerant, case-insensitive. */
+export function match_slash(raw: string): { cmd: SlashCommand; args: string } | null {
+  const s = raw.trimStart()
+  if (!s.startsWith('/')) return null
+  const body = s.slice(1)
+  const sp = body.search(/\s/)
+  const token = sp === -1 ? body : body.slice(0, sp)
+  const args = sp === -1 ? '' : body.slice(sp + 1).trim()
+  // token '' (bare "/") → no match here; T9 autocomplete intentionally uses the empty token to list all commands.
+  const cmd = find(token)
+  return cmd ? { cmd, args } : null
+}
+
+/** Run a slash command. Returns true if `raw` was a slash attempt
+ *  (handled or reported as unknown — caller must NOT fall through to
+ *  send_message), false if it was ordinary chat input. */
+export async function run_slash(raw: string, ctx: SlashCtx): Promise<boolean> {
+  const s = raw.trimStart()
+  if (!s.startsWith('/')) return false
+  const m = match_slash(raw)
+  if (!m) {
+    ctx.emit(`Unknown command. Type /help to see available commands.`)
+    return true
+  }
+  try {
+    await m.cmd.run({ ...ctx, args: m.args })
+  } catch (e) {
+    ctx.emit(`Command /${m.cmd.name} failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+  return true
+}
+
+SLASH_COMMANDS.push({
+  name: 'help',
+  hint: '',
+  summary: 'List all slash commands',
+  run(ctx) {
+    const lines = SLASH_COMMANDS
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(c => `**/${c.name}**${c.hint ? ' ' + c.hint : ''} — ${c.summary}`)
+    ctx.emit(`**CatBot slash commands**\n\n${lines.join('\n')}`)
+  },
+})

--- a/src/lib/chat/slash-commands.ts
+++ b/src/lib/chat/slash-commands.ts
@@ -1,14 +1,7 @@
-import type { ChatMessage } from './types'
+import type { ChatMessage, SessionSummary } from './types'
+import { get_display_text } from './types'
 
-export interface SessionSummary {
-  session_id: string
-  agent: string
-  topic: string
-  created_at: number
-  last_active: number
-  message_count: number
-  model?: string
-}
+export type { SessionSummary } from './types'
 
 export interface SlashCtx {
   tab_id: string
@@ -103,3 +96,50 @@ SLASH_COMMANDS.push(
     run(ctx) { ctx.cancel_generation() },
   },
 )
+
+function rel_time(ms: number): string {
+  const d = Date.now() - ms
+  const m = Math.round(d / 60000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.round(h / 24)}d ago`
+}
+
+function snippet(ctx: SlashCtx, s: SessionSummary): string {
+  const msgs = ctx.load_session_messages(s.session_id)
+  const last = msgs.length ? get_display_text(msgs[msgs.length - 1].content) : ''
+  const topic = (s.topic ?? '').replace(/\s+/g, ' ').trim()
+  const preview = last.replace(/\s+/g, ' ').trim()
+  // Design: each line shows topic AND a snippet of the last message.
+  // topic + preview when both exist; whichever exists alone otherwise.
+  let text: string
+  if (topic && preview) text = `${topic} — ${preview}`
+  else text = topic || preview || '(empty)'
+  return text.length > 60 ? text.slice(0, 60) + '…' : text
+}
+
+SLASH_COMMANDS.push({
+  name: 'resume',
+  hint: '[n]',
+  summary: 'List recent sessions, or resume the nth',
+  run(ctx) {
+    const sorted = ctx.list_sessions().slice().sort((a, b) => b.last_active - a.last_active)
+    if (sorted.length === 0) { ctx.emit('No past sessions found.'); return }
+    if (ctx.args.trim() === '') {
+      const lines = sorted.map((s, i) =>
+        `${i + 1}. ${snippet(ctx, s)} · ${rel_time(s.last_active)}`)
+      ctx.emit(`**Recent sessions** — /resume <n> to open one\n\n${lines.join('\n')}`)
+      return
+    }
+    const n = Number.parseInt(ctx.args.trim(), 10)
+    if (!Number.isInteger(n) || n < 1 || n > sorted.length) {
+      ctx.emit(`/resume expects a number 1–${sorted.length}.`)
+      return
+    }
+    const s = sorted[n - 1]
+    const msgs = ctx.load_session_messages(s.session_id)
+    ctx.resume_session(s.agent, s.session_id, msgs.length ? msgs : undefined, ctx.tab_id)
+  },
+})

--- a/src/lib/chat/slash-commands.ts
+++ b/src/lib/chat/slash-commands.ts
@@ -144,11 +144,11 @@ SLASH_COMMANDS.push({
   },
 })
 
-const RECIPES: { name: string; label: string }[] = [
-  { name: 'oer', label: 'OER' },
-  { name: 'her', label: 'HER' },
-  { name: 'co2rr', label: 'CO2RR' },
-  { name: 'nrr', label: 'NRR' },
+const RECIPES: { name: string; label: string; recipe: string }[] = [
+  { name: 'oer', label: 'OER', recipe: 'OER' },
+  { name: 'her', label: 'HER', recipe: 'HER' },
+  { name: 'co2rr', label: 'CO2RR', recipe: 'CO2RR_2e' },
+  { name: 'nrr', label: 'NRR', recipe: 'NRR' },
 ]
 
 for (const r of RECIPES) {
@@ -162,7 +162,7 @@ for (const r of RECIPES) {
         ctx.emit(`Usage: /${r.name} [mp-id] — e.g. /${r.name} mp-1019. Omit the id to use the current structure.`)
         return
       }
-      await ctx.run_quickbuild(r.name, a === '' ? undefined : a)
+      await ctx.run_quickbuild(r.recipe, a === '' ? undefined : a)
     },
   })
 }

--- a/src/lib/chat/slash-commands.ts
+++ b/src/lib/chat/slash-commands.ts
@@ -166,3 +166,34 @@ for (const r of RECIPES) {
     },
   })
 }
+
+SLASH_COMMANDS.push({
+  name: 'structure',
+  hint: '',
+  summary: 'Put the current structure into the Structure Input node',
+  async run(ctx) { await ctx.inject_structure() },
+})
+
+SLASH_COMMANDS.push({
+  name: 'skip-permission',
+  hint: '[on|off]',
+  summary: 'Toggle the per-session tool-approval gate',
+  run(ctx) {
+    const a = ctx.args.trim().toLowerCase()
+    if (a === '') {
+      ctx.emit(`skip-permission is ${ctx.get_skip_permission() ? 'ON' : 'OFF'}. Use /skip-permission on|off.`)
+      return
+    }
+    if (a === 'on') {
+      ctx.set_skip_permission(true)
+      ctx.emit(`⚠️ Permission prompts disabled for this session — Bash and file tools will run without asking. /skip-permission off to re-enable.`)
+      return
+    }
+    if (a === 'off') {
+      ctx.set_skip_permission(false)
+      ctx.emit(`skip-permission OFF — tool calls will ask for approval again.`)
+      return
+    }
+    ctx.emit(`Usage: /skip-permission on|off`)
+  },
+})

--- a/src/lib/chat/slash-commands.ts
+++ b/src/lib/chat/slash-commands.ts
@@ -88,3 +88,18 @@ SLASH_COMMANDS.push({
     ctx.emit(`**CatBot slash commands**\n\n${lines.join('\n')}`)
   },
 })
+
+SLASH_COMMANDS.push(
+  {
+    name: 'new', hint: '', summary: 'Start a fresh chat session',
+    run(ctx) { ctx.new_session() },
+  },
+  {
+    name: 'clear', hint: '', summary: 'Clear messages, keep the session',
+    run(ctx) { ctx.clear_chat_history() },
+  },
+  {
+    name: 'stop', hint: '', summary: 'Stop the current streaming reply',
+    run(ctx) { ctx.cancel_generation() },
+  },
+)

--- a/src/lib/chat/slash-commands.ts
+++ b/src/lib/chat/slash-commands.ts
@@ -143,3 +143,26 @@ SLASH_COMMANDS.push({
     ctx.resume_session(s.agent, s.session_id, msgs.length ? msgs : undefined, ctx.tab_id)
   },
 })
+
+const RECIPES: { name: string; label: string }[] = [
+  { name: 'oer', label: 'OER' },
+  { name: 'her', label: 'HER' },
+  { name: 'co2rr', label: 'CO2RR' },
+  { name: 'nrr', label: 'NRR' },
+]
+
+for (const r of RECIPES) {
+  SLASH_COMMANDS.push({
+    name: r.name,
+    hint: '[mp-id]',
+    summary: `Quick-build a ${r.label} workflow (optional Materials Project id)`,
+    async run(ctx) {
+      const a = ctx.args.trim()
+      if (a !== '' && !/^mp-\d+$/i.test(a)) {
+        ctx.emit(`Usage: /${r.name} [mp-id] — e.g. /${r.name} mp-1019. Omit the id to use the current structure.`)
+        return
+      }
+      await ctx.run_quickbuild(r.name, a === '' ? undefined : a)
+    },
+  })
+}

--- a/src/lib/server/agent-bridge/adapters/claude.ts
+++ b/src/lib/server/agent-bridge/adapters/claude.ts
@@ -177,6 +177,7 @@ export function createClaudeAdapter(): AgentAdapter {
         permissionCallback,
         abortSignal,
         tabId,
+        skipPermissions,
       } = params
 
       const effectiveController = new AbortController()
@@ -210,6 +211,13 @@ export function createClaudeAdapter(): AgentAdapter {
       ): Promise<any> => {
         // Auto-allow all CatGo MCP tools — they are safe backend operations
         if (toolName.startsWith('mcp__catgo__') || toolName.startsWith('catgo_')) {
+          return { behavior: 'allow' }
+        }
+
+        // Session-scoped user opt-out of the approval gate (/skip-permission).
+        // Captured per-stream so a mid-stream toggle can't retroactively
+        // affect an in-flight round.
+        if (skipPermissions === true) {
           return { behavior: 'allow' }
         }
 

--- a/src/lib/server/agent-bridge/adapters/claude.ts
+++ b/src/lib/server/agent-bridge/adapters/claude.ts
@@ -159,6 +159,23 @@ function* translateMessage(msg: any): Generator<AgentEvent> {
 }
 
 // ---------------------------------------------------------------------------
+// Security gate: pure permission decision helper
+// ---------------------------------------------------------------------------
+
+/** Pure pre-decision for canUseTool. 'allow' = auto-allow without the
+ *  PermissionCard; 'gate' = fall through to the human permissionCallback.
+ *  Security-critical: CatGo MCP tools are always safe; skipPermissions
+ *  only widens that when the user explicitly opted in (strict === true). */
+export function decide_tool_permission(
+  toolName: string,
+  skipPermissions: boolean | undefined,
+): 'allow' | 'gate' {
+  if (toolName.startsWith('mcp__catgo__') || toolName.startsWith('catgo_')) return 'allow'
+  if (skipPermissions === true) return 'allow'
+  return 'gate'
+}
+
+// ---------------------------------------------------------------------------
 // ClaudeAdapter
 // ---------------------------------------------------------------------------
 
@@ -209,15 +226,9 @@ export function createClaudeAdapter(): AgentAdapter {
           agentID?: string
         },
       ): Promise<any> => {
-        // Auto-allow all CatGo MCP tools — they are safe backend operations
-        if (toolName.startsWith('mcp__catgo__') || toolName.startsWith('catgo_')) {
-          return { behavior: 'allow' }
-        }
-
-        // Session-scoped user opt-out of the approval gate (/skip-permission).
-        // Captured per-stream so a mid-stream toggle can't retroactively
-        // affect an in-flight round.
-        if (skipPermissions === true) {
+        // Auto-allow CatGo MCP tools and session-scoped skip-permission opt-out.
+        // decide_tool_permission is the single source of truth for this gate.
+        if (decide_tool_permission(toolName, skipPermissions) === 'allow') {
           return { behavior: 'allow' }
         }
 

--- a/src/lib/server/agent-bridge/server.ts
+++ b/src/lib/server/agent-bridge/server.ts
@@ -95,6 +95,7 @@ function agentCwdFor(agent: AgentType): string {
 async function handleStream(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const body = JSON.parse(await readBody(req))
   const { agent, prompt, sessionId, model, systemPrompt, attachments, tabId, chatId } = body
+  const skipPermissions = body.skipPermissions === true
 
   if (!VALID_AGENTS.includes(agent)) {
     jsonResponse(res, 400, { error: `Invalid agent: must be one of ${VALID_AGENTS.join(', ')}` })
@@ -142,6 +143,7 @@ async function handleStream(req: IncomingMessage, res: ServerResponse): Promise<
       permissionCallback,
       abortSignal: abortController.signal,
       tabId,
+      skipPermissions,
       chatId,
     })) {
       writeEvent(event)

--- a/src/lib/server/agent-bridge/types.ts
+++ b/src/lib/server/agent-bridge/types.ts
@@ -73,6 +73,13 @@ export interface StreamParams {
    */
   tabId?: string
   /**
+   * When true, the Claude adapter's canUseTool auto-allows ALL tools
+   * (not just CatGo MCP) without showing the PermissionCard, for this
+   * stream only. Set per-stream from the chat slice's session-scoped
+   * skip_permission flag; never persisted.
+   */
+  skipPermissions?: boolean
+  /**
    * Per-chat-thread key for the persistent Gemini ACP process pool. When
    * set, repeat `stream()` calls with the same `chatId` reuse one
    * `gemini --acp` process + ACP session, so the model remembers prior

--- a/tests/vitest/agent-bridge/claude-permission.test.ts
+++ b/tests/vitest/agent-bridge/claude-permission.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { decide_tool_permission } from '$lib/server/agent-bridge/adapters/claude'
+
+describe('decide_tool_permission (security gate)', () => {
+  it('always allows CatGo MCP tools regardless of skipPermissions', () => {
+    expect(decide_tool_permission('mcp__catgo__catgo_workflow', false)).toBe('allow')
+    expect(decide_tool_permission('catgo_structure', undefined)).toBe('allow')
+    expect(decide_tool_permission('mcp__catgo__x', true)).toBe('allow')
+  })
+  it('gates non-CatGo tools when skipPermissions is not exactly true', () => {
+    expect(decide_tool_permission('Bash', false)).toBe('gate')
+    expect(decide_tool_permission('Bash', undefined)).toBe('gate')
+    // truthy-but-not-true must NOT escalate
+    expect(decide_tool_permission('Bash', 1 as unknown as boolean)).toBe('gate')
+    expect(decide_tool_permission('Bash', 'true' as unknown as boolean)).toBe('gate')
+  })
+  it('allows non-CatGo tools only when skipPermissions === true', () => {
+    expect(decide_tool_permission('Bash', true)).toBe('allow')
+    expect(decide_tool_permission('Write', true)).toBe('allow')
+  })
+})

--- a/tests/vitest/chat/chat-state-skip.test.ts
+++ b/tests/vitest/chat/chat-state-skip.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { get_chat_slice, new_session, resume_session, clear_chat_history } from '$lib/chat/chat-state.svelte'
+
+describe('skip_permission slice state', () => {
+  it('defaults false and is reset by new_session', () => {
+    const s = get_chat_slice('t-skip')
+    expect(s.skip_permission.value).toBe(false)
+    s.skip_permission.value = true
+    expect(get_chat_slice('t-skip').skip_permission.value).toBe(true)
+    new_session(undefined, 't-skip')
+    expect(get_chat_slice('t-skip').skip_permission.value).toBe(false)
+  })
+
+  it('resume_session clears skip_permission for the tab', () => {
+    const tid = 't-skip-resume'
+    get_chat_slice(tid).skip_permission.value = true
+    resume_session('claude', 's1', undefined, tid)
+    expect(get_chat_slice(tid).skip_permission.value).toBe(false)
+  })
+
+  it('clear_chat_history clears skip_permission for the tab', () => {
+    const tid = 't-skip-clear'
+    get_chat_slice(tid).skip_permission.value = true
+    clear_chat_history(tid)
+    expect(get_chat_slice(tid).skip_permission.value).toBe(false)
+  })
+})

--- a/tests/vitest/chat/slash-commands.test.ts
+++ b/tests/vitest/chat/slash-commands.test.ts
@@ -170,3 +170,39 @@ describe('quickbuild commands', () => {
     expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('mp-'))
   })
 })
+
+describe('/structure', () => {
+  it('calls inject_structure', async () => {
+    const c = ctx(); await run_slash('/structure', c as any)
+    expect(c.inject_structure).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('/skip-permission', () => {
+  it('no arg reports current state', async () => {
+    const c = ctx({ get_skip_permission: vi.fn(() => false) })
+    await run_slash('/skip-permission', c as any)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('OFF'))
+    expect(c.set_skip_permission).not.toHaveBeenCalled()
+  })
+  it('no arg reports ON when skip is enabled', async () => {
+    const c = ctx({ get_skip_permission: vi.fn(() => true) })
+    await run_slash('/skip-permission', c as any)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('ON'))
+    expect(c.set_skip_permission).not.toHaveBeenCalled()
+  })
+  it('on sets true and emits a security warning', async () => {
+    const c = ctx(); await run_slash('/skip-permission on', c as any)
+    expect(c.set_skip_permission).toHaveBeenCalledWith(true)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('⚠️'))
+  })
+  it('off sets false', async () => {
+    const c = ctx(); await run_slash('/skip-permission off', c as any)
+    expect(c.set_skip_permission).toHaveBeenCalledWith(false)
+  })
+  it('garbage arg emits usage, does not change state', async () => {
+    const c = ctx(); await run_slash('/skip-permission maybe', c as any)
+    expect(c.set_skip_permission).not.toHaveBeenCalled()
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('on'))
+  })
+})

--- a/tests/vitest/chat/slash-commands.test.ts
+++ b/tests/vitest/chat/slash-commands.test.ts
@@ -66,3 +66,18 @@ describe('run_slash', () => {
     SLASH_COMMANDS.splice(i, 1)
   })
 })
+
+describe('session commands', () => {
+  it('/new calls new_session', async () => {
+    const c = ctx(); await run_slash('/new', c as any)
+    expect(c.new_session).toHaveBeenCalledTimes(1)
+  })
+  it('/clear calls clear_chat_history', async () => {
+    const c = ctx(); await run_slash('/clear', c as any)
+    expect(c.clear_chat_history).toHaveBeenCalledTimes(1)
+  })
+  it('/stop calls cancel_generation', async () => {
+    const c = ctx(); await run_slash('/stop', c as any)
+    expect(c.cancel_generation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/vitest/chat/slash-commands.test.ts
+++ b/tests/vitest/chat/slash-commands.test.ts
@@ -148,3 +148,25 @@ describe('/resume', () => {
     expect(line).not.toContain('X'.repeat(61))
   })
 })
+
+describe('quickbuild commands', () => {
+  it('/oer with no args calls run_quickbuild("oer", undefined)', async () => {
+    const c = ctx(); await run_slash('/oer', c as any)
+    expect(c.run_quickbuild).toHaveBeenCalledWith('oer', undefined)
+  })
+  it('/her mp-1019 passes the mp id', async () => {
+    const c = ctx(); await run_slash('/her mp-1019', c as any)
+    expect(c.run_quickbuild).toHaveBeenCalledWith('her', 'mp-1019')
+  })
+  it('/co2rr and /nrr are registered', async () => {
+    const c1 = ctx(); await run_slash('/co2rr', c1 as any)
+    expect(c1.run_quickbuild).toHaveBeenCalledWith('co2rr', undefined)
+    const c2 = ctx(); await run_slash('/nrr', c2 as any)
+    expect(c2.run_quickbuild).toHaveBeenCalledWith('nrr', undefined)
+  })
+  it('rejects a malformed mp id with a usage note, no quickbuild call', async () => {
+    const c = ctx(); await run_slash('/oer notanid', c as any)
+    expect(c.run_quickbuild).not.toHaveBeenCalled()
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('mp-'))
+  })
+})

--- a/tests/vitest/chat/slash-commands.test.ts
+++ b/tests/vitest/chat/slash-commands.test.ts
@@ -81,3 +81,70 @@ describe('session commands', () => {
     expect(c.cancel_generation).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('/resume', () => {
+  const sessions = [
+    { session_id: 'sB', agent: 'claude', topic: 'OER on RuO2', created_at: 1, last_active: 200, message_count: 4 },
+    { session_id: 'sA', agent: 'claude', topic: '', created_at: 1, last_active: 100, message_count: 2 },
+  ]
+  it('lists newest-first; shows topic + last-message snippet; falls back to last message when topic empty', async () => {
+    const c = ctx({
+      list_sessions: vi.fn(() => sessions),
+      load_session_messages: vi.fn((id: string) =>
+        id === 'sB' ? [{ role: 'user', content: 'hi', timestamp: 1 },
+                        { role: 'assistant', content: 'Here is the OER workflow summary text', timestamp: 2 }]
+                     : [{ role: 'user', content: 'plain question about slab', timestamp: 1 }]),
+    })
+    await run_slash('/resume', c as any)
+    const out = (c.emit as any).mock.calls[0][0] as string
+    expect(out.indexOf('1.')).toBeLessThan(out.indexOf('2.'))           // sB (newest) first
+    expect(out).toContain('OER on RuO2 — Here is the OER workflow')     // topic + last-msg combined
+    expect(out).toContain('plain question about slab')                  // empty topic → last msg
+    expect(c.resume_session).not.toHaveBeenCalled()
+  })
+  it('shows only the topic when the session has no messages', async () => {
+    const c = ctx({
+      list_sessions: vi.fn(() => [{ session_id: 'sT', agent: 'claude', topic: 'Just a topic', created_at: 1, last_active: 5, message_count: 0 }]),
+      load_session_messages: vi.fn(() => []),
+    })
+    await run_slash('/resume', c as any)
+    const out = (c.emit as any).mock.calls[0][0] as string
+    expect(out).toContain('Just a topic')
+    // The session line must not have a separator — only the header line contains "—"
+    const sessionLine = out.split('\n').find((l: string) => l.startsWith('1.')) ?? ''
+    expect(sessionLine).not.toContain('—')   // no separator when there is no last message
+  })
+  it('numeric arg resumes the nth listed session', async () => {
+    const c = ctx({
+      list_sessions: vi.fn(() => sessions),
+      load_session_messages: vi.fn(() => [{ role: 'user', content: 'x', timestamp: 1 }]),
+    })
+    await run_slash('/resume 1', c as any)
+    expect(c.resume_session).toHaveBeenCalledWith('claude', 'sB',
+      [{ role: 'user', content: 'x', timestamp: 1 }], 'default')
+  })
+  it('out-of-range index emits a usage note, does not throw or resume', async () => {
+    const c = ctx({ list_sessions: vi.fn(() => sessions) })
+    await run_slash('/resume 9', c as any)
+    expect(c.resume_session).not.toHaveBeenCalled()
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('1–2'))
+  })
+  it('empty session list emits a note', async () => {
+    const c = ctx({ list_sessions: vi.fn(() => []) })
+    await run_slash('/resume', c as any)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('No past sessions'))
+  })
+  it('truncates a long composed line to 60 chars + ellipsis', async () => {
+    const longTopic = 'X'.repeat(80)
+    const c = ctx({
+      list_sessions: vi.fn(() => [{ session_id: 's1', agent: 'claude', topic: longTopic, created_at: 1, last_active: 9, message_count: 0 }]),
+      load_session_messages: vi.fn(() => []),
+    })
+    await run_slash('/resume', c as any)
+    const out = (c.emit as any).mock.calls[0][0] as string
+    const line = out.split('\n').find(l => l.startsWith('1.')) as string
+    expect(line).toContain('…')
+    expect(line).toContain('X'.repeat(60))
+    expect(line).not.toContain('X'.repeat(61))
+  })
+})

--- a/tests/vitest/chat/slash-commands.test.ts
+++ b/tests/vitest/chat/slash-commands.test.ts
@@ -150,19 +150,19 @@ describe('/resume', () => {
 })
 
 describe('quickbuild commands', () => {
-  it('/oer with no args calls run_quickbuild("oer", undefined)', async () => {
+  it('/oer with no args calls run_quickbuild("OER", undefined)', async () => {
     const c = ctx(); await run_slash('/oer', c as any)
-    expect(c.run_quickbuild).toHaveBeenCalledWith('oer', undefined)
+    expect(c.run_quickbuild).toHaveBeenCalledWith('OER', undefined)
   })
   it('/her mp-1019 passes the mp id', async () => {
     const c = ctx(); await run_slash('/her mp-1019', c as any)
-    expect(c.run_quickbuild).toHaveBeenCalledWith('her', 'mp-1019')
+    expect(c.run_quickbuild).toHaveBeenCalledWith('HER', 'mp-1019')
   })
   it('/co2rr and /nrr are registered', async () => {
     const c1 = ctx(); await run_slash('/co2rr', c1 as any)
-    expect(c1.run_quickbuild).toHaveBeenCalledWith('co2rr', undefined)
+    expect(c1.run_quickbuild).toHaveBeenCalledWith('CO2RR_2e', undefined)
     const c2 = ctx(); await run_slash('/nrr', c2 as any)
-    expect(c2.run_quickbuild).toHaveBeenCalledWith('nrr', undefined)
+    expect(c2.run_quickbuild).toHaveBeenCalledWith('NRR', undefined)
   })
   it('rejects a malformed mp id with a usage note, no quickbuild call', async () => {
     const c = ctx(); await run_slash('/oer notanid', c as any)

--- a/tests/vitest/chat/slash-commands.test.ts
+++ b/tests/vitest/chat/slash-commands.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { match_slash, run_slash, SLASH_COMMANDS } from '$lib/chat/slash-commands'
+
+function ctx(over = {}) {
+  return {
+    tab_id: 'default', args: '',
+    new_session: vi.fn(), clear_chat_history: vi.fn(), cancel_generation: vi.fn(),
+    resume_session: vi.fn(), list_sessions: vi.fn(() => []), load_session_messages: vi.fn(() => []),
+    run_quickbuild: vi.fn(async () => {}), inject_structure: vi.fn(async () => {}),
+    set_skip_permission: vi.fn(), get_skip_permission: vi.fn(() => false),
+    emit: vi.fn(),
+    ...over,
+  }
+}
+
+describe('match_slash', () => {
+  it('returns null for non-slash', () => {
+    expect(match_slash('hello')).toBeNull()
+    expect(match_slash('  hi /new')).toBeNull()
+  })
+  it('matches command name case-insensitively with args', () => {
+    const m = match_slash('/HELP extra args')
+    expect(m?.cmd.name).toBe('help')
+    expect(m?.args).toBe('extra args')
+  })
+  it('matches with no args and trims', () => {
+    const m = match_slash('  /help  ')
+    expect(m?.cmd.name).toBe('help')
+    expect(m?.args).toBe('')
+  })
+  it('returns null for unknown slash token', () => {
+    expect(match_slash('/bogus')).toBeNull()
+  })
+  it('first token resolves to the help command', () => {
+    const m = match_slash('/HELP')
+    expect(m?.cmd.name).toBe('help')
+  })
+})
+
+describe('run_slash', () => {
+  it('returns false when not a command (no UI side effects)', async () => {
+    const c = ctx()
+    expect(await run_slash('plain text', c as any)).toBe(false)
+    expect(c.emit).not.toHaveBeenCalled()
+  })
+  it('emits unknown-command help hint for unmatched slash', async () => {
+    const c = ctx()
+    expect(await run_slash('/nope', c as any)).toBe(true)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('/help'))
+  })
+  it('/help lists every registered command', async () => {
+    const c = ctx()
+    await run_slash('/help', c as any)
+    const out = (c.emit as any).mock.calls[0][0] as string
+    for (const cmd of SLASH_COMMANDS) expect(out).toContain('/' + cmd.name)
+    expect(out).toContain('List all slash commands') // real help body, not an error string
+    expect(out).not.toContain('failed')
+  })
+  it('emits error message when a command throws', async () => {
+    SLASH_COMMANDS.push({ name: '__test_throw', hint: '', summary: 'x',
+      run() { throw new Error('boom') } })
+    const c = ctx()
+    await run_slash('/__test_throw', c as any)
+    expect(c.emit).toHaveBeenCalledWith(expect.stringContaining('boom'))
+    const i = SLASH_COMMANDS.findIndex(x => x.name === '__test_throw')
+    SLASH_COMMANDS.splice(i, 1)
+  })
+})


### PR DESCRIPTION
Deterministic, zero-LLM-token client-side slash commands for CatBot. Brainstormed → spec → plan → 9 TDD tasks (per-task spec + code-quality review) → final whole-feature review → 10/10 browser smoke test.

## Commands
- `/new` `/clear` `/stop` — session control
- `/resume [n]` — list recent sessions (topic + last-message snippet + relative time, never raw IDs) or resume the nth
- `/oer` `/her` `/co2rr` `/nrr [mp-id]` — POST the real quickbuild endpoint, navigate the originating tab
- `/structure` — fill the durable current-structure into an empty Structure Input node
- `/skip-permission on|off` — session-scoped tool-approval-gate bypass
- `/help` — auto-generated from the registry
- Autocomplete dropdown (typed `/x`, no space) with ↑/↓ Tab/Enter Esc

## Architecture
Single registry module `src/lib/chat/slash-commands.ts` (one source of truth for parse / behavior / `/help` / autocomplete; no UI imports → unit-testable). `ChatPane.handle_send` intercepts `/`-prefixed input strictly before the DOI branch and `send_message` (unknown `/x` never reaches the LLM; non-slash path byte-unchanged).

## Security — /skip-permission
Session-scoped `$state` flag, **never persisted**; reset on new/resume/clear_chat_history; read at send time → JSON body → strict `body.skipPermissions === true` coercion at the HTTP boundary → threaded (parallel to `tabId`) into the Claude adapter `canUseTool`, gated `=== true` AFTER the CatGo-MCP auto-allow and BEFORE the human PermissionCard, closure-captured per-stream (a mid-stream toggle cannot affect an in-flight round). Ignored by Codex/Gemini adapters. Persistent ⚠️ banner whenever ON. The security decision is extracted to a pure `decide_tool_permission()` and unit-tested (incl. truthy-but-not-`true` must NOT escalate). Threat model: localhost-only Tauri sidecar that already runs tools on the user's behalf — `/skip-permission` removes a dialog, not a trust boundary.

## Verification
- 34 vitest tests (registry pure-fns, per command incl. error paths, chat-state skip slice reset on new/resume/clear, the security gate). `svelte-check`: 0 errors.
- Browser smoke (Playwright): 10/10 — autocomplete + keyboard, `/help`/unknown local (no LLM), banner show/hide + reset on `/new`, Esc closes without mutating input, `/oer mp-126` runs locally, `/resume`, non-slash regression (normal LLM round-trip). No JS console errors.

## Known UX quirk (per spec, not a defect)
Argless commands whose full name exactly matches a menu entry (`/new`, `/resume`) complete (Tab-like) on the first Enter while the menu is still open, execute on the second; commands with an arg/space run on a single Enter. Optional future polish: Enter executes directly when the typed token is an exact argless command.

## Docs
Spec `docs/superpowers/specs/2026-05-17-catbot-slash-commands-design.md`, plan `docs/superpowers/plans/2026-05-17-catbot-slash-commands.md` (plan's pre-correction `/resume` snippet annotated as superseded by the design doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)