### PR TITLE
ci: add Linux to desktop build matrix

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -28,6 +28,10 @@ jobs:
             target: aarch64-apple-darwin
             backend_target: aarch64-apple-darwin
             name: macOS (Apple Silicon)
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            backend_target: x86_64-unknown-linux-gnu
+            name: Linux
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.name }})
@@ -42,6 +46,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install Linux build deps (tauri / webkit2gtk)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            patchelf \
+            build-essential
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Adds ubuntu-22.04 (x86_64-unknown-linux-gnu) + webkit2gtk-4.1 apt deps to the tauri build matrix so Linux artifacts build + attach to the release automatically (previously Win/Mac only; Linux was a manual local build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)