### PR TITLE
fix(desktop): surface drag-drop failures + align file gate with Open File

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1124,6 +1124,7 @@
       await webview.onDragDropEvent(async (event) => {
         if (event.payload.type === `drop`) {
           const paths = event.payload.paths
+          console.log(`[Tauri Drop] received`, paths)
           if (paths && paths.length > 0) {
             const now = Date.now()
             // Dedupe on the whole batch (key off first path) so a single
@@ -1172,15 +1173,19 @@
               const pane_idx = target_pane >= 0 ? target_pane : ts.active_pane
               if (files.length > 0) {
                 await import_many(tm.active_tab_id, files.map(f => ({ content: f.content, filename: f.filename, path: f.path })), pane_idx)
+              } else {
+                show_toast({ message: `Could not read any file from the drop`, variant: `warning` })
               }
             } catch (err) {
               console.error(`[Tauri Drop] Error reading file:`, err)
+              show_toast({ message: `Drop failed: ${err instanceof Error ? err.message : String(err)}`, variant: `error` })
             } finally {
               is_loading = false
             }
           }
         }
       })
+      console.log(`[Tauri] file-drop listener registered`)
     } catch (err) {
       console.error(`[Tauri] Failed to set up file drop:`, err)
     }

--- a/src/lib/io/tauri.ts
+++ b/src/lib/io/tauri.ts
@@ -246,7 +246,10 @@ export async function read_dropped_paths(
       const info = await stat(p)
       if (info.isDirectory) {
         await walk_dir(p, accept, collected, 0, max_depth, max_files)
-      } else if (info.isFile && accept(p.split(/[/\\]/).pop() || p)) {
+      } else if (info.isFile) {
+        // Directly-dropped files are read regardless of extension, mirroring the
+        // Open File dialog (which has no accept gate). `accept` still filters
+        // the contents of dropped directories above.
         collected.push(p)
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
Fixes silent failures in the desktop app's drag-and-drop file loading, and adds diagnostics. "Open File" worked but dragging a file onto a structure pane appeared to do nothing.

- **`src/lib/io/tauri.ts`** — directly-dropped files are now read regardless of extension (parity with the Open File dialog, which has no accept gate). The `accept` filter still gates the *contents of dropped directories*.
- **`desktop/App.svelte`** — show a toast when a drop yields no readable files or throws (previously silent, so it looked like drag-drop was dead).
- **`desktop/App.svelte`** — log `onDragDropEvent` registration and each received drop payload.

## Root cause
With `dragDropEnabled: true` (tauri.conf.json), OS file drops are handled exclusively by Tauri's `onDragDropEvent` — the HTML5 `dataTransfer.files` is empty. That handler had no user-facing error path and silently skipped files whose extension `is_structure_file`/`is_trajectory_file`/`is_chgcar_file` didn't recognize.

> **Not fixed here (environment, not code):** the top suspect for "drop never fires at all" is **Windows UIPI** — running the app elevated while dragging from a non-elevated Explorer blocks the drop at the OS level. The new logs distinguish this: if `[Tauri] file-drop listener registered` appears but `[Tauri Drop] received` never logs on a drop, the OS isn't delivering the event (try launching non-elevated).

## Test plan
- [ ] Rebuild desktop app
- [ ] Drag a `.cif` onto a structure pane → loads; console logs `[Tauri Drop] received [...]`
- [ ] Drag an unsupported / odd-extension file → loads or shows a clear toast (no silent failure)
- [ ] If a drop does nothing: confirm `[Tauri] file-drop listener registered` logged, then test a non-elevated launch (UIPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
