### PR TITLE
fix(vasp): KSPACING uses true VASP semantics, not kppvol density

### DIFF
--- a/server/catgo/utils/vasp_input.py
+++ b/server/catgo/utils/vasp_input.py
@@ -570,8 +570,14 @@ def generate_kpoints(
                 kpts=request.kpoints,
             )
     elif request.kspacing:
-        # Automatic k-points based on spacing
-        return Kpoints.automatic_density_by_vol(structure, request.kspacing)
+        # KSPACING (Å^-1, VASP semantics): N_i = max(1, ceil(|b_i| / kspacing)),
+        # where b_i are the 2*pi reciprocal-lattice vectors. (Previously this
+        # mis-used kspacing as a kppvol density, yielding 1x1x1 for small values.)
+        recip = structure.lattice.reciprocal_lattice.abc
+        mesh = [max(1, int(np.ceil(b / request.kspacing))) for b in recip]
+        if is_slab and mesh[2] > 1:
+            mesh[2] = 1
+        return Kpoints.gamma_automatic(kpts=(mesh[0], mesh[1], mesh[2]))
     else:
         # Default: automatic k-points
         kpts = Kpoints.automatic_density_by_vol(structure, 1000)


### PR DESCRIPTION
## Summary
Fixes KSPACING handling in the VASP input generator. `generate_kpoints` forwarded `request.kspacing` to `Kpoints.automatic_density_by_vol()`, which treats its argument as **kppvol** (k-points per Å⁻³ of reciprocal cell), not a k-spacing. So a normal KSPACING (e.g. 0.04 1/Å) collapsed to a `1×1×1` mesh for any cell.

Now uses the VASP definition: `N_i = max(1, ceil(|b_i| / KSPACING))` over the 2π reciprocal-lattice vectors, Gamma-centred, keeping the existing slab clamp (c > 15 Å → k_c = 1).

## Verified (lit311 / pymatgen, live `POST /api/vasp/generate`)
- NaCl: KSPACING 0.5 → `Gamma 3 3 3`; 0.3 → `4 4 4`
- MOF-808 (a≈25 Å): KSPACING 0.5 → `1 1 1` (correct — short reciprocal vectors)

(Before this fix the same calls produced `1 1 1` regardless of KSPACING.)

## Note
A complementary **frontend** PR ports the identical KSPACING semantics to the client-side generator + changes the UI default (0.04 → 0.3 1/Å). Best landed together so the UI's server path and its offline path agree.

## Test plan
- [ ] `POST /api/vasp/generate` with `kspacing` → mesh scales as `ceil(|b_i| / kspacing)`
- [ ] Large cell + small kspacing → `1 1 1` (not an over-dense mesh)
- [ ] Explicit `kpoints` mesh and the default (no kspacing) paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
