### PR TITLE
fix(ci): Linux .deb only (rpm/appimage hang on runners)

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -32,9 +32,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             backend_target: x86_64-unknown-linux-gnu
             name: Linux
-            # Skip AppImage: linuxdeploy hangs/fails on GitHub runners (FUSE +
-            # bundled-tool download). Ship .deb + .rpm, which build reliably.
-            bundles: deb,rpm
+            # Ship .deb only. AppImage (linuxdeploy) and .rpm (rpmbuild) both
+            # hang for 20+ min on GitHub runners; .deb builds in seconds and
+            # covers Debian/Ubuntu — the primary Linux desktop target.
+            bundles: deb
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.name }})


### PR DESCRIPTION
Linux .deb builds in seconds; both rpm (rpmbuild) and AppImage (linuxdeploy) hang 20+ min on GitHub runners. Ship .deb only so the Linux desktop job completes and attaches to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)