### PR TITLE
fix(gesture): stop whole-app freeze on gesture enable→disable→re-enable

### DIFF
--- a/src/lib/gesture/GestureProvider.svelte
+++ b/src/lib/gesture/GestureProvider.svelte
@@ -25,6 +25,7 @@
     onvoice,
     onhand_update,
     on_ai_query,
+    ondisable,
     children,
   }: {
     config: GestureConfig
@@ -33,6 +34,11 @@
     onvoice?: (event: VoiceEvent) => void
     onhand_update?: (hands: HandState[]) => void
     on_ai_query?: (text: string) => Promise<string>
+    // Ask the PARENT to disable gesture control. The parent owns `config`, so
+    // the child must never mutate `config.enabled` directly — doing so is an
+    // unbound-prop mutation that, combined with the enabled→active $effect,
+    // triggers `effect_update_depth_exceeded` and freezes the whole app.
+    ondisable?: () => void
     children?: import('svelte').Snippet
   } = $props()
 
@@ -607,8 +613,10 @@
     <span>{error_msg}</span>
     <button onclick={() => { error_msg = null; start() }}>Retry</button>
     <!-- stop() explicitly releases the webcam stream before disabling,
-         ensuring the camera light turns off even if start() failed partway -->
-    <button onclick={() => { stop(); error_msg = null; config.enabled = false }}>Disable</button>
+         ensuring the camera light turns off even if start() failed partway.
+         Disabling is delegated to the parent via ondisable() — the child must
+         not mutate the unbound `config` prop (see ondisable doc above). -->
+    <button onclick={() => { stop(); error_msg = null; ondisable?.() }}>Disable</button>
   </div>
 {/if}
 

