### PR TITLE
fix(workflow): unique id for loaded edges (each_key_duplicate crash)

### DIFF
--- a/src/lib/workflow/WorkflowEditor.svelte
+++ b/src/lib/workflow/WorkflowEditor.svelte
@@ -1890,7 +1890,13 @@
           y: Number.isFinite(n.y) ? n.y : 0,
         }
       })
-      edges = graph.edges || []
+      // Ensure every loaded edge has a unique id — `to_workflow_json` does not
+      // persist `id`, so round-tripped graphs would otherwise yield duplicate
+      // `undefined` keys and crash the keyed {#each} (each_key_duplicate).
+      edges = (graph.edges || []).map((e: WfEdge, i: number) => ({
+        ...e,
+        id: e.id ?? `e${i}-${e.from ?? `?`}-${e.to ?? `?`}`,
+      }))
       fill_empty_structure_inputs()
       push_history()
       change_det.set_external_change_detected(false)
@@ -1932,7 +1938,13 @@
           y: Number.isFinite(n.y) ? n.y : 0,
         }
       })
-      edges = graph.edges || []
+      // Ensure every loaded edge has a unique id — `to_workflow_json` does not
+      // persist `id`, so round-tripped graphs would otherwise yield duplicate
+      // `undefined` keys and crash the keyed {#each} (each_key_duplicate).
+      edges = (graph.edges || []).map((e: WfEdge, i: number) => ({
+        ...e,
+        id: e.id ?? `e${i}-${e.from ?? `?`}-${e.to ?? `?`}`,
+      }))
       is_loaded = true
       fill_empty_structure_inputs()
       // Auto-layout if any nodes were missing coordinates


### PR DESCRIPTION
WorkflowEditor crashed on loading any saved/round-tripped workflow: `to_workflow_json` doesn't persist edge `id`, so loaded edges had `id=undefined` → keyed `{#each edges (edge.id)}` threw `each_key_duplicate` (duplicate key `undefined` at indexes 0 and 1). Normalize loaded edges with an index-based fallback id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)