### PR TITLE
fix(bonds): fallback when last_bond_structure is null (delete-one-atom-wipes-all)

### DIFF
--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -2053,7 +2053,10 @@
   // H-bonds stay on the legacy Bond-like render path because DashedBond has
   // its own instanced mesh and there's no SoA-store integration for them.
   let instanced_hbond_groups = $derived.by(() => {
-    const bond_struct = bond_state.last_bond_structure
+    // Same fallback as filtered_bond_pairs (see comment there): when
+    // last_bond_structure is null, fall back to the current `structure` so
+    // H-bonds don't briefly disappear during async-compute transitions.
+    const bond_struct = bond_state.last_bond_structure ?? structure
     if (!bond_struct?.sites || h_bond_pairs.length === 0) return []
 
     const instances: { matrix: Float32Array; color_start: string; color_end: string }[] = []
@@ -2398,7 +2401,19 @@
     // Use last_bond_structure for site lookups — bond indices reference the
     // structure bonds were computed against. This also avoids a redundant
     // cascade (filtered → instanced → GPU) every time structure changes.
-    const bond_struct = bond_state.last_bond_structure
+    //
+    // Fallback to `structure` when `last_bond_structure` is null. The async
+    // bond compute path (bond-computation-controller.svelte.ts:336-337) and
+    // a couple of edge-case state transitions briefly set
+    // `last_bond_structure = null`. Without a fallback the user sees every
+    // bond disappear during that window — specifically reproducible when
+    // deleting an atom while the async path was mid-flight: the fast-delete
+    // reindexes bond_state.bond_connectivity correctly, but this $derived
+    // returns [] because last_bond_structure happened to be null at that
+    // instant. Post-delete `structure.sites` and `last_bond_structure.sites`
+    // share the same index space (apply_atom_delete_incremental keeps them
+    // in lockstep), so falling back to `structure` is safe.
+    const bond_struct = bond_state.last_bond_structure ?? structure
     if (!bond_struct?.sites) return []
     // Force reactivity — hidden_elements/hidden_sites/bond_distance_rules/deleted_bond_keys are read inside nested callbacks
     const _hidden_size = _hidden_elements?.size ?? 0


### PR DESCRIPTION
Closes #124.

## Symptom
Right-click an atom → Delete: occasionally **every bond in the structure disappears**, not just the bonds touching the deleted atom. Bonds come back on the next reactivity event. Reproducible "sometimes" — depends on whether the bond compute path is sync or async at delete time.

## Root cause
`StructureScene.svelte:2401` and `:2056` both read `bond_state.last_bond_structure` with no fallback and early-return `[]` when it's null:

```ts
const bond_struct = bond_state.last_bond_structure
if (!bond_struct?.sites) return []
```

The async bond compute path (`bond-computation-controller.svelte.ts:336-337`) synchronously clears `last_bond_structure = null` before dispatching the worker — intentional, so stale cross-frame indices don't render against new positions. The async resolve repopulates it 1-many frames later.

When the user deletes during that window:
- `apply_atom_delete_incremental` correctly reindexes `bond_state.bond_connectivity` against post-delete sites
- Its `if (bond_state.last_bond_structure !== null)` guard skips updating last_bond_structure → it stays `null`
- Next reactive pass: `build_bond_pairs` falls back to `structure` (its own ternary already handles null) and rebuilds bond_pairs fine
- **BUT** `filtered_bond_pairs` and `instanced_hbond_groups` see `last_bond_structure === null` → return `[]` → GPU pipeline sees zero bonds → every bond winks out
- When the async worker completes 200-500 ms later, last_bond_structure repopulates, the $derived re-runs, bonds reappear

## Fix
Mirror the null-fallback pattern that `build_bond_pairs` already uses:

```ts
const bond_struct = bond_state.last_bond_structure ?? structure
if (!bond_struct?.sites) return []
```

`apply_atom_delete_incremental` keeps `bond_state.bond_connectivity` indices in lockstep with `structure.sites` post-delete (same shifted index space), so the fallback is safe.

## Test plan

- [x] `pnpm vitest run tests/vitest/structure` — 21 files, 915 tests pass (46 skipped), 0 fail
- [x] `pnpm vitest run tests/vitest/structure/bonding.test.ts` — 28/28 pass
- [ ] Manual: open a >1000-atom structure, right-click → Delete on any atom while bonds were being computed → bonds touching the deleted atom disappear, but all other bonds stay visible (no "wink out" flicker)
- [ ] H-bond regression: open a structure with hbonds enabled, delete an atom, hbonds incident to deleted atom vanish, rest stay visible

Pre-existing failures in `chat/slash-commands.test.ts` + theme localStorage tests are unrelated to this change — verified by stashing the fix and re-running on clean main: same 24 failures. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)