### PR TITLE
fix(workflow): prevent duplicate Svelte each-key in WorkflowView

### DIFF
--- a/desktop/WorkflowView.svelte
+++ b/desktop/WorkflowView.svelte
@@ -439,7 +439,8 @@
           </div>
         {:else}
           <div class="workflow-list">
-            {#each unified_workflows as wf (wf.id)}              <div class="workflow-card">
+            {#each unified_workflows as wf (`${wf.source}:${wf.id}`)}
+              <div class="workflow-card">
                 <button class="workflow-card-main" onclick={() => {
                   if (wf.source === `Engine`) {
                     v2_workflow_id = wf.id; v2_selected_task = null; view = `v2_dag`


### PR DESCRIPTION
`unified_workflows` concatenates GUI workflows (api.list_workflows) and Engine workflows (list_v2_workflows) — two independent fetches that share one id namespace. A workflow registered in both produced two entries with the same id, and the keyed {#each ... (wf.id)} block threw `each_key_duplicate`, crashing the Workflow view.

Use a composite key `${wf.source}:${wf.id}` instead of deduping by id: the design intentionally shows both cards (distinct GUI/Engine source tags, different routing — GUI opens the editor + delete, Engine opens the v2 DAG). Deduping would drop a card the UI is built to show; the composite key keeps each (source, id) unique while preserving behavior.

Also split the jammed `{#each}` / `<div>` onto separate lines.