### PR TITLE
fix(ci): build catrender-wasm in frontend-build workflows

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -116,6 +116,11 @@ jobs:
         run: |
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
 
+      - name: Build catrender WASM (extensions/catrender-wasm → src/lib/structure/catrender/catrender-wasm-pkg)
+        working-directory: extensions/catrender-wasm
+        run: |
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
+
       - name: Generate docs-chunks.json for CatBot RAG
         run: pnpm build:doc-chunks
 

--- a/.github/workflows/hpc-bundle.yml
+++ b/.github/workflows/hpc-bundle.yml
@@ -65,6 +65,9 @@ jobs:
           cd ../chgdiff-wasm
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
 
+          cd ../catrender-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
+
       - name: Build documentation chunks
         run: pnpm run build:doc-chunks
 

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -118,6 +118,9 @@ jobs:
           cd ../chgdiff-wasm
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
 
+          cd ../catrender-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
+
       - name: Generate documentation chunks
         run: pnpm run build:doc-chunks
 

--- a/.github/workflows/tauri-test-build.yml
+++ b/.github/workflows/tauri-test-build.yml
@@ -93,6 +93,9 @@ jobs:
           cd ../chgdiff-wasm
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
 
+          cd ../catrender-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
+
       - name: Generate documentation chunks
         run: pnpm run build:doc-chunks
 
@@ -189,6 +192,9 @@ jobs:
 
           cd ../chgdiff-wasm
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+          cd ../catrender-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
 
       - name: Generate documentation chunks
         run: pnpm run build:doc-chunks
@@ -291,6 +297,9 @@ jobs:
 
           cd ../chgdiff-wasm
           wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+
+          cd ../catrender-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
 
       - name: Generate documentation chunks
         run: pnpm run build:doc-chunks


### PR DESCRIPTION
Fixes the red `Deploy to Cloudflare Workers` + `Build HPC Bundle` checks on main.

**Root cause:** catrender (#84) does `import('./catrender-wasm-pkg/catrender_wasm.js')`, but `catrender-wasm-pkg/` is gitignored (wasm-pack output, same convention as chgdiff/ferrox). CI builds ferrox-wasm + chgdiff-wasm but never built catrender-wasm, so the production frontend build (vite/rollup) couldn't resolve the import:

```
Could not resolve "./catrender-wasm-pkg/catrender_wasm.js" from "src/lib/structure/catrender/catrender-wasm.ts"
```

**Fix:** add a catrender `wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg` step (mirroring chgdiff) to deploy-cloudflare.yml, hpc-bundle.yml, tauri-build.yml, tauri-test-build.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)