### PR TITLE
fix(ci): vsix-publish continue-on-error (duplicate version)

### DIFF
--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -68,6 +68,9 @@ jobs:
 
       - name: Publish to VS Code Marketplace
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+        # Don't fail the whole job (and skip the release-attach below) when the
+        # version is already published — e.g. re-tagging the same version.
+        continue-on-error: true
         working-directory: extensions/vscode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -75,6 +78,7 @@ jobs:
 
       - name: Publish to Open VSX (Cursor / VSCodium / Theia)
         if: ${{ (github.event_name == 'push' || inputs.dry_run == false) && env.OVSX_PAT != '' }}
+        continue-on-error: true
         working-directory: extensions/vscode
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
Re-tagging the same version made vsce publish fail ('already exists'), failing the job and skipping the release-attach. continue-on-error on the publish steps so the VSIX still attaches to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)