--- a/src/lib/gesture/__tests__/hand-tracker.test.ts
+++ b/src/lib/gesture/__tests__/hand-tracker.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HandTracker } from '../hand-tracker'
+
+// Install a fake navigator.mediaDevices for the duration of one test.
+function set_media_devices(value: unknown): void {
+  Object.defineProperty(globalThis.navigator, `mediaDevices`, {
+    value,
+    configurable: true,
+    writable: true,
+  })
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  set_media_devices(undefined)
+})
+
+describe(`HandTracker.start pre-flight (freeze prevention)`, () => {
+  it(`fails fast WITHOUT calling getUserMedia when no camera is present`, async () => {
+    // This is the core regression guard: on a camera-less machine getUserMedia
+    // can stall and freeze the whole app, so it must never be reached.
+    const getUserMedia = vi.fn(() => new Promise<MediaStream>(() => {})) // would hang forever
+    const enumerateDevices = vi.fn(async () => [
+      { kind: `audioinput`, deviceId: `mic`, label: ``, groupId: `` } as MediaDeviceInfo,
+    ])
+    set_media_devices({ getUserMedia, enumerateDevices })
+
+    const tracker = new HandTracker()
+    await expect(tracker.start(() => {})).rejects.toThrow(/No camera found/)
+    expect(enumerateDevices).toHaveBeenCalledOnce()
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(tracker.is_running).toBe(false)
+  })
+
+  it(`throws a clear message when the camera API is unavailable`, async () => {
+    set_media_devices({}) // no getUserMedia
+    const tracker = new HandTracker()
+    await expect(tracker.start(() => {})).rejects.toThrow(/does not support camera access|desktop app/)
+    expect(tracker.is_running).toBe(false)
+  })
+
+  it(`times out instead of hanging when getUserMedia never resolves`, async () => {
+    vi.useFakeTimers()
+    const getUserMedia = vi.fn(() => new Promise<MediaStream>(() => {})) // never settles
+    const enumerateDevices = vi.fn(async () => [
+      { kind: `videoinput`, deviceId: `cam`, label: ``, groupId: `` } as MediaDeviceInfo,
+    ])
+    set_media_devices({ getUserMedia, enumerateDevices })
+
+    const tracker = new HandTracker()
+    const started = tracker.start(() => {})
+    const assertion = expect(started).rejects.toThrow(/timed out/)
+    await vi.advanceTimersByTimeAsync(8000)
+    await assertion
+    expect(getUserMedia).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/gesture/hand-tracker.ts
+++ b/src/lib/gesture/hand-tracker.ts
@@ -31,20 +31,39 @@ export class HandTracker {
     if (this.running) return
     this.callback = callback
     this.on_error = on_error ?? null
-    this.running = true
 
-    // 1. Guard: check that the browser/webview exposes the camera API.
-    //    Tauri's WKWebView on macOS may not provide navigator.mediaDevices
-    //    even with private-API flags enabled, so we give a clear message
-    //    directing users to the web app (pnpm dev) in Chrome instead.
+    // ── Pre-flight checks — run BEFORE `this.running = true` and BEFORE any
+    //    getUserMedia call so a camera-less machine fails FAST instead of
+    //    hanging. getUserMedia stalls when no device exists — on Chrome it
+    //    blocks UI interaction, on Tauri's WebKitGTK the promise can hang —
+    //    freezing the whole app so the user can't even click "Disable".
+
+    // 1. The browser/webview must expose the camera API at all.
+    //    Tauri's WKWebView on macOS may not provide navigator.mediaDevices.
     if (!navigator.mediaDevices?.getUserMedia) {
       throw new Error(
-        `Camera API not available. ` +
-        (typeof window !== `undefined` && (window as any).__TAURI__
-          ? `Webcam access is not supported in the Tauri desktop app. Please use the web app (pnpm dev) in Chrome instead.`
-          : `Your browser does not support camera access. Please use Chrome, Edge, or Safari.`),
+        typeof window !== `undefined` && (window as any).__TAURI__
+          ? `Webcam access isn't available in the desktop app. Open CatGO in Chrome or Edge instead.`
+          : `Your browser does not support camera access. Please use Chrome, Edge, or Safari.`,
       )
     }
+
+    // 2. Non-blocking probe: enumerateDevices() does NOT open the camera, so it
+    //    returns quickly even with no device — unlike getUserMedia, which is
+    //    the call that freezes the app on a camera-less machine. Bail here if
+    //    there's no video input at all, so getUserMedia is never reached.
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices()
+      if (!devices.some(d => d.kind === `videoinput`)) {
+        throw new Error(`No camera found. Please connect a camera and try again.`)
+      }
+    } catch (e: any) {
+      throw (e instanceof Error && e.message.startsWith(`No camera`))
+        ? e
+        : new Error(`No camera found. Please connect a camera and try again.`)
+    }
+
+    this.running = true
 
     // 2. Create hidden video element for webcam
     this.video = document.createElement(`video`)
@@ -53,17 +72,30 @@ export class HandTracker {
     this.video.style.display = `none`
     document.body.appendChild(this.video)
 
-    // 3. Request webcam access.
-    //    Wrap in try/catch to translate browser error names (NotAllowedError,
-    //    NotFoundError) into human-readable messages instead of [object Event].
+    // 4. Request webcam access. Race against an 8s timeout so a present-but-
+    //    stuck device (or a hung WebKitGTK getUserMedia) can't freeze start()
+    //    forever. The timer runs on the event loop, so it fires even if the
+    //    getUserMedia promise never settles.
     try {
-      this.stream = await navigator.mediaDevices.getUserMedia({
+      const gum = navigator.mediaDevices.getUserMedia({
         video: { width: 640, height: 480, facingMode: `user` },
         audio: false,
       })
+      let timer: ReturnType<typeof setTimeout> | undefined
+      this.stream = await Promise.race([
+        gum,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`Camera request timed out — no response from the device.`)), 8000)
+        }),
+      ])
+      clearTimeout(timer)
+      // If getUserMedia lost the race but resolves later, release that stream
+      // so the camera light doesn't stay on.
+      void gum.then(s => { if (this.stream !== s) s.getTracks().forEach(t => t.stop()) }).catch(() => {})
     } catch (e: any) {
       const msg = e?.name === `NotAllowedError` ? `Camera permission denied. Please allow camera access and try again.`
         : e?.name === `NotFoundError` ? `No camera found. Please connect a camera and try again.`
+        : typeof e?.message === `string` && e.message.startsWith(`Camera request timed out`) ? e.message
         : `Camera access failed: ${e?.message ?? e?.name ?? e}`
       throw new Error(msg)
     }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3552,6 +3552,7 @@
           ongesture={on_gesture}
           onvoice={on_voice}
           on_ai_query={on_voice_ai_query}
+          ondisable={() => { gesture_active = false; gesture_config = { ...gesture_config, enabled: false } }}
         >
           <GestureOverlay container_el={wrapper} />
         </GestureProvider>


### PR DESCRIPTION
## Problem

Toggling gesture control froze the entire app (couldn't even click **Disable**) on a camera-less machine. Reported as "直接卡死".

## Root cause

The **Disable** button in `GestureProvider.svelte` did `config.enabled = false`, mutating the `config` prop **in place**. `config` is passed unbound (`config={gesture_config}` in `Structure.svelte`, not `bind:`). Svelte logged `ownership_invalid_mutation`, and combined with the `$effect` that reads `config.enabled` and writes `active` via `start()`/`stop()`, this formed a read-write-same-state cycle → `effect_update_depth_exceeded` → infinite loop → frozen main thread.

The **"No camera found"** toast was a red herring. The freeze required the **enable → disable → re-enable** sequence (first enable alone was fine).

## Fix

- Add `ondisable?: () => void` prop to `GestureProvider`. The Disable button now calls `ondisable?.()` instead of mutating the prop.
- `Structure.svelte` handles it by reassigning `gesture_config` (clean owner-side reactivity) and resetting `gesture_active` — which also fixes a latent bug where the toolbar toggle stayed lit after Disable.
- Harden `hand-tracker.start()`: non-blocking `enumerateDevices()` pre-check + 8s `getUserMedia` timeout, so a camera-less machine fails fast instead of stalling. (Improvement, not the freeze cause.)
- Unit tests for the no-camera / API-unavailable / timeout paths.

## Verification

- `svelte-check`: 0 errors
- New tests `src/lib/gesture/__tests__/hand-tracker.test.ts`: 3/3 pass
- Reproduced via Chrome DevTools: enable→disable→re-enable cycle now runs with a healthy event loop (heartbeat 14/14/20 ticks, no block), console free of `effect_update_depth_exceeded` and `ownership_invalid_mutation`. Disable correctly resets the toolbar toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)