### PR TITLE
fix: /health liveness probe + Windows bun spawn EINVAL

### DIFF
--- a/scripts/agent-dev.mjs
+++ b/scripts/agent-dev.mjs
@@ -66,8 +66,14 @@ binary, so end users don't need Bun.)
 // IPv4-first on the runtime + Bun avoids the silent stall that
 // otherwise makes CatBot's workflow generation "freeze ~50% of the
 // time" on those hosts. Harmless on healthy networks.
+// which('bun') on Windows usually resolves to the npm shim `bun.cmd`.
+// Node >=18.20/20.12/22 (CVE-2024-27980) refuses to spawn .cmd/.bat
+// without shell:true -> `spawn EINVAL`, which silently kills this pane
+// and surfaces in CatBot as "Load failed". shell:true runs it via
+// cmd.exe so the shim resolves. (bun path & ENTRY are space-free here.)
 const child = spawn(bun, [`run`, ENTRY], {
   stdio: 'inherit',
+  shell: process.platform === 'win32',
   env: {
     ...process.env,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ``} --dns-result-order=ipv4first`.trim(),

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -64,7 +64,12 @@ export async function desktop_backend_available(): Promise<boolean> {
   if (typeof __CATGO_DESKTOP__ === `undefined` || !__CATGO_DESKTOP__) return false
   if (_backend_state !== null) return _backend_state
   try {
-    const resp = await fetch(`${API_BASE}/providers`, {
+    // Liveness probe: hit /health (always present when the backend is up).
+    // Was /providers, which 404s — that route only exists nested at
+    // /api/optimade/providers & /api/chat/providers, so the old probe made
+    // desktop_backend_available() always return false even with a healthy
+    // backend (project.ts/workflow.ts then wrongly took the no-backend path).
+    const resp = await fetch(`${API_BASE}/health`, {
       signal: AbortSignal.timeout(2000),
     })
     _backend_state = resp.ok


### PR DESCRIPTION
## Two Windows native-dev breakers

Found while running the stack natively on Windows (frontend Vite + Python backend, no WSL bridge). Both reproduce on a clean `main` checkout — unrelated to any feature branch.

### 1. `src/lib/api/config.ts` — `desktop_backend_available()` probes a 404 route

`desktop_backend_available()` polled `${API_BASE}/providers` as a liveness check. There is **no** `/api/providers` route (it only exists nested at `/api/optimade/providers` and `/api/chat/providers`), so the probe **always 404s** → `resp.ok === false` → the function **always returns `false` even when the backend is fully healthy**. `project.ts` / `workflow.ts` consume this flag and consequently take the "no backend" path (e.g. not bypassing stale WASM cache) in desktop mode.

**Fix:** probe `${API_BASE}/health` instead — the core FastAPI app always serves it (`{"status":"healthy",...}`, 200).

### 2. `scripts/agent-dev.mjs` — `spawn EINVAL` on Windows kills the agent pane (CatBot "Load failed")

`which('bun')` on Windows resolves to the npm shim `bun.cmd`. Node ≥ 18.20 / 20.12 / 22 (CVE‑2024‑27980) **refuses to `spawn()` a `.cmd`/`.bat` without `shell: true`** and throws `spawn EINVAL` (errno ‑4071). That silently kills the agent‑bridge pane of `pnpm desktop:serve`, and CatBot shows **"Load failed"**.

**Fix:** pass `shell: process.platform === 'win32'` to the `spawn`. On Windows it runs through `cmd.exe`, which resolves the shim; non‑Windows is unchanged. (`bun` path and entry script are space‑free, so the shell‑args caveat doesn't apply.)

## Verification

- Native Windows stack (`vite` + conda‑Python backend, zero WSL): `config.ts` probe now hits `/health` → backend correctly detected; agent‑bridge starts and `GET http://localhost:8001/health` → `{"ok":true,"port":8001}` 200 (no more EINVAL).
- Two-file change, no behavior change off Windows for #2; #1 is strictly more correct on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
