### PR TITLE
fix(ci): Linux deb+rpm only (skip hanging AppImage)

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -32,6 +32,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
             backend_target: x86_64-unknown-linux-gnu
             name: Linux
+            # Skip AppImage: linuxdeploy hangs/fails on GitHub runners (FUSE +
+            # bundled-tool download). Ship .deb + .rpm, which build reliably.
+            bundles: deb,rpm
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.name }})
@@ -193,4 +196,4 @@ jobs:
             See [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.
           releaseDraft: true
           prerelease: false
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }}${{ matrix.bundles && format(' --bundles {0}', matrix.bundles) || '' }}


### PR DESCRIPTION
Linux AppImage (linuxdeploy) hung >1h on GH runners (even with APPIMAGE_EXTRACT_AND_RUN). Ship .deb + .rpm (reliable, cover Linux) via per-matrix `--bundles deb,rpm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)