### PR TITLE
Selected-atom rotation: fixed screen-aligned single-axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ deploy/hpc/bundle/wheels/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/

--- a/docs/superpowers/plans/2026-05-21-selected-atom-rotation-fixed-screen-axes.md
+++ b/docs/superpowers/plans/2026-05-21-selected-atom-rotation-fixed-screen-axes.md
@@ -1,0 +1,608 @@
+# Selected-Atom Rotation — Fixed Screen-Aligned Axes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the free-tumbling quaternion-accumulation rotation of selected atoms with predictable single-axis rotation about a screen-aligned frame anchored at the selection centroid.
+
+**Architecture:** Extract the rotation math into a pure, framework-free module (`rotation-math.ts`) that is unit-tested in isolation, then wire the drag and keyboard paths in `interaction.svelte.ts` to call it. The drag path locks one axis at gesture start (after a dead zone) and recomputes the rotation from the stored initial positions every frame, so no incremental quaternion product is accumulated.
+
+**Tech Stack:** TypeScript, Three.js (`Quaternion`, `Vector3`), Svelte 5 runes (`$state`), Vitest (happy-dom), spec at `docs/superpowers/specs/2026-05-21-selected-atom-rotation-fixed-screen-axes-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `src/lib/structure/rotation-math.ts` — pure rotation helpers (screen frame, axis lock decision, point rotation, drag-delta-to-angle). No Svelte, no DOM. Importable by the controller and by tests.
+- **Create** `tests/vitest/rotation-math.test.ts` — unit tests for every exported helper.
+- **Modify** `src/lib/structure/controllers/interaction.svelte.ts` — add locked-axis + start-anchor state, rewrite the drag mousemove rotation block, refactor `rotate_selected_atoms_keyboard` to use the shared frame, reset new state in `finish_rotation`.
+- **Modify** `src/lib/i18n/en/structure.ts` and `src/lib/i18n/zh/structure.ts` — update the rotate-atoms hint text.
+
+Coordinate frame (origin = centroid; screen = YZ plane):
+- `x` = screen normal toward viewer
+- `y` = screen right
+- `z` = screen up
+
+Input → axis: left-drag horizontal-dominant → `z` (yaw); left-drag vertical-dominant → `y` (pitch); right-drag → `x` (roll). One axis per drag, locked at start after a dead zone.
+
+---
+
+### Task 1: Screen frame from camera quaternion
+
+**Files:**
+- Create: `src/lib/structure/rotation-math.ts`
+- Test: `tests/vitest/rotation-math.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/vitest/rotation-math.test.ts
+import { Quaternion, Vector3 } from 'three'
+import { describe, expect, it } from 'vitest'
+import { screen_frame_from_camera } from '$lib/structure/rotation-math'
+
+describe('screen_frame_from_camera', () => {
+  it('identity camera: x toward viewer, y right, z up', () => {
+    const frame = screen_frame_from_camera(new Quaternion())
+    // identity: world right=(1,0,0), up=(0,1,0), forward=(0,0,-1)
+    // x = -forward = (0,0,1) toward viewer; y = right; z = up
+    expect(frame.x.toArray()).toEqual([0, 0, 1])
+    expect(frame.y.toArray()).toEqual([1, 0, 0])
+    expect(frame.z.toArray()).toEqual([0, 1, 0])
+  })
+
+  it('all axes are unit length and mutually orthogonal', () => {
+    const q = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), 0.7)
+    const f = screen_frame_from_camera(q)
+    for (const v of [f.x, f.y, f.z]) expect(v.length()).toBeCloseTo(1, 6)
+    expect(f.x.dot(f.y)).toBeCloseTo(0, 6)
+    expect(f.y.dot(f.z)).toBeCloseTo(0, 6)
+    expect(f.x.dot(f.z)).toBeCloseTo(0, 6)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: FAIL — `screen_frame_from_camera` not exported / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/lib/structure/rotation-math.ts
+import { Quaternion, Vector3 } from 'three'
+
+/** Screen-aligned orthonormal frame. Origin is the selection centroid
+ *  (supplied separately). x = screen normal toward viewer, y = screen
+ *  right, z = screen up. Screen plane = YZ plane. */
+export interface ScreenFrame {
+  x: Vector3
+  y: Vector3
+  z: Vector3
+}
+
+/** Build the fixed screen frame from the camera quaternion captured at
+ *  gesture start. */
+export function screen_frame_from_camera(cam_quat: Quaternion): ScreenFrame {
+  const right = new Vector3(1, 0, 0).applyQuaternion(cam_quat).normalize()
+  const up = new Vector3(0, 1, 0).applyQuaternion(cam_quat).normalize()
+  const forward = new Vector3(0, 0, -1).applyQuaternion(cam_quat).normalize()
+  return { x: forward.clone().negate(), y: right, z: up }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/rotation-math.ts tests/vitest/rotation-math.test.ts
+git commit -m "feat(rotation): screen_frame_from_camera pure helper"
+```
+
+---
+
+### Task 2: Axis-lock decision with dead zone
+
+**Files:**
+- Modify: `src/lib/structure/rotation-math.ts`
+- Test: `tests/vitest/rotation-math.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to tests/vitest/rotation-math.test.ts
+import { pick_locked_axis } from '$lib/structure/rotation-math'
+
+describe('pick_locked_axis', () => {
+  const dz = 4
+  it('returns null inside the dead zone', () => {
+    expect(pick_locked_axis(2, 2, dz)).toBeNull() // hypot ~2.83 < 4
+  })
+  it('horizontal-dominant drag locks z (yaw)', () => {
+    expect(pick_locked_axis(10, 1, dz)).toBe('z')
+  })
+  it('vertical-dominant drag locks y (pitch)', () => {
+    expect(pick_locked_axis(1, 10, dz)).toBe('y')
+  })
+  it('ties favor horizontal (z)', () => {
+    expect(pick_locked_axis(5, 5, dz)).toBe('z') // hypot ~7.07 > 4
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: FAIL — `pick_locked_axis` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// append to src/lib/structure/rotation-math.ts
+
+export type LockAxis = 'x' | 'y' | 'z'
+
+/** Decide which axis a left-button drag locks onto, from the total
+ *  displacement since mousedown. Returns null until the dead zone is
+ *  exceeded. Horizontal-dominant → z (yaw); vertical-dominant → y (pitch).
+ *  Ties favor horizontal. */
+export function pick_locked_axis(
+  total_dx: number,
+  total_dy: number,
+  deadzone_px: number,
+): 'y' | 'z' | null {
+  if (Math.hypot(total_dx, total_dy) < deadzone_px) return null
+  return Math.abs(total_dx) >= Math.abs(total_dy) ? 'z' : 'y'
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS (6 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/rotation-math.ts tests/vitest/rotation-math.test.ts
+git commit -m "feat(rotation): pick_locked_axis with dead zone"
+```
+
+---
+
+### Task 3: Point rotation about center + drag-delta-to-angle
+
+**Files:**
+- Modify: `src/lib/structure/rotation-math.ts`
+- Test: `tests/vitest/rotation-math.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to tests/vitest/rotation-math.test.ts
+import { rotate_points, drag_delta_for_axis } from '$lib/structure/rotation-math'
+
+describe('rotate_points', () => {
+  it('90° about z maps (1,0,0)+center back to center+(0,1,0)', () => {
+    const center: [number, number, number] = [5, 5, 5]
+    const pts: Array<[number, number, number]> = [[6, 5, 5]] // center + x_hat
+    const out = rotate_points(pts, center, new Vector3(0, 0, 1), Math.PI / 2)
+    expect(out[0][0]).toBeCloseTo(5, 6)
+    expect(out[0][1]).toBeCloseTo(6, 6)
+    expect(out[0][2]).toBeCloseTo(5, 6)
+  })
+  it('zero angle is identity', () => {
+    const out = rotate_points([[1, 2, 3]], [0, 0, 0], new Vector3(0, 1, 0), 0)
+    expect(out[0][0]).toBeCloseTo(1, 6)
+    expect(out[0][1]).toBeCloseTo(2, 6)
+    expect(out[0][2]).toBeCloseTo(3, 6)
+  })
+})
+
+describe('drag_delta_for_axis', () => {
+  it('pitch (y) reads vertical delta', () => {
+    expect(drag_delta_for_axis('y', 3, 9)).toBe(9)
+  })
+  it('yaw (z) and roll (x) read horizontal delta', () => {
+    expect(drag_delta_for_axis('z', 3, 9)).toBe(3)
+    expect(drag_delta_for_axis('x', 3, 9)).toBe(3)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: FAIL — `rotate_points` / `drag_delta_for_axis` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// append to src/lib/structure/rotation-math.ts
+
+/** Rotate each point about `center` by `angle` radians around `axis`.
+ *  Pure: inputs are tuples, output is fresh tuples. */
+export function rotate_points(
+  points: ReadonlyArray<readonly [number, number, number]>,
+  center: readonly [number, number, number],
+  axis: Vector3,
+  angle: number,
+): Array<[number, number, number]> {
+  const quat = new Quaternion().setFromAxisAngle(axis.clone().normalize(), angle)
+  const c = new Vector3(center[0], center[1], center[2])
+  return points.map((p) => {
+    const v = new Vector3(p[0], p[1], p[2]).sub(c).applyQuaternion(quat).add(c)
+    return [v.x, v.y, v.z] as [number, number, number]
+  })
+}
+
+/** Map the locked axis to the relevant pointer-displacement component.
+ *  Pitch (y) uses vertical drag; yaw (z) and roll (x) use horizontal drag. */
+export function drag_delta_for_axis(
+  axis: LockAxis,
+  total_dx: number,
+  total_dy: number,
+): number {
+  return axis === 'y' ? total_dy : total_dx
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS (10 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/rotation-math.ts tests/vitest/rotation-math.test.ts
+git commit -m "feat(rotation): rotate_points + drag_delta_for_axis helpers"
+```
+
+---
+
+### Task 4: Add locked-axis + start-anchor state and a dead-zone constant
+
+**Files:**
+- Modify: `src/lib/structure/controllers/interaction.svelte.ts` (state block near `:222-231`, constant near `:264`, import block)
+
+- [ ] **Step 1: Add the import**
+
+At the top of `interaction.svelte.ts`, alongside the existing `three` import, add:
+
+```ts
+import {
+  screen_frame_from_camera,
+  pick_locked_axis,
+  rotate_points,
+  drag_delta_for_axis,
+  type LockAxis,
+} from '$lib/structure/rotation-math'
+```
+
+(If `Quaternion`/`Vector3` are imported from `three` already, leave that import as-is.)
+
+- [ ] **Step 2: Add new state next to the existing rotation state**
+
+After the existing line `let atom_rotation_angle_deg = $state<number>(0)` (`:231`), add:
+
+```ts
+let atom_rotation_start_x = $state(0)
+let atom_rotation_start_y = $state(0)
+let atom_rotation_locked_axis = $state<LockAxis | null>(null)
+```
+
+- [ ] **Step 3: Add the dead-zone constant**
+
+After `const KEYBOARD_ROTATION_STEP = 0.05 // ~3 degrees per key press` (`:264`), add:
+
+```ts
+const AXIS_LOCK_DEADZONE_PX = 4 // left-drag must exceed this before an axis locks
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS (no behavior change yet; this confirms the import path resolves).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/controllers/interaction.svelte.ts
+git commit -m "feat(rotation): add locked-axis state and dead-zone constant"
+```
+
+---
+
+### Task 5: Initialize the start anchor and reset locked axis
+
+**Files:**
+- Modify: `src/lib/structure/controllers/interaction.svelte.ts` (`start_atom_rotation` `:478-484`, `finish_rotation` `:588-595`)
+
+- [ ] **Step 1: Set the fixed anchor + clear lock in `start_atom_rotation`**
+
+In `start_atom_rotation`, the lines (`:478-484`) currently read:
+
+```ts
+    is_rotating_atoms = true
+    atom_rotation_prev_x = event.clientX
+    atom_rotation_prev_y = event.clientY
+    atom_rotation_cumulative_quat = new Quaternion()
+    atom_rotation_camera_quat = camera.quaternion.clone()
+    atom_rotation_axis = null
+    atom_rotation_angle_deg = 0
+```
+
+Replace with:
+
+```ts
+    is_rotating_atoms = true
+    atom_rotation_prev_x = event.clientX
+    atom_rotation_prev_y = event.clientY
+    atom_rotation_start_x = event.clientX
+    atom_rotation_start_y = event.clientY
+    atom_rotation_locked_axis = atom_rotation_roll_mode ? 'x' : null
+    atom_rotation_cumulative_quat = new Quaternion()
+    atom_rotation_camera_quat = camera.quaternion.clone()
+    atom_rotation_axis = null
+    atom_rotation_angle_deg = 0
+```
+
+Note: `atom_rotation_roll_mode` is set by the mousedown handlers (right button) *before* `start_atom_rotation` runs in the existing code; if a worker finds it is set *after*, move the `atom_rotation_locked_axis` assignment to just after the roll-mode assignment in the mousedown handler instead. Roll always locks to `x` immediately (no dead zone).
+
+- [ ] **Step 2: Reset the new state in `finish_rotation`**
+
+In `finish_rotation`, after `atom_rotation_angle_deg = 0` (`:595`), add:
+
+```ts
+    atom_rotation_locked_axis = null
+    atom_rotation_start_x = 0
+    atom_rotation_start_y = 0
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS (still no behavior change in tests; confirms no type errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/structure/controllers/interaction.svelte.ts
+git commit -m "feat(rotation): init start anchor + reset locked axis on finish"
+```
+
+---
+
+### Task 6: Rewrite the drag mousemove rotation block
+
+**Files:**
+- Modify: `src/lib/structure/controllers/interaction.svelte.ts` (`:1352-1431`)
+
+- [ ] **Step 1: Replace the rotation block**
+
+The block from `if (is_rotating_atoms && atom_rotation_center && deps.get_structure()) {` (`:1352`) through its closing brace (`:1431`) currently accumulates an incremental quaternion. Replace the entire block with:
+
+```ts
+    // 原子旋转中 — 固定屏幕坐标系，单轴锁定
+    if (is_rotating_atoms && atom_rotation_center && deps.get_structure()) {
+      if (!event.shiftKey || event.altKey) {
+        finish_rotation()
+        return
+      }
+
+      atom_rotation_prev_x = event.clientX
+      atom_rotation_prev_y = event.clientY
+
+      // Total displacement from the fixed mousedown anchor (not per-frame).
+      const total_dx = event.clientX - atom_rotation_start_x
+      const total_dy = event.clientY - atom_rotation_start_y
+
+      // Lock the axis once for left-drag (roll already locked to 'x').
+      if (atom_rotation_locked_axis === null) {
+        atom_rotation_locked_axis = pick_locked_axis(total_dx, total_dy, AXIS_LOCK_DEADZONE_PX)
+        if (atom_rotation_locked_axis === null) return // still inside dead zone
+      }
+      const axis = atom_rotation_locked_axis
+
+      const sensitivity = 0.01
+      const cam_quat = atom_rotation_camera_quat
+        || (deps.get_camera() ? deps.get_camera().quaternion : new Quaternion())
+      const frame = screen_frame_from_camera(cam_quat)
+      const axis_vec = frame[axis]
+
+      const angle = drag_delta_for_axis(axis, total_dx, total_dy) * sensitivity
+
+      // Visual feedback.
+      atom_rotation_axis = [axis_vec.x, axis_vec.y, axis_vec.z]
+      atom_rotation_angle_deg = Math.abs(angle) * 180 / Math.PI
+
+      // Recompute every frame from the stored initial positions — idempotent,
+      // no incremental quaternion product.
+      const indices = [...atom_rotation_initial_positions.keys()]
+      const initial = indices.map((idx) => atom_rotation_initial_positions.get(idx)!)
+      const rotated = rotate_points(initial, atom_rotation_center, axis_vec, angle)
+      for (let i = 0; i < indices.length; i++) {
+        pending_rotation_positions.set(indices[i], rotated[i])
+      }
+
+      if (!pending_rotation_update && pending_rotation_positions.size > 0) {
+        pending_rotation_update = true
+        pending_rotation_raf_id = requestAnimationFrame(apply_pending_rotation)
+      }
+    }
+```
+
+- [ ] **Step 2: Confirm `atom_rotation_cumulative_quat` is now unused in the drag path**
+
+Run: `rg -n "atom_rotation_cumulative_quat" src/lib/structure/controllers/interaction.svelte.ts`
+Expected: only the declaration (`:226`) and the resets in `start_atom_rotation`/`finish_rotation` remain — no read in the mousemove block. Leave the declaration and resets (harmless); do not remove in this task.
+
+- [ ] **Step 3: Type-check + run helper tests**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS. (Controller logic is verified manually in Task 9.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/structure/controllers/interaction.svelte.ts
+git commit -m "feat(rotation): single-axis screen-locked drag, drop quat accumulation"
+```
+
+---
+
+### Task 7: Refactor keyboard rotation onto the shared screen frame
+
+**Files:**
+- Modify: `src/lib/structure/controllers/interaction.svelte.ts` (`rotate_selected_atoms_keyboard` `:701-712`)
+
+- [ ] **Step 1: Replace the camera-axis block with the shared frame**
+
+Inside `rotate_selected_atoms_keyboard`, the lines (`:701-712`):
+
+```ts
+    const camera_right = new Vector3(1, 0, 0).applyQuaternion(camera.quaternion).normalize()
+    const camera_up = new Vector3(0, 1, 0).applyQuaternion(camera.quaternion).normalize()
+    const camera_forward = new Vector3(0, 0, -1).applyQuaternion(camera.quaternion).normalize()
+
+    let rotation_axis: Vector3
+    let angle = KEYBOARD_ROTATION_STEP
+    if (direction === 'ArrowLeft') { rotation_axis = camera_up; angle = KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowRight') { rotation_axis = camera_up; angle = -KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowUp') { rotation_axis = camera_right; angle = KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowDown') { rotation_axis = camera_right; angle = -KEYBOARD_ROTATION_STEP }
+    else if (direction === 'Forward') { rotation_axis = camera_forward; angle = KEYBOARD_ROTATION_STEP }
+    else { rotation_axis = camera_forward; angle = -KEYBOARD_ROTATION_STEP }
+```
+
+Replace with:
+
+```ts
+    // Same fixed screen frame as the drag path: x = screen normal toward
+    // viewer, y = screen right, z = screen up.
+    const frame = screen_frame_from_camera(camera.quaternion)
+
+    let rotation_axis: Vector3
+    let angle = KEYBOARD_ROTATION_STEP
+    // Left/Right = yaw about screen-up (z); Up/Down = pitch about screen-right
+    // (y); Forward/Backward = roll about screen-normal (x).
+    if (direction === 'ArrowLeft') { rotation_axis = frame.z; angle = KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowRight') { rotation_axis = frame.z; angle = -KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowUp') { rotation_axis = frame.y; angle = KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowDown') { rotation_axis = frame.y; angle = -KEYBOARD_ROTATION_STEP }
+    else if (direction === 'Forward') { rotation_axis = frame.x; angle = KEYBOARD_ROTATION_STEP }
+    else { rotation_axis = frame.x; angle = -KEYBOARD_ROTATION_STEP }
+```
+
+Note: `frame.z` equals the old `camera_up`, `frame.y` equals `camera_right`, and `frame.x` equals `-camera_forward`. The Forward/Backward roll direction is therefore sign-flipped versus the old code; this matches the drag roll convention. Confirm direction feels natural in Task 9 and flip the two `Forward`/`Backward` signs if not.
+
+- [ ] **Step 2: Type-check + run helper tests**
+
+Run: `pnpm vitest run tests/vitest/rotation-math.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/structure/controllers/interaction.svelte.ts
+git commit -m "refactor(rotation): keyboard rotation uses shared screen frame"
+```
+
+---
+
+### Task 8: Update the rotate-atoms hint strings
+
+**Files:**
+- Modify: `src/lib/i18n/en/structure.ts:614`, `src/lib/i18n/zh/structure.ts:614`
+
+- [ ] **Step 1: Update the English hint**
+
+In `src/lib/i18n/en/structure.ts`, replace:
+
+```ts
+  tip_rotate_atoms_desc: `Shift+drag selected atoms to rotate (left=pitch/yaw, right=roll)`,
+```
+
+with:
+
+```ts
+  tip_rotate_atoms_desc: `Shift+drag to rotate selected atoms — drag horizontally for yaw, vertically for pitch (one axis locks per drag); right-drag for roll`,
+```
+
+- [ ] **Step 2: Update the Chinese hint**
+
+In `src/lib/i18n/zh/structure.ts`, replace:
+
+```ts
+`Shift+拖拽选中的原子进行旋转 (左键=俯仰/偏航，右键=滚动)`,
+```
+
+with:
+
+```ts
+`Shift+拖拽旋转选中原子 — 水平拖拽偏航、垂直拖拽俯仰（每次拖拽锁定一个轴），右键拖拽滚动`,
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `rg -n "tip_rotate_atoms_desc|拖拽旋转选中原子" src/lib/i18n/en/structure.ts src/lib/i18n/zh/structure.ts`
+Expected: both updated strings present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/i18n/en/structure.ts src/lib/i18n/zh/structure.ts
+git commit -m "docs(i18n): update rotate-atoms hint for single-axis rotation"
+```
+
+---
+
+### Task 9: Manual verification in the running app
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm test`
+Expected: all tests pass, including `tests/vitest/rotation-math.test.ts` (10 tests).
+
+- [ ] **Step 2: Launch the app and verify drag behavior**
+
+Start CatGO (`pnpm desktop:serve` or the user's usual command). Load any structure, select ≥1 atom, then:
+- Shift + left-drag horizontally → atoms yaw about the screen-vertical axis; small vertical wobble does NOT add pitch (axis is locked).
+- Shift + left-drag vertically → atoms pitch about the screen-horizontal axis.
+- A tiny shift+click-drag under ~4 px → no rotation (dead zone).
+- Shift + right-drag → atoms roll about the screen normal.
+- Release and re-drag → a fresh axis can be chosen.
+
+Expected: rotation is about the selection centroid, one axis per drag, no tumbling.
+
+- [ ] **Step 3: Verify keyboard behavior**
+
+Select atoms, then Shift+Arrow keys and W/S:
+- Shift+Left/Right → yaw; Shift+Up/Down → pitch; W/S → roll.
+- Confirm roll direction (W vs S) feels natural; if reversed, flip the `Forward`/`Backward` signs in `rotate_selected_atoms_keyboard` (Task 7) and re-commit.
+
+- [ ] **Step 4: Verify commit correctness on a periodic structure**
+
+Load a structure with a lattice, rotate a selection, release. Open the atom panel / export and confirm fractional `abc` updated consistently with the new Cartesian `xyz` (handled by `move_atom`).
+
+- [ ] **Step 5: Commit any sign fix from Step 3 (if needed)**
+
+```bash
+git add src/lib/structure/controllers/interaction.svelte.ts
+git commit -m "fix(rotation): correct roll sign for keyboard W/S"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** centroid origin (Tasks 5/6), screen=YZ frame (Task 1), left-drag direction lock + dead zone (Tasks 2/5/6), right-drag roll about X (Tasks 5/6), scalar-angle single quaternion replacing accumulation (Task 6), keyboard same frame (Task 7), Cartesian math + unchanged commit path (Task 6 reuses `pending_rotation_positions` → `apply_pending_rotation` → `finish_rotation`), hint text (Task 8). All covered.
+- **X-sign open item** from the spec is resolved to `-forward` (toward viewer) and verified empirically in Task 9.
+- **Type consistency:** `LockAxis = 'x'|'y'|'z'`; `pick_locked_axis` returns `'y'|'z'|null` (roll never goes through it); `screen_frame_from_camera` returns `ScreenFrame{x,y,z}`; indexed as `frame[axis]`. Consistent across tasks.

--- a/docs/superpowers/specs/2026-05-21-selected-atom-rotation-fixed-screen-axes-design.md
+++ b/docs/superpowers/specs/2026-05-21-selected-atom-rotation-fixed-screen-axes-design.md
@@ -1,0 +1,120 @@
+# Selected-Atom Rotation — Fixed Screen-Aligned Axes
+
+**Date:** 2026-05-21
+**Status:** Design approved, pending spec review
+**Area:** Structure viewer — interactive rotation of selected atoms (frontend only)
+
+## Problem
+
+Rotating selected atoms today feels "weird." The current implementation
+(`src/lib/structure/controllers/interaction.svelte.ts`) accumulates an
+incremental quaternion every frame from camera-derived axes, and a single
+left-button drag mixes pitch and yaw simultaneously (2 DOF). The compounding
+quaternion product produces a tumbling, gimbal-like feel that is hard to
+control and not reproducible.
+
+## Goal
+
+Replace the free-tumble behavior with a predictable, single-axis-at-a-time
+rotation about a coordinate frame anchored to the selection's geometric center
+and aligned to the screen.
+
+## Coordinate Frame
+
+Established **once at gesture start** and held fixed for the entire drag
+(camera does not move while dragging atoms, so the frame is stable):
+
+- **Origin** = geometric centroid of the selected *original* atoms (image /
+  periodic-copy atoms excluded). Identical to current `atom_rotation_center`
+  computation (`interaction.svelte.ts:487-495`).
+- **Axes** = world axes transformed by the current camera quaternion, then
+  locked:
+  - `X` = screen normal, toward the viewer (`-forward`, i.e.
+    `Vector3(0,0,-1).applyQuaternion(cam_quat)` negated to point at viewer — see Note)
+  - `Y` = screen right (`Vector3(1,0,0).applyQuaternion(cam_quat)`)
+  - `Z` = screen up (`Vector3(0,1,0).applyQuaternion(cam_quat)`)
+
+Screen plane = `YZ` plane; `X` is its normal.
+
+> **Note on X sign:** define `X` so that a positive roll angle reads as a
+> natural counter-clockwise spin from the viewer's perspective. Final sign to
+> be confirmed empirically during implementation; it only affects roll
+> direction, not correctness.
+
+## Input → Axis Mapping
+
+**Left-button drag — direction-locked, one axis per drag:**
+- A dead zone applies at drag start: the axis is **not** locked until the
+  pointer has moved more than a small threshold (`AXIS_LOCK_DEADZONE_PX`,
+  e.g. 4 px) from the mousedown point. This avoids jitter mis-locking.
+- Once the threshold is crossed, the dominant component of the initial
+  displacement picks the axis:
+  - horizontal-dominant → rotate about `Z` (screen vertical axis; yaw)
+  - vertical-dominant → rotate about `Y` (screen horizontal axis; pitch)
+- The locked axis is held for the **entire drag until mouse release**. No
+  mid-drag axis switching. The orthogonal pointer component is ignored.
+
+**Right-button drag — roll:**
+- Rotate about `X` (screen normal), driven by `delta_x`. No dead-zone axis
+  selection needed (axis is always `X`).
+
+## Angle Application
+
+Single scalar angle accumulated about the locked axis:
+
+```
+angle += drag_delta_along_locked_direction * sensitivity
+quat = new Quaternion().setFromAxisAngle(locked_axis, angle)
+```
+
+- `drag_delta_along_locked_direction` is `delta_x` for `Z`/`X` axes and
+  `delta_y` for the `Y` axis (i.e. the dominant pointer component).
+- This **replaces** the per-frame incremental-quaternion accumulation
+  (`interaction.svelte.ts:1377-1396`) — the source of the tumbling feel.
+- Per-atom application is unchanged: translate to centroid-relative, apply
+  the single quaternion, translate back (`interaction.svelte.ts:1410-1424`).
+- Visual feedback (`atom_rotation_axis`, `atom_rotation_angle_deg`) reads
+  directly from the locked axis and scalar angle — no quaternion decomposition
+  needed.
+
+## Keyboard Path
+
+`rotate_selected_atoms_keyboard()` (`interaction.svelte.ts:671-733`) adopts the
+same fixed screen-aligned frame (centroid origin; X/Y/Z = screen
+normal/right/up). Each key rotates a fixed `KEYBOARD_ROTATION_STEP` about one
+fixed axis:
+- Shift+Left/Right → about `Z`
+- Shift+Up/Down → about `Y`
+- W/S → about `X` (roll)
+
+Discrete steps; consistent with the drag frame.
+
+## Out of Scope / Unchanged
+
+- All math stays in **Cartesian** (`xyz`, Å). Fractional `abc` recomputed only
+  at commit by `move_atom` (`src/lib/structure/atom-manipulation.ts:385`).
+- Commit path unchanged: `realtime_position_overrides` Map + `requestAnimationFrame`
+  batching → `finish_rotation` → `commit_rotation_to_structure` →
+  `apply_overrides_to_structure`.
+- Fully client-side; no backend / HTTP request.
+- Camera/view rotation (`interaction-handlers.ts`) untouched.
+
+## Testing
+
+- Unit-test the axis-lock decision: given an initial displacement vector and
+  dead-zone threshold, asserts the chosen axis (none below threshold;
+  Z for horizontal-dominant; Y for vertical-dominant).
+- Unit-test scalar-angle → quaternion → per-atom position for a known
+  centroid and axis (e.g. 90° about Z maps a known atom to expected xyz).
+- Manual: drag locks one axis until release; right-drag rolls; keyboard steps
+  match drag-frame axes; fractional coords correct after commit on a lattice.
+
+## Key Files
+
+- `src/lib/structure/controllers/interaction.svelte.ts`
+  - `start_atom_rotation` `:466`, centroid `:487-495`
+  - drag math to rewrite `:1352-1431` (esp. `:1377-1396`)
+  - `rotate_selected_atoms_keyboard` `:671-733`
+  - commit chain `:584` / `:557` / `:524` / `:416`
+- `src/lib/structure/atom-manipulation.ts:385` — `move_atom` (Cart→frac)
+- `src/lib/i18n/en/structure.ts:613-614` — UI hint strings (update wording)

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -611,7 +611,7 @@ const structure: Record<string, string> = {
   tip_selection: `Selection`,
   tip_selection_desc: `Click atoms to select, Shift+click to add, Ctrl+A to select all`,
   tip_rotate_atoms: `Rotate Atoms`,
-  tip_rotate_atoms_desc: `Shift+drag selected atoms to rotate (left=pitch/yaw, right=roll)`,
+  tip_rotate_atoms_desc: `Shift+drag to rotate selected atoms — drag horizontally for yaw, vertically for pitch (one axis locks per drag); right-drag for roll`,
   tip_move_atoms: `Move Atoms`,
   tip_move_atoms_desc: `Shift+Alt+Arrow (or Ctrl+Arrow) to move selected atoms`,
   tip_trajectory: `Trajectory`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -611,7 +611,7 @@ const structure: Record<string, string> = {
   tip_selection: `原子选择`,
   tip_selection_desc: `点击原子进行选择，Shift+点击多选，Ctrl+A 全选`,
   tip_rotate_atoms: `旋转原子`,
-  tip_rotate_atoms_desc: `Shift+拖拽选中的原子进行旋转 (左键=俯仰/偏航，右键=滚动)`,
+  tip_rotate_atoms_desc: `Shift+拖拽旋转选中原子 — 水平拖拽偏航、垂直拖拽俯仰（每次拖拽锁定一个轴），右键拖拽滚动`,
   tip_move_atoms: `移动原子`,
   tip_move_atoms_desc: `Shift+Alt+方向键 (或 Ctrl+方向键) 移动选中的原子`,
   tip_trajectory: `轨迹播放`,

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -39,6 +39,13 @@ import { get_movement_step } from '../manipulation'
 import { get_center_of_mass, get_rotation_center } from '$lib/structure'
 import { atom_clipboard } from '$lib/state.svelte'
 import { Euler, Plane, Quaternion, Raycaster, Vector2, Vector3 } from 'three'
+import {
+  screen_frame_from_camera,
+  pick_locked_axis,
+  rotate_points,
+  drag_delta_for_axis,
+  type LockAxis,
+} from '$lib/structure/rotation-math'
 import type { ElementSymbol } from '$lib'
 import type { AtomManipulationEvent } from '../index'
 import type { GestureConfig } from '$lib/gesture/gesture-types'
@@ -229,6 +236,9 @@ export function create_interaction_controller(deps: InteractionDeps) {
   let atom_rotation_used_right = $state(false)
   let atom_rotation_axis = $state<[number, number, number] | null>(null)
   let atom_rotation_angle_deg = $state<number>(0)
+  let atom_rotation_start_x = $state(0)
+  let atom_rotation_start_y = $state(0)
+  let atom_rotation_locked_axis = $state<LockAxis | null>(null)
 
   // ═══════════════════════════════════════════════════════════════════
   // RAF 批处理 — 拖拽/旋转时用 requestAnimationFrame 批量更新位置,
@@ -262,6 +272,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
   let keyboard_rotation_undo_saved = $state(false)
   let keyboard_rotation_timeout: ReturnType<typeof setTimeout> | null = null
   const KEYBOARD_ROTATION_STEP = 0.05 // ~3 degrees per key press
+  const AXIS_LOCK_DEADZONE_PX = 4 // left-drag must exceed this before an axis locks
 
   // ═══════════════════════════════════════════════════════════════════
   // 框选状态 — Cmd/Ctrl+拖拽矩形选择多个原子

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -1369,80 +1369,46 @@ export function create_interaction_controller(deps: InteractionDeps) {
       return
     }
 
-    // 原子旋转中
+    // 原子旋转中 — 固定屏幕坐标系，单轴锁定
     if (is_rotating_atoms && atom_rotation_center && deps.get_structure()) {
       if (!event.shiftKey || event.altKey) {
         finish_rotation()
         return
       }
 
-      const delta_x = event.clientX - atom_rotation_prev_x
-      const delta_y = event.clientY - atom_rotation_prev_y
       atom_rotation_prev_x = event.clientX
       atom_rotation_prev_y = event.clientY
 
+      // Total displacement from the fixed mousedown anchor (not per-frame).
+      const total_dx = event.clientX - atom_rotation_start_x
+      const total_dy = event.clientY - atom_rotation_start_y
+
+      // Lock the axis once for left-drag (roll already locked to 'x').
+      if (atom_rotation_locked_axis === null) {
+        atom_rotation_locked_axis = pick_locked_axis(total_dx, total_dy, AXIS_LOCK_DEADZONE_PX)
+        if (atom_rotation_locked_axis === null) return // still inside dead zone
+      }
+      const axis = atom_rotation_locked_axis
+
       const sensitivity = 0.01
-      const cam_quat = atom_rotation_camera_quat || (deps.get_camera() ? deps.get_camera().quaternion : null)
-      let rotation_up: Vector3, rotation_right: Vector3, rotation_forward: Vector3
+      const cam_quat = atom_rotation_camera_quat
+        || (deps.get_camera() ? deps.get_camera().quaternion : new Quaternion())
+      const frame = screen_frame_from_camera(cam_quat)
+      const axis_vec = frame[axis]
 
-      if (cam_quat) {
-        rotation_up = new Vector3(0, 1, 0).applyQuaternion(cam_quat).normalize()
-        rotation_right = new Vector3(1, 0, 0).applyQuaternion(cam_quat).normalize()
-        rotation_forward = new Vector3(0, 0, -1).applyQuaternion(cam_quat).normalize()
-      } else {
-        rotation_up = new Vector3(0, 1, 0)
-        rotation_right = new Vector3(1, 0, 0)
-        rotation_forward = new Vector3(0, 0, -1)
-      }
+      const angle = drag_delta_for_axis(axis, total_dx, total_dy) * sensitivity
 
-      let incremental_quat: Quaternion
-      if (atom_rotation_roll_mode) {
-        const angle_z = delta_x * sensitivity
-        incremental_quat = new Quaternion().setFromAxisAngle(rotation_forward, angle_z)
-      } else {
-        const abs_dx = Math.abs(delta_x)
-        const abs_dy = Math.abs(delta_y)
-        // Suppress the minor axis when one axis clearly dominates,
-        // so a horizontal drag doesn't accumulate pitch noise (and vice-versa).
-        const dominance = 3 // ratio threshold
-        const eff_dx = (abs_dy > dominance * abs_dx) ? 0 : delta_x
-        const eff_dy = (abs_dx > dominance * abs_dy) ? 0 : delta_y
-        const angle_y = eff_dx * sensitivity
-        const angle_x = eff_dy * sensitivity
-        const quat_y = new Quaternion().setFromAxisAngle(rotation_up, angle_y)
-        const quat_x = new Quaternion().setFromAxisAngle(rotation_right, angle_x)
-        incremental_quat = quat_y.multiply(quat_x)
-      }
+      // Visual feedback.
+      atom_rotation_axis = [axis_vec.x, axis_vec.y, axis_vec.z]
+      atom_rotation_angle_deg = Math.abs(angle) * 180 / Math.PI
 
-      atom_rotation_cumulative_quat = incremental_quat.multiply(atom_rotation_cumulative_quat)
-
-      // Extract axis-angle from cumulative quaternion for visual feedback
-      const _cum_angle = 2 * Math.acos(Math.min(1, Math.abs(atom_rotation_cumulative_quat.w)))
-      if (_cum_angle > 1e-6) {
-        const s = Math.sqrt(1 - atom_rotation_cumulative_quat.w * atom_rotation_cumulative_quat.w)
-        atom_rotation_axis = [
-          atom_rotation_cumulative_quat.x / s,
-          atom_rotation_cumulative_quat.y / s,
-          atom_rotation_cumulative_quat.z / s,
-        ]
-      }
-      atom_rotation_angle_deg = _cum_angle * 180 / Math.PI
-
-      for (const idx of atom_rotation_initial_positions.keys()) {
-        const initial_pos = atom_rotation_initial_positions.get(idx)
-        if (initial_pos && atom_rotation_center) {
-          const relative = new Vector3(
-            initial_pos[0] - atom_rotation_center[0],
-            initial_pos[1] - atom_rotation_center[1],
-            initial_pos[2] - atom_rotation_center[2],
-          )
-          relative.applyQuaternion(atom_rotation_cumulative_quat)
-          pending_rotation_positions.set(idx, [
-            atom_rotation_center[0] + relative.x,
-            atom_rotation_center[1] + relative.y,
-            atom_rotation_center[2] + relative.z,
-          ])
-        }
+      // Recompute every frame from the stored initial positions — idempotent,
+      // no incremental quaternion product.
+      const indices = [...atom_rotation_initial_positions.keys()]
+      const initial = indices.map((idx) => atom_rotation_initial_positions.get(idx)!)
+      const rotated = rotate_points(initial, atom_rotation_center, axis_vec, angle)
+      for (let i = 0; i < indices.length; i++) {
+        pending_rotation_positions.set(indices[i], rotated[i])
       }
 
       if (!pending_rotation_update && pending_rotation_positions.size > 0) {

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -489,6 +489,11 @@ export function create_interaction_controller(deps: InteractionDeps) {
     is_rotating_atoms = true
     atom_rotation_prev_x = event.clientX
     atom_rotation_prev_y = event.clientY
+    atom_rotation_start_x = event.clientX
+    atom_rotation_start_y = event.clientY
+    // Default to left-drag (unlocked); the mousedown handlers override to 'x'
+    // for the right-button roll path AFTER this function returns.
+    atom_rotation_locked_axis = null
     atom_rotation_cumulative_quat = new Quaternion()
     atom_rotation_camera_quat = camera.quaternion.clone()
     atom_rotation_axis = null
@@ -604,6 +609,9 @@ export function create_interaction_controller(deps: InteractionDeps) {
     atom_rotation_roll_mode = false
     atom_rotation_axis = null
     atom_rotation_angle_deg = 0
+    atom_rotation_locked_axis = null
+    atom_rotation_start_x = 0
+    atom_rotation_start_y = 0
     pending_rotation_positions = new Map()
     pending_rotation_update = false
     const orbit_controls = deps.get_orbit_controls()
@@ -1129,6 +1137,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
         if (event.button === 2) {
           atom_rotation_roll_mode = true
           atom_rotation_used_right = true
+          atom_rotation_locked_axis = 'x' // roll = rotate about screen normal
         }
         event.stopPropagation()
         event.preventDefault()
@@ -1164,6 +1173,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
         if (event.button === 2) {
           atom_rotation_roll_mode = true
           atom_rotation_used_right = true
+          atom_rotation_locked_axis = 'x' // roll = rotate about screen normal
         }
         event.preventDefault()
         event.stopPropagation()

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -717,18 +717,20 @@ export function create_interaction_controller(deps: InteractionDeps) {
 
     if (!keyboard_rotation_center) return
 
-    const camera_right = new Vector3(1, 0, 0).applyQuaternion(camera.quaternion).normalize()
-    const camera_up = new Vector3(0, 1, 0).applyQuaternion(camera.quaternion).normalize()
-    const camera_forward = new Vector3(0, 0, -1).applyQuaternion(camera.quaternion).normalize()
+    // Same fixed screen frame as the drag path: x = screen normal toward
+    // viewer, y = screen right, z = screen up.
+    const frame = screen_frame_from_camera(camera.quaternion)
 
     let rotation_axis: Vector3
     let angle = KEYBOARD_ROTATION_STEP
-    if (direction === 'ArrowLeft') { rotation_axis = camera_up; angle = KEYBOARD_ROTATION_STEP }
-    else if (direction === 'ArrowRight') { rotation_axis = camera_up; angle = -KEYBOARD_ROTATION_STEP }
-    else if (direction === 'ArrowUp') { rotation_axis = camera_right; angle = KEYBOARD_ROTATION_STEP }
-    else if (direction === 'ArrowDown') { rotation_axis = camera_right; angle = -KEYBOARD_ROTATION_STEP }
-    else if (direction === 'Forward') { rotation_axis = camera_forward; angle = KEYBOARD_ROTATION_STEP }
-    else { rotation_axis = camera_forward; angle = -KEYBOARD_ROTATION_STEP }
+    // Left/Right = yaw about screen-up (z); Up/Down = pitch about screen-right
+    // (y); Forward/Backward = roll about screen-normal (x).
+    if (direction === 'ArrowLeft') { rotation_axis = frame.z; angle = KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowRight') { rotation_axis = frame.z; angle = -KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowUp') { rotation_axis = frame.y; angle = KEYBOARD_ROTATION_STEP }
+    else if (direction === 'ArrowDown') { rotation_axis = frame.y; angle = -KEYBOARD_ROTATION_STEP }
+    else if (direction === 'Forward') { rotation_axis = frame.x; angle = KEYBOARD_ROTATION_STEP }
+    else { rotation_axis = frame.x; angle = -KEYBOARD_ROTATION_STEP }
 
     const rotation_quat = new Quaternion().setFromAxisAngle(rotation_axis, angle)
     const new_overrides = new Map(realtime_position_overrides)

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -226,13 +226,10 @@ export function create_interaction_controller(deps: InteractionDeps) {
   // Shift + 右键拖拽: roll (绕相机 forward 轴)
   // ═══════════════════════════════════════════════════════════════════
   let is_rotating_atoms = $state(false)
-  let atom_rotation_prev_x = $state(0)
-  let atom_rotation_prev_y = $state(0)
   let atom_rotation_center = $state<[number, number, number] | null>(null)
   let atom_rotation_initial_positions = $state<Map<number, [number, number, number]>>(new Map())
   let atom_rotation_cumulative_quat = $state<Quaternion>(new Quaternion())
   let atom_rotation_camera_quat = $state<Quaternion | null>(null)
-  let atom_rotation_roll_mode = $state(false)
   let atom_rotation_used_right = $state(false)
   let atom_rotation_axis = $state<[number, number, number] | null>(null)
   let atom_rotation_angle_deg = $state<number>(0)
@@ -487,8 +484,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
     if (save_undo) deps.push_to_undo()
 
     is_rotating_atoms = true
-    atom_rotation_prev_x = event.clientX
-    atom_rotation_prev_y = event.clientY
     atom_rotation_start_x = event.clientX
     atom_rotation_start_y = event.clientY
     // Default to left-drag (unlocked); the mousedown handlers override to 'x'
@@ -606,7 +601,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
     atom_rotation_initial_positions = new Map()
     atom_rotation_cumulative_quat = new Quaternion()
     atom_rotation_camera_quat = null
-    atom_rotation_roll_mode = false
     atom_rotation_axis = null
     atom_rotation_angle_deg = 0
     atom_rotation_locked_axis = null
@@ -1137,7 +1131,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
       const started = start_atom_rotation(event, true)
       if (started) {
         if (event.button === 2) {
-          atom_rotation_roll_mode = true
           atom_rotation_used_right = true
           atom_rotation_locked_axis = 'x' // roll = rotate about screen normal
         }
@@ -1173,7 +1166,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
       const started = start_atom_rotation(event, !is_rotating_atoms)
       if (started) {
         if (event.button === 2) {
-          atom_rotation_roll_mode = true
           atom_rotation_used_right = true
           atom_rotation_locked_axis = 'x' // roll = rotate about screen normal
         }
@@ -1377,9 +1369,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
         finish_rotation()
         return
       }
-
-      atom_rotation_prev_x = event.clientX
-      atom_rotation_prev_y = event.clientY
 
       // Total displacement from the fixed mousedown anchor (not per-frame).
       const total_dx = event.clientX - atom_rotation_start_x

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -228,7 +228,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
   let is_rotating_atoms = $state(false)
   let atom_rotation_center = $state<[number, number, number] | null>(null)
   let atom_rotation_initial_positions = $state<Map<number, [number, number, number]>>(new Map())
-  let atom_rotation_cumulative_quat = $state<Quaternion>(new Quaternion())
   let atom_rotation_camera_quat = $state<Quaternion | null>(null)
   let atom_rotation_used_right = $state(false)
   let atom_rotation_axis = $state<[number, number, number] | null>(null)
@@ -489,7 +488,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
     // Default to left-drag (unlocked); the mousedown handlers override to 'x'
     // for the right-button roll path AFTER this function returns.
     atom_rotation_locked_axis = null
-    atom_rotation_cumulative_quat = new Quaternion()
     atom_rotation_camera_quat = camera.quaternion.clone()
     atom_rotation_axis = null
     atom_rotation_angle_deg = 0
@@ -599,7 +597,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
     is_rotating_atoms = false
     atom_rotation_center = null
     atom_rotation_initial_positions = new Map()
-    atom_rotation_cumulative_quat = new Quaternion()
     atom_rotation_camera_quat = null
     atom_rotation_axis = null
     atom_rotation_angle_deg = 0

--- a/src/lib/structure/rotation-math.ts
+++ b/src/lib/structure/rotation-math.ts
@@ -1,0 +1,30 @@
+import { Quaternion, Vector3 } from 'three'
+
+/** Screen-aligned orthonormal frame. Origin is the selection centroid
+ *  (supplied separately). x = screen normal toward viewer, y = screen
+ *  right, z = screen up. Screen plane = YZ plane. */
+export interface ScreenFrame {
+  x: Vector3
+  y: Vector3
+  z: Vector3
+}
+
+/** Normalize signed-zero components to +0 so the frame is canonical
+ *  (three.js quaternion math can emit -0 for axis-aligned inputs). */
+function clean_zeros(v: Vector3): Vector3 {
+  const fix = (n: number): number => (n === 0 ? 0 : n)
+  return v.set(fix(v.x), fix(v.y), fix(v.z))
+}
+
+/** Build the fixed screen frame from the camera quaternion captured at
+ *  gesture start. */
+export function screen_frame_from_camera(cam_quat: Quaternion): ScreenFrame {
+  const right = clean_zeros(new Vector3(1, 0, 0).applyQuaternion(cam_quat).normalize())
+  const up = clean_zeros(new Vector3(0, 1, 0).applyQuaternion(cam_quat).normalize())
+  // +Z in camera space points toward the viewer (three.js camera looks
+  // down -Z), so the screen normal is +Z transformed by the quaternion.
+  const toward_viewer = clean_zeros(
+    new Vector3(0, 0, 1).applyQuaternion(cam_quat).normalize(),
+  )
+  return { x: toward_viewer, y: right, z: up }
+}

--- a/src/lib/structure/rotation-math.ts
+++ b/src/lib/structure/rotation-math.ts
@@ -1,4 +1,5 @@
 import { Quaternion, Vector3 } from 'three'
+import type { Vec3 } from '$lib/math'
 
 /** Screen-aligned orthonormal frame. Origin is the selection centroid
  *  (supplied separately). x = screen normal toward viewer, y = screen
@@ -10,7 +11,8 @@ export interface ScreenFrame {
 }
 
 /** Normalize signed-zero components to +0 so the frame is canonical
- *  (three.js quaternion math can emit -0 for axis-aligned inputs). */
+ *  (three.js quaternion math can emit -0 for axis-aligned inputs).
+ *  Mutates `v` in place (only ever called on throwaway vectors). */
 function clean_zeros(v: Vector3): Vector3 {
   const fix = (n: number): number => (n === 0 ? 0 : n)
   return v.set(fix(v.x), fix(v.y), fix(v.z))
@@ -47,16 +49,16 @@ export function pick_locked_axis(
 /** Rotate each point about `center` by `angle` radians around `axis`.
  *  Pure: inputs are tuples, output is fresh tuples. */
 export function rotate_points(
-  points: ReadonlyArray<readonly [number, number, number]>,
-  center: readonly [number, number, number],
+  points: ReadonlyArray<Vec3>,
+  center: Vec3,
   axis: Vector3,
   angle: number,
-): Array<[number, number, number]> {
+): Vec3[] {
   const quat = new Quaternion().setFromAxisAngle(axis.clone().normalize(), angle)
   const c = new Vector3(center[0], center[1], center[2])
   return points.map((p) => {
     const v = new Vector3(p[0], p[1], p[2]).sub(c).applyQuaternion(quat).add(c)
-    return [v.x, v.y, v.z] as [number, number, number]
+    return [v.x, v.y, v.z] as Vec3
   })
 }
 

--- a/src/lib/structure/rotation-math.ts
+++ b/src/lib/structure/rotation-math.ts
@@ -43,3 +43,29 @@ export function pick_locked_axis(
   if (Math.hypot(total_dx, total_dy) < deadzone_px) return null
   return Math.abs(total_dx) >= Math.abs(total_dy) ? 'z' : 'y'
 }
+
+/** Rotate each point about `center` by `angle` radians around `axis`.
+ *  Pure: inputs are tuples, output is fresh tuples. */
+export function rotate_points(
+  points: ReadonlyArray<readonly [number, number, number]>,
+  center: readonly [number, number, number],
+  axis: Vector3,
+  angle: number,
+): Array<[number, number, number]> {
+  const quat = new Quaternion().setFromAxisAngle(axis.clone().normalize(), angle)
+  const c = new Vector3(center[0], center[1], center[2])
+  return points.map((p) => {
+    const v = new Vector3(p[0], p[1], p[2]).sub(c).applyQuaternion(quat).add(c)
+    return [v.x, v.y, v.z] as [number, number, number]
+  })
+}
+
+/** Map the locked axis to the relevant pointer-displacement component.
+ *  Pitch (y) uses vertical drag; yaw (z) and roll (x) use horizontal drag. */
+export function drag_delta_for_axis(
+  axis: LockAxis,
+  total_dx: number,
+  total_dy: number,
+): number {
+  return axis === 'y' ? total_dy : total_dx
+}

--- a/src/lib/structure/rotation-math.ts
+++ b/src/lib/structure/rotation-math.ts
@@ -28,3 +28,18 @@ export function screen_frame_from_camera(cam_quat: Quaternion): ScreenFrame {
   )
   return { x: toward_viewer, y: right, z: up }
 }
+
+export type LockAxis = 'x' | 'y' | 'z'
+
+/** Decide which axis a left-button drag locks onto, from the total
+ *  displacement since mousedown. Returns null until the dead zone is
+ *  exceeded. Horizontal-dominant → z (yaw); vertical-dominant → y (pitch).
+ *  Ties favor horizontal. */
+export function pick_locked_axis(
+  total_dx: number,
+  total_dy: number,
+  deadzone_px: number,
+): 'y' | 'z' | null {
+  if (Math.hypot(total_dx, total_dy) < deadzone_px) return null
+  return Math.abs(total_dx) >= Math.abs(total_dy) ? 'z' : 'y'
+}

--- a/tests/vitest/rotation-math.test.ts
+++ b/tests/vitest/rotation-math.test.ts
@@ -1,6 +1,11 @@
 import { Quaternion, Vector3 } from 'three'
 import { describe, expect, it } from 'vitest'
-import { screen_frame_from_camera, pick_locked_axis } from '$lib/structure/rotation-math'
+import {
+  screen_frame_from_camera,
+  pick_locked_axis,
+  rotate_points,
+  drag_delta_for_axis,
+} from '$lib/structure/rotation-math'
 
 describe('screen_frame_from_camera', () => {
   it('identity camera: x toward viewer, y right, z up', () => {
@@ -32,5 +37,32 @@ describe('pick_locked_axis', () => {
   })
   it('ties favor horizontal (z)', () => {
     expect(pick_locked_axis(5, 5, dz)).toBe('z')
+  })
+})
+
+describe('rotate_points', () => {
+  it('90° about z maps (1,0,0)+center back to center+(0,1,0)', () => {
+    const center: [number, number, number] = [5, 5, 5]
+    const pts: Array<[number, number, number]> = [[6, 5, 5]]
+    const out = rotate_points(pts, center, new Vector3(0, 0, 1), Math.PI / 2)
+    expect(out[0][0]).toBeCloseTo(5, 6)
+    expect(out[0][1]).toBeCloseTo(6, 6)
+    expect(out[0][2]).toBeCloseTo(5, 6)
+  })
+  it('zero angle is identity', () => {
+    const out = rotate_points([[1, 2, 3]], [0, 0, 0], new Vector3(0, 1, 0), 0)
+    expect(out[0][0]).toBeCloseTo(1, 6)
+    expect(out[0][1]).toBeCloseTo(2, 6)
+    expect(out[0][2]).toBeCloseTo(3, 6)
+  })
+})
+
+describe('drag_delta_for_axis', () => {
+  it('pitch (y) reads vertical delta', () => {
+    expect(drag_delta_for_axis('y', 3, 9)).toBe(9)
+  })
+  it('yaw (z) and roll (x) read horizontal delta', () => {
+    expect(drag_delta_for_axis('z', 3, 9)).toBe(3)
+    expect(drag_delta_for_axis('x', 3, 9)).toBe(3)
   })
 })

--- a/tests/vitest/rotation-math.test.ts
+++ b/tests/vitest/rotation-math.test.ts
@@ -1,6 +1,6 @@
 import { Quaternion, Vector3 } from 'three'
 import { describe, expect, it } from 'vitest'
-import { screen_frame_from_camera } from '$lib/structure/rotation-math'
+import { screen_frame_from_camera, pick_locked_axis } from '$lib/structure/rotation-math'
 
 describe('screen_frame_from_camera', () => {
   it('identity camera: x toward viewer, y right, z up', () => {
@@ -16,5 +16,21 @@ describe('screen_frame_from_camera', () => {
     expect(f.x.dot(f.y)).toBeCloseTo(0, 6)
     expect(f.y.dot(f.z)).toBeCloseTo(0, 6)
     expect(f.x.dot(f.z)).toBeCloseTo(0, 6)
+  })
+})
+
+describe('pick_locked_axis', () => {
+  const dz = 4
+  it('returns null inside the dead zone', () => {
+    expect(pick_locked_axis(2, 2, dz)).toBeNull()
+  })
+  it('horizontal-dominant drag locks z (yaw)', () => {
+    expect(pick_locked_axis(10, 1, dz)).toBe('z')
+  })
+  it('vertical-dominant drag locks y (pitch)', () => {
+    expect(pick_locked_axis(1, 10, dz)).toBe('y')
+  })
+  it('ties favor horizontal (z)', () => {
+    expect(pick_locked_axis(5, 5, dz)).toBe('z')
   })
 })

--- a/tests/vitest/rotation-math.test.ts
+++ b/tests/vitest/rotation-math.test.ts
@@ -1,0 +1,20 @@
+import { Quaternion, Vector3 } from 'three'
+import { describe, expect, it } from 'vitest'
+import { screen_frame_from_camera } from '$lib/structure/rotation-math'
+
+describe('screen_frame_from_camera', () => {
+  it('identity camera: x toward viewer, y right, z up', () => {
+    const frame = screen_frame_from_camera(new Quaternion())
+    expect(frame.x.toArray()).toEqual([0, 0, 1])
+    expect(frame.y.toArray()).toEqual([1, 0, 0])
+    expect(frame.z.toArray()).toEqual([0, 1, 0])
+  })
+  it('all axes are unit length and mutually orthogonal', () => {
+    const q = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), 0.7)
+    const f = screen_frame_from_camera(q)
+    for (const v of [f.x, f.y, f.z]) expect(v.length()).toBeCloseTo(1, 6)
+    expect(f.x.dot(f.y)).toBeCloseTo(0, 6)
+    expect(f.y.dot(f.z)).toBeCloseTo(0, 6)
+    expect(f.x.dot(f.z)).toBeCloseTo(0, 6)
+  })
+})

--- a/tests/vitest/rotation-math.test.ts
+++ b/tests/vitest/rotation-math.test.ts
@@ -22,6 +22,14 @@ describe('screen_frame_from_camera', () => {
     expect(f.y.dot(f.z)).toBeCloseTo(0, 6)
     expect(f.x.dot(f.z)).toBeCloseTo(0, 6)
   })
+  it('is right-handed (x cross y ≈ z)', () => {
+    const q = new Quaternion().setFromAxisAngle(new Vector3(1, 1, 0).normalize(), 0.9)
+    const f = screen_frame_from_camera(q)
+    const cross = f.x.clone().cross(f.y)
+    expect(cross.x).toBeCloseTo(f.z.x, 6)
+    expect(cross.y).toBeCloseTo(f.z.y, 6)
+    expect(cross.z).toBeCloseTo(f.z.z, 6)
+  })
 })
 
 describe('pick_locked_axis', () => {


### PR DESCRIPTION
## Summary
Reworks rotation of **selected atoms** in the structure viewer from free-tumbling cumulative-quaternion accumulation to predictable **single-axis rotation about a screen-aligned frame anchored at the selection centroid**.

- New pure module `src/lib/structure/rotation-math.ts` — `screen_frame_from_camera`, `pick_locked_axis`, `rotate_points`, `drag_delta_for_axis` (framework-free, 11 unit tests in `tests/vitest/rotation-math.test.ts`).
- Controller `interaction.svelte.ts` rewired: left-drag locks ONE axis per gesture after a 4px dead zone (horizontal→yaw / screen-up Z, vertical→pitch / screen-right Y); right-drag → roll (screen-normal X). Keyboard (Shift+arrows, W/S) uses the same frame. Per-frame cumulative-quaternion accumulation removed; positions recomputed idempotently from stored initial positions.
- Dead state removed (`atom_rotation_cumulative_quat`, `atom_rotation_prev_x/y`, `atom_rotation_roll_mode`).
- i18n hint strings updated (en + zh).

Coordinate frame: origin = centroid; screen = YZ plane; X = screen normal toward viewer, Y = right, Z = up. All math in Cartesian; commit/undo path unchanged.

Spec + plan: `docs/superpowers/specs/2026-05-21-...-design.md`, `docs/superpowers/plans/2026-05-21-...md`.

## Test Plan
- [x] `pnpm vitest run tests/vitest/rotation-math.test.ts` → 11/11 pass
- [x] `svelte-check` clean for `interaction.svelte.ts`
- [x] Manual: load structure, select atoms — verify horizontal-drag yaw / vertical-drag pitch (single-axis lock, dead zone), right-drag roll, keyboard Shift+arrows + W/S, rotation about centroid, fractional coords correct after commit. (User confirmed feel.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)