### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures and MD trajectories — POSCAR/CIF/XYZ/extXYZ/ASE .traj/HDF5/DCD/XTC/TRR. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, charge-density cube isosurfaces, trajectory scrubbing with energy/force overlays, themes that follow VS Code.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "base64 0.22.1",
  "catgo-graph",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.0.3"
+version = "1.1.0"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump 1.0.3 → 1.1.0 across package.json, tauri.conf.json, src-tauri/Cargo.toml(+lock), vscode extension.

Release highlights: catrender render plugin, full CatGO CLI (P1–P3e), OpenBabel-style bond-order perception, atom glow + index overlay, wheel zoom, CIF export/parser + Set Color fixes, i18n Moiré pane.

Tagging `v1.1.0` after merge triggers the desktop build + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)