### PR TITLE
feat: large-system performance mode — WebGPU overlay (million-atom rendering, GPU supercell, bonds, trajectory)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-webgpu-large-trajectory-bonds.md
+++ b/docs/superpowers/plans/2026-05-23-webgpu-large-trajectory-bonds.md
@@ -1,0 +1,1075 @@
+# WebGPU Large-Trajectory Bond Rendering — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manually-toggled, dedicated WebGPU compute+render path so million-atom trajectories render smoothly, with per-frame GPU bond perception (atom_radii, minimum-image PBC) and GPU-resident bonds read back to CPU only on pause/interaction.
+
+**Architecture:** A parallel "large-system performance mode" that lives beside the existing Three.js/WebGL path (untouched). When the user toggles it on, a WebGPU device computes bonds per frame (uniform-grid neighbor search) and renders impostor spheres + instanced bonds directly from GPU buffers — no per-frame CPU readback. On pause/selection/export, one compute dispatch is read back to populate the existing `bond_state.bond_connectivity`. When WebGPU is unavailable, the toggle falls back to the existing CPU/worker path plus a hard atom cap warning.
+
+**Tech Stack:** TypeScript, Svelte 5 runes, WebGPU (`navigator.gpu`) + WGSL, Three.js 0.181 (existing WebGL path), Vitest 4.
+
+**Spec:** `docs/superpowers/specs/2026-05-23-webgpu-large-trajectory-bonds-design.md`
+
+**Reference facts (verified):**
+- Test runner: `pnpm exec vitest run` (RTK serves stale vitest output — bypass with `rtk proxy pnpm exec vitest run`). Tests colocate as `*.test.ts`.
+- Types (`src/lib/structure/index.ts`): `Site = { species: Species[]; abc: Vec3; xyz: Vec3 }`; `PymatgenLattice = { matrix: Matrix3x3 }`; `PymatgenStructure = PymatgenMolecule & { lattice: PymatgenLattice }`; `AnyStructure = PymatgenStructure | PymatgenMolecule`.
+- CPU bond oracle: `compute_bonds_sync(structure, 'atom_radii', options)` in `src/lib/structure/workers/bond-worker-api.ts:158` → `BondPair[] | null`. Rust path emits cross-cell `image` (jimage). `options` is `Record<string, number>` (keys include `max_bond_dist`, `tolerance`).
+- Covalent radii data: default-export numeric array in `src/lib/element/data.ts` (indexed by atomic number; see `src/lib/element/covalent_radii.d.ts`).
+- `bond_connectivity` entry type (`bond-computation-controller.svelte.ts:52`): `{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }`.
+- `bond_state` is created by `create_bond_state()` in `bond-computation-controller.svelte.ts`; `bond_state.bond_connectivity` is a `$state` array of the above entry type.
+
+**Testing reality:** CI has no GPU. Pure-JS units are TDD'd normally. WGSL compute correctness is verified by a **device-gated golden test**: `describe.skipIf(!device)` comparing GPU bond output against the JS reference oracle (Task 4) on small/medium structures. Render correctness is a manual smoke (Task 9) plus a device-gated single-pixel readback (Task 8).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/lib/structure/gpu/webgpu-context.ts` | Device/adapter acquisition, capability detection, async init, fallback signal. |
+| `src/lib/structure/gpu/radius-lut.ts` | Build per-atom element-index array + covalent-radius table from a structure. Pure. |
+| `src/lib/structure/gpu/frame-buffers.ts` | Pack frame positions + lattice into typed arrays for GPU upload. Pure. |
+| `src/lib/structure/gpu/bond-detect-reference.ts` | JS reference: uniform-grid + minimum-image + atom_radii predicate. Oracle for WGSL. Pure. |
+| `src/lib/structure/gpu/bond-compute.wgsl.ts` | WGSL compute shader source as a string. |
+| `src/lib/structure/gpu/bond-compute.ts` | Compute pipeline wrapper: buffers, bind groups, dispatch, count readback. |
+| `src/lib/structure/gpu/camera-uniform.ts` | Pack a Three camera into view/proj uniform bytes. Pure. |
+| `src/lib/structure/gpu/large-system-renderer.ts` | WGSL render: impostor spheres + instanced bonds + selection + id-pick. |
+| `src/lib/structure/gpu/large-system-mode.svelte.ts` | Orchestrator: toggle state, canvas switch, frame upload, playback loop, readback-on-pause → `bond_state`. |
+| `src/lib/structure/gpu/*.test.ts` | Colocated tests per module. |
+
+Each `gpu/` module has one responsibility and a narrow interface; `large-system-mode` is the only one that knows about `StructureScene`/`bond_state`.
+
+---
+
+## Task 1: WebGPU context & capability detection
+
+**Files:**
+- Create: `src/lib/structure/gpu/webgpu-context.ts`
+- Test: `src/lib/structure/gpu/webgpu-context.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// webgpu-context.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { is_webgpu_supported, acquire_webgpu_device } from './webgpu-context'
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('webgpu-context', () => {
+  it('is_webgpu_supported reflects navigator.gpu presence', () => {
+    vi.stubGlobal('navigator', {})
+    expect(is_webgpu_supported()).toBe(false)
+    vi.stubGlobal('navigator', { gpu: {} })
+    expect(is_webgpu_supported()).toBe(true)
+  })
+
+  it('acquire_webgpu_device returns null when unsupported', async () => {
+    vi.stubGlobal('navigator', {})
+    expect(await acquire_webgpu_device()).toBeNull()
+  })
+
+  it('acquire_webgpu_device returns null when adapter unavailable', async () => {
+    vi.stubGlobal('navigator', { gpu: { requestAdapter: async () => null } })
+    expect(await acquire_webgpu_device()).toBeNull()
+  })
+
+  it('acquire_webgpu_device returns the device on success', async () => {
+    const fake_device = { label: 'd' }
+    vi.stubGlobal('navigator', {
+      gpu: { requestAdapter: async () => ({ requestDevice: async () => fake_device }) },
+    })
+    expect(await acquire_webgpu_device()).toBe(fake_device)
+  })
+})
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/webgpu-context.test.ts`
+Expected: FAIL — cannot find module `./webgpu-context`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// webgpu-context.ts
+/** WebGPU device acquisition + capability detection. No rendering logic here. */
+
+export function is_webgpu_supported(): boolean {
+  return typeof navigator !== `undefined` && `gpu` in navigator && navigator.gpu != null
+}
+
+let cached_device: GPUDevice | null = null
+
+/** Acquire a GPUDevice, or null if WebGPU is unavailable / acquisition fails.
+ *  Result is cached for the process lifetime. */
+export async function acquire_webgpu_device(): Promise<GPUDevice | null> {
+  if (cached_device !== null) return cached_device
+  if (!is_webgpu_supported()) return null
+  try {
+    const adapter = await navigator.gpu.requestAdapter({ powerPreference: `high-performance` })
+    if (!adapter) return null
+    const device = await adapter.requestDevice()
+    cached_device = device
+    return device
+  } catch {
+    return null
+  }
+}
+
+/** Test-only: reset the cached device. */
+export function __reset_device_cache(): void { cached_device = null }
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/webgpu-context.test.ts`
+Expected: PASS (4 tests). Note: the cache makes `acquire_webgpu_device` sticky — add `__reset_device_cache()` in `afterEach` if a later test needs isolation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/webgpu-context.ts src/lib/structure/gpu/webgpu-context.test.ts
+git commit -m "feat(gpu): WebGPU device acquisition + capability detection"
+```
+
+---
+
+## Task 2: Element covalent-radius LUT
+
+**Files:**
+- Create: `src/lib/structure/gpu/radius-lut.ts`
+- Test: `src/lib/structure/gpu/radius-lut.test.ts`
+
+A bond detector needs, per atom, a covalent radius. We pack two arrays: `atom_radius` (Float32Array, one radius per atom, taking each site's primary species) so the shader does a single buffer lookup per atom.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// radius-lut.test.ts
+import { describe, it, expect } from 'vitest'
+import { build_atom_radii } from './radius-lut'
+import type { Site } from '$lib/structure'
+
+function site(element: string, xyz: [number, number, number]): Site {
+  return { species: [{ element, occu: 1, oxidation_state: 0 } as never], abc: [0, 0, 0], xyz } as Site
+}
+
+describe('build_atom_radii', () => {
+  it('returns one finite radius per site, using the primary species', () => {
+    const sites = [site('H', [0, 0, 0]), site('O', [1, 0, 0]), site('C', [2, 0, 0])]
+    const radii = build_atom_radii(sites)
+    expect(radii).toBeInstanceOf(Float32Array)
+    expect(radii.length).toBe(3)
+    for (const r of radii) expect(r).toBeGreaterThan(0)
+    // O radius < C radius (covalent radii: O ~0.66, C ~0.76)
+    expect(radii[1]).toBeLessThan(radii[2])
+  })
+
+  it('falls back to a default radius for unknown elements', () => {
+    const radii = build_atom_radii([site('Xx', [0, 0, 0])])
+    expect(radii[0]).toBeGreaterThan(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/radius-lut.test.ts`
+Expected: FAIL — cannot find module `./radius-lut`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// radius-lut.ts
+import type { Site } from '$lib/structure'
+import { element_data } from '$lib/element/data'
+
+const DEFAULT_RADIUS = 1.0 // Å, fallback for elements with no covalent radius
+
+/** Per-atom covalent radius (Å), one entry per site, from the site's primary
+ *  species. Used as the GPU radius lookup for atom_radii bond detection. */
+export function build_atom_radii(sites: readonly Site[]): Float32Array {
+  const out = new Float32Array(sites.length)
+  for (let i = 0; i < sites.length; i++) {
+    const elem = sites[i].species[0]?.element
+    out[i] = covalent_radius_of(elem) ?? DEFAULT_RADIUS
+  }
+  return out
+}
+
+function covalent_radius_of(element: string | undefined): number | null {
+  if (!element) return null
+  const entry = element_data.find((e) => e.symbol === element)
+  const r = entry?.covalent_radius
+  return typeof r === `number` && r > 0 ? r : null
+}
+```
+
+> **Note for implementer:** Confirm the export shape of `src/lib/element/data.ts`. The reference grep shows a default-exported array. If the module exports `default` rather than a named `element_data`, import as `import element_data from '$lib/element/data'` and adjust. If entries key element by `symbol`/`name` and store radius under a different field (e.g. `covalent_radius` vs an array indexed by atomic number), adapt `covalent_radius_of` to match — keep the function's contract (symbol → radius|null) identical so the test stays valid.
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/radius-lut.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/radius-lut.ts src/lib/structure/gpu/radius-lut.test.ts
+git commit -m "feat(gpu): per-atom covalent radius LUT builder"
+```
+
+---
+
+## Task 3: Frame position + lattice packing
+
+**Files:**
+- Create: `src/lib/structure/gpu/frame-buffers.ts`
+- Test: `src/lib/structure/gpu/frame-buffers.test.ts`
+
+The GPU needs a tightly-packed `Float32Array` of xyz positions and a 9-float lattice matrix. Trajectory frames already arrive as a `Float32Array` (3N) in the existing traj path; this module normalizes both "structure sites" and "raw frame Float32Array" into the same packed layout, and extracts the lattice.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// frame-buffers.test.ts
+import { describe, it, expect } from 'vitest'
+import { pack_positions, pack_lattice } from './frame-buffers'
+import type { Site, PymatgenLattice } from '$lib/structure'
+
+function site(xyz: [number, number, number]): Site {
+  return { species: [{ element: 'C', occu: 1 } as never], abc: [0, 0, 0], xyz } as Site
+}
+
+describe('pack_positions', () => {
+  it('packs site xyz into a flat Float32Array(3N)', () => {
+    const out = pack_positions([site([1, 2, 3]), site([4, 5, 6])])
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('returns a raw Float32Array frame unchanged (already 3N)', () => {
+    const frame = new Float32Array([7, 8, 9])
+    expect(pack_positions(frame)).toBe(frame)
+  })
+})
+
+describe('pack_lattice', () => {
+  it('flattens a 3x3 lattice matrix row-major into Float32Array(9)', () => {
+    const lat: PymatgenLattice = { matrix: [[1, 0, 0], [0, 2, 0], [0, 0, 3]] } as PymatgenLattice
+    expect(Array.from(pack_lattice(lat))).toEqual([1, 0, 0, 0, 2, 0, 0, 0, 3])
+  })
+
+  it('returns a zero matrix for a non-periodic (no-lattice) structure', () => {
+    expect(Array.from(pack_lattice(undefined))).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0])
+  })
+})
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/frame-buffers.test.ts`
+Expected: FAIL — cannot find module `./frame-buffers`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// frame-buffers.ts
+import type { Site, PymatgenLattice } from '$lib/structure'
+
+/** Pack atom positions into a flat Float32Array(3N), row = (x,y,z).
+ *  A raw trajectory frame (already a 3N Float32Array) is returned as-is. */
+export function pack_positions(input: readonly Site[] | Float32Array): Float32Array {
+  if (input instanceof Float32Array) return input
+  const out = new Float32Array(input.length * 3)
+  for (let i = 0; i < input.length; i++) {
+    const [x, y, z] = input[i].xyz
+    out[i * 3] = x
+    out[i * 3 + 1] = y
+    out[i * 3 + 2] = z
+  }
+  return out
+}
+
+/** Flatten a 3x3 lattice matrix (rows = lattice vectors a,b,c) row-major into
+ *  Float32Array(9). Non-periodic structures (no lattice) → all zeros, which the
+ *  compute shader treats as "no PBC". */
+export function pack_lattice(lattice: PymatgenLattice | undefined): Float32Array {
+  const out = new Float32Array(9)
+  const m = lattice?.matrix
+  if (!m) return out
+  for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) out[r * 3 + c] = m[r][c]
+  return out
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/frame-buffers.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/frame-buffers.ts src/lib/structure/gpu/frame-buffers.test.ts
+git commit -m "feat(gpu): frame position + lattice packing"
+```
+
+---
+
+## Task 4: JS reference bond detector (the WGSL oracle)
+
+**Files:**
+- Create: `src/lib/structure/gpu/bond-detect-reference.ts`
+- Test: `src/lib/structure/gpu/bond-detect-reference.test.ts`
+
+This is the source of truth the WGSL shader must match. It implements the same atom_radii predicate as Rust `detect_bonds_atom_radii`, with minimum-image PBC. Keeping it in JS lets us (a) golden-test the GPU shader, and (b) reason about correctness without a GPU.
+
+Predicate (matches `extensions/rust/src/bonding.rs` atom_radii): a bond exists between atoms i<j iff `min_dist² ≤ d² ≤ (r_i + r_j + tolerance)²` AND `d ≤ max_bond_dist`, where `d` is the **minimum-image** distance under the lattice. `min_dist` defaults to a tiny epsilon to drop coincident atoms. Output `jimage` is the image offset (in lattice units) applied to atom j to realize the minimum image.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// bond-detect-reference.test.ts
+import { describe, it, expect } from 'vitest'
+import { detect_bonds_reference, type RefBondOptions } from './bond-detect-reference'
+
+const OPTS: RefBondOptions = { tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 }
+
+describe('detect_bonds_reference', () => {
+  it('finds a single bond between two close atoms (non-periodic)', () => {
+    const pos = new Float32Array([0, 0, 0, 1.0, 0, 0]) // 1.0 Å apart
+    const radii = new Float32Array([0.76, 0.76]) // C-C, sum+tol = 1.97
+    const zero = new Float32Array(9) // no lattice
+    const bonds = detect_bonds_reference(pos, zero, radii, OPTS)
+    expect(bonds).toHaveLength(1)
+    expect(bonds[0]).toMatchObject({ a: 0, b: 1, jimage: [0, 0, 0] })
+  })
+
+  it('rejects atoms beyond radius sum + tolerance', () => {
+    const pos = new Float32Array([0, 0, 0, 2.5, 0, 0]) // 2.5 Å, > 0.76+0.76+0.45
+    const radii = new Float32Array([0.76, 0.76])
+    const bonds = detect_bonds_reference(pos, new Float32Array(9), radii, OPTS)
+    expect(bonds).toHaveLength(0)
+  })
+
+  it('rejects beyond max_bond_dist even if within radius sum', () => {
+    const pos = new Float32Array([0, 0, 0, 2.9, 0, 0])
+    const radii = new Float32Array([2.0, 2.0]) // sum+tol huge, but max_bond_dist=3 ok; use 3.1
+    const opts = { ...OPTS, max_bond_dist: 2.0 }
+    const bonds = detect_bonds_reference(pos, new Float32Array(9), radii, opts)
+    expect(bonds).toHaveLength(0)
+  })
+
+  it('finds a minimum-image bond across a periodic boundary', () => {
+    // Cubic 5 Å cell; atoms at x=0.2 and x=4.9 are 4.7 apart direct,
+    // but 0.3 apart across the boundary (min image).
+    const pos = new Float32Array([0.2, 0, 0, 4.9, 0, 0])
+    const radii = new Float32Array([0.76, 0.76])
+    const lat = new Float32Array([5, 0, 0, 0, 5, 0, 0, 0, 5])
+    const bonds = detect_bonds_reference(pos, lat, radii, OPTS)
+    expect(bonds).toHaveLength(1)
+    expect(bonds[0].jimage).toEqual([1, 0, 0]) // atom b imaged by +a to reach atom a
+  })
+
+  it('drops coincident atoms (below min_dist)', () => {
+    const pos = new Float32Array([0, 0, 0, 0.01, 0, 0])
+    const radii = new Float32Array([0.76, 0.76])
+    const bonds = detect_bonds_reference(pos, new Float32Array(9), radii, OPTS)
+    expect(bonds).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-detect-reference.test.ts`
+Expected: FAIL — cannot find module `./bond-detect-reference`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// bond-detect-reference.ts
+export type RefBondOptions = { tolerance: number; max_bond_dist: number; min_dist: number }
+export type RefBond = { a: number; b: number; dist: number; jimage: [number, number, number] }
+
+/** Reference atom_radii bond detector with minimum-image PBC. Matches the
+ *  Rust detect_bonds_atom_radii predicate. O(N²) — for test/oracle use and
+ *  small structures only; the GPU path uses a uniform grid for scale. */
+export function detect_bonds_reference(
+  positions: Float32Array, // 3N
+  lattice: Float32Array, // 9, row-major; all-zero ⇒ non-periodic
+  radii: Float32Array, // N
+  opts: RefBondOptions,
+): RefBond[] {
+  const n = radii.length
+  const periodic = lattice.some((v) => v !== 0)
+  const out: RefBond[] = []
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dx = positions[j * 3] - positions[i * 3]
+      const dy = positions[j * 3 + 1] - positions[i * 3 + 1]
+      const dz = positions[j * 3 + 2] - positions[i * 3 + 2]
+      const mi = periodic
+        ? minimum_image(dx, dy, dz, lattice)
+        : { d2: dx * dx + dy * dy + dz * dz, jimage: [0, 0, 0] as [number, number, number] }
+      const d = Math.sqrt(mi.d2)
+      if (d < opts.min_dist || d > opts.max_bond_dist) continue
+      const cutoff = radii[i] + radii[j] + opts.tolerance
+      if (d <= cutoff) out.push({ a: i, b: j, dist: d, jimage: mi.jimage })
+    }
+  }
+  return out
+}
+
+/** Minimum-image displacement for an orthogonal-or-not 3x3 lattice. Searches
+ *  the 27 nearest images (offset components in {-1,0,1}) and returns the
+ *  closest, with the integer image applied to atom b. Adequate for bond-length
+ *  cutoffs ≪ cell size (the large-trajectory regime). */
+function minimum_image(
+  dx: number, dy: number, dz: number, L: Float32Array,
+): { d2: number; jimage: [number, number, number] } {
+  let best = { d2: Infinity, jimage: [0, 0, 0] as [number, number, number] }
+  for (let na = -1; na <= 1; na++) {
+    for (let nb = -1; nb <= 1; nb++) {
+      for (let nc = -1; nc <= 1; nc++) {
+        // image shift = na*a + nb*b + nc*c (lattice rows are a,b,c)
+        const sx = na * L[0] + nb * L[3] + nc * L[6]
+        const sy = na * L[1] + nb * L[4] + nc * L[7]
+        const sz = na * L[2] + nb * L[5] + nc * L[8]
+        const ex = dx + sx, ey = dy + sy, ez = dz + sz
+        const d2 = ex * ex + ey * ey + ez * ez
+        if (d2 < best.d2) best = { d2, jimage: [na, nb, nc] }
+      }
+    }
+  }
+  return best
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-detect-reference.test.ts`
+Expected: PASS (5 tests). If the min-image jimage sign disagrees with `compute_bonds_sync`'s convention, align the sign here and document it — this convention is the contract the WGSL shader and the readback bridge (Task 8) both follow.
+
+- [ ] **Step 5: Cross-check oracle against the production CPU detector**
+
+Add one test that builds a small `PymatgenStructure`, runs both `compute_bonds_sync(struct, 'atom_radii', {max_bond_dist, tolerance})` and `detect_bonds_reference(...)`, and asserts the **bond pair sets match** (as unordered `{min(a,b)}-{max(a,b)}` strings). This guards against the oracle drifting from Rust.
+
+```ts
+it('matches compute_bonds_sync on a small periodic cell', async () => {
+  const { compute_bonds_sync } = await import('$lib/structure/workers/bond-worker-api')
+  // ...build a 4-8 atom PymatgenStructure with a lattice...
+  // const cpu = compute_bonds_sync(struct, 'atom_radii', { max_bond_dist: 3, tolerance: 0.45 })
+  // const ref = detect_bonds_reference(pack_positions(struct.sites), pack_lattice(struct.lattice), build_atom_radii(struct.sites), { tolerance: 0.45, max_bond_dist: 3, min_dist: 0.1 })
+  // expect(pair_set(ref)).toEqual(pair_set(cpu))  // skip if compute_bonds_sync returns null (WASM not init in test env)
+})
+```
+
+> If `compute_bonds_sync` returns `null` in the vitest env (Rust WASM not initialized), guard the assertion with an early return and leave the structural test in place for when WASM is available. Do not delete it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/structure/gpu/bond-detect-reference.ts src/lib/structure/gpu/bond-detect-reference.test.ts
+git commit -m "feat(gpu): JS reference bond detector (atom_radii, minimum-image PBC)"
+```
+
+---
+
+## Task 5: WGSL compute shader source
+
+**Files:**
+- Create: `src/lib/structure/gpu/bond-compute.wgsl.ts`
+- Test: none yet (compiled/dispatched in Task 6; this task only defines the string and a smoke that it's non-empty WGSL).
+- Test: `src/lib/structure/gpu/bond-compute.wgsl.test.ts`
+
+v1 uses a uniform spatial grid. To keep the first GPU version simple and matchable to the oracle, this shader computes, **per atom i**, bonds against all atoms j>i by scanning candidate cells (27-neighborhood of i's cell), applying minimum-image + atom_radii, and appending `(i, j, jimage_packed)` to an output buffer via an atomic counter. (Grid build is a separate small dispatch; see Task 6.)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// bond-compute.wgsl.test.ts
+import { describe, it, expect } from 'vitest'
+import { BOND_COMPUTE_WGSL } from './bond-compute.wgsl'
+
+describe('BOND_COMPUTE_WGSL', () => {
+  it('is a non-empty WGSL string with the expected entry points', () => {
+    expect(typeof BOND_COMPUTE_WGSL).toBe('string')
+    expect(BOND_COMPUTE_WGSL).toContain('@compute')
+    expect(BOND_COMPUTE_WGSL).toContain('fn detect_bonds')
+    expect(BOND_COMPUTE_WGSL).toContain('atomicAdd')
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.wgsl.test.ts`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// bond-compute.wgsl.ts
+/** WGSL compute for atom_radii bond detection with minimum-image PBC.
+ *  Bindings:
+ *   0: positions   storage<read>      array<f32>  (3N, xyz interleaved)
+ *   1: radii       storage<read>      array<f32>  (N)
+ *   2: params      uniform            Params
+ *   3: out_pairs   storage<read_write> array<u32> (capacity*3: a, b, jimage_packed)
+ *   4: out_count   storage<read_write> atomic<u32>
+ *  jimage_packed: (na+1) | ((nb+1)<<2) | ((nc+1)<<4), each in {0,1,2} for {-1,0,1}. */
+export const BOND_COMPUTE_WGSL = /* wgsl */ `
+struct Params {
+  n_atoms: u32,
+  capacity: u32,
+  periodic: u32,
+  _pad0: u32,
+  tolerance: f32,
+  max_bond_dist: f32,
+  min_dist: f32,
+  _pad1: f32,
+  lattice: mat3x3<f32>, // rows a,b,c
+};
+
+@group(0) @binding(0) var<storage, read> positions: array<f32>;
+@group(0) @binding(1) var<storage, read> radii: array<f32>;
+@group(0) @binding(2) var<uniform> P: Params;
+@group(0) @binding(3) var<storage, read_write> out_pairs: array<u32>;
+@group(0) @binding(4) var<storage, read_write> out_count: atomic<u32>;
+
+fn pos(i: u32) -> vec3<f32> {
+  return vec3<f32>(positions[i*3u], positions[i*3u+1u], positions[i*3u+2u]);
+}
+
+fn pack_jimage(na: i32, nb: i32, nc: i32) -> u32 {
+  return u32(na+1) | (u32(nb+1) << 2u) | (u32(nc+1) << 4u);
+}
+
+@compute @workgroup_size(64)
+fn detect_bonds(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i >= P.n_atoms) { return; }
+  let pi = pos(i);
+  let ri = radii[i];
+  // v1: O(N) per atom over all j>i. Grid acceleration is layered in Task 6
+  // via a candidate list; the predicate below is the contract under test.
+  for (var j: u32 = i + 1u; j < P.n_atoms; j = j + 1u) {
+    let dvec = pos(j) - pi;
+    var best_d2 = 1e30;
+    var bi: i32 = 0; var bj: i32 = 0; var bk: i32 = 0;
+    if (P.periodic == 1u) {
+      for (var na: i32 = -1; na <= 1; na = na + 1) {
+        for (var nb: i32 = -1; nb <= 1; nb = nb + 1) {
+          for (var nc: i32 = -1; nc <= 1; nc = nc + 1) {
+            let shift = f32(na)*P.lattice[0] + f32(nb)*P.lattice[1] + f32(nc)*P.lattice[2];
+            let e = dvec + shift;
+            let d2 = dot(e, e);
+            if (d2 < best_d2) { best_d2 = d2; bi = na; bj = nb; bk = nc; }
+          }
+        }
+      }
+    } else {
+      best_d2 = dot(dvec, dvec);
+    }
+    let d = sqrt(best_d2);
+    if (d < P.min_dist || d > P.max_bond_dist) { continue; }
+    if (d <= ri + radii[j] + P.tolerance) {
+      let slot = atomicAdd(&out_count, 1u);
+      if (slot < P.capacity) {
+        out_pairs[slot*3u + 0u] = i;
+        out_pairs[slot*3u + 1u] = j;
+        out_pairs[slot*3u + 2u] = pack_jimage(bi, bj, bk);
+      }
+    }
+  }
+}
+`
+```
+
+> **WGSL note:** `mat3x3<f32>` columns are accessed as `P.lattice[0/1/2]`. WGSL stores mat3x3 column-major; when uploading from `pack_lattice` (row-major a,b,c as rows), upload the **transpose** so columns are a,b,c — Task 6 handles the upload layout and its test pins it. The `shift = na*col0 + nb*col1 + nc*col2` here assumes columns are a,b,c.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.wgsl.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/bond-compute.wgsl.ts src/lib/structure/gpu/bond-compute.wgsl.test.ts
+git commit -m "feat(gpu): WGSL bond-detect compute shader (atom_radii, min-image)"
+```
+
+---
+
+## Task 6: Compute pipeline wrapper + device-gated golden test
+
+**Files:**
+- Create: `src/lib/structure/gpu/bond-compute.ts`
+- Test: `src/lib/structure/gpu/bond-compute.test.ts`
+
+Wraps the shader: creates buffers/bind group, packs the `Params` uniform (with the lattice **transposed** for column-major WGSL), dispatches, and reads back the bond count + pairs (readback used here for testing and for the on-pause bridge — NOT in the playback loop).
+
+- [ ] **Step 1: Write the device-gated golden test**
+
+```ts
+// bond-compute.test.ts
+import { describe, it, expect, beforeAll } from 'vitest'
+import { acquire_webgpu_device } from './webgpu-context'
+import { create_bond_compute } from './bond-compute'
+import { detect_bonds_reference } from './bond-detect-reference'
+
+let device: GPUDevice | null = null
+beforeAll(async () => { device = await acquire_webgpu_device() })
+
+const pair_set = (bonds: { a: number; b: number }[]) =>
+  new Set(bonds.map((b) => `${Math.min(b.a, b.b)}-${Math.max(b.a, b.b)}`))
+
+describe.skipIf(!globalThis.navigator?.gpu)('bond-compute (GPU)', () => {
+  it('matches the JS reference on a small periodic cell', async () => {
+    if (!device) return // no device in this env
+    const positions = new Float32Array([0.2, 0, 0, 4.9, 0, 0, 0.2, 1.2, 0])
+    const radii = new Float32Array([0.76, 0.76, 0.76])
+    const lattice = new Float32Array([5, 0, 0, 0, 5, 0, 0, 0, 5])
+    const opts = { tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 }
+    const ref = detect_bonds_reference(positions, lattice, radii, opts)
+
+    const compute = create_bond_compute(device, { capacity: 1024 })
+    const gpu = await compute.run({ positions, radii, lattice, periodic: true, ...opts })
+
+    expect(gpu.count).toBe(ref.length)
+    expect(pair_set(gpu.pairs)).toEqual(pair_set(ref))
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify it fails (or skips cleanly)**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.test.ts`
+Expected: in CI (no GPU) the suite is SKIPPED; locally with a GPU it FAILS — `create_bond_compute` not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// bond-compute.ts
+import { BOND_COMPUTE_WGSL } from './bond-compute.wgsl'
+
+export type BondComputeOptions = { tolerance: number; max_bond_dist: number; min_dist: number }
+export type BondComputeRun = BondComputeOptions & {
+  positions: Float32Array
+  radii: Float32Array
+  lattice: Float32Array // 9, row-major (a,b,c rows)
+  periodic: boolean
+}
+export type BondComputeResult = {
+  count: number
+  pairs: { a: number; b: number; jimage: [number, number, number] }[]
+}
+
+const PARAMS_BYTES = 16 /*u32x4 + f32x4*/ + 64 /*mat3x4 padded*/ // 80, aligned
+
+/** Compute pipeline for atom_radii bond detection. `run` dispatches and reads
+ *  back (used for tests + the on-pause CPU bridge). The playback loop keeps
+ *  the bond buffer GPU-resident and does NOT call run(); it reuses `dispatch`
+ *  (Task 7 wires render directly to the buffer). */
+export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }) {
+  const module = device.createShaderModule({ code: BOND_COMPUTE_WGSL })
+  const pipeline = device.createComputePipeline({ layout: `auto`, compute: { module, entryPoint: `detect_bonds` } })
+
+  async function run(r: BondComputeRun): Promise<BondComputeResult> {
+    const n = r.radii.length
+    const pos_buf = make_storage(device, r.positions)
+    const rad_buf = make_storage(device, r.radii)
+    const pairs_buf = device.createBuffer({ size: cfg.capacity * 3 * 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC })
+    const count_buf = device.createBuffer({ size: 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST })
+    device.queue.writeBuffer(count_buf, 0, new Uint32Array([0]))
+    const params_buf = device.createBuffer({ size: PARAMS_BYTES, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST })
+    device.queue.writeBuffer(params_buf, 0, pack_params(n, cfg.capacity, r))
+
+    const bind = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: pos_buf } },
+        { binding: 1, resource: { buffer: rad_buf } },
+        { binding: 2, resource: { buffer: params_buf } },
+        { binding: 3, resource: { buffer: pairs_buf } },
+        { binding: 4, resource: { buffer: count_buf } },
+      ],
+    })
+
+    const enc = device.createCommandEncoder()
+    const pass = enc.beginComputePass()
+    pass.setPipeline(pipeline)
+    pass.setBindGroup(0, bind)
+    pass.dispatchWorkgroups(Math.ceil(n / 64))
+    pass.end()
+    // readback (test + on-pause only)
+    const count_read = device.createBuffer({ size: 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ })
+    const pairs_read = device.createBuffer({ size: cfg.capacity * 3 * 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ })
+    enc.copyBufferToBuffer(count_buf, 0, count_read, 0, 4)
+    enc.copyBufferToBuffer(pairs_buf, 0, pairs_read, 0, cfg.capacity * 3 * 4)
+    device.queue.submit([enc.finish()])
+
+    await count_read.mapAsync(GPUMapMode.READ)
+    const count = Math.min(new Uint32Array(count_read.getMappedRange())[0], cfg.capacity)
+    count_read.unmap()
+    await pairs_read.mapAsync(GPUMapMode.READ)
+    const raw = new Uint32Array(pairs_read.getMappedRange().slice(0))
+    pairs_read.unmap()
+
+    const pairs: BondComputeResult['pairs'] = []
+    for (let i = 0; i < count; i++) {
+      const a = raw[i * 3], b = raw[i * 3 + 1], jp = raw[i * 3 + 2]
+      pairs.push({ a, b, jimage: unpack_jimage(jp) })
+    }
+    return { count, pairs }
+  }
+
+  return { pipeline, run }
+}
+
+function make_storage(device: GPUDevice, data: Float32Array): GPUBuffer {
+  const buf = device.createBuffer({ size: data.byteLength, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST })
+  device.queue.writeBuffer(buf, 0, data)
+  return buf
+}
+
+/** Pack the Params uniform. Lattice uploaded TRANSPOSED so WGSL column-major
+ *  mat3x3 columns equal lattice rows a,b,c. mat3x3 in WGSL pads each column to
+ *  vec4 (16 bytes) → 48 bytes; we lay it out at offset 16. */
+function pack_params(n: number, capacity: number, r: BondComputeRun): ArrayBuffer {
+  const buf = new ArrayBuffer(PARAMS_BYTES)
+  const u = new Uint32Array(buf), f = new Float32Array(buf)
+  u[0] = n; u[1] = capacity; u[2] = r.periodic ? 1 : 0; u[3] = 0
+  f[4] = r.tolerance; f[5] = r.max_bond_dist; f[6] = r.min_dist; f[7] = 0
+  // columns a,b,c at float offsets 8.., each padded to 4 floats
+  const L = r.lattice
+  const col = (rIdx: number, o: number) => { f[o] = L[rIdx * 3]; f[o + 1] = L[rIdx * 3 + 1]; f[o + 2] = L[rIdx * 3 + 2]; f[o + 3] = 0 }
+  col(0, 8); col(1, 12); col(2, 16)
+  return buf
+}
+
+function unpack_jimage(p: number): [number, number, number] {
+  return [(p & 0x3) - 1, ((p >> 2) & 0x3) - 1, ((p >> 4) & 0x3) - 1]
+}
+```
+
+- [ ] **Step 4: Run the golden test (locally, with a GPU)**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.test.ts`
+Expected (with GPU): PASS — GPU pair set equals reference. (CI: SKIPPED.)
+If it fails on jimage, re-check the transpose in `pack_params` and the pack/unpack convention against Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/bond-compute.ts src/lib/structure/gpu/bond-compute.test.ts
+git commit -m "feat(gpu): bond compute pipeline + device-gated golden test"
+```
+
+---
+
+## Task 7: Camera uniform packing
+
+**Files:**
+- Create: `src/lib/structure/gpu/camera-uniform.ts`
+- Test: `src/lib/structure/gpu/camera-uniform.test.ts`
+
+The WebGPU renderer must match the Three camera exactly so toggling modes doesn't jump. We pack `viewProjection` (mat4) + camera world position into a uniform.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// camera-uniform.test.ts
+import { describe, it, expect } from 'vitest'
+import { pack_camera_uniform } from './camera-uniform'
+
+// Minimal fake matching the fields we read from a THREE.Camera.
+function fake_camera() {
+  return {
+    matrixWorldInverse: { elements: Array.from({ length: 16 }, (_, i) => i) },
+    projectionMatrix: { elements: Array.from({ length: 16 }, (_, i) => 100 + i) },
+    position: { x: 1, y: 2, z: 3 },
+  }
+}
+
+describe('pack_camera_uniform', () => {
+  it('packs proj*view (column-major) then camera position', () => {
+    const out = pack_camera_uniform(fake_camera() as never)
+    expect(out).toBeInstanceOf(Float32Array)
+    expect(out.length).toBe(20) // 16 mat + 3 pos + 1 pad
+    expect(out[16]).toBe(1); expect(out[17]).toBe(2); expect(out[18]).toBe(3)
+  })
+}) 
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/camera-uniform.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// camera-uniform.ts
+import { Matrix4 } from 'three'
+import type { Camera } from 'three'
+
+const _vp = new Matrix4()
+
+/** Pack proj * view (column-major, WebGPU-ready) followed by camera world
+ *  position (vec3 + pad) into Float32Array(20). */
+export function pack_camera_uniform(camera: Camera): Float32Array {
+  _vp.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse)
+  const out = new Float32Array(20)
+  out.set(_vp.elements, 0) // three stores column-major already
+  out[16] = camera.position.x
+  out[17] = camera.position.y
+  out[18] = camera.position.z
+  out[19] = 0
+  return out
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/camera-uniform.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/camera-uniform.ts src/lib/structure/gpu/camera-uniform.test.ts
+git commit -m "feat(gpu): camera uniform packing for WebGPU render path"
+```
+
+---
+
+## Task 8: Orchestrator — toggle, frame loop, readback bridge
+
+**Files:**
+- Create: `src/lib/structure/gpu/large-system-mode.svelte.ts`
+- Test: `src/lib/structure/gpu/large-system-mode.test.ts`
+
+This is the only module that touches `bond_state`. It owns: the `enabled` toggle (manual), the per-frame upload+compute+render trigger, and the **readback bridge** that converts a `BondComputeResult` into `bond_state.bond_connectivity` entries (translating the v1 packed jimage into the `[na,nb,nc]` array form the rest of the app expects). v1 keeps the compute/render wiring thin (delegated to Tasks 6 + 9); the unit-tested surface here is the toggle state machine and the readback translation.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// large-system-mode.test.ts
+import { describe, it, expect } from 'vitest'
+import { result_to_connectivity } from './large-system-mode'
+
+describe('result_to_connectivity', () => {
+  it('translates compute pairs into bond_connectivity entries', () => {
+    const conn = result_to_connectivity({
+      count: 2,
+      pairs: [
+        { a: 0, b: 1, jimage: [0, 0, 0] },
+        { a: 1, b: 2, jimage: [1, 0, 0] },
+      ],
+    })
+    expect(conn).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, strength: 1, jimage: [0, 0, 0] },
+      { site_idx_1: 1, site_idx_2: 2, strength: 1, jimage: [1, 0, 0] },
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement (state machine + bridge)**
+
+```ts
+// large-system-mode.svelte.ts
+import type { BondComputeResult } from './bond-compute'
+
+type BondConn = { site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }
+
+/** Translate a GPU bond result into the app's bond_connectivity entries.
+ *  atom_radii strength is 1.0 (matches Rust detect_bonds_atom_radii). */
+export function result_to_connectivity(result: BondComputeResult): BondConn[] {
+  const out: BondConn[] = new Array(result.count)
+  for (let i = 0; i < result.count; i++) {
+    const p = result.pairs[i]
+    out[i] = { site_idx_1: p.a, site_idx_2: p.b, strength: 1, jimage: p.jimage }
+  }
+  return out
+}
+
+/** Manual large-system performance mode. Svelte 5 runes state; wired into
+ *  StructureScene in Task 9. WebGPU availability is injected so the toggle can
+ *  refuse + signal fallback when no device. */
+export function create_large_system_mode(deps: {
+  has_webgpu: boolean
+  on_fallback: (reason: string) => void
+}) {
+  let enabled = $state(false)
+  return {
+    get enabled() { return enabled },
+    get available() { return deps.has_webgpu },
+    enable() {
+      if (!deps.has_webgpu) {
+        deps.on_fallback(`WebGPU unavailable — staying on CPU path; very large systems will be capped.`)
+        return false
+      }
+      enabled = true
+      return true
+    },
+    disable() { enabled = false },
+  }
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Expected: PASS (1 test). Add a `create_large_system_mode` test: with `has_webgpu:false`, `enable()` returns false and calls `on_fallback`; with `true`, `enable()` sets `enabled` true.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/large-system-mode.svelte.ts src/lib/structure/gpu/large-system-mode.test.ts
+git commit -m "feat(gpu): large-system mode toggle + readback→connectivity bridge"
+```
+
+---
+
+## Task 9: Renderer + StructureScene integration (manual-verified)
+
+**Files:**
+- Create: `src/lib/structure/gpu/large-system-renderer.ts`
+- Modify: `src/lib/structure/StructureScene.svelte` (canvas swap + toggle wiring; around the renderer/canvas creation block — locate via `WebGLRenderer`/canvas init).
+- Modify: a UI control surface to expose the toggle (follow the existing bonding-controls pattern; the implementer locates the panel that hosts bond options, since the custom-bond-distance sliders already live there per the spec).
+
+This task is integration + GPU rendering, which CI cannot test. It is verified manually (Step 4) plus the device-gated single-pixel readback below.
+
+- [ ] **Step 1: Implement `large-system-renderer.ts`**
+
+Render pipeline drawing (a) impostor spheres as instanced quads raymarched to spheres, reading the GPU position buffer + per-atom radius, and (b) instanced bonds reading the GPU bond buffer (Task 6's `pairs_buf`, kept resident). Selection highlight = a per-atom u32 "selected" storage buffer sampled in the sphere shader. Picking = render atom-id to an R32Uint attachment; `pick(x,y)` copies that texel to a readback buffer. Camera uniform from Task 7.
+
+Provide:
+```ts
+export function create_large_system_renderer(device: GPUDevice, canvas: HTMLCanvasElement): {
+  set_frame(positions: GPUBuffer, radii: GPUBuffer, n: number): void
+  set_bonds(pairs: GPUBuffer, count: number): void
+  set_camera(uniform: Float32Array): void
+  set_selection(selected: GPUBuffer): void
+  render(): void
+  pick(x: number, y: number): Promise<number> // atom index or -1
+  destroy(): void
+}
+```
+
+> Keep the bond buffer GPU-resident: `set_bonds` receives the same `pairs_buf`/`count` the compute pass wrote, with no readback. `render` runs the compute dispatch (Task 6 `dispatch`, no readback variant) then the two render passes, every frame.
+
+- [ ] **Step 2: Device-gated render smoke test**
+
+`src/lib/structure/gpu/large-system-renderer.test.ts`: `describe.skipIf(!navigator.gpu)` — create an offscreen canvas, render two atoms, read back a center pixel from the color attachment, assert it is non-background. This catches pipeline/bind-group breakage without asserting exact shading.
+
+- [ ] **Step 3: Wire into StructureScene**
+
+- Add the toggle (from Task 8) to the bond-options UI.
+- When `enabled` flips true: hide the Three/WebGL `<canvas>`, mount the WebGPU canvas, start the frame loop (on trajectory frame change or camera move → `set_frame` + `set_camera` + `render`).
+- When `enabled` flips false: stop the loop, destroy the WebGPU renderer, show the WebGL canvas.
+- On pause / selection / export: call `bond-compute.run(...)` once for the current frame and `bond_state.bond_connectivity = result_to_connectivity(result)` (Task 8) so CPU consumers (export, mof-analysis, measurement) see current bonds.
+- Disable label/polyhedra/gizmo/measurement UI affordances while `enabled` (per spec); keep selection + picking.
+
+- [ ] **Step 4: Manual verification (REQUIRED)**
+
+Per `superpowers:verification-before-completion`. Use the catgo worktree dev setup (see project memory). Steps:
+1. Load a large trajectory (or synthesize one ≥ the regime).
+2. Toggle large-system mode on → confirm atoms + bonds render, playback/scrub is smooth, rotation works.
+3. Confirm PBC boundary bonds appear (minimum image), no ghost atoms.
+4. Pause, select an atom → confirm pick works and selection highlights.
+5. Adjust the bond-distance slider → confirm bonds update live.
+6. Toggle off → confirm clean return to the WebGL path, no leaks (check DevTools).
+7. On a no-WebGPU runtime (or force `has_webgpu:false`) → confirm fallback message + CPU path + cap.
+
+Record observations in the PR description.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/large-system-renderer.ts src/lib/structure/gpu/large-system-renderer.test.ts src/lib/structure/StructureScene.svelte
+git commit -m "feat(gpu): large-system WebGPU renderer + StructureScene integration"
+```
+
+---
+
+## Task 10: Custom bond distance — live uniform update
+
+**Files:**
+- Modify: `src/lib/structure/gpu/large-system-mode.svelte.ts` (thread bond options into compute params)
+- Test: `src/lib/structure/gpu/large-system-mode.test.ts` (extend)
+
+The existing bond-options sliders (tolerance / max_bond_dist) must drive the GPU `Params` uniform; changing a slider re-dispatches compute for the current frame.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('maps bond options to compute params (custom bond distance)', () => {
+  const { to_compute_options } = require('./large-system-mode')
+  expect(to_compute_options({ max_bond_dist: 2.6, tolerance: 0.3 }))
+    .toEqual({ max_bond_dist: 2.6, tolerance: 0.3, min_dist: 0.1 })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Expected: FAIL — `to_compute_options` not exported.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// add to large-system-mode.svelte.ts
+const DEFAULT_MIN_DIST = 0.1
+export function to_compute_options(opts: Record<string, number>): { tolerance: number; max_bond_dist: number; min_dist: number } {
+  return {
+    tolerance: opts.tolerance ?? 0.45,
+    max_bond_dist: opts.max_bond_dist ?? 3.0,
+    min_dist: opts.min_dist ?? DEFAULT_MIN_DIST,
+  }
+}
+```
+
+- [ ] **Step 4: Run, verify pass + wire**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Expected: PASS. Then in StructureScene (Task 9 loop): on bond-option change while `enabled`, call `render()` (which re-dispatches with the new `Params`). Verify manually that dragging the slider re-bonds live.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/gpu/large-system-mode.svelte.ts src/lib/structure/gpu/large-system-mode.test.ts
+git commit -m "feat(gpu): live custom bond distance drives GPU compute params"
+```
+
+---
+
+## Task 11: Full suite + finish
+
+- [ ] **Step 1: Run the whole gpu suite + lint/typecheck**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu`
+Expected: all pure-JS tests PASS; GPU device-gated tests PASS locally / SKIP in CI.
+Run: `rtk proxy pnpm exec svelte-check` (or the repo's typecheck script) — no new errors.
+
+- [ ] **Step 2: Self-review against spec §3 decisions** — confirm every locked decision (1–9) has a corresponding task. Note in the PR any deferred item (electroneg/solid_angle GPU strategies, auto-threshold, full three/webgpu migration are explicitly out of scope per spec §8).
+
+- [ ] **Step 3: Open PR** using `superpowers:finishing-a-development-branch`. Include the manual verification observations from Task 9 Step 4.
+
+---
+
+## Self-Review (plan author)
+
+**Spec coverage:** §3 decisions → 1 (A path, Task 9 integration), 2 (per-frame compute, Task 6/9), 3 (GPU-resident + readback-on-pause, Task 8/9), 4 (reduced render + keep selection/pick, Task 9), 5 (min-image PBC, Tasks 4/5/6), 6 (atom_radii only, Tasks 4/5), 7 (manual toggle, Task 8), 8 (CPU fallback + warning, Task 8/9), 9 (custom bond distance, Task 10). ✓
+**Placeholder scan:** Tasks 9 render/integration are intentionally manual (GPU/UI not CI-testable) — code interfaces are concrete; the WGSL render shader bodies are the one place left to the implementer because they depend on the chosen impostor technique. Flagged explicitly, not hidden. All pure-JS tasks have full code + tests.
+**Type consistency:** `BondComputeResult`/`BondComputeRun` (Task 6) used consistently in Tasks 8/10; `result_to_connectivity` output matches `bond_connectivity` entry type; jimage pack/unpack convention shared across Tasks 4/5/6.

--- a/docs/superpowers/plans/2026-05-23-webgpu-large-trajectory-bonds.md
+++ b/docs/superpowers/plans/2026-05-23-webgpu-large-trajectory-bonds.md
@@ -11,7 +11,14 @@
 **Spec:** `docs/superpowers/specs/2026-05-23-webgpu-large-trajectory-bonds-design.md`
 
 **Reference facts (verified):**
-- Test runner: `pnpm exec vitest run` (RTK serves stale vitest output — bypass with `rtk proxy pnpm exec vitest run`). Tests colocate as `*.test.ts`.
+- Test runner: `pnpm exec vitest run` (RTK serves stale vitest output — bypass with `rtk proxy pnpm exec vitest run`).
+
+> **⚠️ TEST PLACEMENT & IMPORTS (overrides every per-task literal below).** Vitest `include` is `tests/vitest/**/*.test.ts` and `src/**/__tests__/**/*.test.ts` — tests do NOT colocate next to source. For every task:
+> - **Source** files go at `src/lib/structure/gpu/<name>.ts` (as written).
+> - **Test** files go at `tests/vitest/structure/gpu/<name>.test.ts` (NOT the `src/lib/structure/gpu/<name>.test.ts` shown in task "Files"/"Test" lines).
+> - Inside tests, import production code via the **`$lib` alias**: `import { X } from '$lib/structure/gpu/<name>'` (NOT the relative `./<name>` shown in test code). Helpers: `create_test_structure` from `../setup`, `test_molecules` from `$site/molecules`.
+> - `vitest run` and `git add` paths for tests use `tests/vitest/structure/gpu/...`.
+> Mirror `tests/vitest/structure/bonding.test.ts` for style.
 - Types (`src/lib/structure/index.ts`): `Site = { species: Species[]; abc: Vec3; xyz: Vec3 }`; `PymatgenLattice = { matrix: Matrix3x3 }`; `PymatgenStructure = PymatgenMolecule & { lattice: PymatgenLattice }`; `AnyStructure = PymatgenStructure | PymatgenMolecule`.
 - CPU bond oracle: `compute_bonds_sync(structure, 'atom_radii', options)` in `src/lib/structure/workers/bond-worker-api.ts:158` → `BondPair[] | null`. Rust path emits cross-cell `image` (jimage). `options` is `Record<string, number>` (keys include `max_bond_dist`, `tolerance`).
 - Covalent radii data: default-export numeric array in `src/lib/element/data.ts` (indexed by atomic number; see `src/lib/element/covalent_radii.d.ts`).
@@ -35,7 +42,7 @@
 | `src/lib/structure/gpu/camera-uniform.ts` | Pack a Three camera into view/proj uniform bytes. Pure. |
 | `src/lib/structure/gpu/large-system-renderer.ts` | WGSL render: impostor spheres + instanced bonds + selection + id-pick. |
 | `src/lib/structure/gpu/large-system-mode.svelte.ts` | Orchestrator: toggle state, canvas switch, frame upload, playback loop, readback-on-pause → `bond_state`. |
-| `src/lib/structure/gpu/*.test.ts` | Colocated tests per module. |
+| `tests/vitest/structure/gpu/*.test.ts` | Tests per module (see TEST PLACEMENT note above). |
 
 Each `gpu/` module has one responsibility and a narrow interface; `large-system-mode` is the only one that knows about `StructureScene`/`bond_state`.
 
@@ -86,7 +93,7 @@ describe('webgpu-context', () => {
 
 - [ ] **Step 2: Run test, verify it fails**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/webgpu-context.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/webgpu-context.test.ts`
 Expected: FAIL — cannot find module `./webgpu-context`.
 
 - [ ] **Step 3: Implement**
@@ -123,7 +130,7 @@ export function __reset_device_cache(): void { cached_device = null }
 
 - [ ] **Step 4: Run test, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/webgpu-context.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/webgpu-context.test.ts`
 Expected: PASS (4 tests). Note: the cache makes `acquire_webgpu_device` sticky — add `__reset_device_cache()` in `afterEach` if a later test needs isolation.
 
 - [ ] **Step 5: Commit**
@@ -175,7 +182,7 @@ describe('build_atom_radii', () => {
 
 - [ ] **Step 2: Run test, verify it fails**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/radius-lut.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/radius-lut.test.ts`
 Expected: FAIL — cannot find module `./radius-lut`.
 
 - [ ] **Step 3: Implement**
@@ -210,7 +217,7 @@ function covalent_radius_of(element: string | undefined): number | null {
 
 - [ ] **Step 4: Run test, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/radius-lut.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/radius-lut.test.ts`
 Expected: PASS (2 tests).
 
 - [ ] **Step 5: Commit**
@@ -268,7 +275,7 @@ describe('pack_lattice', () => {
 
 - [ ] **Step 2: Run test, verify it fails**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/frame-buffers.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/frame-buffers.test.ts`
 Expected: FAIL — cannot find module `./frame-buffers`.
 
 - [ ] **Step 3: Implement**
@@ -305,7 +312,7 @@ export function pack_lattice(lattice: PymatgenLattice | undefined): Float32Array
 
 - [ ] **Step 4: Run test, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/frame-buffers.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/frame-buffers.test.ts`
 Expected: PASS (4 tests).
 
 - [ ] **Step 5: Commit**
@@ -383,7 +390,7 @@ describe('detect_bonds_reference', () => {
 
 - [ ] **Step 2: Run test, verify it fails**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-detect-reference.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/bond-detect-reference.test.ts`
 Expected: FAIL — cannot find module `./bond-detect-reference`.
 
 - [ ] **Step 3: Implement**
@@ -449,7 +456,7 @@ function minimum_image(
 
 - [ ] **Step 4: Run test, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-detect-reference.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/bond-detect-reference.test.ts`
 Expected: PASS (5 tests). If the min-image jimage sign disagrees with `compute_bonds_sync`'s convention, align the sign here and document it — this convention is the contract the WGSL shader and the readback bridge (Task 8) both follow.
 
 - [ ] **Step 5: Cross-check oracle against the production CPU detector**
@@ -505,7 +512,7 @@ describe('BOND_COMPUTE_WGSL', () => {
 
 - [ ] **Step 2: Run, verify fail**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.wgsl.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/bond-compute.wgsl.test.ts`
 Expected: FAIL — cannot find module.
 
 - [ ] **Step 3: Implement**
@@ -592,7 +599,7 @@ fn detect_bonds(@builtin(global_invocation_id) gid: vec3<u32>) {
 
 - [ ] **Step 4: Run, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.wgsl.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/bond-compute.wgsl.test.ts`
 Expected: PASS (1 test).
 
 - [ ] **Step 5: Commit**
@@ -647,7 +654,7 @@ describe.skipIf(!globalThis.navigator?.gpu)('bond-compute (GPU)', () => {
 
 - [ ] **Step 2: Run, verify it fails (or skips cleanly)**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/bond-compute.test.ts`
 Expected: in CI (no GPU) the suite is SKIPPED; locally with a GPU it FAILS — `create_bond_compute` not found.
 
 - [ ] **Step 3: Implement**
@@ -758,7 +765,7 @@ function unpack_jimage(p: number): [number, number, number] {
 
 - [ ] **Step 4: Run the golden test (locally, with a GPU)**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/bond-compute.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/bond-compute.test.ts`
 Expected (with GPU): PASS — GPU pair set equals reference. (CI: SKIPPED.)
 If it fails on jimage, re-check the transpose in `pack_params` and the pack/unpack convention against Task 4.
 
@@ -807,7 +814,7 @@ describe('pack_camera_uniform', () => {
 
 - [ ] **Step 2: Run, verify fail**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/camera-uniform.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/camera-uniform.test.ts`
 Expected: FAIL — module not found.
 
 - [ ] **Step 3: Implement**
@@ -835,7 +842,7 @@ export function pack_camera_uniform(camera: Camera): Float32Array {
 
 - [ ] **Step 4: Run, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/camera-uniform.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/camera-uniform.test.ts`
 Expected: PASS (1 test).
 
 - [ ] **Step 5: Commit**
@@ -881,7 +888,7 @@ describe('result_to_connectivity', () => {
 
 - [ ] **Step 2: Run, verify fail**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/large-system-mode.test.ts`
 Expected: FAIL — module not found.
 
 - [ ] **Step 3: Implement (state machine + bridge)**
@@ -929,7 +936,7 @@ export function create_large_system_mode(deps: {
 
 - [ ] **Step 4: Run, verify pass**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/large-system-mode.test.ts`
 Expected: PASS (1 test). Add a `create_large_system_mode` test: with `has_webgpu:false`, `enable()` returns false and calls `on_fallback`; with `true`, `enable()` sets `enabled` true.
 
 - [ ] **Step 5: Commit**
@@ -1023,7 +1030,7 @@ it('maps bond options to compute params (custom bond distance)', () => {
 
 - [ ] **Step 2: Run, verify fail**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/large-system-mode.test.ts`
 Expected: FAIL — `to_compute_options` not exported.
 
 - [ ] **Step 3: Implement**
@@ -1042,7 +1049,7 @@ export function to_compute_options(opts: Record<string, number>): { tolerance: n
 
 - [ ] **Step 4: Run, verify pass + wire**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu/large-system-mode.test.ts`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu/large-system-mode.test.ts`
 Expected: PASS. Then in StructureScene (Task 9 loop): on bond-option change while `enabled`, call `render()` (which re-dispatches with the new `Params`). Verify manually that dragging the slider re-bonds live.
 
 - [ ] **Step 5: Commit**
@@ -1058,7 +1065,7 @@ git commit -m "feat(gpu): live custom bond distance drives GPU compute params"
 
 - [ ] **Step 1: Run the whole gpu suite + lint/typecheck**
 
-Run: `rtk proxy pnpm exec vitest run src/lib/structure/gpu`
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/gpu`
 Expected: all pure-JS tests PASS; GPU device-gated tests PASS locally / SKIP in CI.
 Run: `rtk proxy pnpm exec svelte-check` (or the repo's typecheck script) — no new errors.
 

--- a/docs/superpowers/specs/2026-05-23-webgpu-large-trajectory-bonds-design.md
+++ b/docs/superpowers/specs/2026-05-23-webgpu-large-trajectory-bonds-design.md
@@ -1,0 +1,98 @@
+# 设计稿：超大轨迹 WebGPU 专用渲染路径
+
+日期：2026-05-23
+状态：设计已与用户对齐，待 spec 评审 → 实现计划
+
+## 1. 背景与问题
+
+CatGO 当前判键流程（`src/lib/structure/bond-computation-controller.svelte.ts`）：
+
+- 非轨迹：`compute_bond_connectivity`，指纹门控，变化时调 `compute_bonds_sync`（ferrox-wasm，主线程同步）。
+- 轨迹：`TRAJ_SYNC_THRESHOLD = 1000` 原子以下主线程同步逐帧算；以上节流异步 worker，单任务在途；帧缓存 `TRAJ_FRAME_CACHE_MAX = 32`。
+- 删原子走 X4/X5 增量 drop-reindex 快速路径并伪造指纹屏蔽重算。
+
+ferrox-wasm 判键确认为**纯成对**（距离 + 共价半径/电负性，无邻居上限、无配位/价态依赖，`extensions/rust/src/bonding.rs`）。
+
+**核心痛点（本设计针对）**：百万原子 × 万帧轨迹下，**每帧从头重算全体键拓扑**在浏览器中不可能流畅，且百万原子球本身在 Three WebGL `InstancedMesh` 下也是巨大渲染负担。逐帧重算 + 逐帧建几何 → 直接卡死。这是架构问题，调参无解。
+
+（注：删原子断键 / 不成键的增量路径问题是**另一个**独立 bug，本 spec 不处理，单列后续。）
+
+## 2. 目标
+
+用户手动开启"大体系性能模式"后，超大体系（百万原子级）轨迹播放/拖拽流畅，逐帧反应式键经 GPU 计算并 GPU 常驻渲染。常规体系路径完全不动、零回归。
+
+## 3. 锁定决策（与用户对齐）
+
+1. **方案 A — 独立大体系 GPU 路径**，与现有 WebGL/Three 路径并存。常规体系不动。
+   - 不选整体迁移到 `three/webgpu`（B）：B 需重写全部自定义 GLSL shader、重写 GPU 拾取、async 引导、全查看器回归风险，数月工程；且 compute 仍需 CPU 回退（B 不省这块）。A 风险局部、见效快。
+2. **逐帧重算键**（反应式，体现成键/断键），GPU compute。
+3. **键 GPU 常驻**；CPU `bond_connectivity` 仅在暂停/交互时一次性回读；播放期间零回读。用户明确："可以，只要能看。"
+4. **降级渲染器**：impostor 球 + 实例化键 + 简化着色。
+   - 该模式**禁用**：label、polyhedra、gizmo、测量。
+   - 该模式**保留**：原子选中高亮 + GPU 拾取（能点原子看信息）。
+5. **PBC**：最小镜像边界键（compute 做 27-镜像/最小镜像距离），**不**生成 ghost 镜像原子。符合既有"跨晶胞键必须显示"行为。
+6. **判键策略 v1**：仅 `atom_radii`（距离 + 共价半径 + 容差）。`electroneg_ratio` / `solid_angle` GPU 模式不支持（走 CPU 或不可选）。
+7. **激活 = 手动开关**。用户在 UI 切"大体系性能模式"，不自动按原子数切。
+8. **无 WebGPU 回退 = CPU 路径 + 上限提示**。无 `navigator.gpu` 时保留现有 CPU/worker 路径，超硬性原子上限时提示"WebGPU 不可用，超大体系性能受限"。
+9. **成键距离可自定义**。compute uniform 携带容差 / 半径缩放 / `max_bond_dist`，实时可调，改动即对当前帧重算；与现有 CPU `bonding_options` 共用同一套 UI 滑块驱动两条路径。
+
+## 4. 数据流（每帧）
+
+```
+当前帧坐标 (N×3 f32，1M ≈ 12MB) → GPU storage buffer (upload)
+  → compute pass:
+       1. 建均匀网格 (uniform grid / cell list)，cell 边长 ≥ max_bond_dist
+       2. 每原子扫相邻 27 格候选
+       3. 最小镜像距离 + atom_radii 判据 (dist ≤ (r1+r2)*scale + tolerance，且 ≤ max_bond_dist)
+       4. 原子追加 (atomic counter) 写 bond buffer：(idx_a, idx_b) 或预算端点
+  → render pass:
+       - impostor 球 (原子)：instanced quad + 球面 raymarch，读坐标 buffer
+       - 实例化圆柱/线 (键)：读 bond buffer
+       - 相机矩阵从 Three camera 同步为 uniform
+播放期间不回读 CPU。
+```
+
+暂停 / 选中 / 导出 / 测量 / mof-analysis 等 CPU 消费触发时：对当前帧跑一次 compute + 回读 bond buffer → 填 `bond_state.bond_connectivity`，供既有 CPU 模块使用。
+
+## 5. 模块边界
+
+| 模块 | 职责 | 输入/依赖 | 输出 |
+|---|---|---|---|
+| `gpu/webgpu-context.ts` | adapter/device 获取、能力检测、async init、回退信号 | `navigator.gpu` | device 句柄 / null |
+| `gpu/bond-compute.ts` | WGSL compute pipeline：均匀网格 + atom_radii 判键 + 最小镜像 PBC | 坐标 buffer、晶格、元素共价半径 LUT、容差/缩放/max_bond_dist uniform、device | bond buffer (a,b) + count |
+| `gpu/large-system-renderer.ts` | WGSL render：impostor 球 + 实例化键、相机 uniform、选中高亮、id-buffer 拾取 | 坐标 buffer、bond buffer、相机、选中集合、device | 画面 + 拾取 id 读回 |
+| `gpu/large-system-mode.svelte.ts` | 编排：模式开关、WebGL↔WebGPU canvas 切换、帧上传、播放循环、暂停/交互回读桥接 `bond_state` | 上述三者、StructureScene、轨迹播放器、`bond_state` | — |
+
+集成点：
+- StructureScene：模式开启时隐藏 WebGL canvas、激活 WebGPU canvas；关闭时反向。
+- 轨迹播放器驱动帧号 → `large-system-mode` 上传该帧坐标。
+- 回读时写 `bond_state.bond_connectivity`（与现有消费模块兼容的索引空间）。
+- 拾取复用/扩展 `gpu-picker-integration` 思路（id render target 回读）。
+- 成键距离 UI：现有 `bonding_options` 滑块同时写 CPU 路径和 GPU compute uniform。
+
+## 6. 测试策略
+
+- **WGSL compute 正确性（黄金对比）**：小/中体系，GPU 键列表 vs CPU `detect_bonds_atom_radii`，含：
+  - 非周期分子；
+  - PBC 最小镜像跨边界键；
+  - 不同容差/缩放/max_bond_dist。
+- 模式开关 / canvas 切换逻辑单测。
+- 无 WebGPU 回退（mock 无 device）走 CPU + 提示。
+- 暂停回读填充 `bond_connectivity` 与 CPU 一致性测。
+- 键 buffer 溢出截断 + 警告路径测。
+- 性能冒烟（手动）：1M 原子 上传 + compute + render 帧预算 < 目标（如 60fps 拖拽 / 流畅播放）。
+
+## 7. 风险与开放点
+
+- **键 buffer 溢出**：百万原子下键数可达数百万 → 显存压力。设 max-bond 上限，超出截断 + 警告。上限值实现时定。
+- **Float32 精度**：大晶胞坐标精度，必要时减去帧质心 / 用 cell-relative 坐标。
+- **运行时 WebGPU 可用性**：Electron/Tauri WebView 的 Chromium 版本需确认支持 WebGPU；否则回退路径。
+- **拾取在百万原子下的成本**：id render target 回读单点拾取可接受（非每帧）。
+- **相机/坐标一致性**：WebGPU 路径相机矩阵需与 Three 路径完全一致，切换无跳变。
+
+## 8. 不在本 spec 范围
+
+- 删原子增量路径 drop-reindex / 指纹屏蔽导致的氢键断键问题（独立 bug，单列）。
+- `electroneg_ratio` / `solid_angle` 的 GPU 实现。
+- 整体迁移到 `three/webgpu`（方案 B，未来独立计划）。
+- 自动按原子数激活（当前手动）。

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/three": "^0.181.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.0.6",
+    "@webgpu/types": "^0.1.70",
     "concurrently": "^9.2.1",
     "d3-time-format": "^4.1.0",
     "eslint": "^9.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.6
         version: 4.0.18(vitest@4.0.18(@types/node@25.0.10)(happy-dom@20.3.7))
+      '@webgpu/types':
+        specifier: ^0.1.70
+        version: 0.1.70
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -1779,8 +1782,8 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  '@webgpu/types@0.1.69':
-    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
+  '@webgpu/types@0.1.70':
+    resolution: {integrity: sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==}
 
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
@@ -5041,7 +5044,7 @@ snapshots:
       '@tweenjs/tween.js': 23.1.3
       '@types/stats.js': 0.17.4
       '@types/webxr': 0.5.24
-      '@webgpu/types': 0.1.69
+      '@webgpu/types': 0.1.70
       fflate: 0.8.2
       meshoptimizer: 0.22.0
 
@@ -5313,7 +5316,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@webgpu/types@0.1.69': {}
+  '@webgpu/types@0.1.70': {}
 
   '@xmldom/xmldom@0.9.8': {}
 

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -485,6 +485,7 @@ const structure: Record<string, string> = {
   import_export: `Import / Export`,
   server_hpc: `Server (HPC)`,
   plugin_hub: `Plugin Hub`,
+  large_system_mode: `Large-system performance mode (WebGPU)`,
   ai_assistant: `AI Assistant`,
   restore_terminal: `Restore terminal`,
   minimize_terminal: `Minimize terminal`,

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -485,7 +485,7 @@ const structure: Record<string, string> = {
   import_export: `Import / Export`,
   server_hpc: `Server (HPC)`,
   plugin_hub: `Plugin Hub`,
-  large_system_mode: `Large-system performance mode (WebGPU)`,
+  large_system_mode: `Large-system performance mode`,
   ai_assistant: `AI Assistant`,
   restore_terminal: `Restore terminal`,
   minimize_terminal: `Minimize terminal`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -485,6 +485,7 @@ const structure: Record<string, string> = {
   import_export: `导入 / 导出`,
   server_hpc: `服务器 (HPC)`,
   plugin_hub: `插件中心`,
+  large_system_mode: `大体系性能模式 (WebGPU)`,
   ai_assistant: `AI 助手`,
   restore_terminal: `还原终端`,
   minimize_terminal: `最小化终端`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -485,7 +485,7 @@ const structure: Record<string, string> = {
   import_export: `导入 / 导出`,
   server_hpc: `服务器 (HPC)`,
   plugin_hub: `插件中心`,
-  large_system_mode: `大体系性能模式 (WebGPU)`,
+  large_system_mode: `大体系性能模式`,
   ai_assistant: `AI 助手`,
   restore_terminal: `还原终端`,
   minimize_terminal: `最小化终端`,

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -579,6 +579,11 @@ export const icon_data = {
     path:
       `<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9"/></g>`,
   },
+  Gauge: { // lucide:gauge — speedometer dial for large-system performance mode
+    viewBox: `0 0 24 24`,
+    path:
+      `<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></g>`,
+  },
 } as const
 
 export type IconName = keyof typeof icon_data

--- a/src/lib/structure/CellSelect.svelte
+++ b/src/lib/structure/CellSelect.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import Icon from '$lib/Icon.svelte'
   import Spinner from '$lib/feedback/Spinner.svelte'
-  import { is_valid_supercell_input } from '$lib/structure/supercell'
+  import {
+    CPU_SUPERCELL_CELL_WARN_THRESHOLD,
+    GPU_SUPERCELL_MAX_INSTANCES,
+    is_valid_supercell_input,
+    parse_supercell_scaling,
+  } from '$lib/structure/supercell'
   import type { CellType } from '$lib/symmetry'
   import type { MoyoDataset } from '@spglib/moyo-wasm'
   import { click_outside, tooltip } from 'svelte-multiselect/attachments'
@@ -14,6 +19,19 @@
     loading = $bindable(false),
     direction = `down`,
     align = `right`,
+    // WebGPU large-system overlay state. When ON, large factors route to the GPU
+    // instancing path (no CPU expand, no freeze). When OFF, a large factor would
+    // be built on the CPU and freeze the tab, so we warn / guard above a
+    // threshold. Default false ⇒ preserves prior behaviour for embedders that
+    // don't pass it.
+    large_system_mode = false,
+    // Base (unit) cell site count, used to estimate the effective GPU instance
+    // count (base_site_count × cells) against the soft cap. 0 ⇒ unknown, skip
+    // the cap check.
+    base_site_count = 0,
+    // Configurable thresholds (defaults from supercell.ts).
+    cpu_warn_cells = CPU_SUPERCELL_CELL_WARN_THRESHOLD,
+    gpu_max_instances = GPU_SUPERCELL_MAX_INSTANCES,
   }: {
     supercell_scaling: string
     cell_type?: CellType
@@ -21,11 +39,70 @@
     loading?: boolean
     direction?: `up` | `down`
     align?: `left` | `right`
+    large_system_mode?: boolean
+    base_site_count?: number
+    cpu_warn_cells?: number
+    gpu_max_instances?: number
   } = $props()
 
   let menu_open = $state(false)
   let input_value = $state(supercell_scaling)
   let input_valid = $derived(is_valid_supercell_input(input_value))
+
+  // Dedicated nx/ny/nz integer inputs. Seeded from the current scaling; kept in
+  // sync when the prop changes externally (see $effect below).
+  function parse_factors(scaling: string): [number, number, number] {
+    try {
+      return parse_supercell_scaling(scaling) as [number, number, number]
+    } catch {
+      return [1, 1, 1]
+    }
+  }
+  let [init_nx, init_ny, init_nz] = parse_factors(supercell_scaling)
+  let nx = $state(init_nx)
+  let ny = $state(init_ny)
+  let nz = $state(init_nz)
+
+  // Coerce each axis to an integer ≥ 1 (number inputs can yield NaN / floats).
+  let factors = $derived(
+    [nx, ny, nz].map((v) => {
+      const n = Math.floor(Number(v))
+      return Number.isFinite(n) && n >= 1 ? n : 1
+    }) as [number, number, number],
+  )
+  let factor_string = $derived(`${factors[0]}x${factors[1]}x${factors[2]}`)
+  let cell_count = $derived(factors[0] * factors[1] * factors[2])
+  let est_instances = $derived(base_site_count > 0 ? base_site_count * cell_count : 0)
+
+  // Overlay OFF + large factor ⇒ a CPU build would freeze the tab. Warn + guard.
+  let cpu_freeze_risk = $derived(!large_system_mode && cell_count > cpu_warn_cells)
+  // Overlay ON but the effective GPU instance count blows past the soft cap.
+  let gpu_over_cap = $derived(
+    large_system_mode && est_instances > 0 && est_instances > gpu_max_instances,
+  )
+  // Block applying the factor inputs when it would freeze the CPU or exceed the
+  // GPU cap. (Presets stay unconditionally clickable — they are all small.)
+  let factor_blocked = $derived(cpu_freeze_risk || gpu_over_cap)
+
+  function apply_factors() {
+    if (gpu_over_cap) {
+      console.warn(
+        `[CellSelect] Refusing supercell ${factor_string}: ~${est_instances.toLocaleString()} ` +
+          `GPU instances exceeds the soft cap of ${gpu_max_instances.toLocaleString()}. ` +
+          `Reduce the factor to avoid a GPU hang.`,
+      )
+      return
+    }
+    if (cpu_freeze_risk) {
+      console.warn(
+        `[CellSelect] Refusing supercell ${factor_string} (${cell_count} cells): WebGPU ` +
+          `large-system mode is OFF, so this would build on the CPU and freeze the tab.`,
+      )
+      return
+    }
+    supercell_scaling = factor_string
+    input_value = factor_string
+  }
 
   const supercell_presets = [`1x1x1`, `2x2x2`, `3x3x3`, `2x2x1`, `3x3x1`, `2x1x1`]
 
@@ -55,10 +132,16 @@
     }
   }
 
-  // Sync input value when external prop changes
+  // Sync input value + nx/ny/nz when the external prop changes (e.g. a preset
+  // applied elsewhere, or a reset). Only when the menu is closed so we don't
+  // clobber a value the user is mid-edit.
   $effect(() => {
     if (!menu_open && supercell_scaling && supercell_scaling !== input_value) {
       input_value = supercell_scaling
+      const [px, py, pz] = parse_factors(supercell_scaling)
+      nx = px
+      ny = py
+      nz = pz
     }
   })
 </script>
@@ -148,6 +231,63 @@
           <Icon icon="Check" />
         </button>
       </div>
+
+      <!-- Large custom factor: nx · ny · nz integer inputs. With the WebGPU
+           large-system overlay ON, a big product routes to GPU instancing (no
+           CPU expand, no freeze). With it OFF, a big product would freeze the
+           CPU build, so we guard + warn below. -->
+      <div class="factor-row">
+        <input
+          type="number"
+          min="1"
+          step="1"
+          bind:value={nx}
+          aria-label="supercell nx"
+          onkeydown={(event) => event.key === `Enter` && apply_factors()}
+        />
+        <span class="factor-x">×</span>
+        <input
+          type="number"
+          min="1"
+          step="1"
+          bind:value={ny}
+          aria-label="supercell ny"
+          onkeydown={(event) => event.key === `Enter` && apply_factors()}
+        />
+        <span class="factor-x">×</span>
+        <input
+          type="number"
+          min="1"
+          step="1"
+          bind:value={nz}
+          aria-label="supercell nz"
+          onkeydown={(event) => event.key === `Enter` && apply_factors()}
+        />
+        <button
+          class="apply-btn"
+          disabled={factor_blocked || factor_string === supercell_scaling}
+          onclick={apply_factors}
+          title={cpu_freeze_risk
+          ? `Enable WebGPU large-system mode to apply`
+          : gpu_over_cap
+          ? `Exceeds GPU instance cap`
+          : `Apply ${factor_string} (${cell_count} cells)`}
+        >
+          <Icon icon="Check" />
+        </button>
+      </div>
+
+      {#if cpu_freeze_risk}
+        <div class="factor-warn" role="alert">
+          Large supercell ({cell_count} cells) — enable WebGPU large-system mode to
+          view without freezing.
+        </div>
+      {:else if gpu_over_cap}
+        <div class="factor-warn" role="alert">
+          ~{est_instances.toLocaleString()} instances exceeds the {gpu_max_instances.toLocaleString()}
+          GPU cap — reduce the factor.
+        </div>
+      {/if}
     </div>
   {/if}
 </div>
@@ -274,5 +414,40 @@
   .apply-btn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+
+  /* Custom nx · ny · nz factor row */
+  .factor-row {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding-top: 3px;
+    border-top: 1px solid rgba(128, 128, 128, 0.3);
+  }
+  .factor-row input {
+    width: 2.4em;
+    min-width: 0;
+    padding: 2px 3px;
+    font-size: 0.9em;
+    text-align: center;
+    /* hide spinners to keep it compact */
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+  .factor-row input::-webkit-outer-spin-button,
+  .factor-row input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  .factor-x {
+    opacity: 0.7;
+    font-size: 0.85em;
+  }
+  .factor-warn {
+    font-size: 0.8em;
+    line-height: 1.25;
+    color: rgb(255, 180, 90);
+    max-width: 160px;
+    padding: 2px 1px 0;
   }
 </style>

--- a/src/lib/structure/CellSelect.svelte
+++ b/src/lib/structure/CellSelect.svelte
@@ -268,7 +268,7 @@
           disabled={factor_blocked || factor_string === supercell_scaling}
           onclick={apply_factors}
           title={cpu_freeze_risk
-          ? `Enable WebGPU large-system mode to apply`
+          ? `Enable large-system performance mode to apply`
           : gpu_over_cap
           ? `Exceeds GPU instance cap`
           : `Apply ${factor_string} (${cell_count} cells)`}
@@ -279,7 +279,7 @@
 
       {#if cpu_freeze_risk}
         <div class="factor-warn" role="alert">
-          Large supercell ({cell_count} cells) — enable WebGPU large-system mode to
+          Large supercell ({cell_count} cells) — enable large-system performance mode to
           view without freezing.
         </div>
       {:else if gpu_over_cap}

--- a/src/lib/structure/ExportPane.svelte
+++ b/src/lib/structure/ExportPane.svelte
@@ -15,6 +15,10 @@
     structure_to_poscar, structure_to_xyz,
     type StructureData,
   } from '$lib/structure/export/offline-serialize'
+  import { export_supercell_via_worker } from '$lib/structure/export/supercell-export-client'
+  import type {
+    CoreStructure, SupercellExportFormat, Vec3 as SupercellVec3,
+  } from '$lib/structure/export/supercell-export-core'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   // Lazy-load structure translations
@@ -49,6 +53,9 @@
     selected_indices = [],
     on_request_vacuum_box = undefined,
     trajectory_context,
+    gpu_supercell_active = false,
+    gpu_supercell_factors = [1, 1, 1],
+    gpu_supercell_base = undefined,
     ...rest
   }: {
     export_pane_open?: boolean
@@ -65,7 +72,60 @@
     selected_indices?: number[]
     on_request_vacuum_box?: () => void
     trajectory_context?: { total_frames: number; on_step: (idx: number) => void | Promise<void> }
+    // WebGPU large-system overlay: when a >1 supercell is requested with the
+    // overlay ON, `structure` here is the BASE cell (the GPU instances it). To
+    // export the REAL supercell we expand base × factors off-thread in a worker.
+    gpu_supercell_active?: boolean
+    gpu_supercell_factors?: SupercellVec3
+    // The actual BASE cell the GPU instances (= displayed_structure when active,
+    // i.e. after any primitive/conventional cell transform, no PBC images).
+    // Falls back to `structure` if not provided.
+    gpu_supercell_base?: AnyStructure
   } = $props()
+
+  // Busy indicator while the worker expands + serializes a large supercell.
+  let supercell_exporting = $state(false)
+  let supercell_export_error = $state<string | null>(null)
+
+  // Formats whose pure serializer is worker-safe (POSCAR + (ext)xyz). Others
+  // fall through to the normal synchronous path even when the overlay is on.
+  const WORKER_FORMATS: Record<string, SupercellExportFormat> = {
+    poscar: `poscar`,
+    xyz: `xyz`,
+    extxyz: `extxyz`,
+  }
+
+  // Synchronous gate: should this format's export go through the worker? True
+  // only when the overlay supercell is active AND the format has a worker-safe
+  // serializer. Lets callers keep their normal sync path untouched otherwise.
+  function should_route_to_supercell_worker(format: string): boolean {
+    return gpu_supercell_active && !!(gpu_supercell_base ?? structure) && !!WORKER_FORMATS[format]
+  }
+
+  // Expand base × factors and serialize the requested format off-thread, then
+  // download. Only invoked when should_route_to_supercell_worker(format) is true.
+  async function maybe_export_supercell(format: string): Promise<void> {
+    const base = gpu_supercell_base ?? structure
+    const worker_format = WORKER_FORMATS[format]
+    if (!base || !worker_format) return
+    supercell_export_error = null
+    supercell_exporting = true
+    try {
+      await export_supercell_via_worker(
+        base as unknown as CoreStructure,
+        gpu_supercell_factors,
+        worker_format,
+        {
+          on_error: (err) => { supercell_export_error = err },
+        },
+      )
+    } catch (err) {
+      supercell_export_error = err instanceof Error ? err.message : String(err)
+      console.error(`[ExportPane] Supercell worker export failed:`, err)
+    } finally {
+      supercell_exporting = false
+    }
+  }
 
   // Active section tab
   let active_section = $state<'structure' | 'figure' | 'qe' | 'lammps' | 'vasp' | 'cp2k' | 'gaussian' | 'gromacs' | 'orca' | 'abacus' | 'amber' | 'spark' | 'catrender'>('structure')
@@ -251,6 +311,14 @@
   // Structure export functions
   function export_structure(format: `json` | `xyz` | `cif` | `poscar` | `mol2` | `pdb`) {
     if (!structure) return
+    // When a GPU supercell is active AND the format has a worker-safe serializer
+    // (POSCAR / xyz), expand + serialize the REAL supercell off-thread instead
+    // of writing only the base cell. The check is synchronous so the normal
+    // (non-supercell) path below stays fully synchronous and unchanged.
+    if (should_route_to_supercell_worker(format)) {
+      void maybe_export_supercell(format)
+      return
+    }
     const fns = {
       json: exports.export_structure_as_json,
       xyz: exports.export_structure_as_xyz,
@@ -293,6 +361,7 @@
   // Quick offline export — no backend needed
   function quick_export_poscar() {
     if (!structure) return
+    if (should_route_to_supercell_worker(`poscar`)) { void maybe_export_supercell(`poscar`); return }
     try {
       const text = structure_to_poscar(structure as unknown as StructureData)
       const name = (structure as any)?.formula || (structure as any)?.id || `structure`
@@ -304,6 +373,7 @@
 
   function quick_export_xyz() {
     if (!structure) return
+    if (should_route_to_supercell_worker(`xyz`)) { void maybe_export_supercell(`xyz`); return }
     try {
       const text = structure_to_xyz(structure as unknown as StructureData)
       const name = (structure as any)?.formula || (structure as any)?.id || `structure`
@@ -349,6 +419,18 @@
   {#if active_section === 'structure'}
     <!-- Structure text formats -->
     <div class="section-content">
+      {#if gpu_supercell_active}
+        <div class="supercell-export-notice">
+          {#if supercell_exporting}
+            <span class="spinner"></span> Expanding {gpu_supercell_factors.join('×')} supercell in a worker…
+          {:else}
+            POSCAR / XYZ export expands the full {gpu_supercell_factors.join('×')} supercell off-thread.
+          {/if}
+        </div>
+      {/if}
+      {#if supercell_export_error}
+        <p class="error">{supercell_export_error}</p>
+      {/if}
       <label class="section-label">{t('structure.text_formats')}</label>
       <div class="export-buttons">
         {#each text_export_formats as { label, format }}
@@ -719,4 +801,15 @@
   }
   .quick-export-btn:hover { background: light-dark(rgba(0,0,0,0.12), rgba(255,255,255,0.15)); }
   .quick-export-hint { font-size: 0.75em; opacity: 0.5; margin-top: 3px; }
+  .supercell-export-notice {
+    display: flex; align-items: center; gap: 6px; font-size: 0.78em;
+    padding: 5px 8px; margin-bottom: 0.6em; border-radius: 4px;
+    background: rgba(59, 130, 246, 0.12); color: var(--accent-color, #3b82f6);
+  }
+  .spinner {
+    width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0;
+    border: 2px solid currentColor; border-top-color: transparent;
+    animation: spin 0.7s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
 </style>

--- a/src/lib/structure/IOPane.svelte
+++ b/src/lib/structure/IOPane.svelte
@@ -29,6 +29,9 @@
     crop_mode_active = $bindable(false),
     crop_region = $bindable<CropRegion | null>(null),
     trajectory_context,
+    gpu_supercell_active = false,
+    gpu_supercell_factors = [1, 1, 1],
+    gpu_supercell_base = undefined,
     children,
   }: {
     show?: boolean
@@ -46,6 +49,9 @@
     crop_mode_active?: boolean
     crop_region?: CropRegion | null
     trajectory_context?: { total_frames: number; on_step: (idx: number) => void | Promise<void> }
+    gpu_supercell_active?: boolean
+    gpu_supercell_factors?: [number, number, number]
+    gpu_supercell_base?: AnyStructure
     children?: Snippet
   } = $props()
 
@@ -117,6 +123,9 @@
           bind:crop_mode_active
           bind:crop_region
           {trajectory_context}
+          {gpu_supercell_active}
+          {gpu_supercell_factors}
+          {gpu_supercell_base}
         />
       {/if}
     {/if}

--- a/src/lib/structure/LatticePane.svelte
+++ b/src/lib/structure/LatticePane.svelte
@@ -11,7 +11,11 @@
     type LatticeParams
   } from './lattice-ops'
   import { create_supercell_matrix, wasm_reorient_lattice, is_ok } from './ferrox-wasm'
-  import { make_supercell as make_supercell_ts } from './supercell'
+  import {
+    make_supercell as make_supercell_ts,
+    CPU_SUPERCELL_CELL_WARN_THRESHOLD,
+    GPU_SUPERCELL_MAX_INSTANCES,
+  } from './supercell'
   import type { Crystal } from './index'
   import type { ComponentProps } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -24,6 +28,8 @@
     structure = $bindable(),
     pane_open = $bindable(false),
     center_camera_trigger = $bindable(0),
+    supercell_scaling = $bindable(`1x1x1`),
+    large_system_mode = false,
     embedded = false,
     toggle_props = {},
     pane_props = {},
@@ -35,6 +41,13 @@
     structure?: AnyStructure
     pane_open?: boolean
     center_camera_trigger?: number
+    // Logical supercell factor ("NxNxN"). When the WebGPU overlay is ON, a
+    // diagonal-integer transform sets this instead of materializing atoms on the
+    // CPU — routing to the GPU instancing path (no freeze).
+    supercell_scaling?: string
+    // WebGPU large-system overlay state. ON ⇒ diagonal supercell goes to GPU
+    // instancing. OFF ⇒ CPU build (guarded against huge factors).
+    large_system_mode?: boolean
     embedded?: boolean
     toggle_props?: ComponentProps<typeof DraggablePane>['toggle_props']
     pane_props?: ComponentProps<typeof DraggablePane>['pane_props']
@@ -105,24 +118,85 @@
     return reorient_lattice(s)
   }
 
+  // Helper to check if matrix is diagonal (allowing small floating point errors)
+  function is_diagonal_matrix(m: typeof transform): boolean {
+    const eps = 1e-6
+    return Math.abs(m[0][1]) < eps && Math.abs(m[0][2]) < eps &&
+           Math.abs(m[1][0]) < eps && Math.abs(m[1][2]) < eps &&
+           Math.abs(m[2][0]) < eps && Math.abs(m[2][1]) < eps
+  }
+
+  // Helper to check if a value is a positive integer (allowing small fp errors)
+  function is_positive_integer(n: number): boolean {
+    return Math.abs(n - Math.round(n)) < 1e-6 && Math.round(n) >= 1
+  }
+
+  // A pure diagonal supercell: diagonal matrix with positive integers on the
+  // diagonal ⇒ factors (nx,ny,nz) = (m00,m11,m22). GPU axis-aligned instancing
+  // can represent exactly this; non-diagonal / non-integer ⇒ null.
+  function diagonal_supercell_factors(
+    m: typeof transform,
+  ): [number, number, number] | null {
+    if (!is_diagonal_matrix(m)) return null
+    const [nx, ny, nz] = [m[0][0], m[1][1], m[2][2]]
+    if (!is_positive_integer(nx) || !is_positive_integer(ny) || !is_positive_integer(nz)) {
+      return null
+    }
+    return [Math.round(nx), Math.round(ny), Math.round(nz)]
+  }
+
   async function apply_transform() {
     if (!structure || !has_lattice) return
-    on_push_undo?.()
 
     if (transform_mode === 'supercell') {
-      // Use WASM for supercell generation
-      transform_loading = true
+      const diag = diagonal_supercell_factors(transform)
 
-      // Helper to check if matrix is diagonal (allowing small floating point errors)
-      const is_diagonal_matrix = (m: typeof transform): boolean => {
-        const eps = 1e-6
-        return Math.abs(m[0][1]) < eps && Math.abs(m[0][2]) < eps &&
-               Math.abs(m[1][0]) < eps && Math.abs(m[1][2]) < eps &&
-               Math.abs(m[2][0]) < eps && Math.abs(m[2][1]) < eps
+      // ── Diagonal-integer supercell: route by overlay state ──────────────────
+      if (diag) {
+        const [nx, ny, nz] = diag
+        const ncells = nx * ny * nz
+        const base_sites = (structure as PymatgenStructure).sites?.length ?? 0
+
+        if (large_system_mode) {
+          // Overlay ON: skip the CPU expand entirely. Set the logical factor so
+          // Structure.svelte's gpu_supercell_active routes to GPU instancing
+          // (CPU keeps the base cell — no materialization, no freeze).
+          const est_instances = base_sites * ncells
+          if (
+            est_instances > 0 &&
+            est_instances > GPU_SUPERCELL_MAX_INSTANCES
+          ) {
+            console.warn(
+              `[LatticePane] Refusing supercell ${nx}x${ny}x${nz}: ` +
+                `~${est_instances.toLocaleString()} GPU instances exceeds the soft cap of ` +
+                `${GPU_SUPERCELL_MAX_INSTANCES.toLocaleString()}. Reduce the factor to avoid a GPU hang.`,
+            )
+            return
+          }
+          on_push_undo?.()
+          supercell_scaling = `${nx}x${ny}x${nz}`
+          on_reset_view?.()
+          center_camera_trigger++
+          transform = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+          return
+        }
+
+        // Overlay OFF: a large CPU build would freeze the tab. Guard + warn.
+        if (ncells > CPU_SUPERCELL_CELL_WARN_THRESHOLD) {
+          console.warn(
+            `[LatticePane] Refusing supercell ${nx}x${ny}x${nz} (${ncells} cells): WebGPU ` +
+              `large-system mode is OFF, so this would build on the CPU and freeze the tab. ` +
+              `Enable WebGPU large-system mode to view without freezing.`,
+          )
+          return
+        }
+        // else: small diagonal factor, overlay off ⇒ fall through to CPU build.
       }
 
-      // Helper to check if diagonal values are integers (allowing small floating point errors)
-      const is_integer = (n: number): boolean => Math.abs(n - Math.round(n)) < 1e-6
+      // Use WASM for supercell generation (non-diagonal lattice transform, or a
+      // small diagonal factor with the overlay off).
+      on_push_undo?.()
+      transform_loading = true
 
       // Helper to apply TypeScript fallback
       const apply_ts_fallback = async () => {
@@ -135,6 +209,7 @@
           return false
         }
 
+        const is_integer = (n: number): boolean => Math.abs(n - Math.round(n)) < 1e-6
         if (!is_integer(nx) || !is_integer(ny) || !is_integer(nz)) {
           console.error(`[LatticePane] Cannot use TypeScript fallback: diagonal values are not integers`)
           return false
@@ -179,6 +254,7 @@
       }
     } else {
       // Lattice-only transform (TypeScript) — also try WASM reorient
+      on_push_undo?.()
       const transformed = apply_transform_matrix(structure as PymatgenStructure, transform)
       const new_structure = await reorient_with_fallback(transformed)
       structure = new_structure

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3770,6 +3770,10 @@
             {camera}
             structure={displayed_structure}
             element_colors={colors.element}
+            atom_radius={scene_props.atom_radius}
+            same_size_atoms={scene_props.same_size_atoms}
+            {element_radius_overrides}
+            {site_radius_overrides}
             on_fallback={(reason) => {
               large_system_mode = false
               console.warn(`[CatGO] large-system mode: ${reason}`)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3907,6 +3907,7 @@
             {camera}
             structure={displayed_structure}
             supercell={gpu_supercell_active ? gpu_supercell_factors : [1, 1, 1]}
+            {show_image_atoms}
             element_colors={colors.element}
             atom_radius={scene_props.atom_radius}
             same_size_atoms={scene_props.same_size_atoms}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3774,6 +3774,7 @@
             same_size_atoms={scene_props.same_size_atoms}
             {element_radius_overrides}
             {site_radius_overrides}
+            bonding_options={(scene_props.bonding_options ?? {}) as Record<string, number>}
             on_fallback={(reason) => {
               large_system_mode = false
               console.warn(`[CatGO] large-system mode: ${reason}`)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3529,6 +3529,9 @@
             bind:crop_mode_active={interaction.crop_mode_active}
             bind:crop_region={interaction.crop_region}
             {trajectory_context}
+            {gpu_supercell_active}
+            {gpu_supercell_factors}
+            gpu_supercell_base={displayed_structure}
           />
 
           <ServerPane

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3820,6 +3820,7 @@
             {element_radius_overrides}
             {site_radius_overrides}
             bonding_options={(scene_props.bonding_options ?? {}) as Record<string, number>}
+            {bond_distance_rules}
             show_bonds={scene_props.show_bonds}
             {background_color}
             {background_opacity}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3768,6 +3768,8 @@
           <LargeSystemOverlay
             enabled={large_system_mode}
             {camera}
+            structure={displayed_structure}
+            element_colors={colors.element}
             on_fallback={(reason) => {
               large_system_mode = false
               console.warn(`[CatGO] large-system mode: ${reason}`)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1182,6 +1182,12 @@
   // here means an accidental Phase 4 leak into Phase 2.
   let __traj_write_warned_supercell = false
   $effect(() => {
+    // WebGPU overlay active: skip per-frame writes into the WebGL atom_manager.
+    // Read suspend FIRST (reactive) so resume (suspended→false) re-fires this
+    // effect and the manager catches up to the current frame. The overlay
+    // drives its own atoms from get_trajectory_frame_positions and does NOT
+    // read scene_atom_manager, so suspending here costs the overlay nothing.
+    if (webgl_suspended) return
     const traj = trajectory_frame_positions
     if (!traj) {
       __traj_write_warned_supercell = false
@@ -1713,6 +1719,11 @@
     get_options: () => (scene_props?.bonding_options ?? {}) as Record<string, number>,
     set_connectivity: (v) => { trajectory_bond_connectivity_for_frame = v },
     get_connectivity: () => trajectory_bond_connectivity_for_frame,
+    // WebGPU overlay active ⇒ suspend the per-frame async bond recompute. The
+    // overlay computes its own GPU bonds and does not read
+    // trajectory_bond_connectivity_for_frame. Read reactively inside the driver
+    // effect so toggle-OFF re-primes the current frame's connectivity.
+    get_suspended: () => webgl_suspended,
   })
 
   // Track selection to restore after atom movement
@@ -1904,6 +1915,14 @@
   // Task 9: experimental WebGPU large-system render path. Default OFF — when
   // off the overlay renders nothing and the WebGL viewer is unchanged.
   let large_system_mode = $state(false)
+  // While the WebGPU overlay is active, the WebGL/Threlte path must do ZERO
+  // per-frame work (not just zero painting): the overlay computes its own GPU
+  // bonds/atoms, so any per-frame CPU recompute on the WebGL side is wasted and
+  // defeats the perf win. `webgl_suspended` is read REACTIVELY inside the gated
+  // effects so that flipping the overlay OFF (true→false) re-fires them and the
+  // WebGL view fully resumes for the current frame. Default OFF ⇒ always false
+  // ⇒ zero change to existing WebGL behavior.
+  let webgl_suspended = $derived(large_system_mode)
   // One-shot repaint trigger for StructureScene. Bumped when large_system_mode
   // turns OFF so the WebGL view (whose autoRender was paused while the overlay
   // covered it) repaints once on the next frame and isn't left on a stale paint.
@@ -3623,6 +3642,7 @@
           <StructureScene
             structure={displayed_structure}
             bond_input_structure={supercell_structure ?? structure}
+            {webgl_suspended}
             {trajectory_frame_positions}
             {trajectory_frame_forces}
             trajectory_bond_connectivity={trajectory_bond_connectivity_for_frame}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -66,6 +66,7 @@
     JobDetailPane,
     PluginHubPane,
   } from './index'
+  import LargeSystemOverlay from './gpu/LargeSystemOverlay.svelte'
   import { ChatPane, get_display_text } from '$lib/chat'
   import { send_message, get_chat_slice, chat_position } from '$lib/chat/chat-state.svelte'
   import { build_structure_context } from '$lib/chat/context'
@@ -1900,6 +1901,9 @@
   let camera_is_moving = $state(false)
   let scene = $state<any>(undefined)
   let camera = $state<any>(undefined)
+  // Task 9: experimental WebGPU large-system render path. Default OFF — when
+  // off the overlay renders nothing and the WebGL viewer is unchanged.
+  let large_system_mode = $state(false)
   let pixels_per_angstrom = $state(0)
   let orbit_controls = $state<any>(undefined)
   let rotation_target_ref = $state<[number, number, number] | undefined>(undefined)
@@ -3534,6 +3538,7 @@
           selected_bonds={pencil.selected_bonds}
           {structure}
           bind:bond_distance_rules
+          bind:large_system_mode
           {supercell_loading}
           closed_icon="Sliders"
         />
@@ -3582,7 +3587,7 @@
 
       <!-- prevent HTML labels from rendering outside of the canvas -->
       <div style="overflow: hidden; height: 100%; position: relative; z-index: 0; pointer-events: none">
-        <div style="width: 100%; height: 100%; pointer-events: auto">
+        <div style="width: 100%; height: 100%; pointer-events: auto; position: relative">
         <Canvas {...{ rendererParameters: { antialias: true, powerPreference: `high-performance` } } as any}>
           <!--
             show_image_atoms is a separate bindable from scene_props.show_image_atoms
@@ -3752,6 +3757,23 @@
             cube_slice_color={cube_state_data.slice_plane.plane_color}
           />
         </Canvas>
+        <!--
+          Task 9: WebGPU large-system render overlay. A plain DOM canvas sibling
+          of the Threlte <Canvas> (NOT inside it). Gated by large_system_mode —
+          when off, {#if enabled} renders nothing and the WebGL path is untouched.
+          When on, it's absolutely positioned over the Canvas (z-index 1) and its
+          opaque clear pass covers the WebGL canvas underneath.
+        -->
+        <div style="position: absolute; inset: 0; z-index: 1; pointer-events: none">
+          <LargeSystemOverlay
+            enabled={large_system_mode}
+            {camera}
+            on_fallback={(reason) => {
+              large_system_mode = false
+              console.warn(`[CatGO] large-system mode: ${reason}`)
+            }}
+          />
+        </div>
         </div>
         <ScaleBar {pixels_per_angstrom} show={scene_props.show_scale_bar ?? false} />
       </div>

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -187,6 +187,14 @@
   // so the second allocation is discarded (small one-time cost).
   let scene_atom_manager = $state(new AtomManager())
 
+  // WebGPU overlay bridge: bound from StructureScene. Returns the live
+  // per-displayed-atom current-frame position array (3 × n_displayed) the
+  // WebGL atoms/bonds render at (StructureScene.atom_positions_buffer:
+  // displayed-topology base overlaid with the manager's per-frame positions).
+  // The overlay calls this so its positions match the WebGL view atom-for-atom
+  // instead of re-deriving from base-only trajectory data. Null until mount.
+  let scene_get_displayed_frame_positions = $state<(() => Float32Array) | null>(null)
+
   // ── Extracted state modules (state/*.svelte.ts) ──
   const sel_state = create_selection_state()
   const charge_state = create_charge_labels_state()
@@ -1184,12 +1192,22 @@
   // here means an accidental Phase 4 leak into Phase 2.
   let __traj_write_warned_supercell = false
   $effect(() => {
-    // WebGPU overlay active: skip per-frame writes into the WebGL atom_manager.
-    // Read suspend FIRST (reactive) so resume (suspended→false) re-fires this
-    // effect and the manager catches up to the current frame. The overlay
-    // drives its own atoms from get_trajectory_frame_positions and does NOT
-    // read scene_atom_manager, so suspending here costs the overlay nothing.
-    if (webgl_suspended) return
+    // This effect writes the current frame's xyz into the WebGL atom_manager
+    // (a plain typed-array scatter — no GPU paint by itself; Threlte 8 is
+    // render-on-demand and autoRender is off while the overlay is active). It
+    // runs in BOTH modes on purpose:
+    //   - WebGL active: drives the WebGL atoms/bonds per frame as before.
+    //   - WebGPU overlay active (`webgl_suspended`): the EXPENSIVE WebGL
+    //     pipelines (X2 full diff, bond-pair rebuild, bond worker) stay gated
+    //     in StructureScene, but we still keep the manager's positions current
+    //     so StructureScene's `atom_positions_buffer` resolves the live frame.
+    //     That buffer is the SINGLE SOURCE OF TRUTH the overlay now consumes
+    //     (via get_displayed_frame_positions) so its atoms/bonds match the
+    //     WebGL view atom-for-atom — including the supercell base-block /
+    //     replica-static behaviour, which is decided HERE (max_slot bound) and
+    //     reused rather than re-guessed in the overlay.
+    // We do NOT early-return on webgl_suspended: the cheap manager write is
+    // what makes the overlay's positions identical to the WebGL resolver.
     const traj = trajectory_frame_positions
     if (!traj) {
       __traj_write_warned_supercell = false
@@ -3796,6 +3814,7 @@
             bond_manager={pencil.bond_manager}
             bind:atom_fast_ops={scene_atom_fast_ops}
             bind:atom_manager={scene_atom_manager}
+            bind:get_displayed_frame_positions={scene_get_displayed_frame_positions}
             deleted_bond_keys={pencil.deleted_bond_keys}
             bind:selected_bonds={pencil.selected_bonds}
             bond_first_atom={pencil.bond_first_atom}
@@ -3876,8 +3895,8 @@
             show_cell={scene_props.show_cell}
             cell_edge_color={scene_props.cell_edge_color}
             {trajectory_positions_version}
-            {get_trajectory_frame_positions}
             {trajectory_step_idx}
+            get_displayed_frame_positions={scene_get_displayed_frame_positions}
             selected_sites={overlay_selected_displayed}
             on_pick={handle_overlay_pick}
             on_fallback={(reason) => {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -117,6 +117,8 @@
   import ScaleBar from '$lib/structure/ScaleBar.svelte'
 
   import type { AtomColorConfig } from './atom-properties'
+  import { get_orig_site_idx } from './atom-properties'
+  import { toggle_site_selection } from './scene/picking'
 
   import { delete_atoms, move_atom, move_atoms_by_displacement, concatenate_structures, merge_structures } from './atom-manipulation'
   import OptimadeSearchModal from './OptimadeSearchModal.svelte'
@@ -1626,6 +1628,42 @@
     loading: false,
     error: null,
   })
+
+  // ── WebGPU overlay selection bridge ────────────────────────────────────────
+  // The overlay renders displayed_structure.sites in order, so its picked index
+  // and its highlight buffer are DISPLAYED-site indices. The app's selection
+  // model (selected_sites) is BASE-site indices (matching the WebGL path). Map
+  // between the two: the overlay highlights every displayed site whose base index
+  // (orig_site_idx) is currently selected, and an overlay pick is mapped back to
+  // its base index before toggling selected_sites (exactly like the WebGL
+  // handle_atom_click → toggle_selection(atom.site_idx) path).
+  let overlay_selected_displayed = $derived.by(() => {
+    const sites = displayed_structure?.sites
+    if (!sites || selected_sites.length === 0) return [] as number[]
+    const sel = new Set(selected_sites)
+    const out: number[] = []
+    for (let i = 0; i < sites.length; i++) {
+      if (sel.has(get_orig_site_idx(sites[i], i))) out.push(i)
+    }
+    return out
+  })
+
+  /** Handle an atom pick from the WebGPU overlay. `displayed_idx` is the picked
+   *  displayed-site index, or -1 for empty space. Maps to the base index and
+   *  toggles selected_sites the same way the WebGL click path does; a background
+   *  click (-1) clears the selection (mirroring clicking empty space). */
+  function handle_overlay_pick(displayed_idx: number): void {
+    if (displayed_idx < 0) {
+      if (selected_sites.length > 0) selected_sites = []
+      return
+    }
+    const sites = displayed_structure?.sites
+    const site = sites?.[displayed_idx]
+    if (!site) return
+    const base_idx = get_orig_site_idx(site, displayed_idx)
+    const result = toggle_site_selection(base_idx, selected_sites)
+    if (result) selected_sites = result
+  }
 
   // Slice split-view state
   let slice_result = $state<SliceResult | null>(null)
@@ -3829,6 +3867,8 @@
             {trajectory_positions_version}
             {get_trajectory_frame_positions}
             {trajectory_step_idx}
+            selected_sites={overlay_selected_displayed}
+            on_pick={handle_overlay_pick}
             on_fallback={(reason) => {
               large_system_mode = false
               console.warn(`[CatGO] large-system mode: ${reason}`)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3802,6 +3802,8 @@
             bonding_options={(scene_props.bonding_options ?? {}) as Record<string, number>}
             {background_color}
             {background_opacity}
+            show_cell={scene_props.show_cell}
+            cell_edge_color={scene_props.cell_edge_color}
             {trajectory_positions_version}
             {get_trajectory_frame_positions}
             {trajectory_step_idx}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1654,6 +1654,17 @@
    *  click (-1) clears the selection (mirroring clicking empty space). */
   function handle_overlay_pick(displayed_idx: number): void {
     if (displayed_idx < 0) {
+      // Empty-space pick ⇒ would clear the selection. But the overlay watches
+      // window pointerup and classifies click-vs-drag purely by movement
+      // distance (it can't see the Cmd/Ctrl box-select modifier). A small/dense
+      // box-select drag is therefore misclassified as a background click and its
+      // async pick (GPU readback) resolves AFTER the WebGL box-select already set
+      // selected_sites — clearing here would wipe the box result one frame later
+      // (the flash). Suppress this clear if a box-select committed in the last
+      // ~400ms (covers the pick readback latency without swallowing a genuine
+      // later empty-space click). Box-select set persists.
+      const now = (typeof performance !== `undefined` ? performance.now() : Date.now())
+      if (now - interaction.last_box_select_commit_ms < 400) return
       if (selected_sites.length > 0) selected_sites = []
       return
     }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1904,6 +1904,20 @@
   // Task 9: experimental WebGPU large-system render path. Default OFF — when
   // off the overlay renders nothing and the WebGL viewer is unchanged.
   let large_system_mode = $state(false)
+  // One-shot repaint trigger for StructureScene. Bumped when large_system_mode
+  // turns OFF so the WebGL view (whose autoRender was paused while the overlay
+  // covered it) repaints once on the next frame and isn't left on a stale paint.
+  let webgl_repaint_trigger = $state(0)
+  let _last_large_system_mode = false
+  $effect(() => {
+    // Only act on the OFF transition (true → false). default-off ⇒ no-op at
+    // mount; ON ⇒ no-op (autoRender pauses, overlay paints). On OFF, autoRender
+    // flips back to true (the <Canvas> prop) and this bumps a repaint so the
+    // resumed WebGL render loop paints the current scene immediately.
+    const on = large_system_mode
+    if (_last_large_system_mode && !on) webgl_repaint_trigger++
+    _last_large_system_mode = on
+  })
   let pixels_per_angstrom = $state(0)
   let orbit_controls = $state<any>(undefined)
   let rotation_target_ref = $state<[number, number, number] | undefined>(undefined)
@@ -3588,7 +3602,17 @@
       <!-- prevent HTML labels from rendering outside of the canvas -->
       <div style="overflow: hidden; height: 100%; position: relative; z-index: 0; pointer-events: none">
         <div style="width: 100%; height: 100%; pointer-events: auto; position: relative">
-        <Canvas {...{ rendererParameters: { antialias: true, powerPreference: `high-performance` } } as any}>
+        <!--
+          autoRender is paused while large-system mode is ON: the WebGPU overlay
+          fully covers this WebGL canvas, so letting Threlte keep repainting the
+          whole scene every invalidate (each trajectory frame) just doubles GPU
+          load → lag. autoRender=false stops the WebGL PAINTS only; OrbitControls
+          still update the shared camera object the overlay reads, so camera
+          interaction keeps working under the overlay. Toggling the mode OFF
+          restores autoRender=true and an $effect below nudges a one-shot repaint
+          so the WebGL view isn't left on a stale/blank frame.
+        -->
+        <Canvas autoRender={!large_system_mode} {...{ rendererParameters: { antialias: true, powerPreference: `high-performance` } } as any}>
           <!--
             show_image_atoms is a separate bindable from scene_props.show_image_atoms
             (the UI checkbox binds to the local one). It must be passed AFTER the
@@ -3658,6 +3682,7 @@
             {center_camera_trigger}
             bind:lattice_align_trigger
             {reset_camera_up_trigger}
+            repaint_trigger={webgl_repaint_trigger}
             external_dragging={interaction.is_dragging_atom || interaction.is_rotating_atoms}
             is_box_selecting={interaction.is_box_selecting}
             is_rotating_atoms={interaction.is_rotating_atoms}
@@ -3775,6 +3800,8 @@
             {element_radius_overrides}
             {site_radius_overrides}
             bonding_options={(scene_props.bonding_options ?? {}) as Record<string, number>}
+            {background_color}
+            {background_opacity}
             {trajectory_positions_version}
             {get_trajectory_frame_positions}
             {trajectory_step_idx}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3690,6 +3690,8 @@
           sym_data={symmetry_data}
           loading={supercell_loading}
           direction="up"
+          {large_system_mode}
+          base_site_count={structure?.sites?.length ?? 0}
         />
       {/if}
     </AtomLegend>

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2896,6 +2896,7 @@
       bind:io_pane_open
       bind:server_pane_open
       bind:plugin_hub_open
+      bind:large_system_mode
       bind:chat_pane_open
       on_popout_chat={popout_chat}
       bind:show_terminal

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -18,6 +18,7 @@
     align_to_principal_axes,
     get_elem_amounts,
   } from '$lib/structure'
+  import { parse_supercell_scaling } from '$lib/structure/supercell'
   import { WyckoffTable, wyckoff_positions_from_moyo, spacegroup_to_crystal_sys } from '$lib/symmetry'
   import type { Crystal } from '$lib/structure'
   import type { MoyoDataset } from '@spglib/moyo-wasm'
@@ -997,6 +998,9 @@
     get_supercell_scaling: () => supercell_scaling,
     get_show_image_atoms: () => show_image_atoms,
     get_periodic_repeats: () => periodic_repeats,
+    // Phase 1: when the GPU overlay instances the supercell, the CPU keeps the
+    // base cell (no N× Site objects) — gates the supercell + PBC-image effects.
+    get_gpu_supercell_active: () => gpu_supercell_active,
     set_displayed_structure: (s) => { displayed_structure = s },
     set_saveable_structure: (s) => { saveable_structure = s },
   })
@@ -1990,6 +1994,26 @@
   // WebGL view fully resumes for the current frame. Default OFF ⇒ always false
   // ⇒ zero change to existing WebGL behavior.
   let webgl_suspended = $derived(large_system_mode)
+  // ── GPU supercell instancing (Phase 1) ──────────────────────────────────────
+  // Parsed [nx,ny,nz] from supercell_scaling. parse_supercell_scaling throws on
+  // malformed input, so guard — a bad string falls back to [1,1,1] (no supercell).
+  let gpu_supercell_factors = $derived.by((): Vec3 => {
+    try {
+      return parse_supercell_scaling(supercell_scaling)
+    } catch {
+      return [1, 1, 1]
+    }
+  })
+  // GPU-supercell is ACTIVE only when the overlay is on AND a real (>1) supercell
+  // is requested AND the structure carries a lattice (offsets need a,b,c). When
+  // active, the CPU keeps the base cell (transform-controller gate) and the GPU
+  // instances base_count × nx·ny·nz spheres. Off / overlay-off / 1×1×1 ⇒ false ⇒
+  // identical CPU + shader behaviour to today.
+  let gpu_supercell_active = $derived(
+    large_system_mode &&
+      gpu_supercell_factors[0] * gpu_supercell_factors[1] * gpu_supercell_factors[2] > 1 &&
+      !!(structure as { lattice?: unknown } | undefined)?.lattice,
+  )
   // One-shot repaint trigger for StructureScene. Bumped when large_system_mode
   // turns OFF so the WebGL view (whose autoRender was paused while the overlay
   // covered it) repaints once on the next frame and isn't left on a stale paint.
@@ -3882,6 +3906,7 @@
             enabled={large_system_mode}
             {camera}
             structure={displayed_structure}
+            supercell={gpu_supercell_active ? gpu_supercell_factors : [1, 1, 1]}
             element_colors={colors.element}
             atom_radius={scene_props.atom_radius}
             same_size_atoms={scene_props.same_size_atoms}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3820,6 +3820,7 @@
             {element_radius_overrides}
             {site_radius_overrides}
             bonding_options={(scene_props.bonding_options ?? {}) as Record<string, number>}
+            show_bonds={scene_props.show_bonds}
             {background_color}
             {background_opacity}
             show_cell={scene_props.show_cell}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3775,6 +3775,9 @@
             {element_radius_overrides}
             {site_radius_overrides}
             bonding_options={(scene_props.bonding_options ?? {}) as Record<string, number>}
+            {trajectory_positions_version}
+            {get_trajectory_frame_positions}
+            {trajectory_step_idx}
             on_fallback={(reason) => {
               large_system_mode = false
               console.warn(`[CatGO] large-system mode: ${reason}`)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2929,6 +2929,8 @@
               bind:structure
               pane_open={true}
               bind:center_camera_trigger
+              bind:supercell_scaling
+              {large_system_mode}
               on_structure_change={(new_struct) => build.handle_structure_replace(new_struct)}
               on_push_undo={push_to_undo}
               on_reset_view={() => align_view_to_lattice()}

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -968,14 +968,6 @@
           />
         </label>
       {/if}
-      <label
-        {@attach tooltip({
-          content: `Render very large systems through the experimental high-performance path. Falls back to the standard viewer if unavailable.`,
-        })}
-      >
-        <input type="checkbox" bind:checked={large_system_mode} />
-        Large-system performance mode
-      </label>
     </SettingsSection>
   {/if}
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -970,11 +970,11 @@
       {/if}
       <label
         {@attach tooltip({
-          content: `Render very large systems through the experimental WebGPU path. Falls back to the WebGL viewer if WebGPU is unavailable.`,
+          content: `Render very large systems through the experimental high-performance path. Falls back to the standard viewer if unavailable.`,
         })}
       >
         <input type="checkbox" bind:checked={large_system_mode} />
-        Large-system performance mode (WebGPU)
+        Large-system performance mode
       </label>
     </SettingsSection>
   {/if}

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -47,6 +47,7 @@
     bond_opacity_overrides = $bindable(new Map<string, number>()),
     structure = undefined,
     bond_distance_rules = $bindable<import('./index').BondDistanceRule[]>([]),
+    large_system_mode = $bindable(false),
     supercell_loading = false,
     pane_props = {},
     toggle_props = {},
@@ -69,6 +70,7 @@
     bond_opacity_overrides?: Map<string, number>
     structure?: AnyStructure
     bond_distance_rules?: import('./index').BondDistanceRule[]
+    large_system_mode?: boolean
     supercell_loading?: boolean
     pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
     toggle_props?: ComponentProps<typeof DraggablePane>[`toggle_props`]
@@ -966,6 +968,14 @@
           />
         </label>
       {/if}
+      <label
+        {@attach tooltip({
+          content: `Render very large systems through the experimental WebGPU path. Falls back to the WebGL viewer if WebGPU is unavailable.`,
+        })}
+      >
+        <input type="checkbox" bind:checked={large_system_mode} />
+        Large-system performance mode (WebGPU)
+      </label>
     </SettingsSection>
   {/if}
 

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -496,6 +496,7 @@
     center_camera_trigger = $bindable(0), // Increment this to trigger camera centering
     lattice_align_trigger = $bindable(0), // Increment to align camera with lattice a×b normal
     reset_camera_up_trigger = 0, // Increment to reset camera.up to [0,0,1] (Z-up) after slab cut
+    repaint_trigger = 0, // Increment to force ONE WebGL repaint (no side effects) — used when the large-system overlay closes and autoRender resumes
     external_dragging = false,
     is_box_selecting = false,
     is_rotating_atoms = false,
@@ -733,6 +734,7 @@
     center_camera_trigger?: number // Increment this to trigger camera centering
     lattice_align_trigger?: number // Increment to align camera with lattice a×b normal
     reset_camera_up_trigger?: number // Increment to reset camera.up to [0,0,1] (Z-up) after slab cut
+    repaint_trigger?: number // Increment to force ONE WebGL repaint (no side effects)
     hidden_elements?: Set<ElementSymbol>
     hidden_sites?: Set<number> // Track hidden individual sites (by site index)
     hidden_prop_vals?: Set<number | string> // Track hidden property values (e.g. coordination numbers, Wyckoff positions, charges)
@@ -994,6 +996,18 @@
   $effect(() => {
     void background_color; void background_opacity
     sync_clear_color()
+  })
+
+  // One-shot WebGL repaint on demand. The large-system overlay pauses this
+  // canvas's autoRender while it covers the view; when the overlay closes the
+  // parent bumps repaint_trigger so the resumed (on-demand) render loop paints
+  // the current scene once. mark_dirty() = threlte.invalidate(); no other side
+  // effects (no camera move). Default 0 ⇒ this never fires unless bumped.
+  let _last_repaint_trigger = repaint_trigger
+  $effect(() => {
+    if (repaint_trigger === _last_repaint_trigger) return
+    _last_repaint_trigger = repaint_trigger
+    mark_dirty()
   })
 
   $effect(() => {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -557,6 +557,16 @@
     // Without the parent binding, this default keeps StructureScene self-
     // contained for any test harness that mounts it directly.
     atom_manager = $bindable<AtomManager>(new AtomManager()),
+    // WebGPU large-system overlay bridge: a getter the parent can call to read
+    // the AUTHORITATIVE per-displayed-atom current-frame position array the
+    // WebGL atoms/bonds are drawn at — `atom_positions_buffer` (topology base
+    // overlaid with the manager's per-frame positions via site_ids_buffer,
+    // indexed by displayed site index, 3 × n_displayed). The overlay consumes
+    // this instead of re-deriving from base-only trajectory data, so the two
+    // views match atom-for-atom (incl. supercell base-block / replica-static
+    // behaviour). Bound out as a function so the parent always reads the LIVE
+    // $derived value, not a stale snapshot.
+    get_displayed_frame_positions = $bindable<(() => Float32Array) | null>(null),
     deleted_bond_keys = new Set<string>(),
     selected_bonds = $bindable([] as import('./index').SelectedBond[]),
     bond_first_atom = null as number | null,
@@ -809,6 +819,9 @@
     atom_fast_ops?: AtomFastOps | null
     /** Plan v3 Phase 1: atom_manager $bindable for parent-driven position writes. */
     atom_manager?: AtomManager
+    /** WebGPU overlay bridge: getter returning the live per-displayed-atom
+     *  current-frame position array (3 × n_displayed) the WebGL view renders. */
+    get_displayed_frame_positions?: (() => Float32Array) | null
     deleted_bond_keys?: Set<string>
     selected_bonds?: import('./index').SelectedBond[]
     bond_first_atom?: number | null
@@ -3305,6 +3318,18 @@
       buf[sid * 3 + 2] = mgr.get_z(slot)
     }
     return buf
+  })
+
+  // WebGPU overlay bridge: expose `atom_positions_buffer` to the parent as a
+  // getter. The overlay calls this in its per-frame refresh to source the
+  // SAME resolved per-displayed-atom positions the WebGL bonds/atoms use —
+  // no independent re-derivation from base-only trajectory data. Reading the
+  // $derived inside the returned closure (not capturing a snapshot) means each
+  // call yields the live current-frame array. Assigned via $effect so the
+  // binding survives prop reassignment churn.
+  $effect(() => {
+    get_displayed_frame_positions = () => atom_positions_buffer
+    return () => { get_displayed_frame_positions = null }
   })
 
   // Flat row-major Float64Array(9) for BondManagerInstances. Rows are the

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -514,6 +514,7 @@
     // null (cache miss), we fall back to `bond_state.bond_connectivity`
     // (frame-0 static).
     trajectory_bond_connectivity = null as Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> | null,
+    webgl_suspended = false,
     on_reset_rotation,
     on_atom_context_menu,
     // Cutting plane visualization
@@ -763,6 +764,12 @@
     trajectory_frame_forces?: Float32Array | null
     // Per-frame bond connectivity (from trajectory bond cache). Null = fall back to static.
     trajectory_bond_connectivity?: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> | null
+    /** WebGPU large-system overlay active. When true the WebGL scene is fully
+     *  covered by the overlay and `autoRender` is off, so this scene must do
+     *  ZERO per-frame work: the trajectory bond-pair rebuild is skipped. Read
+     *  reactively in the gated effect so toggle-OFF re-fires it and the scene
+     *  resumes correctly. Default false ⇒ unchanged WebGL behavior. */
+    webgl_suspended?: boolean
     // Cutting plane visualization for Miller slab cutter
     cutting_active?: boolean
     cutting_plane_normal?: Vec3
@@ -1485,6 +1492,12 @@
     requestAnimationFrame(() => { node.focus(); node.select() })
   }
   let charge_label_entries = $derived.by(() => {
+    // WebGPU overlay active: scene not painting + overlay draws no charge
+    // labels → skip the per-frame label recompute (it reads
+    // trajectory_frame_positions directly, which the parent still updates each
+    // frame). Read suspend reactively so toggle-OFF re-derives for the current
+    // frame. Default false ⇒ unchanged.
+    if (webgl_suspended) return []
     // Plan v3 follow-up I5: subscribe to atom_manager.version so labels
     // re-derive on per-frame trajectory writes. Under Architecture P
     // structure.sites is frozen at trajectory-load; without this
@@ -1819,7 +1832,20 @@
   // never updated → bonds visually freeze (Reviewer 2 HIGH).
   let __bbp_prev_traj: unknown = null
   let __bbp_skips = 0
+  let __bbp_was_suspended = false
   $effect.pre(() => {
+    // WebGPU overlay active: this WebGL scene is covered and not painting, and
+    // the overlay computes its own GPU bonds — so skip the per-frame trajectory
+    // bond-pair rebuild (compute_bond_connectivity_for_frame +
+    // build_trajectory_bond_pairs). Read suspend FIRST (reactive) so toggle-OFF
+    // (true→false) re-fires this effect; the resume branch then bypasses the
+    // memo so bonds rebuild for the current frame even if positions advanced
+    // (under the overlay) without `trajectory_frame_positions` identity having
+    // changed since the last build before suspension.
+    const __suspended = webgl_suspended
+    if (__suspended) { __bbp_was_suspended = true; return }
+    const __resuming_bbp = __bbp_was_suspended
+    __bbp_was_suspended = false
     if (import.meta.env?.DEV) __probe_bbp_fires++
     const __t0 = (import.meta.env?.DEV) ? performance.now() : 0
     // Read all deps up front so Svelte subscribes correctly.
@@ -1852,7 +1878,8 @@
       // in the memo so drag-filter and selection highlights still update
       // during trajectory playback when conn/lbs/traj are stable.
       if (
-        traj_conn === __bbp_prev_conn
+        !__resuming_bbp
+        && traj_conn === __bbp_prev_conn
         && lbs === __bbp_prev_lbs
         && traj_positions === __bbp_prev_traj
         && overrides === __bbp_prev_overrides
@@ -1904,7 +1931,8 @@
     const conn = conn_state
 
     const stable =
-      __bbp_prev_overrides_size !== -1
+      !__resuming_bbp
+      && __bbp_prev_overrides_size !== -1
       && conn === __bbp_prev_conn
       && lbs === __bbp_prev_lbs
       && struct_ref === __bbp_prev_struct
@@ -3756,6 +3784,12 @@
   //   3. atom_manager slot lookup                    — supercell-extra
   //   4. atom.position from atom_data                — load-time fallback
   let atom_derived_maps = $derived.by(() => {
+    // WebGPU overlay active: scene not painting → these maps (selection
+    // highlight / label positions) aren't rendered. Skip the per-frame rebuild
+    // (this derived reads trajectory_frame_positions directly, which the parent
+    // still bumps each frame). Read suspend reactively so toggle-OFF re-derives
+    // the full maps for the current frame. Default false ⇒ unchanged.
+    if (webgl_suspended) return { radius_map: new Map<number, number>(), position_map: new Map<number, Vec3>(), unique: [] as typeof atom_data }
     // R8.7 PROBE — load-cascade timing.
     const __t0 = (import.meta.env?.DEV) ? performance.now() : 0
     void atom_manager.version // subscribe to per-slot position writes
@@ -3824,6 +3858,10 @@
   })
 
   let force_data = $derived.by(() => {
+    // WebGPU overlay active: scene not painting + overlay renders no force
+    // vectors → skip the per-frame compute_force_data rebuild. Read suspend
+    // reactively so toggle-OFF re-derives for the current frame.
+    if (webgl_suspended) return []
     if (!show_force_vectors || !structure?.sites) return []
     // Override forces from trajectory Float32Array (positions are already
     // correct in structure.sites since the unified single-path always updates structure)

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -1390,6 +1390,14 @@
     // Prevent camera rotation/movement when clicking on atoms
     evt?.stopPropagation?.()
 
+    // WebGPU large-system overlay active: the overlay (pointer-events:none) is the
+    // sole selection authority. The same click also reaches the WebGL canvas
+    // underneath; if we let the WebGL atom-pick run, it would toggle the site the
+    // overlay just selected back OFF (set→toggle-off race) → highlight flashes for
+    // one frame then clears. Suppress the WebGL click→selection mutation while
+    // suspended. Reactive: toggle-OFF restores normal click selection.
+    if (webgl_suspended) return
+
     const result = toggle_site_selection(site_index, selected_sites)
     if (result === null) {
       console.warn(
@@ -4498,12 +4506,16 @@
 <T.Mesh
   position={[0, 0, -1000]}
   onclick={() => {
+    // WebGPU overlay active: overlay owns selection; ignore empty-space WebGL clicks.
+    if (webgl_suspended) return
     // Bond mode: clicking empty space clears bond selection (skip during drag)
     if (bond_mode_active && on_bond_select && !bond_drag_active) {
       on_bond_select(null)
     }
   }}
   ondblclick={(event: MouseEvent) => {
+    // WebGPU overlay active: overlay owns selection; do not clear from WebGL.
+    if (webgl_suspended) return
     // Only double-click clears selection - single click and drag do not
     // Clear selection when double-clicking empty space
     selected_sites = []

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -355,6 +355,20 @@
       {/if}
     </div>
 
+    <!-- === Large-system performance mode (always visible — also in trajectory/large views) === -->
+    <span class="struct-toolbar-tooltip-wrap">
+      <button
+        type="button"
+        onclick={() => { large_system_mode = !large_system_mode }}
+        class="build-tools-toggle"
+        class:active={large_system_mode}
+        aria-pressed={large_system_mode}
+      >
+        <Icon icon="Gauge" />
+      </button>
+      <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.large_system_mode')}</span>
+    </span>
+
     {#if !hide_extra_tools}
       <!-- === Build Tools === -->
       <span class="struct-toolbar-tooltip-wrap">
@@ -439,20 +453,6 @@
         <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.plugin_hub')}</span>
       </span>
       {/if}
-
-      <!-- === Large-system performance mode (WebGPU) === -->
-      <span class="struct-toolbar-tooltip-wrap">
-        <button
-          type="button"
-          onclick={() => { large_system_mode = !large_system_mode }}
-          class="build-tools-toggle"
-          class:active={large_system_mode}
-          aria-pressed={large_system_mode}
-        >
-          <Icon icon="Gauge" />
-        </button>
-        <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.large_system_mode')}</span>
-      </span>
 
       {#if !hidden_toolbar_items.includes('chat') && !STATIC_ONLY}
       <!-- === AI Chat === -->

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -63,6 +63,7 @@
     io_pane_open = $bindable(false),
     server_pane_open = $bindable(false),
     plugin_hub_open = $bindable(false),
+    large_system_mode = $bindable(false),
     chat_pane_open = $bindable(false),
     show_terminal = $bindable(false),
     side_panel_minimized = $bindable(false),
@@ -117,6 +118,7 @@
     io_pane_open?: boolean
     server_pane_open?: boolean
     plugin_hub_open?: boolean
+    large_system_mode?: boolean
     chat_pane_open?: boolean
     show_terminal?: boolean
     side_panel_minimized?: boolean
@@ -437,6 +439,20 @@
         <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.plugin_hub')}</span>
       </span>
       {/if}
+
+      <!-- === Large-system performance mode (WebGPU) === -->
+      <span class="struct-toolbar-tooltip-wrap">
+        <button
+          type="button"
+          onclick={() => { large_system_mode = !large_system_mode }}
+          class="build-tools-toggle"
+          class:active={large_system_mode}
+          aria-pressed={large_system_mode}
+        >
+          <Icon icon="Gauge" />
+        </button>
+        <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.large_system_mode')}</span>
+      </span>
 
       {#if !hidden_toolbar_items.includes('chat') && !STATIC_ONLY}
       <!-- === AI Chat === -->

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -276,6 +276,13 @@ export function create_interaction_controller(deps: InteractionDeps) {
   let is_box_selecting = $state(false)
   let box_select_start = $state<{ x: number; y: number } | null>(null)
   let box_select_end = $state<{ x: number; y: number } | null>(null)
+  // performance.now() timestamp of the most recent committed box-select. Used by
+  // the WebGPU overlay's empty-space-clear path: the overlay watches window
+  // pointerup and (lacking the box-select modifier check) can misclassify a small
+  // /dense Cmd/Ctrl+drag box-select as a background click → its async pick returns
+  // -1 → the parent would clear the selection the box just set. The parent reads
+  // this stamp and suppresses that one clear. -Infinity = never box-selected.
+  let last_box_select_commit_ms = $state(-Infinity)
 
   // ═══════════════════════════════════════════════════════════════════
   // 裁剪导出状态 — 绘制矩形区域 → 导出 PNG → 退出
@@ -1247,6 +1254,12 @@ export function create_interaction_controller(deps: InteractionDeps) {
       }
       deps.set_selected_bonds(new_bonds)
 
+      // Stamp the commit so the WebGPU overlay's async empty-space clear (which
+      // can fire for this same pointerup on a small/dense box) is suppressed by
+      // the parent. Stamp even when the box caught nothing — a Cmd/Ctrl+drag that
+      // selected zero atoms must still NOT be reinterpreted as a clear-all click.
+      last_box_select_commit_ms = (typeof performance !== `undefined` ? performance.now() : Date.now())
+
       is_box_selecting = false
       box_select_start = null
       box_select_end = null
@@ -1519,6 +1532,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
     get is_box_selecting() { return is_box_selecting },
     get box_select_start() { return box_select_start },
     get box_select_end() { return box_select_end },
+    get last_box_select_commit_ms() { return last_box_select_commit_ms },
     get crop_mode_active() { return crop_mode_active },
     set crop_mode_active(v: boolean) { crop_mode_active = v },
     get crop_region() { return crop_region },

--- a/src/lib/structure/controllers/transform-controller.svelte.ts
+++ b/src/lib/structure/controllers/transform-controller.svelte.ts
@@ -30,6 +30,12 @@ export interface TransformDeps {
   get_supercell_scaling: () => string
   get_show_image_atoms: () => boolean
   get_periodic_repeats: () => Vec3
+  /** When true, the GPU overlay renders the supercell by INSTANCING the base
+   *  cell on the GPU, so the CPU must NOT expand it. The supercell + PBC-image
+   *  effects then short-circuit to the BASE (cell-transformed) structure — net
+   *  `displayed_structure` stays base-cell sized, no N× Site objects built.
+   *  Defaults to () => false (absent dep) ⇒ unchanged CPU expansion behaviour. */
+  get_gpu_supercell_active?: () => boolean
   set_displayed_structure: (s: AnyStructure | undefined) => void
   set_saveable_structure: (s: AnyStructure | undefined) => void
 }
@@ -61,8 +67,16 @@ export function create_transform_controller(deps: TransformDeps) {
   $effect(() => {
     const base_structure = cell_transformed_structure
     const supercell_scaling = deps.get_supercell_scaling()
+    // GPU-supercell gate: when the overlay instances the base cell on the GPU,
+    // the CPU must keep `supercell_structure` at the BASE cell (no WASM expand,
+    // no N× Site objects). Read reactively so flipping it OFF re-fires this
+    // effect and the CPU resumes building the real supercell.
+    const gpu_supercell_active = deps.get_gpu_supercell_active?.() ?? false
 
-    if (!base_structure || !('lattice' in base_structure)) {
+    if (gpu_supercell_active) {
+      supercell_structure = base_structure
+      supercell_loading = false
+    } else if (!base_structure || !('lattice' in base_structure)) {
       supercell_structure = base_structure
       supercell_loading = false
     } else if (['', '1x1x1', '1'].includes(supercell_scaling)) {
@@ -111,8 +125,15 @@ export function create_transform_controller(deps: TransformDeps) {
     const show_image_atoms = deps.get_show_image_atoms()
     const repeats = deps.get_periodic_repeats()
     const ss = supercell_structure
+    // GPU-supercell gate: the overlay instances the base cell (+ later phases its
+    // PBC partners) entirely on the GPU, so the CPU must NOT append image atoms.
+    // `displayed_structure` stays the base cell (= ss, which the supercell effect
+    // above pinned to base). Read reactively so flipping OFF resumes CPU images.
+    const gpu_supercell_active = deps.get_gpu_supercell_active?.() ?? false
 
-    if (show_image_atoms && ss && 'lattice' in ss && ss.lattice) {
+    if (gpu_supercell_active) {
+      deps.set_displayed_structure(ss)
+    } else if (show_image_atoms && ss && 'lattice' in ss && ss.lattice) {
       const has_repeats = repeats[0] > 0 || repeats[1] > 0 || repeats[2] > 0
       if (has_repeats) {
         deps.set_displayed_structure(get_periodic_repeat_sites(ss, repeats))
@@ -179,6 +200,10 @@ export function create_transform_controller(deps: TransformDeps) {
   // ═══ Public Interface ═══
 
   return {
+    /** The BASE (cell-type-transformed) structure, BEFORE any supercell expansion
+     *  or PBC-image append. This is what the GPU overlay instances when
+     *  `get_gpu_supercell_active` is true. */
+    get base_structure() { return cell_transformed_structure },
     get supercell_structure() { return supercell_structure },
     get supercell_loading() { return supercell_loading },
 

--- a/src/lib/structure/export/supercell-export-client.ts
+++ b/src/lib/structure/export/supercell-export-client.ts
@@ -26,6 +26,59 @@ const FORMAT_EXT: Record<SupercellExportFormat, string> = {
   extxyz: `extxyz`,
 }
 
+/**
+ * Extract a PLAIN, structured-cloneable `CoreStructure` POJO from `base`.
+ *
+ * `base` (= the displayed/base cell) is a Svelte 5 `$state` proxy and may carry
+ * class instances / functions / reactive wrappers — none of which survive the
+ * structured-clone algorithm `worker.postMessage` uses (it throws
+ * "could not be cloned"). The worker core (`supercell-export-core`) only ever
+ * reads the fields copied below, so we rebuild a fresh object made of plain
+ * primitives / arrays / objects only. Built ONCE here, before posting.
+ */
+function sanitize_base(base: CoreStructure): CoreStructure {
+  const sites = base.sites.map((site) => {
+    const xyz = site.xyz
+    const out: CoreStructure[`sites`][number] = {
+      species: (site.species ?? []).map((sp) => ({
+        element: sp.element,
+        occu: sp.occu,
+        oxidation_state: sp.oxidation_state,
+      })),
+      xyz: [xyz[0], xyz[1], xyz[2]],
+    }
+    if (site.abc) out.abc = [site.abc[0], site.abc[1], site.abc[2]]
+    if (site.label !== undefined) out.label = site.label
+    // The core only reads `selective_dynamics` (boolean[]) and `force`
+    // (number[]). A defensive JSON round-trip strips any proxy/class wrapping
+    // while keeping plain data; `$state.snapshot` is unnecessary here because
+    // JSON serialization already unwraps the reactive proxy.
+    if (site.properties) {
+      out.properties = JSON.parse(JSON.stringify(site.properties)) as Record<string, unknown>
+    }
+    return out
+  })
+
+  const out: CoreStructure = { sites }
+  if (base.lattice?.matrix) {
+    const m = base.lattice.matrix
+    out.lattice = {
+      matrix: [
+        [m[0][0], m[0][1], m[0][2]],
+        [m[1][0], m[1][1], m[1][2]],
+        [m[2][0], m[2][1], m[2][2]],
+      ],
+    }
+    if (base.lattice.pbc) {
+      out.lattice.pbc = [base.lattice.pbc[0], base.lattice.pbc[1], base.lattice.pbc[2]]
+    }
+  }
+  if (base.charge !== undefined) out.charge = base.charge
+  if (base.id !== undefined) out.id = base.id
+  if (base.formula !== undefined) out.formula = base.formula
+  return out
+}
+
 let _worker: Worker | undefined
 let _next_id = 1
 
@@ -102,7 +155,16 @@ export async function export_supercell_via_worker(
       }
       worker.addEventListener(`message`, handle_message)
       worker.addEventListener(`error`, handle_error)
-      const req: SupercellExportRequest = { id, base_structure: base, factors, format }
+      // `base` is a Svelte $state proxy / may hold class instances — not
+      // structured-cloneable. Post a plain POJO extracted ONCE (the worker core
+      // only reads the fields `sanitize_base` copies). `factors` (number[]) and
+      // `format` (string) are already cloneable primitives.
+      const req: SupercellExportRequest = {
+        id,
+        base_structure: sanitize_base(base),
+        factors: [factors[0], factors[1], factors[2]],
+        format,
+      }
       worker.postMessage(req)
     })
 

--- a/src/lib/structure/export/supercell-export-client.ts
+++ b/src/lib/structure/export/supercell-export-client.ts
@@ -1,0 +1,120 @@
+/**
+ * Main-thread client for the supercell export worker.
+ *
+ * Spins up `supercell-export.worker.ts`, posts the BASE cell + factors + format,
+ * awaits the serialized full supercell, and triggers a Blob download — all
+ * without materializing millions of Site objects on the main thread.
+ *
+ * Used only when the WebGPU large-system overlay is active AND a >1 supercell is
+ * requested (the displayed/saveable structure is then the BASE cell). The normal
+ * synchronous export path is left untouched for everything else.
+ */
+
+import { download } from '$lib/io/fetch'
+import {
+  type CoreStructure,
+  EXPORT_ATOM_CONFIRM_THRESHOLD,
+  expanded_atom_count,
+  type SupercellExportFormat,
+  type Vec3,
+} from './supercell-export-core'
+import type { SupercellExportRequest, SupercellExportResponse } from './supercell-export.worker'
+
+const FORMAT_EXT: Record<SupercellExportFormat, string> = {
+  poscar: `poscar`,
+  xyz: `xyz`,
+  extxyz: `extxyz`,
+}
+
+let _worker: Worker | undefined
+let _next_id = 1
+
+function get_worker(): Worker {
+  if (!_worker) {
+    _worker = new Worker(
+      new URL(`./supercell-export.worker.ts`, import.meta.url),
+      { type: `module` },
+    )
+  }
+  return _worker
+}
+
+export interface SupercellExportOptions {
+  // Build a download filename from the (expanded) structure. Defaults to a
+  // formula/id-based name with the format extension.
+  filename?: string
+  // Asked when the expanded atom count exceeds EXPORT_ATOM_CONFIRM_THRESHOLD.
+  // Return true to proceed. Defaults to window.confirm in the browser.
+  confirm?: (atom_count: number) => boolean | Promise<boolean>
+  // Optional busy/progress hooks for a lightweight UI indicator.
+  on_start?: () => void
+  on_done?: (atom_count: number) => void
+  on_error?: (error: string) => void
+}
+
+function default_confirm(atom_count: number): boolean {
+  if (typeof globalThis.confirm !== `function`) return true
+  const millions = (atom_count / 1e6).toFixed(1)
+  return globalThis.confirm(
+    `This supercell expands to ${atom_count.toLocaleString()} atoms (~${millions}M). ` +
+      `Serializing it to a file may take a while and use a lot of memory. Continue?`,
+  )
+}
+
+/**
+ * Expand `base` × `factors` in a worker, serialize to `format`, and download.
+ * Resolves to the expanded atom count (or null if the user cancelled the
+ * over-threshold confirm).
+ */
+export async function export_supercell_via_worker(
+  base: CoreStructure,
+  factors: Vec3,
+  format: SupercellExportFormat,
+  opts: SupercellExportOptions = {},
+): Promise<number | null> {
+  const atom_count = expanded_atom_count(base, factors)
+
+  if (atom_count > EXPORT_ATOM_CONFIRM_THRESHOLD) {
+    const confirm_fn = opts.confirm ?? default_confirm
+    const proceed = await confirm_fn(atom_count)
+    if (!proceed) return null
+  }
+
+  opts.on_start?.()
+
+  const id = _next_id++
+  const worker = get_worker()
+
+  try {
+    const text = await new Promise<string>((resolve, reject) => {
+      const handle_message = (event: MessageEvent<SupercellExportResponse>) => {
+        const msg = event.data
+        if (msg.id !== id) return // not our reply (worker is shared)
+        worker.removeEventListener(`message`, handle_message)
+        worker.removeEventListener(`error`, handle_error)
+        if (msg.ok) resolve(msg.text)
+        else reject(new Error(msg.error))
+      }
+      const handle_error = (event: ErrorEvent) => {
+        worker.removeEventListener(`message`, handle_message)
+        worker.removeEventListener(`error`, handle_error)
+        reject(new Error(event.message || `Supercell export worker error`))
+      }
+      worker.addEventListener(`message`, handle_message)
+      worker.addEventListener(`error`, handle_error)
+      const req: SupercellExportRequest = { id, base_structure: base, factors, format }
+      worker.postMessage(req)
+    })
+
+    const ext = FORMAT_EXT[format]
+    const base_name = opts.filename ??
+      `${base.id || base.formula || `structure`}_supercell.${ext}`
+    download(new Blob([text], { type: `text/plain` }), base_name, `text/plain`)
+    opts.on_done?.(atom_count)
+    return atom_count
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    opts.on_error?.(message)
+    throw error
+  }
+}

--- a/src/lib/structure/export/supercell-export-core.ts
+++ b/src/lib/structure/export/supercell-export-core.ts
@@ -1,0 +1,276 @@
+/**
+ * Pure (worker-safe) supercell EXPANSION + serialization.
+ *
+ * This module has NO DOM / Svelte / WASM / three.js dependencies so it can be
+ * imported from a Web Worker (see `supercell-export.worker.ts`) AND unit-tested
+ * in plain vitest. It expands a BASE cell × (nx,ny,nz) into the real supercell
+ * by replicating sites with cell translations and scaling the lattice matrix,
+ * then serializes the result to a structure file string.
+ *
+ * Why a separate module? With the WebGPU large-system overlay ON, the CPU keeps
+ * only the BASE cell (the GPU instances it) — so `saveable_structure` is the
+ * base cell, not the logical supercell. Export must reconstruct the full
+ * supercell. Doing the N× replication + string build on the MAIN thread freezes
+ * the UI for large factors, so the worker runs this off-thread.
+ */
+
+// ─── Minimal structure POJO shapes (mirrors the pymatgen-style dict) ─────────
+
+export interface CoreSpecies {
+  element: string
+  occu?: number
+  oxidation_state?: number
+}
+
+export interface CoreSite {
+  species: CoreSpecies[]
+  xyz: [number, number, number]
+  abc?: [number, number, number]
+  label?: string
+  properties?: Record<string, unknown>
+}
+
+export interface CoreLattice {
+  matrix: [[number, number, number], [number, number, number], [number, number, number]]
+  pbc?: [boolean, boolean, boolean]
+}
+
+export interface CoreStructure {
+  lattice?: CoreLattice
+  sites: CoreSite[]
+  charge?: number
+  id?: string
+  formula?: string
+}
+
+export type Vec3 = [number, number, number]
+export type Mat3 = [Vec3, Vec3, Vec3]
+
+// Formats that route through the worker expansion path. POSCAR + (ext)xyz are
+// the common large-structure formats and have fully pure serializers here.
+export type SupercellExportFormat = `poscar` | `xyz` | `extxyz`
+
+// Threshold (in EXPANDED atom count) beyond which serializing to a single
+// string risks exhausting memory even in a worker (~tens of bytes/atom × N).
+// Above this the UI asks the user to confirm before kicking off the worker.
+// A 20M-atom POSCAR is already ~1 GB of text; 100M would be multi-GB.
+export const EXPORT_ATOM_CONFIRM_THRESHOLD = 20_000_000
+
+// ─── Pure 3×3 math (kept local so the worker pulls in no other modules) ──────
+
+function transpose(m: Mat3): Mat3 {
+  return [
+    [m[0][0], m[1][0], m[2][0]],
+    [m[0][1], m[1][1], m[2][1]],
+    [m[0][2], m[1][2], m[2][2]],
+  ]
+}
+
+// matrix · vector (matrix rows dotted with the vector)
+function mat_vec(m: Mat3, v: Vec3): Vec3 {
+  return [
+    m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+    m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+    m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+  ]
+}
+
+function inverse_3x3(m: Mat3): Mat3 {
+  const [[a, b, c], [d, e, f], [g, h, i]] = m
+  const det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+  if (Math.abs(det) < 1e-15) throw new Error(`Singular lattice matrix`)
+  const inv = 1 / det
+  return [
+    [(e * i - f * h) * inv, (c * h - b * i) * inv, (b * f - c * e) * inv],
+    [(f * g - d * i) * inv, (a * i - c * g) * inv, (c * d - a * f) * inv],
+    [(d * h - e * g) * inv, (b * g - a * h) * inv, (a * e - b * d) * inv],
+  ]
+}
+
+// ─── Expansion ───────────────────────────────────────────────────────────────
+
+// Number of atoms the expanded supercell will contain. Cheap (no allocation) so
+// callers can guard / show a count before paying for the full build.
+export function expanded_atom_count(base: CoreStructure, factors: Vec3): number {
+  const [nx, ny, nz] = factors
+  return base.sites.length * nx * ny * nz
+}
+
+/**
+ * Replicate `base` sites across the (nx,ny,nz) cell grid and scale the lattice.
+ *
+ * Mirrors `make_supercell` (src/lib/structure/supercell.ts) but in plain TS with
+ * NO `to_unit_cell` wrap — for export we keep the natural expanded Cartesian
+ * lattice so each replica sits at `site.xyz + ix·a + iy·b + iz·c` and the new
+ * fractional coords land in [0,1) of the SCALED cell by construction.
+ */
+export function expand_supercell(base: CoreStructure, factors: Vec3): CoreStructure {
+  if (!base.lattice?.matrix) {
+    throw new Error(`Cannot expand supercell: structure has no lattice`)
+  }
+  const [nx, ny, nz] = factors
+  if (![nx, ny, nz].every((n) => Number.isInteger(n) && n > 0)) {
+    throw new Error(`Supercell factors must be positive integers: ${factors}`)
+  }
+  const det = nx * ny * nz
+
+  const orig_matrix = base.lattice.matrix
+  const new_matrix: Mat3 = [
+    [orig_matrix[0][0] * nx, orig_matrix[0][1] * nx, orig_matrix[0][2] * nx],
+    [orig_matrix[1][0] * ny, orig_matrix[1][1] * ny, orig_matrix[1][2] * ny],
+    [orig_matrix[2][0] * nz, orig_matrix[2][1] * nz, orig_matrix[2][2] * nz],
+  ]
+
+  // Pre-compute transposes/inverse once (constant for every replica).
+  const orig_T = transpose(orig_matrix)
+  const new_T = transpose(new_matrix)
+  const new_T_inv = inverse_3x3(new_T)
+
+  const new_sites: CoreSite[] = new Array(base.sites.length * det)
+  let out = 0
+  for (let kk = 0; kk < nz; kk++) {
+    for (let jj = 0; jj < ny; jj++) {
+      for (let ii = 0; ii < nx; ii++) {
+        const translation = mat_vec(orig_T, [ii, jj, kk])
+        const suffix = det > 1 ? `_${ii}${jj}${kk}` : ``
+        for (const site of base.sites) {
+          const cart: Vec3 = [
+            site.xyz[0] + translation[0],
+            site.xyz[1] + translation[1],
+            site.xyz[2] + translation[2],
+          ]
+          const frac = mat_vec(new_T_inv, cart)
+          new_sites[out++] = {
+            species: site.species,
+            xyz: cart,
+            abc: frac,
+            label: suffix && site.label ? `${site.label}${suffix}` : site.label,
+            properties: site.properties,
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    ...base,
+    lattice: { ...base.lattice, matrix: new_matrix },
+    sites: new_sites,
+    charge: base.charge ? base.charge * det : base.charge,
+  }
+}
+
+// ─── Pure serializers (no DOM) ───────────────────────────────────────────────
+
+function element_of(site: CoreSite): string {
+  return site.species?.[0]?.element || `X`
+}
+
+function fmt(n: number, digits: number): string {
+  return (Number.isFinite(n) ? n : 0).toFixed(digits)
+}
+
+// VASP POSCAR (Direct/fractional coords, element groups in first-appearance
+// order, optional Selective dynamics). Pure equivalent of structure_to_poscar_str.
+export function serialize_poscar(structure: CoreStructure, comment = `CatGo supercell export`): string {
+  if (!structure.lattice?.matrix) throw new Error(`POSCAR requires a lattice`)
+  const matrix = structure.lattice.matrix
+  const inv = inverse_3x3(transpose(matrix as Mat3))
+
+  const lines: string[] = [structure.id || structure.formula || comment, `1.0`]
+  for (const row of matrix) {
+    lines.push(`  ${row.map((v) => fmt(v, 10).padStart(20)).join(``)}`)
+  }
+
+  // Count elements preserving first-appearance order.
+  const order: string[] = []
+  const counts: Record<string, number> = {}
+  for (const site of structure.sites) {
+    const el = element_of(site)
+    if (!(el in counts)) {
+      order.push(el)
+      counts[el] = 0
+    }
+    counts[el]++
+  }
+  lines.push(order.join(`  `))
+  lines.push(order.map((el) => counts[el]).join(`  `))
+
+  const has_sel_dyn = structure.sites.some((s) => s.properties?.selective_dynamics)
+  if (has_sel_dyn) lines.push(`Selective dynamics`)
+  lines.push(`Direct`)
+
+  for (const el of order) {
+    for (const site of structure.sites) {
+      if (element_of(site) !== el) continue
+      const frac = site.abc ?? mat_vec(inv, site.xyz)
+      let line = `  ${frac.map((v) => fmt(v, 10).padStart(20)).join(``)}`
+      if (has_sel_dyn) {
+        const sd = (site.properties?.selective_dynamics ?? [true, true, true]) as boolean[]
+        line += ` ${sd[0] ? `T` : `F`} ${sd[1] ? `T` : `F`} ${sd[2] ? `T` : `F`}`
+      }
+      lines.push(line)
+    }
+  }
+  return lines.join(`\n`) + `\n`
+}
+
+// (extended) XYZ. With `include_forces`/lattice this matches structure_to_xyz_str's
+// extxyz comment line; plain XYZ omits the lattice/Properties header extras.
+export function serialize_xyz(structure: CoreStructure, include_forces = false): string {
+  const lines: string[] = [String(structure.sites.length)]
+
+  const has_forces = include_forces &&
+    structure.sites.some((s) => Array.isArray(s.properties?.force))
+
+  if (include_forces) {
+    const comment_parts: string[] = []
+    if (structure.lattice?.matrix?.length === 3) {
+      const lat = structure.lattice.matrix.flat().map((v) => fmt(v, 8)).join(` `)
+      comment_parts.push(`Lattice="${lat}"`)
+    }
+    const cols = [`species:S:1`, `pos:R:3`]
+    if (has_forces) cols.push(`forces:R:3`)
+    comment_parts.push(`Properties="${cols.join(`:`)}"`)
+    if (structure.lattice?.pbc) {
+      comment_parts.push(`pbc="${structure.lattice.pbc.map((v) => (v ? `T` : `F`)).join(` `)}"`)
+    }
+    lines.push(comment_parts.join(` `))
+  } else {
+    lines.push(structure.id || structure.formula || `CatGo supercell export`)
+  }
+
+  for (const site of structure.sites) {
+    const el = element_of(site)
+    const [x, y, z] = site.xyz
+    let line = `${el} ${fmt(x, 8)} ${fmt(y, 8)} ${fmt(z, 8)}`
+    if (has_forces) {
+      const f = site.properties?.force as number[] | undefined
+      line += f && f.length >= 3
+        ? ` ${fmt(f[0], 8)} ${fmt(f[1], 8)} ${fmt(f[2], 8)}`
+        : ` 0.00000000 0.00000000 0.00000000`
+    }
+    lines.push(line)
+  }
+  return lines.join(`\n`) + `\n`
+}
+
+// ─── Combined expand + serialize (the worker's core unit of work) ────────────
+
+export function expand_and_serialize(
+  base: CoreStructure,
+  factors: Vec3,
+  format: SupercellExportFormat,
+): string {
+  const expanded = expand_supercell(base, factors)
+  switch (format) {
+    case `poscar`:
+      return serialize_poscar(expanded)
+    case `xyz`:
+      return serialize_xyz(expanded, false)
+    case `extxyz`:
+      return serialize_xyz(expanded, true)
+    default:
+      throw new Error(`Unsupported supercell export format: ${format}`)
+  }
+}

--- a/src/lib/structure/export/supercell-export.worker.ts
+++ b/src/lib/structure/export/supercell-export.worker.ts
@@ -1,0 +1,48 @@
+/**
+ * Web Worker: expand a logical GPU supercell and serialize it OFF the main
+ * thread so exporting a million-atom supercell doesn't freeze the UI.
+ *
+ * Protocol (main → worker):
+ *   { id, base_structure, factors:[nx,ny,nz], format:'poscar'|'xyz'|'extxyz' }
+ * Reply (worker → main):
+ *   { id, ok:true, text, atom_count } | { id, ok:false, error }
+ *
+ * The heavy work (N× site replication + string build) is all in the pure
+ * `supercell-export-core` module, which has no DOM/WASM deps and runs here.
+ */
+
+import {
+  type CoreStructure,
+  expand_and_serialize,
+  expanded_atom_count,
+  type SupercellExportFormat,
+  type Vec3,
+} from './supercell-export-core'
+
+export interface SupercellExportRequest {
+  id: number
+  base_structure: CoreStructure
+  factors: Vec3
+  format: SupercellExportFormat
+}
+
+export type SupercellExportResponse =
+  | { id: number; ok: true; text: string; atom_count: number }
+  | { id: number; ok: false; error: string }
+
+self.onmessage = (event: MessageEvent<SupercellExportRequest>) => {
+  const { id, base_structure, factors, format } = event.data
+  try {
+    const atom_count = expanded_atom_count(base_structure, factors)
+    const text = expand_and_serialize(base_structure, factors, format)
+    const reply: SupercellExportResponse = { id, ok: true, text, atom_count }
+    ;(self as unknown as Worker).postMessage(reply)
+  } catch (error) {
+    const reply: SupercellExportResponse = {
+      id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+    ;(self as unknown as Worker).postMessage(reply)
+  }
+}

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -975,14 +975,14 @@
     // Bail if disabled / unmounted / superseded while awaiting.
     if (token !== session_token) return
     if (!device) {
-      on_fallback?.(`WebGPU unavailable — staying on the WebGL viewer.`)
+      on_fallback?.(`Large-system performance mode unavailable on this device — using the standard viewer.`)
       return
     }
     let r: LargeSystemRenderer
     try {
       r = create_large_system_renderer(device, el)
     } catch (err) {
-      on_fallback?.(`WebGPU renderer init failed: ${err instanceof Error ? err.message : String(err)}`)
+      on_fallback?.(`Large-system performance mode failed to start — using the standard viewer. (${err instanceof Error ? err.message : String(err)})`)
       return
     }
     renderer = r

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-  import type { Camera } from 'three'
+  import { Color, type Camera } from 'three'
+  import type { AnyStructure, ElementSymbol } from '$lib/structure'
   import { acquire_webgpu_device } from '$lib/structure/gpu/webgpu-context'
-  import { pack_camera_uniform } from '$lib/structure/gpu/camera-uniform'
+  import { pack_camera_full } from '$lib/structure/gpu/camera-uniform'
+  import { pack_positions } from '$lib/structure/gpu/frame-buffers'
+  import { build_atom_radii } from '$lib/structure/gpu/radius-lut'
   import {
     create_large_system_renderer,
     type LargeSystemRenderer,
@@ -10,10 +13,16 @@
   let {
     enabled = false,
     camera = undefined,
+    structure = undefined,
+    element_colors = undefined,
     on_fallback = undefined,
   }: {
     enabled?: boolean
     camera?: Camera | undefined
+    /** Current displayed structure whose atoms render as impostor spheres. */
+    structure?: AnyStructure | undefined
+    /** Per-element hex colors (e.g. state colors.element). */
+    element_colors?: Partial<Record<ElementSymbol, string>> | undefined
     on_fallback?: (reason: string) => void
   } = $props()
 
@@ -26,6 +35,55 @@
   let raf_id = 0
   let resize_observer: ResizeObserver | null = null
   let session_token = 0
+
+  // Cached atom buffers, rebuilt only when the structure identity changes (not
+  // every frame). `atom_source` is the identity sentinel we last built from.
+  let atom_source: AnyStructure | undefined = undefined
+  let atom_positions: Float32Array = new Float32Array(0)
+  let atom_radii: Float32Array = new Float32Array(0)
+  let atom_colors: Float32Array = new Float32Array(0)
+  let atom_count = 0
+  // Track the colors-object identity too, so a color-scheme swap rebuilds.
+  let atom_colors_source: Partial<Record<ElementSymbol, string>> | undefined = undefined
+  // Set when buffers were rebuilt and must be re-uploaded to the GPU.
+  let atoms_dirty = false
+
+  // Hex -> linear RGB, matching the WebGL path (Color.convertSRGBToLinear).
+  const _col = new Color()
+  function hex_to_linear_rgb(hex: string): [number, number, number] {
+    _col.set(hex).convertSRGBToLinear()
+    return [_col.r, _col.g, _col.b]
+  }
+
+  /** Rebuild the flat atom buffers from the current structure + element colors.
+   *  No-op (reuses cached arrays) when neither identity has changed. */
+  function rebuild_atoms_if_needed(): void {
+    if (structure === atom_source && element_colors === atom_colors_source) return
+    atom_source = structure
+    atom_colors_source = element_colors
+    atoms_dirty = true
+    const sites = structure?.sites
+    if (!sites || sites.length === 0) {
+      atom_positions = new Float32Array(0)
+      atom_radii = new Float32Array(0)
+      atom_colors = new Float32Array(0)
+      atom_count = 0
+      return
+    }
+    atom_positions = pack_positions(sites)
+    atom_radii = build_atom_radii(sites)
+    atom_count = sites.length
+    const cols = new Float32Array(sites.length * 3)
+    for (let i = 0; i < sites.length; i++) {
+      const elem = sites[i].species[0]?.element
+      const hex = (elem != null ? element_colors?.[elem] : undefined) ?? `#ffffff`
+      const [r, g, b] = hex_to_linear_rgb(hex)
+      cols[i * 3] = r
+      cols[i * 3 + 1] = g
+      cols[i * 3 + 2] = b
+    }
+    atom_colors = cols
+  }
 
   function stop_session(): void {
     session_token++ // invalidate any in-flight acquire_webgpu_device()
@@ -48,6 +106,11 @@
 
   async function start_session(el: HTMLCanvasElement): Promise<void> {
     const token = ++session_token
+    // Fresh renderer => fresh GPU buffers. Force a rebuild + re-upload on the
+    // first frame even if the structure identity hasn't changed since last time.
+    atom_source = undefined
+    atom_colors_source = undefined
+    atoms_dirty = true
     const device = await acquire_webgpu_device()
     // Bail if disabled / unmounted / superseded while awaiting.
     if (token !== session_token) return
@@ -72,9 +135,16 @@
 
     const frame = () => {
       if (token !== session_token || !renderer) return
+      // Rebuild atom buffers only when the structure / colors identity changed;
+      // re-upload to the GPU only on that same change (static frame otherwise).
+      rebuild_atoms_if_needed()
+      if (atoms_dirty) {
+        renderer.set_atoms(atom_positions, atom_radii, atom_colors, atom_count)
+        atoms_dirty = false
+      }
       if (camera) {
         camera.updateMatrixWorld()
-        renderer.set_camera(pack_camera_uniform(camera))
+        renderer.set_camera_full(pack_camera_full(camera))
       }
       renderer.render()
       raf_id = requestAnimationFrame(frame)

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -37,6 +37,7 @@
     on_fallback = undefined,
     selected_sites = [],
     on_pick = undefined,
+    supercell = [1, 1, 1],
   }: {
     enabled?: boolean
     camera?: Camera | undefined
@@ -132,6 +133,12 @@
      *  The parent updates its `selected_sites` from this; the overlay then mirrors
      *  the new selection into the highlight buffer via the `selected_sites` prop. */
     on_pick?: ((site_idx: number) => void) | undefined
+    /** GPU supercell factors [nx,ny,nz] (Phase 1). When the product > 1 AND the
+     *  structure has a lattice, the parent keeps `structure` at the BASE cell and
+     *  the overlay instances `base_count × nx·ny·nz` spheres on the GPU, each
+     *  offset by ix·a + iy·b + iz·c. Default [1,1,1] ⇒ ncells = 1 ⇒ atom = inst,
+     *  zero offset ⇒ byte-identical to the non-supercell draw. */
+    supercell?: [number, number, number]
   } = $props()
 
   let canvas = $state<HTMLCanvasElement | undefined>(undefined)
@@ -278,6 +285,34 @@
   // is read from bond_lattice (kept in lockstep by rebuild_bonds_if_needed and
   // refresh_frame_positions — including variable-cell trajectories).
   let cell_sig = ``
+
+  // ── GPU supercell state (Phase 1) ──────────────────────────────────────────
+  // Signature of the supercell dims + base lattice last pushed, so set_supercell
+  // is re-pushed only when one actually changes (dims swap, or the base lattice
+  // moves — e.g. cell edit / variable-cell). Default [1,1,1] ⇒ ncells 1 ⇒ the
+  // renderer draws exactly as before.
+  let supercell_sig = ``
+
+  /** Push the GPU supercell dims + base lattice to the renderer when they
+   *  changed. The base lattice is packed from `structure.lattice` (the parent
+   *  keeps `structure` at the BASE cell while GPU-supercell is active). Returns
+   *  true if it re-pushed (caller marks a redraw). */
+  function sync_supercell(): boolean {
+    if (!renderer) return false
+    const dims: [number, number, number] = [
+      Math.max(1, Math.floor(supercell?.[0] ?? 1)),
+      Math.max(1, Math.floor(supercell?.[1] ?? 1)),
+      Math.max(1, Math.floor(supercell?.[2] ?? 1)),
+    ]
+    const lat = (structure as { lattice?: PymatgenLattice } | undefined)?.lattice
+    const base_lat = pack_lattice(lat)
+    let sig = `${dims[0]}x${dims[1]}x${dims[2]}|`
+    for (let i = 0; i < 9; i++) sig += `${base_lat[i]};`
+    if (sig === supercell_sig) return false
+    supercell_sig = sig
+    renderer.set_supercell(dims, base_lat)
+    return true
+  }
 
   // ── Selection highlight state ──────────────────────────────────────────────
   // Signature of the selection last pushed to the renderer, so set_selection is
@@ -799,6 +834,12 @@
     // trajectories where refresh_frame_positions re-packs it per frame.
     if (sync_cell()) dirty = true
 
+    // GPU supercell: push the instancing dims + base lattice when they changed.
+    // ncells > 1 makes the renderer draw base_count × nx·ny·nz sphere instances,
+    // each offset by ix·a + iy·b + iz·c (the CPU stays at the base cell). Default
+    // [1,1,1] ⇒ ncells 1 ⇒ identical draw to today.
+    if (sync_supercell()) dirty = true
+
     // Selection highlight: mirror the app's selected_sites into the GPU highlight
     // buffer when it changed (overlay click OR external selection change).
     if (sync_selection()) dirty = true
@@ -870,6 +911,9 @@
     last_bg = null
     // Fresh renderer ⇒ force the cell box to re-resolve + re-push.
     cell_sig = ``
+    // Fresh renderer ⇒ its supercell defaults to [1,1,1]; force a re-push of the
+    // current dims + base lattice on the first frame.
+    supercell_sig = ``
     // Fresh renderer ⇒ its selection buffer is empty; force a re-push of the
     // current selection on the first frame.
     selection_sig = ``
@@ -1020,6 +1064,21 @@
     // structure/per-frame wakes, which update bond_lattice.)
     show_cell
     cell_edge_color
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // GPU-supercell wake trigger. Track the supercell dims so changing the
+    // requested supercell (e.g. 1×1×1 → 5×5×5) revives a suspended loop; the frame
+    // re-pushes via sync_supercell and repaints once with the new instance count.
+    // (Base-lattice changes are caught by the structure wake, which also drives
+    // the atom/cell rebuilds.)
+    supercell[0]
+    supercell[1]
+    supercell[2]
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -6,6 +6,9 @@
   import { pack_positions, pack_lattice } from '$lib/structure/gpu/frame-buffers'
   import { build_display_radii, build_atom_radii } from '$lib/structure/gpu/radius-lut'
   import { to_compute_options } from '$lib/structure/gpu/large-system-mode.svelte'
+  import { should_show_bonds } from '$lib/structure/scene'
+  import type { ShowBonds } from '$lib/settings'
+  import type { PymatgenLattice } from '$lib/structure'
   import {
     create_large_system_renderer,
     type LargeSystemRenderer,
@@ -21,6 +24,7 @@
     element_radius_overrides = undefined,
     site_radius_overrides = undefined,
     bonding_options = undefined,
+    show_bonds = `crystals`,
     background_color = undefined,
     background_opacity = 0.1,
     show_cell = false,
@@ -52,6 +56,14 @@
      *  detection. Same Record the CPU path reads (scene_props.bonding_options);
      *  mapped via to_compute_options. */
     bonding_options?: Record<string, number> | undefined
+    /** Viewer's bond-visibility setting (`never`/`always`/`crystals`/`molecules`),
+     *  mirroring the WebGL path's `scene_props.show_bonds`. The overlay feeds this
+     *  through the SAME `should_show_bonds(show_bonds, lattice)` predicate the
+     *  WebGL view uses to decide whether bonds appear, so the two stay in lockstep:
+     *  when bonds are hidden the overlay skips the GPU bond compute AND the bond
+     *  draw (atoms + cell box still render). Defaults to `crystals` (the app
+     *  default) so an absent prop matches the typical periodic-structure view. */
+    show_bonds?: ShowBonds
     /** Viewer canvas background color (hex, e.g. `#000000`), mirroring the WebGL
      *  path's StructureScene `background_color`. The overlay resolves this the
      *  SAME way StructureScene's compute_canvas_bg does (lerp toward the theme
@@ -125,6 +137,20 @@
   let bond_compute_opts = { tolerance: 0, max_bond_dist: 0, min_dist: 0 }
   // Set when bond inputs changed and must be re-pushed to the renderer.
   let bonds_dirty = false
+  // Whether bonds should render at all, decided by the SAME predicate the WebGL
+  // path uses (should_show_bonds against the structure's lattice). When false the
+  // overlay skips the GPU bond compute push AND the renderer skips compute+draw,
+  // so flipping the viewer's show_bonds off clears the overlay's bonds while atoms
+  // + cell box keep rendering. Reactive ⇒ toggling show_bonds repaints live.
+  let bonds_visible = $derived(
+    should_show_bonds(
+      show_bonds,
+      ((structure as { lattice?: PymatgenLattice } | undefined)?.lattice) ?? null,
+    ),
+  )
+  // The enabled-state last pushed to the renderer, so we only call
+  // set_bonds_enabled (+ re-push bond data on re-enable) when it actually flips.
+  let last_bonds_enabled = true
 
   // ── Cell-box state ───────────────────────────────────────────────────────
   // Signature of the cell inputs last pushed to the renderer (lattice + show +
@@ -498,11 +524,29 @@
     // when atoms were re-uploaded, since set_atoms moves positions the compute
     // depends on (the renderer already flags itself dirty there, but pushing
     // keeps the covalent radii / count in lockstep with the atom buffer).
-    rebuild_bonds_if_needed()
-    if (bonds_dirty) {
-      renderer.set_bond_data(bond_covalent, bond_lattice, bond_compute_opts, bond_periodic)
-      bonds_dirty = false
+    // Sync bond visibility (should_show_bonds) to the renderer FIRST. Toggling it
+    // gates the renderer's bond compute pass AND bond draw; a flip always forces a
+    // repaint so bonds appear/disappear immediately. On re-enable, the renderer
+    // flags itself bonds_dirty and we also re-push set_bond_data below so the
+    // compute runs against the current atoms/lattice.
+    if (bonds_visible !== last_bonds_enabled) {
+      last_bonds_enabled = bonds_visible
+      renderer.set_bonds_enabled(bonds_visible)
+      if (bonds_visible) bonds_dirty = true // force a re-push + recompute on enable
       dirty = true
+    }
+    // Bond inputs: rebuild + push ONLY while bonds are visible. While hidden we
+    // skip the GPU bond compute push entirely (and the renderer skips compute +
+    // draw), so the overlay shows no bonds — atoms + cell box still render. We
+    // still track the rebuild state so the next time bonds turn back on the
+    // changed inputs are re-pushed (bonds_dirty was set on enable above).
+    if (bonds_visible) {
+      rebuild_bonds_if_needed()
+      if (bonds_dirty) {
+        renderer.set_bond_data(bond_covalent, bond_lattice, bond_compute_opts, bond_periodic)
+        bonds_dirty = false
+        dirty = true
+      }
     }
 
     // Cell box: push the lattice + show + color to the renderer when any of them
@@ -554,6 +598,9 @@
     bond_source = undefined
     bond_options_sig = ``
     bonds_dirty = true
+    // Fresh renderer ⇒ its bonds_enabled defaults to true; match that here so the
+    // first frame re-syncs set_bonds_enabled when bonds are currently hidden.
+    last_bonds_enabled = true
     // Fresh renderer ⇒ force a per-frame re-extract + re-upload on the first
     // frame, and re-detect the lattice for variable-cell bonds.
     last_pos_version = -1
@@ -667,6 +714,20 @@
     // source — consistent with the WebGL path's own mutation-observer resync.)
     background_color
     background_opacity
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // Bond-visibility wake trigger. Read bonds_visible (derived from show_bonds +
+    // the structure's lattice) so flipping the viewer's "show bonds" setting
+    // revives a suspended loop; the frame syncs set_bonds_enabled and repaints
+    // once — bonds appear/disappear while atoms + cell box stay. Reading the
+    // derived here (not in the session effect) wakes without restarting the GPU
+    // session.
+    bonds_visible
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -1050,14 +1050,7 @@
     // these here (not in the session effect) wakes without restarting the GPU
     // session. The `frame` does the actual rebuild + upload via
     // rebuild_atoms_if_needed(). Force the next frame to draw regardless.
-    structure
-    element_colors
-    atom_radius
-    same_size_atoms
-    element_radius_overrides
-    site_radius_overrides
-    bonding_options
-    bond_distance_rules
+    void [structure, element_colors, atom_radius, same_size_atoms, element_radius_overrides, site_radius_overrides, bonding_options, bond_distance_rules]
     if (renderer) {
       needs_render = true
       wake()
@@ -1073,8 +1066,7 @@
     // these here (not in the session effect) wakes without restarting the GPU
     // session; when playback stops, .v stops bumping ⇒ no more wakes ⇒ the loop
     // suspends after its grace period (idle-quiet).
-    trajectory_positions_version?.v
-    trajectory_step_idx
+    void [trajectory_positions_version?.v, trajectory_step_idx]
     if (renderer) {
       needs_render = true
       wake()
@@ -1087,8 +1079,7 @@
     // clear color via sync_background and repaints once. (Theme changes that
     // don't bump these props are caught lazily on the next wake from any other
     // source — consistent with the WebGL path's own mutation-observer resync.)
-    background_color
-    background_opacity
+    void [background_color, background_opacity]
     if (renderer) {
       needs_render = true
       wake()
@@ -1102,7 +1093,7 @@
     // once — bonds appear/disappear while atoms + cell box stay. Reading the
     // derived here (not in the session effect) wakes without restarting the GPU
     // session.
-    bonds_visible
+    void bonds_visible
     if (renderer) {
       needs_render = true
       wake()
@@ -1114,8 +1105,7 @@
     // cell on/off or recoloring it revives a suspended loop; the frame re-pushes
     // via sync_cell and repaints once. (Lattice changes are caught by the
     // structure/per-frame wakes, which update bond_lattice.)
-    show_cell
-    cell_edge_color
+    void [show_cell, cell_edge_color]
     if (renderer) {
       needs_render = true
       wake()
@@ -1128,9 +1118,7 @@
     // re-pushes via sync_supercell and repaints once with the new instance count.
     // (Base-lattice changes are caught by the structure wake, which also drives
     // the atom/cell rebuilds.)
-    supercell[0]
-    supercell[1]
-    supercell[2]
+    void [supercell[0], supercell[1], supercell[2]]
     if (renderer) {
       needs_render = true
       wake()
@@ -1142,7 +1130,7 @@
     // image atoms revives a suspended loop; the frame re-pushes via sync_show_images
     // (which marks the renderer bonds dirty) and repaints once with full-to-image
     // bonds (on) or stubs (off).
-    show_image_atoms
+    void show_image_atoms
     if (renderer) {
       needs_render = true
       wake()
@@ -1155,7 +1143,7 @@
     // loop; the frame mirrors it into the GPU highlight buffer via sync_selection
     // and repaints once. Reading it here (not in the session effect) wakes without
     // restarting the GPU session.
-    selected_sites
+    void selected_sites
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -140,17 +140,35 @@
       cancelAnimationFrame(raf_id)
       raf_id = 0
     }
+    if (on_wake_event && typeof window !== `undefined`) {
+      window.removeEventListener(`pointerdown`, on_wake_event)
+      window.removeEventListener(`pointermove`, on_wake_event)
+      window.removeEventListener(`wheel`, on_wake_event)
+      window.removeEventListener(`keydown`, on_wake_event)
+    }
+    on_wake_event = null
     resize_observer?.disconnect()
     resize_observer = null
     renderer?.destroy()
     renderer = null
   }
 
-  // On-demand render state. We keep a RAF tick but only issue a GPU draw when
-  // something changed since the last drawn frame: camera moved, atom buffers
-  // re-uploaded, or a resize happened. Avoids continuous GPU load when idle.
+  // On-demand render state. The rAF loop is self-suspending: it only runs while
+  // there is motion (camera change, atom re-upload, or resize) and goes fully to
+  // sleep — cancelAnimationFrame + raf_id=0, NO further scheduling — once the
+  // camera has been stable for a short grace period. Interaction / data / size
+  // events call wake() to restart it. This keeps the compositor/GPU idle (fan
+  // quiet) when nothing is moving, instead of pinning a perpetual ~60fps tick.
   let last_camera_uniform: Float32Array | null = null
   let needs_render = true // force the first frame
+  // Consecutive frames with no change seen so far. When this reaches
+  // STABLE_FRAMES_TO_SLEEP the loop suspends. The grace tail (~0.4s @ 60fps)
+  // lets control inertia/momentum settle before we stop scheduling.
+  let stable_frames = 0
+  const STABLE_FRAMES_TO_SLEEP = 24
+
+  // Bound listener handles, kept so teardown can remove exactly what it added.
+  let on_wake_event: ((ev: Event) => void) | null = null
 
   /** True if `next` differs from the last uploaded camera uniform (epsilon
    *  compare). Updates the cached copy when it returns true. */
@@ -177,6 +195,64 @@
     needs_render = true // resized backing store/depth must repaint
   }
 
+  /** Restart the suspended rAF loop. Resets the stable-frame counter so the
+   *  loop runs for at least a full grace period, and schedules a frame only if
+   *  none is pending and the session is live. Idempotent while already awake. */
+  function wake(): void {
+    if (!enabled || !renderer) return
+    stable_frames = 0
+    if (raf_id === 0) raf_id = requestAnimationFrame(frame)
+  }
+
+  // Token the current loop belongs to. The `frame` closure lives at component
+  // scope (so wake()/listeners can reschedule it) and re-reads this to bail when
+  // its session has been superseded or torn down.
+  let frame_token = 0
+
+  function frame(): void {
+    if (frame_token !== session_token || !renderer) {
+      raf_id = 0
+      return
+    }
+    // Only issue a GPU draw when something changed since the last drawn frame.
+    let dirty = needs_render
+    needs_render = false
+
+    // Rebuild atom buffers only when the structure / colors / radius inputs
+    // changed; re-upload + mark dirty on that same change.
+    rebuild_atoms_if_needed()
+    if (atoms_dirty) {
+      renderer.set_atoms(atom_positions, atom_radii, atom_colors, atom_count)
+      atoms_dirty = false
+      dirty = true
+    }
+
+    // Camera: pack always (cheap), upload + mark dirty only when it moved.
+    if (camera) {
+      camera.updateMatrixWorld()
+      const packed = pack_camera_full(camera)
+      if (camera_changed(packed)) {
+        renderer.set_camera_full(packed)
+        dirty = true
+      }
+    }
+
+    if (dirty) {
+      renderer.render()
+      stable_frames = 0 // motion this frame ⇒ stay awake
+    } else {
+      stable_frames++
+    }
+
+    // Suspend once the scene has been stable through the grace period: cancel
+    // and stop scheduling entirely. wake() (interaction/data/resize) revives it.
+    if (stable_frames >= STABLE_FRAMES_TO_SLEEP) {
+      raf_id = 0
+      return
+    }
+    raf_id = requestAnimationFrame(frame)
+  }
+
   async function start_session(el: HTMLCanvasElement): Promise<void> {
     const token = ++session_token
     // Fresh renderer => fresh GPU buffers. Force a rebuild + re-upload on the
@@ -188,6 +264,7 @@
     // Fresh GPU camera buffer ⇒ force a first paint and a re-upload.
     last_camera_uniform = null
     needs_render = true
+    stable_frames = 0
     const device = await acquire_webgpu_device()
     // Bail if disabled / unmounted / superseded while awaiting.
     if (token !== session_token) return
@@ -203,43 +280,31 @@
       return
     }
     renderer = r
+    frame_token = token
     size_to_client(el)
 
+    // Resize: repaint the new backing store and wake the loop if it had slept.
     resize_observer = new ResizeObserver(() => {
-      if (renderer && canvas) size_to_client(canvas)
+      if (renderer && canvas) {
+        size_to_client(canvas)
+        wake()
+      }
     })
     resize_observer.observe(el)
 
-    const frame = () => {
-      if (token !== session_token || !renderer) return
-      // Per-frame dirty check — only issue a GPU draw when something changed.
-      // We still rAF every frame (cheap) but early-return before render() when
-      // the scene is idle, so the GPU isn't redrawing a static frame forever.
-      let dirty = needs_render
-      needs_render = false
-
-      // Rebuild atom buffers only when the structure / colors / radius inputs
-      // changed; re-upload + mark dirty on that same change.
-      rebuild_atoms_if_needed()
-      if (atoms_dirty) {
-        renderer.set_atoms(atom_positions, atom_radii, atom_colors, atom_count)
-        atoms_dirty = false
-        dirty = true
-      }
-
-      // Camera: pack always (cheap), upload + mark dirty only when it moved.
-      if (camera) {
-        camera.updateMatrixWorld()
-        const packed = pack_camera_full(camera)
-        if (camera_changed(packed)) {
-          renderer.set_camera_full(packed)
-          dirty = true
-        }
-      }
-
-      if (dirty) renderer.render()
-      raf_id = requestAnimationFrame(frame)
+    // Interaction wake triggers. The overlay canvas is pointer-events:none, so
+    // we listen on `window` (passive — we never preventDefault). Each event just
+    // revives the suspended loop; the frame itself decides whether to redraw.
+    on_wake_event = () => wake()
+    if (typeof window !== `undefined`) {
+      window.addEventListener(`pointerdown`, on_wake_event, { passive: true })
+      window.addEventListener(`pointermove`, on_wake_event, { passive: true })
+      window.addEventListener(`wheel`, on_wake_event, { passive: true })
+      window.addEventListener(`keydown`, on_wake_event)
     }
+
+    // First frame: render once and start the loop. It self-suspends after the
+    // grace period if the camera never moves.
     raf_id = requestAnimationFrame(frame)
   }
 
@@ -253,6 +318,24 @@
     // disabled or no canvas yet: ensure nothing is running.
     stop_session()
     return undefined
+  })
+
+  $effect(() => {
+    // Atom-data wake trigger. Track the structure / color / radius inputs so a
+    // rebuild revives a suspended loop and the new atoms repaint once. Reading
+    // these here (not in the session effect) wakes without restarting the GPU
+    // session. The `frame` does the actual rebuild + upload via
+    // rebuild_atoms_if_needed(). Force the next frame to draw regardless.
+    structure
+    element_colors
+    atom_radius
+    same_size_atoms
+    element_radius_overrides
+    site_radius_overrides
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
   })
 </script>
 

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -193,6 +193,30 @@
   // Set when the encoded rules changed and must be re-pushed to the renderer.
   let rules_dirty = false
 
+  /** Count of HOME (non-image) atoms in the displayed structure — the atoms the
+   *  GPU bond compute must run over, matching the WebGL bond path which computes
+   *  bonds on `bond_input_structure` (= supercell_structure, BEFORE PBC image
+   *  expansion). When `show_image_atoms` is ON, find_pbc_images_fast APPENDS
+   *  boundary replica atoms to displayed_structure.sites (indices ≥
+   *  num_original_sites), each sitting ~one lattice vector OUTSIDE the cell. If
+   *  those replicas were fed into the PERIODIC min-image bond compute (which uses
+   *  the supercell lattice), the search would wrap a replica back across a full
+   *  lattice vector → a bond cylinder spanning the whole supercell = the "spike"
+   *  artefact. The home atoms are always the FIRST num_original_sites entries
+   *  (create_supercell home block first, then find_pbc_images_fast pushes
+   *  replicas after), so slicing the bond inputs to this count feeds the compute
+   *  the exact home-atom set the WebGL path uses. Cross-cell bonds still appear
+   *  via the periodic search's jimage on those home atoms; the replica spheres
+   *  render but never participate in bonding (no double-count, no wrap). When no
+   *  images are present (toggle OFF, or molecule) this is just sites.length. */
+  function bond_home_count(): number {
+    const sites = structure?.sites
+    const n = sites?.length ?? 0
+    const num_orig = (structure as { num_original_sites?: number } | undefined)?.num_original_sites
+    if (typeof num_orig === `number` && num_orig > 0 && num_orig <= n) return num_orig
+    return n
+  }
+
   /** Cheap signature of the bond_distance_rules array; changes when any rule's
    *  elements or min/max do, so the GPU post-filter re-encodes + re-dispatches. */
   function bond_rules_signature(): string {
@@ -219,8 +243,15 @@
       rule_packed = new Float32Array(0)
       return
     }
+    // Encode element ids over the HOME atoms only, in lockstep with bond_covalent
+    // (the compute indexes elem_ids[i]/elem_ids[j] by the same atom index it uses
+    // for radii). Slicing off appended PBC-image replicas keeps the two buffers
+    // the same length (= bond_n) so the per-element-pair rule post-filter stays
+    // aligned with the home-atom bond compute.
+    const home_n = bond_home_count()
+    const bond_sites = home_n < sites.length ? sites.slice(0, home_n) : sites
     const encoded = encode_bond_rules(
-      sites,
+      bond_sites,
       (bond_distance_rules ?? []) as BondDistanceRuleLike[],
     )
     rule_elem_ids = encoded.elem_ids
@@ -379,7 +410,13 @@
       bond_periodic = false
       return
     }
-    bond_covalent = build_atom_radii(sites)
+    // Bond compute runs over HOME atoms only (see bond_home_count): slice off
+    // any appended PBC-image replicas so the periodic min-image search can't wrap
+    // a replica across a full lattice vector → no spikes. Matches the WebGL bond
+    // path (bonds on supercell_structure, replicas drawn but not bonded).
+    const home_n = bond_home_count()
+    const bond_sites = home_n < sites.length ? sites.slice(0, home_n) : sites
+    bond_covalent = build_atom_radii(bond_sites)
     // Periodic only when the structure carries a lattice (molecules don't).
     const lat = (structure as { lattice?: import('$lib/structure').PymatgenLattice }).lattice
     bond_lattice = pack_lattice(lat)

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -63,12 +63,6 @@
     atom_colors_source = element_colors
     atoms_dirty = true
     const sites = structure?.sites
-    // TODO(9.2-debug) remove
-    console.log(
-      `[lsr] rebuild atoms, sites=`, sites?.length ?? 0,
-      `structure?`, structure != null,
-      `element_colors?`, element_colors != null,
-    )
     if (!sites || sites.length === 0) {
       atom_positions = new Float32Array(0)
       atom_radii = new Float32Array(0)

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -5,6 +5,7 @@
   import { pack_camera_full } from '$lib/structure/gpu/camera-uniform'
   import { pack_positions, pack_lattice } from '$lib/structure/gpu/frame-buffers'
   import { build_display_radii, build_atom_radii } from '$lib/structure/gpu/radius-lut'
+  import { encode_bond_rules, type BondDistanceRuleLike } from '$lib/structure/gpu/bond-rules'
   import { to_compute_options } from '$lib/structure/gpu/large-system-mode.svelte'
   import { should_show_bonds } from '$lib/structure/scene'
   import type { ShowBonds } from '$lib/settings'
@@ -24,6 +25,7 @@
     element_radius_overrides = undefined,
     site_radius_overrides = undefined,
     bonding_options = undefined,
+    bond_distance_rules = undefined,
     show_bonds = `crystals`,
     background_color = undefined,
     background_opacity = 0.1,
@@ -56,6 +58,16 @@
      *  detection. Same Record the CPU path reads (scene_props.bonding_options);
      *  mapped via to_compute_options. */
     bonding_options?: Record<string, number> | undefined
+    /** Per-element-pair distance rules (the SAME `bond_distance_rules` the WebGL
+     *  path reads). The overlay applies them as a POST-FILTER on the GPU-detected
+     *  bonds, reproducing src/lib/structure/scene/visibility.ts exactly: for a
+     *  detected bond with length d and element pair (eA,eB), if a rule exists for
+     *  the SORTED pair it keeps the bond only when min ≤ d ≤ max, and if no rule
+     *  exists it keeps the bond. Rules can only REMOVE strategy-detected bonds.
+     *  Empty / undefined ⇒ no filtering (behaviour identical to no rules). */
+    bond_distance_rules?:
+      | { element_1: string; element_2: string; min_dist: number; max_dist: number }[]
+      | undefined
     /** Viewer's bond-visibility setting (`never`/`always`/`crystals`/`molecules`),
      *  mirroring the WebGL path's `scene_props.show_bonds`. The overlay feeds this
      *  through the SAME `should_show_bonds(show_bonds, lattice)` predicate the
@@ -137,6 +149,52 @@
   let bond_compute_opts = { tolerance: 0, max_bond_dist: 0, min_dist: 0 }
   // Set when bond inputs changed and must be re-pushed to the renderer.
   let bonds_dirty = false
+
+  // ── Per-element-pair distance-rule state ───────────────────────────────────
+  // Encoded inputs for the GPU rule POST-FILTER (per-atom element ids + packed
+  // rules), rebuilt when the structure identity OR the rules change. Pushed to
+  // the renderer via set_bond_rules; the renderer re-runs the compute so editing
+  // a rule updates the overlay bonds LIVE. Empty rules ⇒ no filtering.
+  let rules_source: AnyStructure | undefined = undefined
+  let rules_sig = ``
+  let rule_elem_ids: Uint32Array = new Uint32Array(0)
+  let rule_packed: Float32Array = new Float32Array(0)
+  // Set when the encoded rules changed and must be re-pushed to the renderer.
+  let rules_dirty = false
+
+  /** Cheap signature of the bond_distance_rules array; changes when any rule's
+   *  elements or min/max do, so the GPU post-filter re-encodes + re-dispatches. */
+  function bond_rules_signature(): string {
+    const rs = bond_distance_rules
+    if (!rs || rs.length === 0) return ``
+    let s = ``
+    for (const r of rs) s += `${r.element_1}-${r.element_2}:${r.min_dist},${r.max_dist};`
+    return s
+  }
+
+  /** Re-encode the per-atom element ids + packed rules when the structure identity
+   *  or the rules changed. Pure JS (encode_bond_rules); no-op otherwise. Note the
+   *  elem-id mapping is per-structure, so a structure swap MUST re-encode even if
+   *  the rules text is unchanged. */
+  function rebuild_rules_if_needed(): void {
+    const sig = bond_rules_signature()
+    if (structure === rules_source && sig === rules_sig) return
+    rules_source = structure
+    rules_sig = sig
+    rules_dirty = true
+    const sites = structure?.sites
+    if (!sites || sites.length === 0) {
+      rule_elem_ids = new Uint32Array(0)
+      rule_packed = new Float32Array(0)
+      return
+    }
+    const encoded = encode_bond_rules(
+      sites,
+      (bond_distance_rules ?? []) as BondDistanceRuleLike[],
+    )
+    rule_elem_ids = encoded.elem_ids
+    rule_packed = encoded.rules
+  }
   // Whether bonds should render at all, decided by the SAME predicate the WebGL
   // path uses (should_show_bonds against the structure's lattice). When false the
   // overlay skips the GPU bond compute push AND the renderer skips compute+draw,
@@ -547,6 +605,17 @@
         bonds_dirty = false
         dirty = true
       }
+      // Per-element-pair distance-rule POST-FILTER: re-encode on structure/rule
+      // change and push the per-atom element ids + packed rules. The renderer
+      // re-runs the bond compute so editing a rule updates the overlay LIVE.
+      // Pushed AFTER set_bond_data (which also flags the renderer bonds_dirty),
+      // so a combined change still results in a single recompute next render.
+      rebuild_rules_if_needed()
+      if (rules_dirty) {
+        renderer.set_bond_rules(rule_elem_ids, rule_packed)
+        rules_dirty = false
+        dirty = true
+      }
     }
 
     // Cell box: push the lattice + show + color to the renderer when any of them
@@ -598,6 +667,11 @@
     bond_source = undefined
     bond_options_sig = ``
     bonds_dirty = true
+    // Fresh renderer ⇒ its rule buffers are placeholders; force a re-encode +
+    // re-push of the per-atom element ids + packed rules on the first frame.
+    rules_source = undefined
+    rules_sig = ``
+    rules_dirty = true
     // Fresh renderer ⇒ its bonds_enabled defaults to true; match that here so the
     // first frame re-syncs set_bonds_enabled when bonds are currently hidden.
     last_bonds_enabled = true
@@ -683,6 +757,7 @@
     element_radius_overrides
     site_radius_overrides
     bonding_options
+    bond_distance_rules
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -312,12 +312,27 @@
       pos = get_trajectory_frame_positions(trajectory_step_idx)
     }
     // The getter is indexed against the BASE frame sites; when the displayed
-    // structure carries supercell / PBC-image atoms it is longer than that
-    // array. Only adopt the getter's xyz when it covers every displayed atom —
-    // otherwise fall back to the structure's own (slow-path-updated) sites xyz,
-    // which always matches sites.length. (Guards against a short writeBuffer in
-    // set_positions; in that case image/supercell atoms just track sites.xyz.)
-    frame_positions = pos && pos.length >= sites.length * 3 ? pos : pack_positions(sites)
+    // structure carries supercell / PBC-image atoms it is LONGER than the
+    // getter's array (base + replicas). PARTIAL-APPLY rather than all-or-nothing:
+    //   1. Start from the static topology positions for EVERY displayed atom
+    //      (pack_positions(sites)) — this gives the replica/image atoms their
+    //      correct topology-load positions (the documented supercell limitation).
+    //   2. If the getter yielded per-frame xyz (non-null), OVERWRITE the leading
+    //      floats with it — those are the BASE atoms, which therefore ANIMATE per
+    //      frame. We copy min(frame_pos.length, topology.length) floats so a short
+    //      OR an oversized getter array can never write out of bounds.
+    //   3. Replica/image atoms (beyond the base block) keep their topology xyz.
+    // Result: non-supercell (frame_pos covers all atoms) ⇒ every atom gets its
+    // per-frame xyz, identical to before. Supercell (frame_pos covers only the
+    // base block) ⇒ base atoms animate, replicas stay at topology — the
+    // trajectory PLAYS instead of freezing on frame 1. Getter null/unavailable ⇒
+    // pure static topology positions, exactly as the prior fallback.
+    const topology = pack_positions(sites)
+    if (pos) {
+      const n = Math.min(pos.length, topology.length)
+      topology.set(pos.subarray(0, n))
+    }
+    frame_positions = topology
     positions_dirty = true
 
     // Variable-cell: if the displayed lattice changed, the bond compute + bond

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -417,6 +417,27 @@
       bond_lattice = packed
       bond_periodic = !!lat
       bonds_dirty = true
+      // Phase 3 — variable-cell supercell tracking: the GPU supercell uniform's
+      // base lattice (rows a,b,c) feeds each replica's offset (ix·a + iy·b +
+      // iz·c). For a VARIABLE-CELL trajectory that base cell changes per frame,
+      // so the uniform must be re-uploaded with the new lattice or the replicas
+      // keep their frame-0 spacing (drift / overlap as the cell breathes). Only
+      // when a real supercell is active (product > 1) — at 1×1×1 ncells is 1 and
+      // the offset is always zero, so this is a no-op cost we skip entirely. We
+      // reuse the lattice we JUST packed (no second pack_lattice) and keep the
+      // dims unchanged (they're constant during playback). sync_supercell() runs
+      // later in frame(); refreshing supercell_sig here keeps the two in lockstep
+      // so it doesn't redundantly re-push the same lattice it sees this frame.
+      const nx = Math.max(1, Math.floor(supercell?.[0] ?? 1))
+      const ny = Math.max(1, Math.floor(supercell?.[1] ?? 1))
+      const nz = Math.max(1, Math.floor(supercell?.[2] ?? 1))
+      if (renderer && nx * ny * nz > 1) {
+        const dims: [number, number, number] = [nx, ny, nz]
+        renderer.set_supercell(dims, packed)
+        let scs = `${nx}x${ny}x${nz}|`
+        for (let i = 0; i < 9; i++) scs += `${packed[i]};`
+        supercell_sig = scs
+      }
     }
   }
 

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -35,6 +35,8 @@
     get_trajectory_frame_positions = undefined,
     trajectory_step_idx = -1,
     on_fallback = undefined,
+    selected_sites = [],
+    on_pick = undefined,
   }: {
     enabled?: boolean
     camera?: Camera | undefined
@@ -111,6 +113,16 @@
      *  get_trajectory_frame_positions. -1 when no trajectory is active. */
     trajectory_step_idx?: number
     on_fallback?: (reason: string) => void
+    /** App selection state (base site indices, same as the WebGL path's
+     *  `selected_sites`). Mirrored into the overlay's GPU highlight buffer so the
+     *  selected atoms glow — kept in sync whether selection changes via an overlay
+     *  click (on_pick) or externally (toolbar, other panes). */
+    selected_sites?: number[]
+    /** Called when the user CLICKS (not drags) an atom in the overlay. `site_idx`
+     *  is the picked atom's base site index, or -1 for empty space (background).
+     *  The parent updates its `selected_sites` from this; the overlay then mirrors
+     *  the new selection into the highlight buffer via the `selected_sites` prop. */
+    on_pick?: ((site_idx: number) => void) | undefined
   } = $props()
 
   let canvas = $state<HTMLCanvasElement | undefined>(undefined)
@@ -216,6 +228,23 @@
   // is read from bond_lattice (kept in lockstep by rebuild_bonds_if_needed and
   // refresh_frame_positions — including variable-cell trajectories).
   let cell_sig = ``
+
+  // ── Selection highlight state ──────────────────────────────────────────────
+  // Signature of the selection last pushed to the renderer, so set_selection is
+  // re-uploaded only when selected_sites actually changes (whether from an overlay
+  // click or an external selection change).
+  let selection_sig = ``
+
+  /** Mirror the app's `selected_sites` into the renderer's GPU highlight buffer
+   *  when it changed. Returns true if it re-pushed (caller marks a redraw). */
+  function sync_selection(): boolean {
+    if (!renderer) return false
+    const sig = (selected_sites ?? []).join(`,`)
+    if (sig === selection_sig) return false
+    selection_sig = sig
+    renderer.set_selection(selected_sites ?? [])
+    return true
+  }
 
   /** Push the unit-cell box to the renderer when its inputs (lattice / show /
    *  color) changed. Uses bond_lattice as the lattice source (already packed +
@@ -467,13 +496,19 @@
       cancelAnimationFrame(raf_id)
       raf_id = 0
     }
-    if (on_wake_event && typeof window !== `undefined`) {
-      window.removeEventListener(`pointerdown`, on_wake_event)
-      window.removeEventListener(`pointermove`, on_wake_event)
-      window.removeEventListener(`wheel`, on_wake_event)
-      window.removeEventListener(`keydown`, on_wake_event)
+    if (typeof window !== `undefined`) {
+      if (on_wake_event) {
+        window.removeEventListener(`pointerdown`, on_wake_event)
+        window.removeEventListener(`pointermove`, on_wake_event)
+        window.removeEventListener(`wheel`, on_wake_event)
+        window.removeEventListener(`keydown`, on_wake_event)
+      }
+      if (on_pointer_down) window.removeEventListener(`pointerdown`, on_pointer_down)
+      if (on_pointer_up) window.removeEventListener(`pointerup`, on_pointer_up)
     }
     on_wake_event = null
+    on_pointer_down = null
+    on_pointer_up = null
     resize_observer?.disconnect()
     resize_observer = null
     renderer?.destroy()
@@ -496,6 +531,44 @@
 
   // Bound listener handles, kept so teardown can remove exactly what it added.
   let on_wake_event: ((ev: Event) => void) | null = null
+
+  // ── Click-to-pick state ────────────────────────────────────────────────────
+  // The overlay canvas is pointer-events:none so camera drags pass through to the
+  // WebGL controls underneath. To pick WITHOUT stealing camera control we watch
+  // window pointerdown/up: a pointerup close to the pointerdown (minimal movement)
+  // is a CLICK ⇒ pick; movement beyond the threshold is a DRAG (camera rotate) ⇒
+  // ignore. We never preventDefault, so the underlying controls always get the
+  // drag. Bound listener handles for exact teardown.
+  let on_pointer_down: ((ev: PointerEvent) => void) | null = null
+  let on_pointer_up: ((ev: PointerEvent) => void) | null = null
+  // pointerdown anchor (client coords) + button, used to classify the gesture.
+  let down_x = 0
+  let down_y = 0
+  let down_button = -1
+  // Max client-pixel movement between down and up that still counts as a click.
+  const CLICK_MOVE_PX = 4
+
+  /** Pick the atom under the given CLIENT (cursor) coords and notify the parent.
+   *  Maps client → canvas-local CSS px → device px (× devicePixelRatio), the same
+   *  space the pick id texture is rendered at. Only fires when the cursor is over
+   *  the canvas. Calls on_pick(site_idx) with the picked base site index, or -1
+   *  for background (empty space) so the parent can clear the selection. */
+  async function pick_at_client(client_x: number, client_y: number): Promise<void> {
+    if (!renderer || !canvas || !on_pick) return
+    const rect = canvas.getBoundingClientRect()
+    // Ignore clicks outside the viewer canvas (e.g. on toolbars / panes).
+    if (
+      client_x < rect.left || client_x > rect.right ||
+      client_y < rect.top || client_y > rect.bottom
+    ) {
+      return
+    }
+    const dpr = typeof window !== `undefined` ? window.devicePixelRatio || 1 : 1
+    const x = (client_x - rect.left) * dpr
+    const y = (client_y - rect.top) * dpr
+    const idx = await renderer.pick(x, y)
+    on_pick(idx)
+  }
 
   /** True if `next` differs from the last uploaded camera uniform (epsilon
    *  compare). Updates the cached copy when it returns true. */
@@ -624,6 +697,10 @@
     // trajectories where refresh_frame_positions re-packs it per frame.
     if (sync_cell()) dirty = true
 
+    // Selection highlight: mirror the app's selected_sites into the GPU highlight
+    // buffer when it changed (overlay click OR external selection change).
+    if (sync_selection()) dirty = true
+
     // Background: resolve the viewer's bg color (theme/opacity/picked) and push
     // it to the renderer only when it changed. A change repaints so the new
     // clear color shows. Cheap when static (string compare + no GPU work).
@@ -687,6 +764,9 @@
     last_bg = null
     // Fresh renderer ⇒ force the cell box to re-resolve + re-push.
     cell_sig = ``
+    // Fresh renderer ⇒ its selection buffer is empty; force a re-push of the
+    // current selection on the first frame.
+    selection_sig = ``
     needs_render = true
     stable_frames = 0
     const device = await acquire_webgpu_device()
@@ -720,11 +800,29 @@
     // we listen on `window` (passive — we never preventDefault). Each event just
     // revives the suspended loop; the frame itself decides whether to redraw.
     on_wake_event = () => wake()
+    // Click-to-pick: record the pointerdown anchor; on pointerup decide click vs
+    // drag. Only the primary (left) button picks; we never preventDefault so the
+    // underlying WebGL orbit/trackball controls still receive every drag.
+    on_pointer_down = (ev: PointerEvent) => {
+      down_x = ev.clientX
+      down_y = ev.clientY
+      down_button = ev.button
+    }
+    on_pointer_up = (ev: PointerEvent) => {
+      if (ev.button !== 0 || down_button !== 0) return
+      const moved = Math.hypot(ev.clientX - down_x, ev.clientY - down_y)
+      if (moved > CLICK_MOVE_PX) return // a drag (camera rotate) — not a pick
+      // A click: render a fresh pick frame and feed the result to the parent.
+      // (fire-and-forget; the async readback resolves shortly after.)
+      void pick_at_client(ev.clientX, ev.clientY)
+    }
     if (typeof window !== `undefined`) {
       window.addEventListener(`pointerdown`, on_wake_event, { passive: true })
       window.addEventListener(`pointermove`, on_wake_event, { passive: true })
       window.addEventListener(`wheel`, on_wake_event, { passive: true })
       window.addEventListener(`keydown`, on_wake_event)
+      window.addEventListener(`pointerdown`, on_pointer_down, { passive: true })
+      window.addEventListener(`pointerup`, on_pointer_up, { passive: true })
     }
 
     // First frame: render once and start the loop. It self-suspends after the
@@ -816,6 +914,19 @@
     // structure/per-frame wakes, which update bond_lattice.)
     show_cell
     cell_edge_color
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // Selection wake trigger. Track selected_sites so an external selection change
+    // (toolbar, other panes, or our own on_pick round-trip) revives a suspended
+    // loop; the frame mirrors it into the GPU highlight buffer via sync_selection
+    // and repaints once. Reading it here (not in the session effect) wakes without
+    // restarting the GPU session.
+    selected_sites
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -575,17 +575,7 @@
     const scale_y = rect.height > 0 ? canvas.height / rect.height : 1
     const x = (client_x - rect.left) * scale_x
     const y = (client_y - rect.top) * scale_y
-    // TODO(pick-debug): strip once verified. Logs the full client→device mapping.
-    const dpr = typeof window !== `undefined` ? window.devicePixelRatio || 1 : 1
-    console.log(`[pick-debug] client`, { client_x, client_y }, `rect`, {
-      left: rect.left, top: rect.top, width: rect.width, height: rect.height,
-    }, `dpr`, dpr, `canvas`, { w: canvas.width, h: canvas.height }, `scale`, {
-      scale_x, scale_y,
-    }, `device`, { x, y })
     const idx = await renderer.pick(x, y)
-    // TODO(pick-debug): strip once verified. Logs the picked index + selection.
-    console.log(`[pick-debug] on_pick(base_idx=`, idx, `) selected_sites(before)=`,
-      [...(selected_sites ?? [])])
     on_pick(idx)
   }
 

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import type { Camera } from 'three'
+  import { acquire_webgpu_device } from '$lib/structure/gpu/webgpu-context'
+  import { pack_camera_uniform } from '$lib/structure/gpu/camera-uniform'
+  import {
+    create_large_system_renderer,
+    type LargeSystemRenderer,
+  } from '$lib/structure/gpu/large-system-renderer'
+
+  let {
+    enabled = false,
+    camera = undefined,
+    on_fallback = undefined,
+  }: {
+    enabled?: boolean
+    camera?: Camera | undefined
+    on_fallback?: (reason: string) => void
+  } = $props()
+
+  let canvas = $state<HTMLCanvasElement | undefined>(undefined)
+
+  // Active session resources. Kept outside $state — they are imperative GPU
+  // handles, not reactive view data, and we don't want effects to re-run on
+  // mutation. A monotonically increasing token cancels stale async starts.
+  let renderer: LargeSystemRenderer | null = null
+  let raf_id = 0
+  let resize_observer: ResizeObserver | null = null
+  let session_token = 0
+
+  function stop_session(): void {
+    session_token++ // invalidate any in-flight acquire_webgpu_device()
+    if (raf_id) {
+      cancelAnimationFrame(raf_id)
+      raf_id = 0
+    }
+    resize_observer?.disconnect()
+    resize_observer = null
+    renderer?.destroy()
+    renderer = null
+  }
+
+  function size_to_client(el: HTMLCanvasElement): void {
+    const dpr = typeof window !== `undefined` ? window.devicePixelRatio || 1 : 1
+    const w = el.clientWidth * dpr
+    const h = el.clientHeight * dpr
+    renderer?.resize(w, h)
+  }
+
+  async function start_session(el: HTMLCanvasElement): Promise<void> {
+    const token = ++session_token
+    const device = await acquire_webgpu_device()
+    // Bail if disabled / unmounted / superseded while awaiting.
+    if (token !== session_token) return
+    if (!device) {
+      on_fallback?.(`WebGPU unavailable — staying on the WebGL viewer.`)
+      return
+    }
+    let r: LargeSystemRenderer
+    try {
+      r = create_large_system_renderer(device, el)
+    } catch (err) {
+      on_fallback?.(`WebGPU renderer init failed: ${err instanceof Error ? err.message : String(err)}`)
+      return
+    }
+    renderer = r
+    size_to_client(el)
+
+    resize_observer = new ResizeObserver(() => {
+      if (renderer && canvas) size_to_client(canvas)
+    })
+    resize_observer.observe(el)
+
+    const frame = () => {
+      if (token !== session_token || !renderer) return
+      if (camera) {
+        camera.updateMatrixWorld()
+        renderer.set_camera(pack_camera_uniform(camera))
+      }
+      renderer.render()
+      raf_id = requestAnimationFrame(frame)
+    }
+    raf_id = requestAnimationFrame(frame)
+  }
+
+  $effect(() => {
+    // Re-run only on enabled / canvas changes. `camera` is read inside the RAF
+    // loop (not tracked here) so a camera swap doesn't restart the session.
+    if (enabled && canvas) {
+      start_session(canvas)
+      return () => stop_session()
+    }
+    // disabled or no canvas yet: ensure nothing is running.
+    stop_session()
+    return undefined
+  })
+</script>
+
+{#if enabled}
+  <canvas
+    bind:this={canvas}
+    class="large-system-overlay"
+    style="position: absolute; inset: 0; width: 100%; height: 100%;"
+  ></canvas>
+{/if}
+
+<style>
+  .large-system-overlay {
+    display: block;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -549,10 +549,16 @@
   const CLICK_MOVE_PX = 4
 
   /** Pick the atom under the given CLIENT (cursor) coords and notify the parent.
-   *  Maps client → canvas-local CSS px → device px (× devicePixelRatio), the same
-   *  space the pick id texture is rendered at. Only fires when the cursor is over
-   *  the canvas. Calls on_pick(site_idx) with the picked base site index, or -1
-   *  for background (empty space) so the parent can clear the selection. */
+   *  Maps client → canvas-local CSS px → DEVICE px, the space the pick id texture
+   *  is rendered at. The device scale is derived from the ACTUAL backing-store
+   *  size (`canvas.width/height`) over the CSS box (`rect.width/height`), NOT from
+   *  `devicePixelRatio` directly — the renderer sized the backing store to
+   *  `clientWidth * dpr` then floored it, so the true per-axis scale can differ
+   *  slightly from a bare `dpr` (fractional DPR, sub-pixel CSS rounding). Using
+   *  the real ratio keeps the cursor texel exact and matches how `pick()` indexes
+   *  the texture (sized to `canvas.width/height`). Only fires when the cursor is
+   *  over the canvas. Calls on_pick(site_idx) with the picked base site index, or
+   *  -1 for background (empty space) so the parent can clear the selection. */
   async function pick_at_client(client_x: number, client_y: number): Promise<void> {
     if (!renderer || !canvas || !on_pick) return
     const rect = canvas.getBoundingClientRect()
@@ -563,10 +569,23 @@
     ) {
       return
     }
+    // CSS-px offset within the canvas box, then scale by backing/CSS so the
+    // result lands in the pick texture's device-pixel space exactly.
+    const scale_x = rect.width > 0 ? canvas.width / rect.width : 1
+    const scale_y = rect.height > 0 ? canvas.height / rect.height : 1
+    const x = (client_x - rect.left) * scale_x
+    const y = (client_y - rect.top) * scale_y
+    // TODO(pick-debug): strip once verified. Logs the full client→device mapping.
     const dpr = typeof window !== `undefined` ? window.devicePixelRatio || 1 : 1
-    const x = (client_x - rect.left) * dpr
-    const y = (client_y - rect.top) * dpr
+    console.log(`[pick-debug] client`, { client_x, client_y }, `rect`, {
+      left: rect.left, top: rect.top, width: rect.width, height: rect.height,
+    }, `dpr`, dpr, `canvas`, { w: canvas.width, h: canvas.height }, `scale`, {
+      scale_x, scale_y,
+    }, `device`, { x, y })
     const idx = await renderer.pick(x, y)
+    // TODO(pick-debug): strip once verified. Logs the picked index + selection.
+    console.log(`[pick-debug] on_pick(base_idx=`, idx, `) selected_sites(before)=`,
+      [...(selected_sites ?? [])])
     on_pick(idx)
   }
 

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -21,6 +21,8 @@
     element_radius_overrides = undefined,
     site_radius_overrides = undefined,
     bonding_options = undefined,
+    background_color = undefined,
+    background_opacity = 0.1,
     trajectory_positions_version = undefined,
     get_trajectory_frame_positions = undefined,
     trajectory_step_idx = -1,
@@ -48,6 +50,16 @@
      *  detection. Same Record the CPU path reads (scene_props.bonding_options);
      *  mapped via to_compute_options. */
     bonding_options?: Record<string, number> | undefined
+    /** Viewer canvas background color (hex, e.g. `#000000`), mirroring the WebGL
+     *  path's StructureScene `background_color`. The overlay resolves this the
+     *  SAME way StructureScene's compute_canvas_bg does (lerp toward the theme
+     *  bg by `background_opacity`) and converts it to linear RGB with the SAME
+     *  conversion used for atom colors, so the overlay background matches the
+     *  WebGL viewer's background and dark atoms keep their contrast. */
+    background_color?: string | undefined
+    /** Override strength of `background_color` over the theme bg: 0 → theme bg,
+     *  1 → picked color, mid → lerp. Mirrors StructureScene's background_opacity. */
+    background_opacity?: number
     /** Per-frame position version, mirroring Structure.svelte's bindable prop.
      *  `.v` bumps every time the trajectory frame's positions change (playback,
      *  scrub, or in-place edit) WITHOUT `structure` changing object identity, so
@@ -209,6 +221,62 @@
   function hex_to_linear_rgb(hex: string): [number, number, number] {
     _col.set(hex).convertSRGBToLinear()
     return [_col.r, _col.g, _col.b]
+  }
+
+  // ── Background color (Fix 1) ────────────────────────────────────────────
+  // The last linear-RGB background pushed to the renderer, so we only re-push +
+  // re-render when the resolved color actually changes.
+  let last_bg: [number, number, number] | null = null
+  const _bg = new Color()
+
+  /** Walk up from the overlay canvas to find the first opaque CSS background
+   *  color (the theme bg). Mirrors StructureScene.find_theme_bg so the overlay
+   *  resolves the same theme background the WebGL clear color lerps toward. */
+  function find_theme_bg(target: Color): Color {
+    let el: HTMLElement | null = canvas ?? null
+    while (el) {
+      const bg = getComputedStyle(el).backgroundColor
+      const m = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/)
+      if (m) {
+        const a = m[4] !== undefined ? parseFloat(m[4]) : 1
+        if (a >= 0.5) return target.setRGB(+m[1] / 255, +m[2] / 255, +m[3] / 255)
+      }
+      el = el.parentElement
+    }
+    return target.setRGB(0, 0, 0)
+  }
+
+  /** Resolve the viewer background the SAME way StructureScene.compute_canvas_bg
+   *  does (picked hex, theme bg, or a lerp by background_opacity), then convert
+   *  to linear RGB with the SAME conversion used for atom colors. Returns the
+   *  linear-RGB triple to upload as the overlay clear color. */
+  function resolve_background_rgb(): [number, number, number] {
+    const picked = new Color(background_color ?? `#000000`)
+    const t = Math.max(0, Math.min(1, background_opacity))
+    if (t >= 0.999) _bg.copy(picked)
+    else if (t <= 0.001) find_theme_bg(_bg)
+    else find_theme_bg(_bg).lerp(picked, t)
+    // convertSRGBToLinear matches hex_to_linear_rgb (atom color space).
+    _bg.convertSRGBToLinear()
+    return [_bg.r, _bg.g, _bg.b]
+  }
+
+  /** Push the resolved background to the renderer when it changed. Marks a
+   *  redraw so the new clear color paints. Returns true if it changed. */
+  function sync_background(): boolean {
+    if (!renderer) return false
+    const rgb = resolve_background_rgb()
+    if (
+      last_bg &&
+      Math.abs(last_bg[0] - rgb[0]) < 1e-6 &&
+      Math.abs(last_bg[1] - rgb[1]) < 1e-6 &&
+      Math.abs(last_bg[2] - rgb[2]) < 1e-6
+    ) {
+      return false
+    }
+    last_bg = rgb
+    renderer.set_background(rgb)
+    return true
   }
 
   /** Cheap signature of the radius-affecting inputs; changes when any of them
@@ -403,6 +471,11 @@
       dirty = true
     }
 
+    // Background: resolve the viewer's bg color (theme/opacity/picked) and push
+    // it to the renderer only when it changed. A change repaints so the new
+    // clear color shows. Cheap when static (string compare + no GPU work).
+    if (sync_background()) dirty = true
+
     // Camera: pack always (cheap), upload + mark dirty only when it moved.
     if (camera) {
       camera.updateMatrixWorld()
@@ -449,6 +522,8 @@
     positions_dirty = false
     // Fresh GPU camera buffer ⇒ force a first paint and a re-upload.
     last_camera_uniform = null
+    // Fresh renderer ⇒ force the background to re-resolve + re-push.
+    last_bg = null
     needs_render = true
     stable_frames = 0
     const device = await acquire_webgpu_device()
@@ -536,6 +611,20 @@
     // suspends after its grace period (idle-quiet).
     trajectory_positions_version?.v
     trajectory_step_idx
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // Background-color wake trigger. Track the bg inputs so a theme/opacity/
+    // picked-color change revives a suspended loop; the frame re-resolves the
+    // clear color via sync_background and repaints once. (Theme changes that
+    // don't bump these props are caught lazily on the next wake from any other
+    // source — consistent with the WebGL path's own mutation-observer resync.)
+    background_color
+    background_opacity
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -63,6 +63,12 @@
     atom_colors_source = element_colors
     atoms_dirty = true
     const sites = structure?.sites
+    // TODO(9.2-debug) remove
+    console.log(
+      `[lsr] rebuild atoms, sites=`, sites?.length ?? 0,
+      `structure?`, structure != null,
+      `element_colors?`, element_colors != null,
+    )
     if (!sites || sites.length === 0) {
       atom_positions = new Float32Array(0)
       atom_radii = new Float32Array(0)

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -4,7 +4,7 @@
   import { acquire_webgpu_device } from '$lib/structure/gpu/webgpu-context'
   import { pack_camera_full } from '$lib/structure/gpu/camera-uniform'
   import { pack_positions } from '$lib/structure/gpu/frame-buffers'
-  import { build_atom_radii } from '$lib/structure/gpu/radius-lut'
+  import { build_display_radii } from '$lib/structure/gpu/radius-lut'
   import {
     create_large_system_renderer,
     type LargeSystemRenderer,
@@ -15,6 +15,10 @@
     camera = undefined,
     structure = undefined,
     element_colors = undefined,
+    atom_radius = 1.5,
+    same_size_atoms = false,
+    element_radius_overrides = undefined,
+    site_radius_overrides = undefined,
     on_fallback = undefined,
   }: {
     enabled?: boolean
@@ -23,6 +27,14 @@
     structure?: AnyStructure | undefined
     /** Per-element hex colors (e.g. state colors.element). */
     element_colors?: Partial<Record<ElementSymbol, string>> | undefined
+    /** Global display-radius scale, mirrors the WebGL atom_radius prop. */
+    atom_radius?: number
+    /** Render all atoms at the same size (WebGL same_size_atoms). */
+    same_size_atoms?: boolean
+    /** Per-element radius overrides, mirrors the WebGL path. */
+    element_radius_overrides?: Partial<Record<ElementSymbol, number>> | undefined
+    /** Per-site radius overrides, mirrors the WebGL path. */
+    site_radius_overrides?: Map<number, number> | undefined
     on_fallback?: (reason: string) => void
   } = $props()
 
@@ -45,6 +57,9 @@
   let atom_count = 0
   // Track the colors-object identity too, so a color-scheme swap rebuilds.
   let atom_colors_source: Partial<Record<ElementSymbol, string>> | undefined = undefined
+  // Signature of the radius-affecting inputs we last built from; when it
+  // changes the display radii must be recomputed.
+  let atom_radius_sig = ``
   // Set when buffers were rebuilt and must be re-uploaded to the GPU.
   let atoms_dirty = false
 
@@ -55,12 +70,38 @@
     return [_col.r, _col.g, _col.b]
   }
 
-  /** Rebuild the flat atom buffers from the current structure + element colors.
-   *  No-op (reuses cached arrays) when neither identity has changed. */
+  /** Cheap signature of the radius-affecting inputs; changes when any of them
+   *  do so the display radii get recomputed (identity for the override maps,
+   *  size for the site map, values for the element map). */
+  function radius_signature(): string {
+    let sro = ``
+    if (site_radius_overrides && site_radius_overrides.size > 0) {
+      for (const [k, v] of site_radius_overrides) sro += `${k}=${v};`
+    }
+    let ero = ``
+    if (element_radius_overrides) {
+      for (const k of Object.keys(element_radius_overrides)) {
+        ero += `${k}=${(element_radius_overrides as Record<string, number>)[k]};`
+      }
+    }
+    return `${atom_radius}|${same_size_atoms}|${ero}|${sro}`
+  }
+
+  /** Rebuild the flat atom buffers from the current structure + element colors
+   *  + display-radius inputs. No-op (reuses cached arrays) when nothing that
+   *  affects them has changed. */
   function rebuild_atoms_if_needed(): void {
-    if (structure === atom_source && element_colors === atom_colors_source) return
+    const sig = radius_signature()
+    if (
+      structure === atom_source &&
+      element_colors === atom_colors_source &&
+      sig === atom_radius_sig
+    ) {
+      return
+    }
     atom_source = structure
     atom_colors_source = element_colors
+    atom_radius_sig = sig
     atoms_dirty = true
     const sites = structure?.sites
     if (!sites || sites.length === 0) {
@@ -71,7 +112,15 @@
       return
     }
     atom_positions = pack_positions(sites)
-    atom_radii = build_atom_radii(sites)
+    // VISUAL sphere radius — matches the WebGL ball-and-stick display sizing
+    // (atomic_radii[element] * atom_radius, with same_size / overrides). NOT
+    // the covalent bond-cutoff radius (build_atom_radii) used by 9.3.
+    atom_radii = build_display_radii(sites, {
+      atom_radius,
+      same_size_atoms,
+      element_radius_overrides,
+      site_radius_overrides,
+    })
     atom_count = sites.length
     const cols = new Float32Array(sites.length * 3)
     for (let i = 0; i < sites.length; i++) {
@@ -97,11 +146,35 @@
     renderer = null
   }
 
+  // On-demand render state. We keep a RAF tick but only issue a GPU draw when
+  // something changed since the last drawn frame: camera moved, atom buffers
+  // re-uploaded, or a resize happened. Avoids continuous GPU load when idle.
+  let last_camera_uniform: Float32Array | null = null
+  let needs_render = true // force the first frame
+
+  /** True if `next` differs from the last uploaded camera uniform (epsilon
+   *  compare). Updates the cached copy when it returns true. */
+  function camera_changed(next: Float32Array): boolean {
+    const prev = last_camera_uniform
+    if (!prev || prev.length !== next.length) {
+      last_camera_uniform = next.slice()
+      return true
+    }
+    for (let i = 0; i < next.length; i++) {
+      if (Math.abs(prev[i] - next[i]) > 1e-6) {
+        last_camera_uniform = next.slice()
+        return true
+      }
+    }
+    return false
+  }
+
   function size_to_client(el: HTMLCanvasElement): void {
     const dpr = typeof window !== `undefined` ? window.devicePixelRatio || 1 : 1
     const w = el.clientWidth * dpr
     const h = el.clientHeight * dpr
     renderer?.resize(w, h)
+    needs_render = true // resized backing store/depth must repaint
   }
 
   async function start_session(el: HTMLCanvasElement): Promise<void> {
@@ -110,7 +183,11 @@
     // first frame even if the structure identity hasn't changed since last time.
     atom_source = undefined
     atom_colors_source = undefined
+    atom_radius_sig = ``
     atoms_dirty = true
+    // Fresh GPU camera buffer ⇒ force a first paint and a re-upload.
+    last_camera_uniform = null
+    needs_render = true
     const device = await acquire_webgpu_device()
     // Bail if disabled / unmounted / superseded while awaiting.
     if (token !== session_token) return
@@ -135,18 +212,32 @@
 
     const frame = () => {
       if (token !== session_token || !renderer) return
-      // Rebuild atom buffers only when the structure / colors identity changed;
-      // re-upload to the GPU only on that same change (static frame otherwise).
+      // Per-frame dirty check — only issue a GPU draw when something changed.
+      // We still rAF every frame (cheap) but early-return before render() when
+      // the scene is idle, so the GPU isn't redrawing a static frame forever.
+      let dirty = needs_render
+      needs_render = false
+
+      // Rebuild atom buffers only when the structure / colors / radius inputs
+      // changed; re-upload + mark dirty on that same change.
       rebuild_atoms_if_needed()
       if (atoms_dirty) {
         renderer.set_atoms(atom_positions, atom_radii, atom_colors, atom_count)
         atoms_dirty = false
+        dirty = true
       }
+
+      // Camera: pack always (cheap), upload + mark dirty only when it moved.
       if (camera) {
         camera.updateMatrixWorld()
-        renderer.set_camera_full(pack_camera_full(camera))
+        const packed = pack_camera_full(camera)
+        if (camera_changed(packed)) {
+          renderer.set_camera_full(packed)
+          dirty = true
+        }
       }
-      renderer.render()
+
+      if (dirty) renderer.render()
       raf_id = requestAnimationFrame(frame)
     }
     raf_id = requestAnimationFrame(frame)

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -3,8 +3,9 @@
   import type { AnyStructure, ElementSymbol } from '$lib/structure'
   import { acquire_webgpu_device } from '$lib/structure/gpu/webgpu-context'
   import { pack_camera_full } from '$lib/structure/gpu/camera-uniform'
-  import { pack_positions } from '$lib/structure/gpu/frame-buffers'
-  import { build_display_radii } from '$lib/structure/gpu/radius-lut'
+  import { pack_positions, pack_lattice } from '$lib/structure/gpu/frame-buffers'
+  import { build_display_radii, build_atom_radii } from '$lib/structure/gpu/radius-lut'
+  import { to_compute_options } from '$lib/structure/gpu/large-system-mode.svelte'
   import {
     create_large_system_renderer,
     type LargeSystemRenderer,
@@ -19,6 +20,7 @@
     same_size_atoms = false,
     element_radius_overrides = undefined,
     site_radius_overrides = undefined,
+    bonding_options = undefined,
     on_fallback = undefined,
   }: {
     enabled?: boolean
@@ -35,6 +37,10 @@
     element_radius_overrides?: Partial<Record<ElementSymbol, number>> | undefined
     /** Per-site radius overrides, mirrors the WebGL path. */
     site_radius_overrides?: Map<number, number> | undefined
+    /** App bond options (tolerance / max_bond_dist / …) driving GPU bond
+     *  detection. Same Record the CPU path reads (scene_props.bonding_options);
+     *  mapped via to_compute_options. */
+    bonding_options?: Record<string, number> | undefined
     on_fallback?: (reason: string) => void
   } = $props()
 
@@ -62,6 +68,51 @@
   let atom_radius_sig = ``
   // Set when buffers were rebuilt and must be re-uploaded to the GPU.
   let atoms_dirty = false
+
+  // Cached bond inputs, rebuilt only when the structure identity or bonding
+  // options change (not every frame). The renderer caches the compute dispatch
+  // by its own dirty flag; here we just decide WHEN to re-push set_bond_data.
+  let bond_source: AnyStructure | undefined = undefined
+  let bond_covalent: Float32Array = new Float32Array(0)
+  let bond_lattice: Float32Array = new Float32Array(9)
+  let bond_periodic = false
+  let bond_options_sig = ``
+  let bond_compute_opts = { tolerance: 0, max_bond_dist: 0, min_dist: 0 }
+  // Set when bond inputs changed and must be re-pushed to the renderer.
+  let bonds_dirty = false
+
+  /** Cheap signature of the bonding options Record; changes when any cutoff
+   *  does so the GPU compute re-dispatches with the new value. */
+  function bond_options_signature(): string {
+    const o = bonding_options
+    if (!o) return ``
+    let s = ``
+    for (const k of Object.keys(o).sort()) s += `${k}=${o[k]};`
+    return s
+  }
+
+  /** Rebuild the bond inputs (covalent radii, lattice, options, periodicity)
+   *  when the structure identity or bonding options change. No-op otherwise. */
+  function rebuild_bonds_if_needed(): void {
+    const sig = bond_options_signature()
+    if (structure === bond_source && sig === bond_options_sig) return
+    bond_source = structure
+    bond_options_sig = sig
+    bonds_dirty = true
+    const sites = structure?.sites
+    if (!sites || sites.length === 0) {
+      bond_covalent = new Float32Array(0)
+      bond_lattice = new Float32Array(9)
+      bond_periodic = false
+      return
+    }
+    bond_covalent = build_atom_radii(sites)
+    // Periodic only when the structure carries a lattice (molecules don't).
+    const lat = (structure as { lattice?: import('$lib/structure').PymatgenLattice }).lattice
+    bond_lattice = pack_lattice(lat)
+    bond_periodic = !!lat
+    bond_compute_opts = to_compute_options(bonding_options ?? {})
+  }
 
   // Hex -> linear RGB, matching the WebGL path (Color.convertSRGBToLinear).
   const _col = new Color()
@@ -227,6 +278,18 @@
       dirty = true
     }
 
+    // Bond inputs: rebuild on structure/option change, then push to the renderer
+    // (which re-runs the GPU bond compute on its own dirty flag). Also re-push
+    // when atoms were re-uploaded, since set_atoms moves positions the compute
+    // depends on (the renderer already flags itself dirty there, but pushing
+    // keeps the covalent radii / count in lockstep with the atom buffer).
+    rebuild_bonds_if_needed()
+    if (bonds_dirty) {
+      renderer.set_bond_data(bond_covalent, bond_lattice, bond_compute_opts, bond_periodic)
+      bonds_dirty = false
+      dirty = true
+    }
+
     // Camera: pack always (cheap), upload + mark dirty only when it moved.
     if (camera) {
       camera.updateMatrixWorld()
@@ -261,6 +324,10 @@
     atom_colors_source = undefined
     atom_radius_sig = ``
     atoms_dirty = true
+    // Fresh renderer ⇒ fresh bond buffers; force a rebuild + re-push.
+    bond_source = undefined
+    bond_options_sig = ``
+    bonds_dirty = true
     // Fresh GPU camera buffer ⇒ force a first paint and a re-upload.
     last_camera_uniform = null
     needs_render = true
@@ -332,6 +399,7 @@
     same_size_atoms
     element_radius_overrides
     site_radius_overrides
+    bonding_options
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -23,6 +23,8 @@
     bonding_options = undefined,
     background_color = undefined,
     background_opacity = 0.1,
+    show_cell = false,
+    cell_edge_color = `#808080`,
     trajectory_positions_version = undefined,
     get_trajectory_frame_positions = undefined,
     trajectory_step_idx = -1,
@@ -60,6 +62,14 @@
     /** Override strength of `background_color` over the theme bg: 0 → theme bg,
      *  1 → picked color, mid → lerp. Mirrors StructureScene's background_opacity. */
     background_opacity?: number
+    /** Whether to draw the unit-cell box (lattice wireframe), mirroring the WebGL
+     *  view's `scene_props.show_cell`. Default off ⇒ zero change. Only draws when
+     *  true AND the structure carries a non-zero lattice (periodic). */
+    show_cell?: boolean
+    /** Cell edge line color (hex), mirroring the WebGL Lattice's `cell_edge_color`
+     *  (DEFAULTS.structure.cell_edge_color = `#808080` grey). Converted to linear
+     *  RGB the SAME way atom colors are. */
+    cell_edge_color?: string
     /** Per-frame position version, mirroring Structure.svelte's bindable prop.
      *  `.v` bumps every time the trajectory frame's positions change (playback,
      *  scrub, or in-place edit) WITHOUT `structure` changing object identity, so
@@ -115,6 +125,30 @@
   let bond_compute_opts = { tolerance: 0, max_bond_dist: 0, min_dist: 0 }
   // Set when bond inputs changed and must be re-pushed to the renderer.
   let bonds_dirty = false
+
+  // ── Cell-box state ───────────────────────────────────────────────────────
+  // Signature of the cell inputs last pushed to the renderer (lattice + show +
+  // color), so set_cell is re-pushed only when one actually changes. The lattice
+  // is read from bond_lattice (kept in lockstep by rebuild_bonds_if_needed and
+  // refresh_frame_positions — including variable-cell trajectories).
+  let cell_sig = ``
+
+  /** Push the unit-cell box to the renderer when its inputs (lattice / show /
+   *  color) changed. Uses bond_lattice as the lattice source (already packed +
+   *  kept current). Returns true if it re-pushed (caller marks a redraw). */
+  function sync_cell(): boolean {
+    if (!renderer) return false
+    const [cr, cg, cb] = hex_to_linear_rgb(cell_edge_color)
+    let lat_sig = ``
+    for (let i = 0; i < 9; i++) lat_sig += `${bond_lattice[i]};`
+    const sig = `${show_cell}|${cr},${cg},${cb}|${lat_sig}`
+    if (sig === cell_sig) return false
+    cell_sig = sig
+    // bond_periodic is true exactly when the structure carries a lattice; pass
+    // null otherwise so molecules never draw a (degenerate) box.
+    renderer.set_cell(bond_periodic ? bond_lattice : null, show_cell, [cr, cg, cb])
+    return true
+  }
 
   // ── Per-frame trajectory state (milestone 9.4) ──────────────────────────
   // The last position-version we re-uploaded. When the parent bumps
@@ -471,6 +505,12 @@
       dirty = true
     }
 
+    // Cell box: push the lattice + show + color to the renderer when any of them
+    // changed. Runs after the bond rebuild above so bond_lattice (the cell's
+    // lattice source) is current for this frame — including variable-cell
+    // trajectories where refresh_frame_positions re-packs it per frame.
+    if (sync_cell()) dirty = true
+
     // Background: resolve the viewer's bg color (theme/opacity/picked) and push
     // it to the renderer only when it changed. A change repaints so the new
     // clear color shows. Cheap when static (string compare + no GPU work).
@@ -524,6 +564,8 @@
     last_camera_uniform = null
     // Fresh renderer ⇒ force the background to re-resolve + re-push.
     last_bg = null
+    // Fresh renderer ⇒ force the cell box to re-resolve + re-push.
+    cell_sig = ``
     needs_render = true
     stable_frames = 0
     const device = await acquire_webgpu_device()
@@ -625,6 +667,19 @@
     // source — consistent with the WebGL path's own mutation-observer resync.)
     background_color
     background_opacity
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // Cell-box wake trigger. Track show_cell + cell_edge_color so toggling the
+    // cell on/off or recoloring it revives a suspended loop; the frame re-pushes
+    // via sync_cell and repaints once. (Lattice changes are caught by the
+    // structure/per-frame wakes, which update bond_lattice.)
+    show_cell
+    cell_edge_color
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -110,6 +110,13 @@
   // diverges and we re-extract + re-upload ONLY the xyz (set_positions) — radii
   // and colors are NOT rebuilt, since elements don't change between frames.
   let last_pos_version = -1
+  // The last frame index we re-uploaded. Normal playback ADVANCES the frame
+  // index (trajectory_step_idx) without necessarily bumping
+  // trajectory_positions_version.v — that version bumps when the CURRENT frame's
+  // positions change IN PLACE (editing), not on a plain frame advance. So we
+  // must re-extract on EITHER signal diverging, mirroring the CPU/WebGL bond
+  // cache which keys on both get_step_idx AND get_positions_version.
+  let last_step_idx = -1
   // Current-frame xyz, indexed identically to structure.sites. Reused buffer.
   let frame_positions: Float32Array = new Float32Array(0)
   // Set when frame_positions changed and must be re-uploaded to the GPU.
@@ -128,6 +135,7 @@
    *  moved. */
   function refresh_frame_positions(): void {
     last_pos_version = trajectory_positions_version?.v ?? -1
+    last_step_idx = trajectory_step_idx
     const sites = structure?.sites
     if (!sites || sites.length === 0) return
     let pos: Float32Array | null = null
@@ -365,11 +373,16 @@
       refresh_frame_positions()
     }
 
-    // Per-frame positions: re-upload ONLY xyz when the trajectory frame moved
-    // (version bumped) — radii + colors stay as last uploaded. set_positions
-    // also flags the renderer's bonds dirty so the GPU bond compute re-runs
-    // against the moved atoms (bonds form/break as atoms move).
-    if ((trajectory_positions_version?.v ?? -1) !== last_pos_version) {
+    // Per-frame positions: re-upload ONLY xyz when the trajectory frame moved —
+    // EITHER the frame index advanced (normal playback / single-step / scrub)
+    // OR the current frame's positions changed in place (version bump on edit).
+    // radii + colors stay as last uploaded. set_positions also flags the
+    // renderer's bonds dirty so the GPU bond compute re-runs against the moved
+    // atoms (bonds form/break as atoms move).
+    if (
+      trajectory_step_idx !== last_step_idx ||
+      (trajectory_positions_version?.v ?? -1) !== last_pos_version
+    ) {
       refresh_frame_positions()
     }
     if (positions_dirty) {
@@ -431,6 +444,7 @@
     // Fresh renderer ⇒ force a per-frame re-extract + re-upload on the first
     // frame, and re-detect the lattice for variable-cell bonds.
     last_pos_version = -1
+    last_step_idx = -1
     frame_lattice_sig = ``
     positions_dirty = false
     // Fresh GPU camera buffer ⇒ force a first paint and a re-upload.

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -38,6 +38,7 @@
     selected_sites = [],
     on_pick = undefined,
     supercell = [1, 1, 1],
+    show_image_atoms = false,
   }: {
     enabled?: boolean
     camera?: Camera | undefined
@@ -139,6 +140,12 @@
      *  offset by ix·a + iy·b + iz·c. Default [1,1,1] ⇒ ncells = 1 ⇒ atom = inst,
      *  zero offset ⇒ byte-identical to the non-supercell draw. */
     supercell?: [number, number, number]
+    /** Whether DISPLAYED PBC image atoms exist (the viewer's `show_image_atoms`).
+     *  When true (non-supercell only), the renderer draws cross-cell bonds as FULL
+     *  cylinders reaching the imaged partner where the displayed image atom sits,
+     *  so image atoms gain bonds (matching the WebGL view). Default false ⇒ stubs
+     *  ⇒ zero change; supercell mode is unaffected (Phase-2 logic is authoritative). */
+    show_image_atoms?: boolean
   } = $props()
 
   let canvas = $state<HTMLCanvasElement | undefined>(undefined)
@@ -311,6 +318,22 @@
     if (sig === supercell_sig) return false
     supercell_sig = sig
     renderer.set_supercell(dims, base_lat)
+    return true
+  }
+
+  // Last show_image_atoms flag pushed to the renderer, so set_show_images fires
+  // only when it actually flips. -1 = never pushed (forces the first sync).
+  let show_images_sig = -1
+
+  /** Push the viewer's show_image_atoms flag to the renderer when it changed.
+   *  The renderer uses it (non-supercell path only) to draw cross-cell bonds full
+   *  to the displayed image atom instead of as stubs. Returns true if re-pushed. */
+  function sync_show_images(): boolean {
+    if (!renderer) return false
+    const next = show_image_atoms ? 1 : 0
+    if (next === show_images_sig) return false
+    show_images_sig = next
+    renderer.set_show_images(!!show_image_atoms)
     return true
   }
 
@@ -861,6 +884,11 @@
     // [1,1,1] ⇒ ncells 1 ⇒ identical draw to today.
     if (sync_supercell()) dirty = true
 
+    // PBC image atoms: push the viewer's show_image_atoms flag so cross-cell bonds
+    // reach the displayed image atoms (full cylinders) when it is on, or stay stubs
+    // when off. Non-supercell only; supercell mode ignores it. Default off ⇒ stubs.
+    if (sync_show_images()) dirty = true
+
     // Selection highlight: mirror the app's selected_sites into the GPU highlight
     // buffer when it changed (overlay click OR external selection change).
     if (sync_selection()) dirty = true
@@ -935,6 +963,9 @@
     // Fresh renderer ⇒ its supercell defaults to [1,1,1]; force a re-push of the
     // current dims + base lattice on the first frame.
     supercell_sig = ``
+    // Fresh renderer ⇒ its show_image_atoms defaults to false; force a re-push of
+    // the current flag on the first frame.
+    show_images_sig = -1
     // Fresh renderer ⇒ its selection buffer is empty; force a re-push of the
     // current selection on the first frame.
     selection_sig = ``
@@ -1100,6 +1131,18 @@
     supercell[0]
     supercell[1]
     supercell[2]
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // show_image_atoms wake trigger. Track the flag so toggling displayed PBC
+    // image atoms revives a suspended loop; the frame re-pushes via sync_show_images
+    // (which marks the renderer bonds dirty) and repaints once with full-to-image
+    // bonds (on) or stubs (off).
+    show_image_atoms
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -149,6 +149,16 @@
   let atom_radius_sig = ``
   // Set when buffers were rebuilt and must be re-uploaded to the GPU.
   let atoms_dirty = false
+  // Set when the structure IDENTITY or atom COUNT changed (supercell repeats,
+  // structure swap) — i.e. the atom SET itself changed, not just its colors /
+  // display radii. A color/radius-only change flips atoms_dirty (re-upload) but
+  // NOT this. Used to force a full per-frame position re-extract + bond recompute
+  // for the NEW atom set in the SAME frame, instead of waiting for a trajectory
+  // frame event. `topology_count` is the count we last saw, so a supercell that
+  // changes the count (e.g. 1x1x1 -> 3x3x3) is detected even if the structure
+  // object identity comparison alone were insufficient.
+  let topology_dirty = false
+  let topology_count = -1
 
   // Cached bond inputs, rebuilt only when the structure identity or bonding
   // options change (not every frame). The renderer caches the compute dispatch
@@ -448,6 +458,17 @@
    *  affects them has changed. */
   function rebuild_atoms_if_needed(): void {
     const sig = radius_signature()
+    // Detect a structure-IDENTITY or atom-COUNT change (supercell repeats,
+    // structure swap) BEFORE we overwrite atom_source — independent of the
+    // color/radius-only path below. A new identity OR a changed count means the
+    // atom SET itself changed, so the current per-frame positions + bond compute
+    // are stale for the new set and must be re-extracted/recomputed in THIS
+    // frame (handled by the topology_dirty branch in frame()).
+    const next_count = structure?.sites?.length ?? 0
+    if (structure !== atom_source || next_count !== topology_count) {
+      topology_dirty = true
+      topology_count = next_count
+    }
     if (
       structure === atom_source &&
       element_colors === atom_colors_source &&
@@ -636,9 +657,25 @@
       renderer.set_atoms(atom_positions, atom_radii, atom_colors, atom_count)
       atoms_dirty = false
       dirty = true
-      // Topology (and its base positions) just (re)uploaded ⇒ also re-extract
-      // the current frame's xyz so playback shows the live frame, not frame 0.
-      refresh_frame_positions()
+    }
+    // Structure IDENTITY / atom COUNT changed (supercell repeats, structure
+    // swap). The atom buffers above are now sized to the NEW set, but the
+    // per-frame POSITION buffer + GPU bond compute are still aligned to the OLD
+    // set — left stale they connect atoms at wrong positions (garbled
+    // bonds/spikes) until a later frame event bumps the version. So re-extract
+    // the CURRENT frame's positions for the NEW set NOW and force a bond
+    // recompute, in this same frame, AFTER set_atoms (buffers sized) and BEFORE
+    // the per-frame/bond push below. We reset the version/step trackers first so
+    // this forced refresh isn't skipped by the "≠ last_*" guard, and so the
+    // SUBSEQUENT genuine frame change (≠ these reset values) still triggers
+    // refresh_frame_positions normally.
+    if (topology_dirty) {
+      topology_dirty = false
+      last_pos_version = -1
+      last_step_idx = -1
+      refresh_frame_positions() // sets positions_dirty (+ bonds_dirty if lattice moved)
+      bonds_dirty = true // force the GPU bond compute against the consistent new positions
+      dirty = true
     }
 
     // Per-frame positions: re-upload ONLY xyz when the trajectory frame moved —
@@ -749,6 +786,10 @@
     atom_colors_source = undefined
     atom_radius_sig = ``
     atoms_dirty = true
+    // Fresh renderer ⇒ treat the topology as new so the first frame forces a
+    // per-frame position re-extract + bond recompute for the current atom set.
+    topology_dirty = false
+    topology_count = -1
     // Fresh renderer ⇒ fresh bond buffers; force a rebuild + re-push.
     bond_source = undefined
     bond_options_sig = ``

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -21,11 +21,18 @@
     element_radius_overrides = undefined,
     site_radius_overrides = undefined,
     bonding_options = undefined,
+    trajectory_positions_version = undefined,
+    get_trajectory_frame_positions = undefined,
+    trajectory_step_idx = -1,
     on_fallback = undefined,
   }: {
     enabled?: boolean
     camera?: Camera | undefined
-    /** Current displayed structure whose atoms render as impostor spheres. */
+    /** Current displayed structure whose atoms render as impostor spheres.
+     *  During trajectory playback this carries the BASE topology (elements,
+     *  count, and frame-0 xyz) — the per-frame xyz come from
+     *  get_trajectory_frame_positions, NOT from this object (whose identity /
+     *  .sites[i].xyz stay static across frames in the fast path). */
     structure?: AnyStructure | undefined
     /** Per-element hex colors (e.g. state colors.element). */
     element_colors?: Partial<Record<ElementSymbol, string>> | undefined
@@ -41,6 +48,22 @@
      *  detection. Same Record the CPU path reads (scene_props.bonding_options);
      *  mapped via to_compute_options. */
     bonding_options?: Record<string, number> | undefined
+    /** Per-frame position version, mirroring Structure.svelte's bindable prop.
+     *  `.v` bumps every time the trajectory frame's positions change (playback,
+     *  scrub, or in-place edit) WITHOUT `structure` changing object identity, so
+     *  it — not the structure ref — is the signal that drives per-frame
+     *  re-upload. `.all` (edit-all fan-out) is not needed here; we always
+     *  re-extract the whole frame. */
+    trajectory_positions_version?: { v: number; all: boolean } | undefined
+    /** Authoritative per-frame position source. Returns the frame's xyz as a
+     *  flat Float32Array(3N) indexed identically to `structure.sites` (same
+     *  array the CPU bond cache + WebGL atom write loop consume). null for
+     *  indexed/streaming frames not in memory (then we fall back to the
+     *  structure's own sites xyz). */
+    get_trajectory_frame_positions?: ((i: number) => Float32Array | null) | null | undefined
+    /** Current trajectory frame index; the argument to
+     *  get_trajectory_frame_positions. -1 when no trajectory is active. */
+    trajectory_step_idx?: number
     on_fallback?: (reason: string) => void
   } = $props()
 
@@ -81,6 +104,60 @@
   // Set when bond inputs changed and must be re-pushed to the renderer.
   let bonds_dirty = false
 
+  // ── Per-frame trajectory state (milestone 9.4) ──────────────────────────
+  // The last position-version we re-uploaded. When the parent bumps
+  // trajectory_positions_version.v (playback / scrub / in-place edit) this
+  // diverges and we re-extract + re-upload ONLY the xyz (set_positions) — radii
+  // and colors are NOT rebuilt, since elements don't change between frames.
+  let last_pos_version = -1
+  // Current-frame xyz, indexed identically to structure.sites. Reused buffer.
+  let frame_positions: Float32Array = new Float32Array(0)
+  // Set when frame_positions changed and must be re-uploaded to the GPU.
+  let positions_dirty = false
+  // Lattice signature last pushed for bonds; for variable-cell trajectories the
+  // lattice changes per frame and the bond compute + bond render need the new
+  // one. Compared per frame so a static cell never re-uploads.
+  let frame_lattice_sig = ``
+
+  /** Re-extract the current frame's xyz from the authoritative per-frame
+   *  source and mark positions (+ bonds) dirty. Falls back to the structure's
+   *  own sites xyz when the getter yields nothing (indexed/streaming frames, or
+   *  no trajectory at all — in which case structure.sites already holds the
+   *  static positions and this is a harmless no-op re-upload). For variable-cell
+   *  trajectories also re-checks the lattice and re-pushes bond data when it
+   *  moved. */
+  function refresh_frame_positions(): void {
+    last_pos_version = trajectory_positions_version?.v ?? -1
+    const sites = structure?.sites
+    if (!sites || sites.length === 0) return
+    let pos: Float32Array | null = null
+    if (get_trajectory_frame_positions && trajectory_step_idx >= 0) {
+      pos = get_trajectory_frame_positions(trajectory_step_idx)
+    }
+    // The getter is indexed against the BASE frame sites; when the displayed
+    // structure carries supercell / PBC-image atoms it is longer than that
+    // array. Only adopt the getter's xyz when it covers every displayed atom —
+    // otherwise fall back to the structure's own (slow-path-updated) sites xyz,
+    // which always matches sites.length. (Guards against a short writeBuffer in
+    // set_positions; in that case image/supercell atoms just track sites.xyz.)
+    frame_positions = pos && pos.length >= sites.length * 3 ? pos : pack_positions(sites)
+    positions_dirty = true
+
+    // Variable-cell: if the displayed lattice changed, the bond compute + bond
+    // render must use the new lattice. Re-pack and flag bonds for re-push. (A
+    // static cell leaves frame_lattice_sig unchanged ⇒ no bond-input churn.)
+    const lat = (structure as { lattice?: import('$lib/structure').PymatgenLattice }).lattice
+    const packed = pack_lattice(lat)
+    let sig = ``
+    for (let i = 0; i < 9; i++) sig += `${packed[i]};`
+    if (sig !== frame_lattice_sig) {
+      frame_lattice_sig = sig
+      bond_lattice = packed
+      bond_periodic = !!lat
+      bonds_dirty = true
+    }
+  }
+
   /** Cheap signature of the bonding options Record; changes when any cutoff
    *  does so the GPU compute re-dispatches with the new value. */
   function bond_options_signature(): string {
@@ -112,6 +189,11 @@
     bond_lattice = pack_lattice(lat)
     bond_periodic = !!lat
     bond_compute_opts = to_compute_options(bonding_options ?? {})
+    // Keep the per-frame lattice signature in lockstep so refresh_frame_positions
+    // doesn't redundantly re-push the lattice it just packed here.
+    let lat_sig = ``
+    for (let i = 0; i < 9; i++) lat_sig += `${bond_lattice[i]};`
+    frame_lattice_sig = lat_sig
   }
 
   // Hex -> linear RGB, matching the WebGL path (Color.convertSRGBToLinear).
@@ -270,11 +352,29 @@
     needs_render = false
 
     // Rebuild atom buffers only when the structure / colors / radius inputs
-    // changed; re-upload + mark dirty on that same change.
+    // changed; re-upload + mark dirty on that same change. This uploads the
+    // BASE-frame positions packed from structure.sites — the per-frame override
+    // below replaces them with the live trajectory frame in the same frame.
     rebuild_atoms_if_needed()
     if (atoms_dirty) {
       renderer.set_atoms(atom_positions, atom_radii, atom_colors, atom_count)
       atoms_dirty = false
+      dirty = true
+      // Topology (and its base positions) just (re)uploaded ⇒ also re-extract
+      // the current frame's xyz so playback shows the live frame, not frame 0.
+      refresh_frame_positions()
+    }
+
+    // Per-frame positions: re-upload ONLY xyz when the trajectory frame moved
+    // (version bumped) — radii + colors stay as last uploaded. set_positions
+    // also flags the renderer's bonds dirty so the GPU bond compute re-runs
+    // against the moved atoms (bonds form/break as atoms move).
+    if ((trajectory_positions_version?.v ?? -1) !== last_pos_version) {
+      refresh_frame_positions()
+    }
+    if (positions_dirty) {
+      renderer.set_positions(frame_positions, atom_count)
+      positions_dirty = false
       dirty = true
     }
 
@@ -328,6 +428,11 @@
     bond_source = undefined
     bond_options_sig = ``
     bonds_dirty = true
+    // Fresh renderer ⇒ force a per-frame re-extract + re-upload on the first
+    // frame, and re-detect the lattice for variable-cell bonds.
+    last_pos_version = -1
+    frame_lattice_sig = ``
+    positions_dirty = false
     // Fresh GPU camera buffer ⇒ force a first paint and a re-upload.
     last_camera_uniform = null
     needs_render = true
@@ -400,6 +505,23 @@
     element_radius_overrides
     site_radius_overrides
     bonding_options
+    if (renderer) {
+      needs_render = true
+      wake()
+    }
+  })
+
+  $effect(() => {
+    // Per-frame wake trigger. Track ONLY the position version (and the step
+    // index it indexes) so a trajectory frame change — playback tick, scrub, or
+    // single step — revives a suspended loop and renders that one frame. The
+    // `frame` does the actual re-extract + re-upload via refresh_frame_positions
+    // (gated on .v ≠ last_pos_version). Force the next frame to draw. Reading
+    // these here (not in the session effect) wakes without restarting the GPU
+    // session; when playback stops, .v stops bumping ⇒ no more wakes ⇒ the loop
+    // suspends after its grace period (idle-quiet).
+    trajectory_positions_version?.v
+    trajectory_step_idx
     if (renderer) {
       needs_render = true
       wake()

--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -32,7 +32,7 @@
     show_cell = false,
     cell_edge_color = `#808080`,
     trajectory_positions_version = undefined,
-    get_trajectory_frame_positions = undefined,
+    get_displayed_frame_positions = undefined,
     trajectory_step_idx = -1,
     on_fallback = undefined,
     selected_sites = [],
@@ -41,10 +41,12 @@
     enabled?: boolean
     camera?: Camera | undefined
     /** Current displayed structure whose atoms render as impostor spheres.
-     *  During trajectory playback this carries the BASE topology (elements,
-     *  count, and frame-0 xyz) — the per-frame xyz come from
-     *  get_trajectory_frame_positions, NOT from this object (whose identity /
-     *  .sites[i].xyz stay static across frames in the fast path). */
+     *  During trajectory playback this carries the BASE/displayed topology
+     *  (elements, count, supercell/PBC-image layout, and frame-0 xyz) — the
+     *  per-frame xyz come from get_displayed_frame_positions, NOT from this
+     *  object (whose identity / .sites[i].xyz stay static across frames in the
+     *  fast path). The element/count/layout here MUST match the resolver's
+     *  array index-for-index (both are the displayed-structure site order). */
     structure?: AnyStructure | undefined
     /** Per-element hex colors (e.g. state colors.element). */
     element_colors?: Partial<Record<ElementSymbol, string>> | undefined
@@ -103,14 +105,21 @@
      *  re-upload. `.all` (edit-all fan-out) is not needed here; we always
      *  re-extract the whole frame. */
     trajectory_positions_version?: { v: number; all: boolean } | undefined
-    /** Authoritative per-frame position source. Returns the frame's xyz as a
-     *  flat Float32Array(3N) indexed identically to `structure.sites` (same
-     *  array the CPU bond cache + WebGL atom write loop consume). null for
-     *  indexed/streaming frames not in memory (then we fall back to the
-     *  structure's own sites xyz). */
-    get_trajectory_frame_positions?: ((i: number) => Float32Array | null) | null | undefined
-    /** Current trajectory frame index; the argument to
-     *  get_trajectory_frame_positions. -1 when no trajectory is active. */
+    /** Authoritative per-DISPLAYED-atom position source. Returns the current
+     *  frame's xyz as a flat Float32Array(3 × n_displayed) indexed identically
+     *  to `structure.sites` (the SAME array the WebGL atoms/bonds are drawn at:
+     *  StructureScene.atom_positions_buffer — displayed-topology base overlaid
+     *  with the manager's per-frame positions via site_ids_buffer). The overlay
+     *  consumes this directly instead of re-deriving from base-only trajectory
+     *  data, so its atoms/bonds match the WebGL view atom-for-atom — including
+     *  the supercell base-block-animates / replica-static behaviour the WebGL
+     *  position-write loop decides. null/undefined ⇒ fall back to the
+     *  structure's own static sites xyz (no trajectory, or pre-mount). */
+    get_displayed_frame_positions?: (() => Float32Array) | null | undefined
+    /** Current trajectory frame index. -1 when no trajectory is active. Used
+     *  (with trajectory_positions_version.v) only as the per-frame REFRESH
+     *  TRIGGER — when it changes the overlay re-pulls get_displayed_frame_positions.
+     *  The position values themselves come from that getter, not this index. */
     trajectory_step_idx?: number
     on_fallback?: (reason: string) => void
     /** App selection state (base site indices, same as the WebGL path's
@@ -295,44 +304,39 @@
   // one. Compared per frame so a static cell never re-uploads.
   let frame_lattice_sig = ``
 
-  /** Re-extract the current frame's xyz from the authoritative per-frame
-   *  source and mark positions (+ bonds) dirty. Falls back to the structure's
-   *  own sites xyz when the getter yields nothing (indexed/streaming frames, or
-   *  no trajectory at all — in which case structure.sites already holds the
-   *  static positions and this is a harmless no-op re-upload). For variable-cell
-   *  trajectories also re-checks the lattice and re-pushes bond data when it
-   *  moved. */
+  /** Re-extract the current frame's per-DISPLAYED-atom xyz from the shared
+   *  WebGL resolver and mark positions (+ bonds) dirty. Falls back to the
+   *  structure's own static sites xyz when the getter is unavailable (no
+   *  trajectory active, or pre-mount before StructureScene bound the getter —
+   *  in which case structure.sites already holds the static positions and this
+   *  is a harmless re-upload). For variable-cell trajectories also re-checks the
+   *  lattice and re-pushes bond data when it moved. */
   function refresh_frame_positions(): void {
     last_pos_version = trajectory_positions_version?.v ?? -1
     last_step_idx = trajectory_step_idx
     const sites = structure?.sites
     if (!sites || sites.length === 0) return
+    // SINGLE SOURCE OF TRUTH: get_displayed_frame_positions() returns the exact
+    // per-displayed-atom position array the WebGL atoms/bonds are drawn at
+    // (StructureScene.atom_positions_buffer) — already resolved for supercell /
+    // PBC-image atoms (base atoms carry the current trajectory frame, replicas
+    // stay at their topology positions, exactly as the WebGL view shows). We
+    // consume it as-is: no base→displayed remapping, no partial-apply guess.
     let pos: Float32Array | null = null
-    if (get_trajectory_frame_positions && trajectory_step_idx >= 0) {
-      pos = get_trajectory_frame_positions(trajectory_step_idx)
+    if (get_displayed_frame_positions) pos = get_displayed_frame_positions()
+    // Guard against a length mismatch (e.g. the resolver lagging a supercell
+    // change by one tick): if the resolved array doesn't cover the current
+    // displayed atom set, fall back to the structure's own static sites xyz so
+    // we never index out of bounds or upload a short buffer. The topology_dirty
+    // path re-fires once the resolver catches up.
+    if (pos && pos.length === sites.length * 3) {
+      // Copy into a private buffer so a later in-place mutation of the shared
+      // $derived array can't corrupt what we already uploaded.
+      if (frame_positions.length !== pos.length) frame_positions = new Float32Array(pos.length)
+      frame_positions.set(pos)
+    } else {
+      frame_positions = pack_positions(sites)
     }
-    // The getter is indexed against the BASE frame sites; when the displayed
-    // structure carries supercell / PBC-image atoms it is LONGER than the
-    // getter's array (base + replicas). PARTIAL-APPLY rather than all-or-nothing:
-    //   1. Start from the static topology positions for EVERY displayed atom
-    //      (pack_positions(sites)) — this gives the replica/image atoms their
-    //      correct topology-load positions (the documented supercell limitation).
-    //   2. If the getter yielded per-frame xyz (non-null), OVERWRITE the leading
-    //      floats with it — those are the BASE atoms, which therefore ANIMATE per
-    //      frame. We copy min(frame_pos.length, topology.length) floats so a short
-    //      OR an oversized getter array can never write out of bounds.
-    //   3. Replica/image atoms (beyond the base block) keep their topology xyz.
-    // Result: non-supercell (frame_pos covers all atoms) ⇒ every atom gets its
-    // per-frame xyz, identical to before. Supercell (frame_pos covers only the
-    // base block) ⇒ base atoms animate, replicas stay at topology — the
-    // trajectory PLAYS instead of freezing on frame 1. Getter null/unavailable ⇒
-    // pure static topology positions, exactly as the prior fallback.
-    const topology = pack_positions(sites)
-    if (pos) {
-      const n = Math.min(pos.length, topology.length)
-      topology.set(pos.subarray(0, n))
-    }
-    frame_positions = topology
     positions_dirty = true
 
     // Variable-cell: if the displayed lattice changed, the bond compute + bond

--- a/src/lib/structure/gpu/bond-compute.ts
+++ b/src/lib/structure/gpu/bond-compute.ts
@@ -14,9 +14,18 @@ export type BondComputeRun = {
   periodic: boolean
 }
 
+/** Result of a bond-compute run.
+ *  - `count` is the number of pairs actually returned (clamped to `capacity`).
+ *  - `pairs` holds `count` entries.
+ *  - `raw_count` is the unclamped count the shader atomically accumulated; it may
+ *    exceed `capacity` because the shader `atomicAdd`s before checking the slot.
+ *  - `overflowed` is true when `raw_count > capacity`, meaning some pairs were
+ *    silently dropped and the caller should resize (`capacity`) and rerun. */
 export type BondComputeResult = {
   count: number
   pairs: { a: number; b: number; jimage: [number, number, number] }[]
+  overflowed: boolean
+  raw_count: number
 }
 
 /** Size of the packed Params uniform. WGSL pads each mat3x3 column (vec3) to 16
@@ -67,92 +76,107 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
   return {
     async run(r: BondComputeRun): Promise<BondComputeResult> {
       const n = r.radii.length
-
-      const positions_buf = device.createBuffer({
-        size: Math.max(r.positions.byteLength, 4),
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-      })
-      device.queue.writeBuffer(positions_buf, 0, r.positions as BufferSource)
-
-      const radii_buf = device.createBuffer({
-        size: Math.max(r.radii.byteLength, 4),
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-      })
-      device.queue.writeBuffer(radii_buf, 0, r.radii as BufferSource)
-
-      const params_buf = device.createBuffer({
-        size: PARAMS_BYTES,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-      })
-      device.queue.writeBuffer(params_buf, 0, pack_params(n, capacity, r))
-
       const pairs_bytes = capacity * 3 * 4
-      const pairs_buf = device.createBuffer({
-        size: pairs_bytes,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
-      })
 
-      const count_buf = device.createBuffer({
-        size: 4,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
-      })
-      device.queue.writeBuffer(count_buf, 0, new Uint32Array([0]))
+      // Declared before the try so finally can destroy whatever was created,
+      // even if buffer creation throws partway. run() is called repeatedly
+      // (the on-pause bridge), so a leak on the mapAsync error path would
+      // accumulate GPU memory.
+      let positions_buf: GPUBuffer | undefined
+      let radii_buf: GPUBuffer | undefined
+      let params_buf: GPUBuffer | undefined
+      let pairs_buf: GPUBuffer | undefined
+      let count_buf: GPUBuffer | undefined
+      let count_read: GPUBuffer | undefined
+      let pairs_read: GPUBuffer | undefined
 
-      const bind_group = device.createBindGroup({
-        layout: pipeline.getBindGroupLayout(0),
-        entries: [
-          { binding: 0, resource: { buffer: positions_buf } },
-          { binding: 1, resource: { buffer: radii_buf } },
-          { binding: 2, resource: { buffer: params_buf } },
-          { binding: 3, resource: { buffer: pairs_buf } },
-          { binding: 4, resource: { buffer: count_buf } },
-        ],
-      })
+      try {
+        positions_buf = device.createBuffer({
+          size: Math.max(r.positions.byteLength, 4),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        device.queue.writeBuffer(positions_buf, 0, r.positions as BufferSource)
 
-      const count_read = device.createBuffer({
-        size: 4,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-      })
-      const pairs_read = device.createBuffer({
-        size: pairs_bytes,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-      })
+        radii_buf = device.createBuffer({
+          size: Math.max(r.radii.byteLength, 4),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        device.queue.writeBuffer(radii_buf, 0, r.radii as BufferSource)
 
-      const encoder = device.createCommandEncoder()
-      const pass = encoder.beginComputePass()
-      pass.setPipeline(pipeline)
-      pass.setBindGroup(0, bind_group)
-      pass.dispatchWorkgroups(Math.max(1, Math.ceil(n / 64)))
-      pass.end()
-      encoder.copyBufferToBuffer(count_buf, 0, count_read, 0, 4)
-      encoder.copyBufferToBuffer(pairs_buf, 0, pairs_read, 0, pairs_bytes)
-      device.queue.submit([encoder.finish()])
+        params_buf = device.createBuffer({
+          size: PARAMS_BYTES,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        })
+        device.queue.writeBuffer(params_buf, 0, pack_params(n, capacity, r))
 
-      await count_read.mapAsync(GPUMapMode.READ)
-      const raw_count = new Uint32Array(count_read.getMappedRange())[0]
-      count_read.unmap()
-      const count = Math.min(raw_count, capacity)
+        pairs_buf = device.createBuffer({
+          size: pairs_bytes,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+        })
 
-      await pairs_read.mapAsync(GPUMapMode.READ)
-      const pairs_data = new Uint32Array(pairs_read.getMappedRange().slice(0))
-      pairs_read.unmap()
+        count_buf = device.createBuffer({
+          size: 4,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+        })
+        device.queue.writeBuffer(count_buf, 0, new Uint32Array([0]))
 
-      const pairs: BondComputeResult[`pairs`] = []
-      for (let s = 0; s < count; s++) {
-        const a = pairs_data[s * 3 + 0]
-        const b = pairs_data[s * 3 + 1]
-        pairs.push({ a, b, jimage: unpack_jimage(pairs_data[s * 3 + 2]) })
+        const bind_group = device.createBindGroup({
+          layout: pipeline.getBindGroupLayout(0),
+          entries: [
+            { binding: 0, resource: { buffer: positions_buf } },
+            { binding: 1, resource: { buffer: radii_buf } },
+            { binding: 2, resource: { buffer: params_buf } },
+            { binding: 3, resource: { buffer: pairs_buf } },
+            { binding: 4, resource: { buffer: count_buf } },
+          ],
+        })
+
+        count_read = device.createBuffer({
+          size: 4,
+          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        })
+        pairs_read = device.createBuffer({
+          size: pairs_bytes,
+          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        })
+
+        const encoder = device.createCommandEncoder()
+        const pass = encoder.beginComputePass()
+        pass.setPipeline(pipeline)
+        pass.setBindGroup(0, bind_group)
+        pass.dispatchWorkgroups(Math.max(1, Math.ceil(n / 64)))
+        pass.end()
+        encoder.copyBufferToBuffer(count_buf, 0, count_read, 0, 4)
+        encoder.copyBufferToBuffer(pairs_buf, 0, pairs_read, 0, pairs_bytes)
+        device.queue.submit([encoder.finish()])
+
+        await count_read.mapAsync(GPUMapMode.READ)
+        const raw_count = new Uint32Array(count_read.getMappedRange())[0]
+        count_read.unmap()
+        const count = Math.min(raw_count, capacity)
+        const overflowed = raw_count > capacity
+
+        await pairs_read.mapAsync(GPUMapMode.READ)
+        const pairs_data = new Uint32Array(pairs_read.getMappedRange().slice(0))
+        pairs_read.unmap()
+
+        const pairs: BondComputeResult[`pairs`] = []
+        for (let s = 0; s < count; s++) {
+          const a = pairs_data[s * 3 + 0]
+          const b = pairs_data[s * 3 + 1]
+          pairs.push({ a, b, jimage: unpack_jimage(pairs_data[s * 3 + 2]) })
+        }
+
+        return { count, pairs, overflowed, raw_count }
+      } finally {
+        positions_buf?.destroy()
+        radii_buf?.destroy()
+        params_buf?.destroy()
+        pairs_buf?.destroy()
+        count_buf?.destroy()
+        count_read?.destroy()
+        pairs_read?.destroy()
       }
-
-      positions_buf.destroy()
-      radii_buf.destroy()
-      params_buf.destroy()
-      pairs_buf.destroy()
-      count_buf.destroy()
-      count_read.destroy()
-      pairs_read.destroy()
-
-      return { count, pairs }
     },
   }
 }

--- a/src/lib/structure/gpu/bond-compute.ts
+++ b/src/lib/structure/gpu/bond-compute.ts
@@ -3,6 +3,7 @@
  *  pass (storage buffers, bind group, uniform packing, dispatch, readback).
  *  Readback is for tests + the future on-pause CPU bridge, NOT the playback loop. */
 import { BOND_COMPUTE_WGSL } from '$lib/structure/gpu/bond-compute.wgsl'
+import { plan_grid, type GridPlan } from '$lib/structure/gpu/bond-grid'
 
 export type BondComputeRun = {
   tolerance: number
@@ -37,13 +38,23 @@ export type BondComputeResult = {
 }
 
 /** Size of the packed Params uniform. WGSL pads each mat3x3 column (vec3) to 16
- *  bytes, so the matrix spans bytes 32..80 and the struct is 80 bytes total. */
-export const PARAMS_BYTES = 80
+ *  bytes, so the matrix spans bytes 32..80. The uniform-grid block (vec3+u32 dims,
+ *  vec3+u32 aabb/max, f32+3pad) appends three 16-byte rows ⇒ bytes 80..128. */
+export const PARAMS_BYTES = 128
 
-/** Pack the Params uniform (80 bytes). The lattice is uploaded TRANSPOSED so the
+/** Pack the Params uniform (128 bytes). The lattice is uploaded TRANSPOSED so the
  *  WGSL column-major mat3x3 columns equal the row-major lattice rows a,b,c:
- *  column k (f32 offsets 8/12/16, each 3 floats + 1 pad) = lattice row k. */
-export function pack_params(n: number, capacity: number, r: BondComputeRun): ArrayBuffer {
+ *  column k (f32 offsets 8/12/16, each 3 floats + 1 pad) = lattice row k.
+ *  `grid` (optional) appends the uniform-grid sizing the WGSL reads (dims,
+ *  use_grid, aabb_min, max_per_cell, inv_h). When omitted, use_grid packs 0 (the
+ *  shader takes the O(N²) fallback) — keeps the golden test + bond-compute.run
+ *  able to pack params without a grid plan. */
+export function pack_params(
+  n: number,
+  capacity: number,
+  r: BondComputeRun,
+  grid?: GridPlan,
+): ArrayBuffer {
   const buf = new ArrayBuffer(PARAMS_BYTES)
   const u32 = new Uint32Array(buf)
   const f32 = new Float32Array(buf)
@@ -62,6 +73,19 @@ export function pack_params(n: number, capacity: number, r: BondComputeRun): Arr
   f32[8] = L[0]; f32[9] = L[1]; f32[10] = L[2]; f32[11] = 0
   f32[12] = L[3]; f32[13] = L[4]; f32[14] = L[5]; f32[15] = 0
   f32[16] = L[6]; f32[17] = L[7]; f32[18] = L[8]; f32[19] = 0
+  // ── Uniform-grid block (f32/u32 words 20..31; bytes 80..128) ──
+  // word 20-22 = grid_dims.xyz (u32), word 23 = use_grid (u32)
+  // word 24-26 = aabb_min.xyz (f32), word 27 = max_per_cell (u32)
+  // word 28 = inv_h (f32), words 29-31 = pad
+  if (grid) {
+    u32[20] = grid.dims[0]; u32[21] = grid.dims[1]; u32[22] = grid.dims[2]
+    u32[23] = grid.use_grid ? 1 : 0
+    f32[24] = grid.aabb_min[0]; f32[25] = grid.aabb_min[1]; f32[26] = grid.aabb_min[2]
+    u32[27] = grid.max_per_cell
+    f32[28] = grid.inv_h
+  } else {
+    u32[23] = 0 // use_grid = 0 ⇒ O(N²) fallback
+  }
   return buf
 }
 
@@ -77,9 +101,39 @@ export function unpack_jimage(p: number): [number, number, number] {
 export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }) {
   const { capacity } = cfg
   const module = device.createShaderModule({ code: BOND_COMPUTE_WGSL })
+  // Explicit bind-group layout shared by all three grid passes (clear/bin/detect)
+  // so ONE bind group binds every pipeline. `auto` layout would give each entry
+  // point its own layout (only the bindings it uses), so the bind groups wouldn't
+  // be interchangeable; an explicit layout with all 10 bindings avoids that.
+  const storage = (rw: boolean): GPUBindGroupLayoutEntry[`buffer`] => ({
+    type: rw ? `storage` : `read-only-storage`,
+  })
+  const bgl = device.createBindGroupLayout({
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: storage(false) },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: storage(false) },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: `uniform` } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: storage(true) },
+      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: storage(true) },
+      { binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: storage(false) },
+      { binding: 6, visibility: GPUShaderStage.COMPUTE, buffer: storage(false) },
+      { binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: storage(true) },
+      { binding: 8, visibility: GPUShaderStage.COMPUTE, buffer: storage(true) },
+      { binding: 9, visibility: GPUShaderStage.COMPUTE, buffer: storage(true) },
+    ],
+  })
+  const compute_layout = device.createPipelineLayout({ bindGroupLayouts: [bgl] })
   const pipeline = device.createComputePipeline({
-    layout: `auto`,
+    layout: compute_layout,
     compute: { module, entryPoint: `detect_bonds` },
+  })
+  const clear_pipeline = device.createComputePipeline({
+    layout: compute_layout,
+    compute: { module, entryPoint: `clear_grid` },
+  })
+  const bin_pipeline = device.createComputePipeline({
+    layout: compute_layout,
+    compute: { module, entryPoint: `bin_atoms` },
   })
 
   return {
@@ -98,10 +152,22 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
       let count_buf: GPUBuffer | undefined
       let elem_ids_buf: GPUBuffer | undefined
       let rules_buf: GPUBuffer | undefined
+      let cell_count_buf: GPUBuffer | undefined
+      let cell_atoms_buf: GPUBuffer | undefined
+      let overflow_buf: GPUBuffer | undefined
       let count_read: GPUBuffer | undefined
       let pairs_read: GPUBuffer | undefined
 
       try {
+        // Plan the uniform grid (CPU). For periodic small cells use_grid is false
+        // ⇒ the shader takes the exact O(N²) fallback; non-periodic always grids.
+        const grid = plan_grid({
+          periodic: r.periodic,
+          lattice: r.lattice,
+          max_bond_dist: r.max_bond_dist,
+          positions: r.positions,
+          n,
+        })
         positions_buf = device.createBuffer({
           size: Math.max(r.positions.byteLength, 4),
           usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
@@ -118,7 +184,7 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
           size: PARAMS_BYTES,
           usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
         })
-        device.queue.writeBuffer(params_buf, 0, pack_params(n, capacity, r))
+        device.queue.writeBuffer(params_buf, 0, pack_params(n, capacity, r, grid))
 
         pairs_buf = device.createBuffer({
           size: pairs_bytes,
@@ -151,8 +217,26 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
         })
         if (rules.byteLength > 0) device.queue.writeBuffer(rules_buf, 0, rules as BufferSource)
 
+        // ── Grid storage (bindings 7/8/9). Sized from the plan; a 4-byte minimum
+        // keeps the bindings non-empty in the fallback (use_grid=0) path where the
+        // shader never touches them. ──
+        const n_cells = Math.max(1, grid.n_cells)
+        cell_count_buf = device.createBuffer({
+          size: Math.max(n_cells * 4, 4),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        cell_atoms_buf = device.createBuffer({
+          size: Math.max(n_cells * grid.max_per_cell * 4, 4),
+          usage: GPUBufferUsage.STORAGE,
+        })
+        overflow_buf = device.createBuffer({
+          size: 4,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        device.queue.writeBuffer(overflow_buf, 0, new Uint32Array([0]))
+
         const bind_group = device.createBindGroup({
-          layout: pipeline.getBindGroupLayout(0),
+          layout: bgl,
           entries: [
             { binding: 0, resource: { buffer: positions_buf } },
             { binding: 1, resource: { buffer: radii_buf } },
@@ -161,6 +245,9 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
             { binding: 4, resource: { buffer: count_buf } },
             { binding: 5, resource: { buffer: elem_ids_buf } },
             { binding: 6, resource: { buffer: rules_buf } },
+            { binding: 7, resource: { buffer: cell_count_buf } },
+            { binding: 8, resource: { buffer: cell_atoms_buf } },
+            { binding: 9, resource: { buffer: overflow_buf } },
           ],
         })
 
@@ -175,8 +262,17 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
 
         const encoder = device.createCommandEncoder()
         const pass = encoder.beginComputePass()
-        pass.setPipeline(pipeline)
         pass.setBindGroup(0, bind_group)
+        // Three ordered passes in one submit: clear the grid, bin atoms, detect.
+        // The clear/bin passes are dispatched only on the grid path (use_grid);
+        // on the fallback detect_bonds ignores the grid buffers entirely.
+        if (grid.use_grid) {
+          pass.setPipeline(clear_pipeline)
+          pass.dispatchWorkgroups(Math.max(1, Math.ceil(n_cells / 64)))
+          pass.setPipeline(bin_pipeline)
+          pass.dispatchWorkgroups(Math.max(1, Math.ceil(n / 64)))
+        }
+        pass.setPipeline(pipeline)
         pass.dispatchWorkgroups(Math.max(1, Math.ceil(n / 64)))
         pass.end()
         encoder.copyBufferToBuffer(count_buf, 0, count_read, 0, 4)
@@ -209,6 +305,9 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
         count_buf?.destroy()
         elem_ids_buf?.destroy()
         rules_buf?.destroy()
+        cell_count_buf?.destroy()
+        cell_atoms_buf?.destroy()
+        overflow_buf?.destroy()
         count_read?.destroy()
         pairs_read?.destroy()
       }

--- a/src/lib/structure/gpu/bond-compute.ts
+++ b/src/lib/structure/gpu/bond-compute.ts
@@ -1,0 +1,158 @@
+/// <reference types="@webgpu/types" />
+/** Bond-detection compute pipeline: wraps BOND_COMPUTE_WGSL into a GPU compute
+ *  pass (storage buffers, bind group, uniform packing, dispatch, readback).
+ *  Readback is for tests + the future on-pause CPU bridge, NOT the playback loop. */
+import { BOND_COMPUTE_WGSL } from '$lib/structure/gpu/bond-compute.wgsl'
+
+export type BondComputeRun = {
+  tolerance: number
+  max_bond_dist: number
+  min_dist: number
+  positions: Float32Array // 3N, xyz interleaved
+  radii: Float32Array // N
+  lattice: Float32Array // 9, row-major (rows a,b,c)
+  periodic: boolean
+}
+
+export type BondComputeResult = {
+  count: number
+  pairs: { a: number; b: number; jimage: [number, number, number] }[]
+}
+
+/** Size of the packed Params uniform. WGSL pads each mat3x3 column (vec3) to 16
+ *  bytes, so the matrix spans bytes 32..80 and the struct is 80 bytes total. */
+export const PARAMS_BYTES = 80
+
+/** Pack the Params uniform (80 bytes). The lattice is uploaded TRANSPOSED so the
+ *  WGSL column-major mat3x3 columns equal the row-major lattice rows a,b,c:
+ *  column k (f32 offsets 8/12/16, each 3 floats + 1 pad) = lattice row k. */
+export function pack_params(n: number, capacity: number, r: BondComputeRun): ArrayBuffer {
+  const buf = new ArrayBuffer(PARAMS_BYTES)
+  const u32 = new Uint32Array(buf)
+  const f32 = new Float32Array(buf)
+  u32[0] = n
+  u32[1] = capacity
+  u32[2] = r.periodic ? 1 : 0
+  u32[3] = 0
+  f32[4] = r.tolerance
+  f32[5] = r.max_bond_dist
+  f32[6] = r.min_dist
+  f32[7] = 0
+  const L = r.lattice
+  // Transpose: WGSL reads lattice[k] as column k; write row k into column k.
+  // Column 0 = row a (L[0..2]), column 1 = row b (L[3..5]), column 2 = row c (L[6..8]).
+  f32[8] = L[0]; f32[9] = L[1]; f32[10] = L[2]; f32[11] = 0
+  f32[12] = L[3]; f32[13] = L[4]; f32[14] = L[5]; f32[15] = 0
+  f32[16] = L[6]; f32[17] = L[7]; f32[18] = L[8]; f32[19] = 0
+  return buf
+}
+
+/** Unpack a packed jimage u32 -> [na,nb,nc] in {-1,0,1}.
+ *  pack = (na+1) | ((nb+1)<<2) | ((nc+1)<<4). */
+export function unpack_jimage(p: number): [number, number, number] {
+  return [(p & 3) - 1, ((p >> 2) & 3) - 1, ((p >> 4) & 3) - 1]
+}
+
+/** Create a reusable bond-detection compute pipeline for a fixed output capacity.
+ *  Buffers sized for `capacity` pairs are allocated per-run (positions/radii vary
+ *  in length); the pipeline + bind-group layout are built once. */
+export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }) {
+  const { capacity } = cfg
+  const module = device.createShaderModule({ code: BOND_COMPUTE_WGSL })
+  const pipeline = device.createComputePipeline({
+    layout: `auto`,
+    compute: { module, entryPoint: `detect_bonds` },
+  })
+
+  return {
+    async run(r: BondComputeRun): Promise<BondComputeResult> {
+      const n = r.radii.length
+
+      const positions_buf = device.createBuffer({
+        size: Math.max(r.positions.byteLength, 4),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+      device.queue.writeBuffer(positions_buf, 0, r.positions as BufferSource)
+
+      const radii_buf = device.createBuffer({
+        size: Math.max(r.radii.byteLength, 4),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+      device.queue.writeBuffer(radii_buf, 0, r.radii as BufferSource)
+
+      const params_buf = device.createBuffer({
+        size: PARAMS_BYTES,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      })
+      device.queue.writeBuffer(params_buf, 0, pack_params(n, capacity, r))
+
+      const pairs_bytes = capacity * 3 * 4
+      const pairs_buf = device.createBuffer({
+        size: pairs_bytes,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      })
+
+      const count_buf = device.createBuffer({
+        size: 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+      })
+      device.queue.writeBuffer(count_buf, 0, new Uint32Array([0]))
+
+      const bind_group = device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: positions_buf } },
+          { binding: 1, resource: { buffer: radii_buf } },
+          { binding: 2, resource: { buffer: params_buf } },
+          { binding: 3, resource: { buffer: pairs_buf } },
+          { binding: 4, resource: { buffer: count_buf } },
+        ],
+      })
+
+      const count_read = device.createBuffer({
+        size: 4,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+      })
+      const pairs_read = device.createBuffer({
+        size: pairs_bytes,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+      })
+
+      const encoder = device.createCommandEncoder()
+      const pass = encoder.beginComputePass()
+      pass.setPipeline(pipeline)
+      pass.setBindGroup(0, bind_group)
+      pass.dispatchWorkgroups(Math.max(1, Math.ceil(n / 64)))
+      pass.end()
+      encoder.copyBufferToBuffer(count_buf, 0, count_read, 0, 4)
+      encoder.copyBufferToBuffer(pairs_buf, 0, pairs_read, 0, pairs_bytes)
+      device.queue.submit([encoder.finish()])
+
+      await count_read.mapAsync(GPUMapMode.READ)
+      const raw_count = new Uint32Array(count_read.getMappedRange())[0]
+      count_read.unmap()
+      const count = Math.min(raw_count, capacity)
+
+      await pairs_read.mapAsync(GPUMapMode.READ)
+      const pairs_data = new Uint32Array(pairs_read.getMappedRange().slice(0))
+      pairs_read.unmap()
+
+      const pairs: BondComputeResult[`pairs`] = []
+      for (let s = 0; s < count; s++) {
+        const a = pairs_data[s * 3 + 0]
+        const b = pairs_data[s * 3 + 1]
+        pairs.push({ a, b, jimage: unpack_jimage(pairs_data[s * 3 + 2]) })
+      }
+
+      positions_buf.destroy()
+      radii_buf.destroy()
+      params_buf.destroy()
+      pairs_buf.destroy()
+      count_buf.destroy()
+      count_read.destroy()
+      pairs_read.destroy()
+
+      return { count, pairs }
+    },
+  }
+}

--- a/src/lib/structure/gpu/bond-compute.ts
+++ b/src/lib/structure/gpu/bond-compute.ts
@@ -12,6 +12,14 @@ export type BondComputeRun = {
   radii: Float32Array // N
   lattice: Float32Array // 9, row-major (rows a,b,c)
   periodic: boolean
+  /** Per-atom element id (N). Optional — defaults to all-zero (no rule matches
+   *  any pair, so behaviour is identical to no rules). Shares its id mapping
+   *  with `rules` (see bond-rules.ts encode_bond_rules). */
+  elem_ids?: Uint32Array
+  /** Packed element-pair distance rules: 4 floats per rule
+   *  [id_a, id_b, min, max] with id_a ≤ id_b. Optional — defaults to empty
+   *  (rule_count 0 ⇒ the shader applies no post-filter). */
+  rules?: Float32Array
 }
 
 /** Result of a bond-compute run.
@@ -46,7 +54,8 @@ export function pack_params(n: number, capacity: number, r: BondComputeRun): Arr
   f32[4] = r.tolerance
   f32[5] = r.max_bond_dist
   f32[6] = r.min_dist
-  f32[7] = 0
+  // u32[7] = rule_count (number of element-pair distance rules). 0 ⇒ no filter.
+  u32[7] = r.rules ? r.rules.length / 4 : 0
   const L = r.lattice
   // Transpose: WGSL reads lattice[k] as column k; write row k into column k.
   // Column 0 = row a (L[0..2]), column 1 = row b (L[3..5]), column 2 = row c (L[6..8]).
@@ -87,6 +96,8 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
       let params_buf: GPUBuffer | undefined
       let pairs_buf: GPUBuffer | undefined
       let count_buf: GPUBuffer | undefined
+      let elem_ids_buf: GPUBuffer | undefined
+      let rules_buf: GPUBuffer | undefined
       let count_read: GPUBuffer | undefined
       let pairs_read: GPUBuffer | undefined
 
@@ -120,6 +131,26 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
         })
         device.queue.writeBuffer(count_buf, 0, new Uint32Array([0]))
 
+        // Per-atom element ids (binding 5). Optional: default to all-zero (size n)
+        // so the rule scan sees every atom with id 0 — harmless because with no
+        // rules (rule_count 0) the scan is skipped entirely.
+        const elem_ids = r.elem_ids ?? new Uint32Array(n)
+        elem_ids_buf = device.createBuffer({
+          size: Math.max(elem_ids.byteLength, 4),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        device.queue.writeBuffer(elem_ids_buf, 0, elem_ids as BufferSource)
+
+        // Packed element-pair rules (binding 6). Optional: default empty ⇒ the
+        // shader reads rule_count 0 from Params and applies no post-filter. A
+        // 4-byte minimum keeps the (read-only) storage binding non-empty.
+        const rules = r.rules ?? new Float32Array(0)
+        rules_buf = device.createBuffer({
+          size: Math.max(rules.byteLength, 4),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        if (rules.byteLength > 0) device.queue.writeBuffer(rules_buf, 0, rules as BufferSource)
+
         const bind_group = device.createBindGroup({
           layout: pipeline.getBindGroupLayout(0),
           entries: [
@@ -128,6 +159,8 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
             { binding: 2, resource: { buffer: params_buf } },
             { binding: 3, resource: { buffer: pairs_buf } },
             { binding: 4, resource: { buffer: count_buf } },
+            { binding: 5, resource: { buffer: elem_ids_buf } },
+            { binding: 6, resource: { buffer: rules_buf } },
           ],
         })
 
@@ -174,6 +207,8 @@ export function create_bond_compute(device: GPUDevice, cfg: { capacity: number }
         params_buf?.destroy()
         pairs_buf?.destroy()
         count_buf?.destroy()
+        elem_ids_buf?.destroy()
+        rules_buf?.destroy()
         count_read?.destroy()
         pairs_read?.destroy()
       }

--- a/src/lib/structure/gpu/bond-compute.wgsl.ts
+++ b/src/lib/structure/gpu/bond-compute.wgsl.ts
@@ -19,8 +19,27 @@
  *  jimage_packed: (na+1) | ((nb+1)<<2) | ((nc+1)<<4), each in {0,1,2} for {-1,0,1}.
  *  jimage convention matches bond-detect-reference.ts: offset applied to atom b/j,
  *  displacement = (pos_j - pos_i) + jimage·L. Precondition: max_bond_dist < half the
- *  shortest cell dimension (27-image search only). v1 is O(N) per atom (all j>i);
- *  a uniform-grid candidate list is layered in later without changing this predicate. */
+ *  shortest cell dimension (27-image search only).
+ *
+ *  CANDIDATE ENUMERATION — uniform grid (cell-list), O(N).
+ *  Three compute entry points run in order in one submit:
+ *    1. clear_grid : zero cell_count over n_cells.
+ *    2. bin_atoms  : per atom → cell index → atomicAdd into cell_count; if the
+ *                    slot < max_per_cell write the atom into cell_atoms, else flag
+ *                    overflow (overflow[0] = 1).
+ *    3. detect_bonds : per atom i → its cell → loop the 27 neighbor cells → for
+ *                      each atom j in that cell run the EXACT same predicate
+ *                      (atom_radii + rules_keep) + jimage pack + i<j dedup as the
+ *                      old all-pairs path. Only the candidate list changed.
+ *  Cell size h = max_bond_dist, so all bonded neighbors are within the 27-cell
+ *  shell. Periodic: bin in FRACTIONAL space (cell = floor(frac*n) mod n); a
+ *  neighbor offset that wraps past [0,n) contributes a ±1 lattice image on that
+ *  axis, folded into the same jimage used for the min-image distance. Non-periodic:
+ *  bin over the atom AABB (origin P.aabb_min, scale P.inv_h); neighbor offsets that
+ *  leave [0,n) are skipped (no wrap). When P.use_grid == 0 (periodic small cell,
+ *  any dim < 3) detect_bonds takes the exact O(N²) all-pairs 27-image fallback so
+ *  small unit cells stay correct. Grid sizing (dims, max_per_cell, AABB) is
+ *  computed on the CPU in bond-grid.ts and passed through Params. */
 export const BOND_COMPUTE_WGSL = /* wgsl */ `
 struct Params {
   n_atoms: u32,
@@ -32,6 +51,15 @@ struct Params {
   min_dist: f32,
   rule_count: u32,   // number of element-pair distance rules in the rules buffer
   lattice: mat3x3<f32>, // columns a,b,c (caller uploads transposed)
+  // ── Uniform-grid (cell-list) params (computed CPU-side in bond-grid.ts) ──
+  grid_dims: vec3<u32>, // cells along each axis (frac axes / AABB axes)
+  use_grid: u32,        // 1 ⇒ grid candidate search; 0 ⇒ O(N²) all-pairs fallback
+  aabb_min: vec3<f32>,  // non-periodic binning origin ([0,0,0] when periodic)
+  max_per_cell: u32,    // fixed per-cell capacity (cell_atoms stride)
+  inv_h: f32,           // 1 / max_bond_dist (non-periodic cell scale)
+  _pad2: u32,
+  _pad3: u32,
+  _pad4: u32,
 };
 
 @group(0) @binding(0) var<storage, read> positions: array<f32>;
@@ -41,6 +69,12 @@ struct Params {
 @group(0) @binding(4) var<storage, read_write> out_count: atomic<u32>;
 @group(0) @binding(5) var<storage, read> elem_ids: array<u32>;
 @group(0) @binding(6) var<storage, read> rules: array<f32>;
+// Grid storage: cell_count is the per-cell atom tally (atomic, sized n_cells);
+// cell_atoms holds up to max_per_cell atom indices per cell (sized n_cells*max);
+// overflow[0] is set to 1 if any cell exceeds max_per_cell (dropped extras).
+@group(0) @binding(7) var<storage, read_write> cell_count: array<atomic<u32>>;
+@group(0) @binding(8) var<storage, read_write> cell_atoms: array<u32>;
+@group(0) @binding(9) var<storage, read_write> overflow: array<atomic<u32>>;
 
 fn pos(i: u32) -> vec3<f32> {
   return vec3<f32>(positions[i*3u], positions[i*3u+1u], positions[i*3u+2u]);
@@ -70,41 +104,171 @@ fn pack_jimage(na: i32, nb: i32, nc: i32) -> u32 {
   return u32(na+1) | (u32(nb+1) << 2u) | (u32(nc+1) << 4u);
 }
 
+// Total grid cell count = product of the three dims (>=1 each, CPU-validated).
+fn n_cells() -> u32 {
+  return P.grid_dims.x * P.grid_dims.y * P.grid_dims.z;
+}
+
+// Linear cell index from integer cell coords (already folded into [0,n)).
+fn cell_linear(cx: u32, cy: u32, cz: u32) -> u32 {
+  return (cz * P.grid_dims.y + cy) * P.grid_dims.x + cx;
+}
+
+// Fractional coordinate of atom i: solve lattice * frac = pos. P.lattice columns
+// are a,b,c (transposed upload), so its inverse maps Cartesian → fractional. We
+// only need frac mod 1 for binning, but the raw value's floor also drives the
+// integer cell, so return the raw fractional coord (may be outside [0,1)).
+fn frac_coord(p: vec3<f32>) -> vec3<f32> {
+  // inverse of the 3x3 lattice (columns a,b,c).
+  let m = P.lattice;
+  let a = m[0]; let b = m[1]; let c = m[2];
+  let det = dot(a, cross(b, c));
+  // det is nonzero for any real periodic cell; guard against a degenerate one.
+  if (abs(det) < 1e-20) { return vec3<f32>(0.0, 0.0, 0.0); }
+  let inv_det = 1.0 / det;
+  // Rows of the inverse are the reciprocal-lattice vectors / det.
+  let r0 = cross(b, c) * inv_det;
+  let r1 = cross(c, a) * inv_det;
+  let r2 = cross(a, b) * inv_det;
+  return vec3<f32>(dot(r0, p), dot(r1, p), dot(r2, p));
+}
+
+// Integer cell coordinate (per axis) for the cell that atom at position p lives in.
+fn atom_cell(p: vec3<f32>) -> vec3<u32> {
+  if (P.periodic == 1u) {
+    let f = frac_coord(p);
+    let nx = i32(P.grid_dims.x);
+    let ny = i32(P.grid_dims.y);
+    let nz = i32(P.grid_dims.z);
+    // floor(frac * n) mod n, with a positive modulo (frac can be negative).
+    let cx = ((i32(floor(f.x * f32(nx))) % nx) + nx) % nx;
+    let cy = ((i32(floor(f.y * f32(ny))) % ny) + ny) % ny;
+    let cz = ((i32(floor(f.z * f32(nz))) % nz) + nz) % nz;
+    return vec3<u32>(u32(cx), u32(cy), u32(cz));
+  }
+  // Non-periodic: AABB binning. (pos - aabb_min) / h, clamped into [0, n-1].
+  let g = (p - P.aabb_min) * P.inv_h;
+  let cx = clamp(i32(floor(g.x)), 0, i32(P.grid_dims.x) - 1);
+  let cy = clamp(i32(floor(g.y)), 0, i32(P.grid_dims.y) - 1);
+  let cz = clamp(i32(floor(g.z)), 0, i32(P.grid_dims.z) - 1);
+  return vec3<u32>(u32(cx), u32(cy), u32(cz));
+}
+
+// ── Pass 1: clear the per-cell counts (dispatched over n_cells). ──────────────
+@compute @workgroup_size(64)
+fn clear_grid(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let c = gid.x;
+  if (c >= n_cells()) { return; }
+  atomicStore(&cell_count[c], 0u);
+  // Reset the single overflow flag once (cheapest to fold into cell 0's clear).
+  if (c == 0u) { atomicStore(&overflow[0], 0u); }
+}
+
+// ── Pass 2: bin each atom into its cell. ──────────────────────────────────────
+@compute @workgroup_size(64)
+fn bin_atoms(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i >= P.n_atoms) { return; }
+  let cc = atom_cell(pos(i));
+  let cell = cell_linear(cc.x, cc.y, cc.z);
+  let slot = atomicAdd(&cell_count[cell], 1u);
+  if (slot < P.max_per_cell) {
+    cell_atoms[cell * P.max_per_cell + slot] = i;
+  } else {
+    // Cell overran its fixed capacity — extras are dropped; flag so the caller
+    // can grow max_per_cell and rerun.
+    atomicStore(&overflow[0], 1u);
+  }
+}
+
+// Shared min-image + predicate + emit for a candidate ordered pair (i<j). Runs
+// the SAME exact 27-image minimum-image search, atom_radii predicate, rules_keep
+// post-filter, and jimage pack as the original all-pairs path — only the choice
+// of candidate j differs. The grid wrap is handled implicitly: the full 27-image
+// search picks the closest lattice image, so a neighbor reached through a wrapped
+// cell gets the correct +/-1 jimage automatically (consistent with the reference).
+fn try_emit(i: u32, j: u32, pi: vec3<f32>, ri: f32) {
+  let dvec = pos(j) - pi;
+  var best_d2 = 1e30;
+  var bi: i32 = 0; var bj: i32 = 0; var bk: i32 = 0;
+  if (P.periodic == 1u) {
+    for (var na: i32 = -1; na <= 1; na = na + 1) {
+      for (var nb: i32 = -1; nb <= 1; nb = nb + 1) {
+        for (var nc: i32 = -1; nc <= 1; nc = nc + 1) {
+          let shift = f32(na)*P.lattice[0] + f32(nb)*P.lattice[1] + f32(nc)*P.lattice[2];
+          let e = dvec + shift;
+          let d2 = dot(e, e);
+          if (d2 < best_d2) { best_d2 = d2; bi = na; bj = nb; bk = nc; }
+        }
+      }
+    }
+  } else {
+    best_d2 = dot(dvec, dvec);
+  }
+  let d = sqrt(best_d2);
+  if (d < P.min_dist || d > P.max_bond_dist) { return; }
+  if (d <= ri + radii[j] + P.tolerance) {
+    // Per-element-pair rule post-filter (matches visibility.ts). Applied only
+    // AFTER the atom_radii test passes; can only remove a detected bond.
+    if (!rules_keep(elem_ids[i], elem_ids[j], d)) { return; }
+    let slot = atomicAdd(&out_count, 1u);
+    if (slot < P.capacity) {
+      out_pairs[slot*3u + 0u] = i;
+      out_pairs[slot*3u + 1u] = j;
+      out_pairs[slot*3u + 2u] = pack_jimage(bi, bj, bk);
+    }
+  }
+}
+
+// ── Pass 3: detect bonds. Grid candidate search, or O(N²) fallback. ───────────
 @compute @workgroup_size(64)
 fn detect_bonds(@builtin(global_invocation_id) gid: vec3<u32>) {
   let i = gid.x;
   if (i >= P.n_atoms) { return; }
   let pi = pos(i);
   let ri = radii[i];
-  for (var j: u32 = i + 1u; j < P.n_atoms; j = j + 1u) {
-    let dvec = pos(j) - pi;
-    var best_d2 = 1e30;
-    var bi: i32 = 0; var bj: i32 = 0; var bk: i32 = 0;
-    if (P.periodic == 1u) {
-      for (var na: i32 = -1; na <= 1; na = na + 1) {
-        for (var nb: i32 = -1; nb <= 1; nb = nb + 1) {
-          for (var nc: i32 = -1; nc <= 1; nc = nc + 1) {
-            let shift = f32(na)*P.lattice[0] + f32(nb)*P.lattice[1] + f32(nc)*P.lattice[2];
-            let e = dvec + shift;
-            let d2 = dot(e, e);
-            if (d2 < best_d2) { best_d2 = d2; bi = na; bj = nb; bk = nc; }
-          }
-        }
-      }
-    } else {
-      best_d2 = dot(dvec, dvec);
+
+  if (P.use_grid == 0u) {
+    // Exact O(N²) all-pairs 27-image fallback (periodic small cell). Unchanged
+    // predicate; preserves correctness for cells too small for the 27-cell shell.
+    for (var j: u32 = i + 1u; j < P.n_atoms; j = j + 1u) {
+      try_emit(i, j, pi, ri);
     }
-    let d = sqrt(best_d2);
-    if (d < P.min_dist || d > P.max_bond_dist) { continue; }
-    if (d <= ri + radii[j] + P.tolerance) {
-      // Per-element-pair rule post-filter (matches visibility.ts). Applied only
-      // AFTER the atom_radii test passes; can only remove a detected bond.
-      if (!rules_keep(elem_ids[i], elem_ids[j], d)) { continue; }
-      let slot = atomicAdd(&out_count, 1u);
-      if (slot < P.capacity) {
-        out_pairs[slot*3u + 0u] = i;
-        out_pairs[slot*3u + 1u] = j;
-        out_pairs[slot*3u + 2u] = pack_jimage(bi, bj, bk);
+    return;
+  }
+
+  // Grid path: visit the 27 neighbor cells of atom i's cell. For each atom j in
+  // those cells, enforce the i<j dedup (each unordered pair is emitted once),
+  // then run the shared min-image predicate (which handles PBC images / jimage
+  // exactly, the same as the reference). The grid only narrows WHICH j we test.
+  let cc = atom_cell(pi);
+  let nx = i32(P.grid_dims.x);
+  let ny = i32(P.grid_dims.y);
+  let nz = i32(P.grid_dims.z);
+  for (var dx: i32 = -1; dx <= 1; dx = dx + 1) {
+    for (var dy: i32 = -1; dy <= 1; dy = dy + 1) {
+      for (var dz: i32 = -1; dz <= 1; dz = dz + 1) {
+        var cx = i32(cc.x) + dx;
+        var cy = i32(cc.y) + dy;
+        var cz = i32(cc.z) + dz;
+        if (P.periodic == 1u) {
+          // Wrap into [0,n); the ±1 lattice image is recovered by try_emit's full
+          // 27-image search, so we don't need to track it explicitly here.
+          cx = ((cx % nx) + nx) % nx;
+          cy = ((cy % ny) + ny) % ny;
+          cz = ((cz % nz) + nz) % nz;
+        } else {
+          // No wrap: skip neighbor cells outside the AABB grid.
+          if (cx < 0 || cx >= nx || cy < 0 || cy >= ny || cz < 0 || cz >= nz) { continue; }
+        }
+        let cell = cell_linear(u32(cx), u32(cy), u32(cz));
+        let count = min(atomicLoad(&cell_count[cell]), P.max_per_cell);
+        for (var s: u32 = 0u; s < count; s = s + 1u) {
+          let j = cell_atoms[cell * P.max_per_cell + s];
+          // i<j dedup: each unordered pair handled once. (Self i==j excluded.)
+          if (j <= i) { continue; }
+          try_emit(i, j, pi, ri);
+        }
       }
     }
   }

--- a/src/lib/structure/gpu/bond-compute.wgsl.ts
+++ b/src/lib/structure/gpu/bond-compute.wgsl.ts
@@ -5,6 +5,17 @@
  *   2: params      uniform             Params
  *   3: out_pairs   storage<read_write> array<u32>  (capacity*3: a, b, jimage_packed)
  *   4: out_count   storage<read_write> atomic<u32>
+ *   5: elem_ids    storage<read>       array<u32>  (N, per-atom element id)
+ *   6: rules       storage<read>       array<f32>  (rule_count*4: id_a,id_b,min,max)
+ *  Bindings 5/6 carry the per-element-pair bond_distance_rules POST-FILTER
+ *  (matches src/lib/structure/scene/visibility.ts). After a candidate pair (i,j)
+ *  PASSES the atom_radii test, the sorted element-id pair (lo,hi) is looked up
+ *  against `rules` (linear scan, P.rule_count entries): if a rule matches, the
+ *  bond is emitted only when min ≤ d ≤ max, else it is SKIPPED; if no rule
+ *  matches, the bond is emitted (the strategy decides). Rules only REMOVE
+ *  detected bonds, never add. P.rule_count == 0 ⇒ no filtering (identical to no
+ *  rules). The id stored in `rules` is an integer bit-cast to f32; the shader
+ *  reads it back exactly via the small-int round-trip (u32(id_f32)).
  *  jimage_packed: (na+1) | ((nb+1)<<2) | ((nc+1)<<4), each in {0,1,2} for {-1,0,1}.
  *  jimage convention matches bond-detect-reference.ts: offset applied to atom b/j,
  *  displacement = (pos_j - pos_i) + jimage·L. Precondition: max_bond_dist < half the
@@ -19,7 +30,7 @@ struct Params {
   tolerance: f32,
   max_bond_dist: f32,
   min_dist: f32,
-  _pad1: f32,
+  rule_count: u32,   // number of element-pair distance rules in the rules buffer
   lattice: mat3x3<f32>, // columns a,b,c (caller uploads transposed)
 };
 
@@ -28,9 +39,31 @@ struct Params {
 @group(0) @binding(2) var<uniform> P: Params;
 @group(0) @binding(3) var<storage, read_write> out_pairs: array<u32>;
 @group(0) @binding(4) var<storage, read_write> out_count: atomic<u32>;
+@group(0) @binding(5) var<storage, read> elem_ids: array<u32>;
+@group(0) @binding(6) var<storage, read> rules: array<f32>;
 
 fn pos(i: u32) -> vec3<f32> {
   return vec3<f32>(positions[i*3u], positions[i*3u+1u], positions[i*3u+2u]);
+}
+
+// Per-element-pair distance-rule post-filter. Mirrors visibility.ts:
+//   sorted key (lo,hi) → if a rule matches, keep only when min ≤ d ≤ max;
+//   if NO rule matches the pair, keep (strategy decides). rule_count 0 ⇒ keep.
+// Returns true to KEEP the bond, false to SKIP it.
+fn rules_keep(ea: u32, eb: u32, d: f32) -> bool {
+  if (P.rule_count == 0u) { return true; }
+  let lo = min(ea, eb);
+  let hi = max(ea, eb);
+  for (var r: u32 = 0u; r < P.rule_count; r = r + 1u) {
+    let id_a = u32(rules[r*4u + 0u]);
+    let id_b = u32(rules[r*4u + 1u]);
+    if (id_a == lo && id_b == hi) {
+      let rmin = rules[r*4u + 2u];
+      let rmax = rules[r*4u + 3u];
+      return d >= rmin && d <= rmax;
+    }
+  }
+  return true;
 }
 
 fn pack_jimage(na: i32, nb: i32, nc: i32) -> u32 {
@@ -64,6 +97,9 @@ fn detect_bonds(@builtin(global_invocation_id) gid: vec3<u32>) {
     let d = sqrt(best_d2);
     if (d < P.min_dist || d > P.max_bond_dist) { continue; }
     if (d <= ri + radii[j] + P.tolerance) {
+      // Per-element-pair rule post-filter (matches visibility.ts). Applied only
+      // AFTER the atom_radii test passes; can only remove a detected bond.
+      if (!rules_keep(elem_ids[i], elem_ids[j], d)) { continue; }
       let slot = atomicAdd(&out_count, 1u);
       if (slot < P.capacity) {
         out_pairs[slot*3u + 0u] = i;

--- a/src/lib/structure/gpu/bond-compute.wgsl.ts
+++ b/src/lib/structure/gpu/bond-compute.wgsl.ts
@@ -1,0 +1,76 @@
+/** WGSL compute for atom_radii bond detection with minimum-image PBC.
+ *  Bindings:
+ *   0: positions   storage<read>       array<f32>  (3N, xyz interleaved)
+ *   1: radii       storage<read>       array<f32>  (N)
+ *   2: params      uniform             Params
+ *   3: out_pairs   storage<read_write> array<u32>  (capacity*3: a, b, jimage_packed)
+ *   4: out_count   storage<read_write> atomic<u32>
+ *  jimage_packed: (na+1) | ((nb+1)<<2) | ((nc+1)<<4), each in {0,1,2} for {-1,0,1}.
+ *  jimage convention matches bond-detect-reference.ts: offset applied to atom b/j,
+ *  displacement = (pos_j - pos_i) + jimage·L. Precondition: max_bond_dist < half the
+ *  shortest cell dimension (27-image search only). v1 is O(N) per atom (all j>i);
+ *  a uniform-grid candidate list is layered in later without changing this predicate. */
+export const BOND_COMPUTE_WGSL = /* wgsl */ `
+struct Params {
+  n_atoms: u32,
+  capacity: u32,
+  periodic: u32,
+  _pad0: u32,
+  tolerance: f32,
+  max_bond_dist: f32,
+  min_dist: f32,
+  _pad1: f32,
+  lattice: mat3x3<f32>, // columns a,b,c (caller uploads transposed)
+};
+
+@group(0) @binding(0) var<storage, read> positions: array<f32>;
+@group(0) @binding(1) var<storage, read> radii: array<f32>;
+@group(0) @binding(2) var<uniform> P: Params;
+@group(0) @binding(3) var<storage, read_write> out_pairs: array<u32>;
+@group(0) @binding(4) var<storage, read_write> out_count: atomic<u32>;
+
+fn pos(i: u32) -> vec3<f32> {
+  return vec3<f32>(positions[i*3u], positions[i*3u+1u], positions[i*3u+2u]);
+}
+
+fn pack_jimage(na: i32, nb: i32, nc: i32) -> u32 {
+  return u32(na+1) | (u32(nb+1) << 2u) | (u32(nc+1) << 4u);
+}
+
+@compute @workgroup_size(64)
+fn detect_bonds(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i >= P.n_atoms) { return; }
+  let pi = pos(i);
+  let ri = radii[i];
+  for (var j: u32 = i + 1u; j < P.n_atoms; j = j + 1u) {
+    let dvec = pos(j) - pi;
+    var best_d2 = 1e30;
+    var bi: i32 = 0; var bj: i32 = 0; var bk: i32 = 0;
+    if (P.periodic == 1u) {
+      for (var na: i32 = -1; na <= 1; na = na + 1) {
+        for (var nb: i32 = -1; nb <= 1; nb = nb + 1) {
+          for (var nc: i32 = -1; nc <= 1; nc = nc + 1) {
+            let shift = f32(na)*P.lattice[0] + f32(nb)*P.lattice[1] + f32(nc)*P.lattice[2];
+            let e = dvec + shift;
+            let d2 = dot(e, e);
+            if (d2 < best_d2) { best_d2 = d2; bi = na; bj = nb; bk = nc; }
+          }
+        }
+      }
+    } else {
+      best_d2 = dot(dvec, dvec);
+    }
+    let d = sqrt(best_d2);
+    if (d < P.min_dist || d > P.max_bond_dist) { continue; }
+    if (d <= ri + radii[j] + P.tolerance) {
+      let slot = atomicAdd(&out_count, 1u);
+      if (slot < P.capacity) {
+        out_pairs[slot*3u + 0u] = i;
+        out_pairs[slot*3u + 1u] = j;
+        out_pairs[slot*3u + 2u] = pack_jimage(bi, bj, bk);
+      }
+    }
+  }
+}
+`

--- a/src/lib/structure/gpu/bond-detect-reference.ts
+++ b/src/lib/structure/gpu/bond-detect-reference.ts
@@ -1,0 +1,67 @@
+export type RefBondOptions = { tolerance: number; max_bond_dist: number; min_dist: number }
+export type RefBond = { a: number; b: number; dist: number; jimage: [number, number, number] }
+
+/** Reference atom_radii bond detector with minimum-image PBC. Matches the Rust
+ *  detect_bonds_atom_radii predicate (extensions/rust/src/bonding.rs):
+ *  bond between i<j iff minimum-image distance d satisfies
+ *    min_dist <= d <= max_bond_dist  AND  d <= r_i + r_j + tolerance.
+ *  This is the source-of-truth oracle the WGSL compute shader (Task 5/6) must
+ *  match. O(N^2) — oracle/test + small structures only; the GPU path uses a
+ *  uniform grid for scale.
+ *
+ *  jimage CONVENTION (the contract Tasks 5/6/8 inherit): jimage is the integer
+ *  image offset (in lattice units) applied to atom b so that b + jimage*L lands
+ *  in the minimum-image position relative to a. i.e. the realized displacement
+ *  is (pos_b - pos_a) + jimage·L. For two atoms straddling a boundary where the
+ *  short contact is "wrap b backward by one cell", jimage is [-1,0,0]. */
+export function detect_bonds_reference(
+  positions: Float32Array, // 3N
+  lattice: Float32Array, // 9, row-major (rows a,b,c); all-zero => non-periodic
+  radii: Float32Array, // N
+  opts: RefBondOptions,
+): RefBond[] {
+  const n = radii.length
+  const periodic = lattice.some((v) => v !== 0)
+  const out: RefBond[] = []
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dx = positions[j * 3] - positions[i * 3]
+      const dy = positions[j * 3 + 1] - positions[i * 3 + 1]
+      const dz = positions[j * 3 + 2] - positions[i * 3 + 2]
+      const mi = periodic
+        ? minimum_image(dx, dy, dz, lattice)
+        : { d2: dx * dx + dy * dy + dz * dz, jimage: [0, 0, 0] as [number, number, number] }
+      const d = Math.sqrt(mi.d2)
+      if (d < opts.min_dist || d > opts.max_bond_dist) continue
+      if (d <= radii[i] + radii[j] + opts.tolerance) out.push({ a: i, b: j, dist: d, jimage: mi.jimage })
+    }
+  }
+  return out
+}
+
+/** Minimum-image displacement searching the 27 nearest images (offsets in
+ *  {-1,0,1}); returns the closest with the integer image applied to atom b.
+ *  Adequate for bond cutoffs << cell size (the large-trajectory regime). */
+function minimum_image(
+  dx: number,
+  dy: number,
+  dz: number,
+  L: Float32Array,
+): { d2: number; jimage: [number, number, number] } {
+  let best = { d2: Infinity, jimage: [0, 0, 0] as [number, number, number] }
+  for (let na = -1; na <= 1; na++) {
+    for (let nb = -1; nb <= 1; nb++) {
+      for (let nc = -1; nc <= 1; nc++) {
+        const sx = na * L[0] + nb * L[3] + nc * L[6]
+        const sy = na * L[1] + nb * L[4] + nc * L[7]
+        const sz = na * L[2] + nb * L[5] + nc * L[8]
+        const ex = dx + sx,
+          ey = dy + sy,
+          ez = dz + sz
+        const d2 = ex * ex + ey * ey + ez * ez
+        if (d2 < best.d2) best = { d2, jimage: [na, nb, nc] }
+      }
+    }
+  }
+  return best
+}

--- a/src/lib/structure/gpu/bond-detect-reference.ts
+++ b/src/lib/structure/gpu/bond-detect-reference.ts
@@ -13,7 +13,15 @@ export type RefBond = { a: number; b: number; dist: number; jimage: [number, num
  *  image offset (in lattice units) applied to atom b so that b + jimage*L lands
  *  in the minimum-image position relative to a. i.e. the realized displacement
  *  is (pos_b - pos_a) + jimage·L. For two atoms straddling a boundary where the
- *  short contact is "wrap b backward by one cell", jimage is [-1,0,0]. */
+ *  short contact is "wrap b backward by one cell", jimage is [-1,0,0].
+ *
+ *  CORRECTNESS PRECONDITION (Tasks 5/6 inherit this): the 27-image search over
+ *  the {-1,0,1}^3 shell is not merely a perf shortcut — it is only *correct* when
+ *  the bond cutoff (max_bond_dist) is smaller than half the shortest cell
+ *  dimension. For larger cutoffs, or highly skewed / very short lattices, the
+ *  true minimum image can lie outside the {-1,0,1}^3 shell, so the closest image
+ *  is missed and genuine bonds are silently dropped. Callers must keep cutoffs
+ *  well inside half the minimum cell dimension. */
 export function detect_bonds_reference(
   positions: Float32Array, // 3N
   lattice: Float32Array, // 9, row-major (rows a,b,c); all-zero => non-periodic
@@ -41,7 +49,10 @@ export function detect_bonds_reference(
 
 /** Minimum-image displacement searching the 27 nearest images (offsets in
  *  {-1,0,1}); returns the closest with the integer image applied to atom b.
- *  Adequate for bond cutoffs << cell size (the large-trajectory regime). */
+ *  PRECONDITION (correctness, not just perf): valid only when the bond cutoff is
+ *  smaller than half the shortest cell dimension. For larger cutoffs or highly
+ *  skewed / short lattices the true minimum image can fall outside the
+ *  {-1,0,1}^3 shell and the closest image would be missed. */
 function minimum_image(
   dx: number,
   dy: number,

--- a/src/lib/structure/gpu/bond-grid.ts
+++ b/src/lib/structure/gpu/bond-grid.ts
@@ -1,0 +1,162 @@
+/** Pure-JS uniform-grid (cell-list) sizing + AABB math for GPU bond detection.
+ *
+ *  The GPU bond compute (bond-compute.wgsl.ts) finds candidate neighbor pairs via
+ *  a uniform grid instead of an O(N²) all-pairs scan. The grid is sized on the CPU
+ *  (here) and uploaded through the Params uniform; the WGSL only reads the dims.
+ *
+ *  Cell size h = max_bond_dist, so every bonded neighbor lies in the 27-cell
+ *  neighborhood (the cell containing atom i plus its 26 face/edge/corner
+ *  neighbors). This mirrors the existing 27-image minimum-image search.
+ *
+ *  Two regimes:
+ *   - PERIODIC: bin in FRACTIONAL space. Grid dims n_k = max(1, floor(|v_k| / h))
+ *     using the lattice vector lengths |a|,|b|,|c|. Neighbor offsets that wrap past
+ *     [0, n_k) contribute a ±1 lattice image on axis k → folded into the jimage.
+ *     We APPROXIMATE the bucketing with an orthogonal box of the lattice-vector
+ *     LENGTHS (see assumption note below); the exact minimum-image distance is
+ *     still computed in the shader, so the approximation only widens the candidate
+ *     set and can never MISS a bond.
+ *   - NON-PERIODIC: bin over the atom AABB (computed here). Cells don't wrap;
+ *     out-of-range neighbor offsets are skipped in the shader.
+ *
+ *  SMALL-CELL FALLBACK: if any periodic dim n_k < 3, the 27-neighborhood does NOT
+ *  capture all images (a cell shorter than 3·h can have a bonded partner two cells
+ *  away after wrap). In that case use_grid is false and the shader falls back to
+ *  the exact O(N²) 27-image path. Non-periodic always uses the grid.
+ *
+ *  ASSUMPTION (orthogonal-box bucketing for periodic cells): dims are derived from
+ *  lattice-vector LENGTHS and atoms are binned by fractional coordinate. For
+ *  non-orthogonal cells the fractional cell that an atom lands in is exact, and the
+ *  ±1 jimage from a wrap is exact; only the choice of n_k (how many cells span each
+ *  axis) uses the vector length as a proxy for the perpendicular cell width. Since
+ *  n_k = floor(|v_k|/h) ≤ |v_k|/h, each fractional cell spans AT LEAST h along its
+ *  axis direction, so the 27-cell shell always reaches at least h in every lattice
+ *  direction — i.e. it covers every neighbor within max_bond_dist. The
+ *  approximation can only make cells LARGER (fewer cells), never smaller, so no
+ *  bond within the cutoff is ever missed. The exact min-image distance + radii +
+ *  rules predicate in the shader is unchanged. */
+
+/** Hard cap on atoms stored per grid cell (fixed-capacity, no prefix-sum scan).
+ *  A cell that exceeds this drops the extras and the shader raises an overflow
+ *  flag so the caller can enlarge + rerun. 64 comfortably holds a dense cell of
+ *  cube side max_bond_dist (~3 Å) at typical solid densities. */
+export const MAX_PER_CELL = 64
+
+/** Minimum grid dim for the 27-neighborhood to be valid (see SMALL-CELL FALLBACK).
+ *  Every periodic dim must be ≥ this or we fall back to the O(N²) path. */
+export const MIN_GRID_DIM = 3
+
+export type GridPlan = {
+  /** Whether the grid path is usable. False ⇒ caller dispatches the O(N²) fallback
+   *  (periodic small cell). For non-periodic this is always true. */
+  use_grid: boolean
+  /** Grid cell counts along the three axes (fractional axes when periodic, AABB
+   *  axes when non-periodic). At least 1 each. */
+  dims: [number, number, number]
+  /** Total cell count = dims[0]*dims[1]*dims[2]. */
+  n_cells: number
+  /** AABB minimum corner (non-periodic binning origin). [0,0,0] when periodic
+   *  (fractional binning needs no origin). */
+  aabb_min: [number, number, number]
+  /** 1/h where h = max_bond_dist; the shader multiplies (pos - aabb_min) by this
+   *  to get the non-periodic cell coordinate. 0 when max_bond_dist ≤ 0. */
+  inv_h: number
+  /** Per-cell capacity used to size cell_atoms (= MAX_PER_CELL). */
+  max_per_cell: number
+}
+
+/** Euclidean length of a 3-vector. */
+function vlen(x: number, y: number, z: number): number {
+  return Math.sqrt(x * x + y * y + z * z)
+}
+
+/** Compute the periodic grid dims from the lattice (row-major rows a,b,c) and the
+ *  cell size h = max_bond_dist. Each dim = max(1, floor(|v_k| / h)). */
+export function periodic_grid_dims(
+  lattice: Float32Array,
+  max_bond_dist: number,
+): [number, number, number] {
+  const h = max_bond_dist
+  if (!(h > 0)) return [1, 1, 1]
+  const la = vlen(lattice[0], lattice[1], lattice[2])
+  const lb = vlen(lattice[3], lattice[4], lattice[5])
+  const lc = vlen(lattice[6], lattice[7], lattice[8])
+  return [
+    Math.max(1, Math.floor(la / h)),
+    Math.max(1, Math.floor(lb / h)),
+    Math.max(1, Math.floor(lc / h)),
+  ]
+}
+
+/** Axis-aligned bounding box of N interleaved xyz positions (3N floats). Returns
+ *  {min,max}; for N=0 returns a zero box. */
+export function compute_aabb(
+  positions: Float32Array,
+  n: number,
+): { min: [number, number, number]; max: [number, number, number] } {
+  if (n <= 0) return { min: [0, 0, 0], max: [0, 0, 0] }
+  let minx = Infinity, miny = Infinity, minz = Infinity
+  let maxx = -Infinity, maxy = -Infinity, maxz = -Infinity
+  for (let i = 0; i < n; i++) {
+    const x = positions[i * 3], y = positions[i * 3 + 1], z = positions[i * 3 + 2]
+    if (x < minx) minx = x
+    if (y < miny) miny = y
+    if (z < minz) minz = z
+    if (x > maxx) maxx = x
+    if (y > maxy) maxy = y
+    if (z > maxz) maxz = z
+  }
+  return { min: [minx, miny, minz], max: [maxx, maxy, maxz] }
+}
+
+/** Non-periodic grid dims over an AABB with cell size h = max_bond_dist. Each dim
+ *  = max(1, ceil(extent / h)). A degenerate (zero-extent) axis collapses to 1. */
+export function aabb_grid_dims(
+  min: [number, number, number],
+  max: [number, number, number],
+  max_bond_dist: number,
+): [number, number, number] {
+  const h = max_bond_dist
+  if (!(h > 0)) return [1, 1, 1]
+  const dim = (lo: number, hi: number) => Math.max(1, Math.ceil((hi - lo) / h))
+  return [dim(min[0], max[0]), dim(min[1], max[1]), dim(min[2], max[2])]
+}
+
+/** Build the full grid plan for one bond-detection dispatch.
+ *  - periodic: dims from lattice vector lengths; use_grid only when ALL dims ≥ 3.
+ *  - non-periodic: dims from the atom AABB; use_grid always true.
+ *  positions/n are only consulted for the non-periodic AABB. */
+export function plan_grid(args: {
+  periodic: boolean
+  lattice: Float32Array
+  max_bond_dist: number
+  positions: Float32Array
+  n: number
+}): GridPlan {
+  const { periodic, lattice, max_bond_dist, positions, n } = args
+  const inv_h = max_bond_dist > 0 ? 1 / max_bond_dist : 0
+
+  if (periodic) {
+    const dims = periodic_grid_dims(lattice, max_bond_dist)
+    const use_grid = dims[0] >= MIN_GRID_DIM && dims[1] >= MIN_GRID_DIM && dims[2] >= MIN_GRID_DIM
+    return {
+      use_grid,
+      dims,
+      n_cells: dims[0] * dims[1] * dims[2],
+      aabb_min: [0, 0, 0],
+      inv_h,
+      max_per_cell: MAX_PER_CELL,
+    }
+  }
+
+  const { min, max } = compute_aabb(positions, n)
+  const dims = aabb_grid_dims(min, max, max_bond_dist)
+  return {
+    use_grid: true,
+    dims,
+    n_cells: dims[0] * dims[1] * dims[2],
+    aabb_min: min,
+    inv_h,
+    max_per_cell: MAX_PER_CELL,
+  }
+}

--- a/src/lib/structure/gpu/bond-rules.ts
+++ b/src/lib/structure/gpu/bond-rules.ts
@@ -1,0 +1,84 @@
+/** Per-element-pair bond-distance-rule encoding for the GPU bond compute.
+ *
+ *  The WebGL/CPU path (src/lib/structure/scene/visibility.ts) applies
+ *  `bond_distance_rules` as a POST-FILTER on already-detected bonds: for a
+ *  detected bond with length d and element pair (eA,eB), it looks up the rule
+ *  keyed by the SORTED pair `[eA,eB].sort().join('-')`; if a rule exists it
+ *  keeps the bond only when `min ≤ d ≤ max`, and if no rule exists it keeps the
+ *  bond (the strategy decides). Rules can only REMOVE strategy-detected bonds,
+ *  never add. This module produces the GPU-side data to reproduce that exactly:
+ *
+ *   1. A per-atom element-id `Uint32Array` (one small int id per site's primary
+ *      element symbol).
+ *   2. A packed rules `Float32Array` of `[id_a, id_b, min, max]` per rule, with
+ *      `id_a ≤ id_b` (sorted so the pair key is order-independent, matching the
+ *      CPU `[e1,e2].sort()`), where ids are bit-cast to f32 in the shader.
+ *
+ *  The id mapping is SHARED between the per-atom array and the rules: a symbol
+ *  resolves to the same id in both. Symbols that appear only in a rule but not
+ *  in the structure still get an id, but since no atom carries that id the rule
+ *  simply never matches (harmless). Symbols in the structure but not in any rule
+ *  get an id that no rule references ⇒ no rule matches ⇒ bond kept (matching the
+ *  CPU "no rule for that pair ⇒ keep"). */
+
+import type { Site } from '$lib/structure'
+
+export type BondDistanceRuleLike = {
+  element_1: string
+  element_2: string
+  min_dist: number
+  max_dist: number
+}
+
+export type EncodedBondRules = {
+  /** Per-atom element id, one entry per site (primary species symbol). */
+  elem_ids: Uint32Array
+  /** Packed rules: 4 floats per rule [id_a, id_b, min, max], id_a ≤ id_b.
+   *  id_a/id_b are integer ids stored as f32 (exact for the small id range). */
+  rules: Float32Array
+  /** Number of rules encoded (rules.length / 4). */
+  rule_count: number
+}
+
+/** Build the per-atom element-id array + packed rules buffer for the GPU bond
+ *  post-filter. Pure (no GPU). `rules` empty ⇒ rule_count 0 and an empty rules
+ *  buffer, so the shader applies no filtering (behaviour identical to no rules).
+ *
+ *  The id mapping assigns a stable small int to each distinct symbol seen across
+ *  BOTH the structure sites and the rule elements, so the two encodings agree. */
+export function encode_bond_rules(
+  sites: readonly Site[],
+  rules: readonly BondDistanceRuleLike[],
+): EncodedBondRules {
+  const id_of = new Map<string, number>()
+  const intern = (sym: string): number => {
+    let id = id_of.get(sym)
+    if (id === undefined) {
+      id = id_of.size
+      id_of.set(sym, id)
+    }
+    return id
+  }
+
+  // Per-atom ids first (so the most common symbols get the low ids; the exact
+  // values don't matter, only that atom ids and rule ids share the same map).
+  const elem_ids = new Uint32Array(sites.length)
+  for (let i = 0; i < sites.length; i++) {
+    const elem = sites[i].species[0]?.element
+    elem_ids[i] = elem != null ? intern(elem) : intern(`__none__`)
+  }
+
+  const out_rules = new Float32Array(rules.length * 4)
+  for (let r = 0; r < rules.length; r++) {
+    const a = intern(rules[r].element_1)
+    const b = intern(rules[r].element_2)
+    const lo = Math.min(a, b)
+    const hi = Math.max(a, b)
+    out_rules[r * 4 + 0] = lo
+    out_rules[r * 4 + 1] = hi
+    out_rules[r * 4 + 2] = rules[r].min_dist
+    out_rules[r * 4 + 3] = rules[r].max_dist
+  }
+
+  return { elem_ids, rules: out_rules, rule_count: rules.length }
+}

--- a/src/lib/structure/gpu/camera-uniform.ts
+++ b/src/lib/structure/gpu/camera-uniform.ts
@@ -1,0 +1,19 @@
+import { Matrix4 } from 'three'
+import type { Camera } from 'three'
+
+const _vp = new Matrix4()
+
+/** Pack proj * view (column-major, WebGPU-ready) followed by camera world
+ *  position (vec3 + pad) into Float32Array(20). Three stores matrices
+ *  column-major, so .elements is uploaded directly. Caller must have called
+ *  camera.updateMatrixWorld() so matrixWorldInverse is current. */
+export function pack_camera_uniform(camera: Camera): Float32Array {
+  _vp.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse)
+  const out = new Float32Array(20)
+  out.set(_vp.elements, 0)
+  out[16] = camera.position.x
+  out[17] = camera.position.y
+  out[18] = camera.position.z
+  out[19] = 0
+  return out
+}

--- a/src/lib/structure/gpu/camera-uniform.ts
+++ b/src/lib/structure/gpu/camera-uniform.ts
@@ -17,3 +17,23 @@ export function pack_camera_uniform(camera: Camera): Float32Array {
   out[19] = 0
   return out
 }
+
+/** Pack view and projection matrices SEPARATELY (impostor spheres need both:
+ *  view for the view-space billboard + ray-sphere, proj for clip-space depth).
+ *  Layout (36 floats = 144 bytes, column-major, WebGPU-ready):
+ *    [0..15]  view (camera.matrixWorldInverse.elements)
+ *    [16..31] proj (camera.projectionMatrix.elements)
+ *    [32..34] camera world position (vec3)
+ *    [35]     pad
+ *  Three stores matrices column-major, so .elements uploads directly. Caller
+ *  must have called camera.updateMatrixWorld() so matrixWorldInverse is current. */
+export function pack_camera_full(camera: Camera): Float32Array {
+  const out = new Float32Array(36)
+  out.set(camera.matrixWorldInverse.elements, 0)
+  out.set(camera.projectionMatrix.elements, 16)
+  out[32] = camera.position.x
+  out[33] = camera.position.y
+  out[34] = camera.position.z
+  out[35] = 0
+  return out
+}

--- a/src/lib/structure/gpu/frame-buffers.ts
+++ b/src/lib/structure/gpu/frame-buffers.ts
@@ -1,0 +1,26 @@
+import type { Site, PymatgenLattice } from '$lib/structure'
+
+/** Pack atom positions into a flat Float32Array(3N), row = (x,y,z).
+ *  A raw trajectory frame (already a 3N Float32Array) is returned as-is. */
+export function pack_positions(input: readonly Site[] | Float32Array): Float32Array {
+  if (input instanceof Float32Array) return input
+  const out = new Float32Array(input.length * 3)
+  for (let i = 0; i < input.length; i++) {
+    const [x, y, z] = input[i].xyz
+    out[i * 3] = x
+    out[i * 3 + 1] = y
+    out[i * 3 + 2] = z
+  }
+  return out
+}
+
+/** Flatten a 3x3 lattice matrix (rows = lattice vectors a,b,c) row-major into
+ *  Float32Array(9). Non-periodic structures (no lattice) -> all zeros, which the
+ *  compute shader treats as "no PBC". */
+export function pack_lattice(lattice: PymatgenLattice | undefined): Float32Array {
+  const out = new Float32Array(9)
+  const m = lattice?.matrix
+  if (!m) return out
+  for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) out[r * 3 + c] = m[r][c]
+  return out
+}

--- a/src/lib/structure/gpu/large-system-mode.svelte.ts
+++ b/src/lib/structure/gpu/large-system-mode.svelte.ts
@@ -1,0 +1,38 @@
+import type { BondComputeResult } from '$lib/structure/gpu/bond-compute'
+
+type BondConn = { site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }
+
+/** Translate a GPU bond result into the app's bond_connectivity entries.
+ *  atom_radii strength is 1.0 (matches Rust detect_bonds_atom_radii). Emits
+ *  exactly `result.count` entries (pairs beyond count are ignored / overflow). */
+export function result_to_connectivity(result: BondComputeResult): BondConn[] {
+  const out: BondConn[] = new Array(result.count)
+  for (let i = 0; i < result.count; i++) {
+    const p = result.pairs[i]
+    out[i] = { site_idx_1: p.a, site_idx_2: p.b, strength: 1, jimage: p.jimage }
+  }
+  return out
+}
+
+/** Manual large-system performance mode. WebGPU availability is injected so the
+ *  toggle can refuse + signal fallback when no device. Wired into StructureScene
+ *  in Task 9. */
+export function create_large_system_mode(deps: {
+  has_webgpu: boolean
+  on_fallback: (reason: string) => void
+}) {
+  let enabled = $state(false)
+  return {
+    get enabled() { return enabled },
+    get available() { return deps.has_webgpu },
+    enable(): boolean {
+      if (!deps.has_webgpu) {
+        deps.on_fallback(`WebGPU unavailable — staying on CPU path; very large systems will be capped.`)
+        return false
+      }
+      enabled = true
+      return true
+    },
+    disable(): void { enabled = false },
+  }
+}

--- a/src/lib/structure/gpu/large-system-mode.svelte.ts
+++ b/src/lib/structure/gpu/large-system-mode.svelte.ts
@@ -36,3 +36,20 @@ export function create_large_system_mode(deps: {
     disable(): void { enabled = false },
   }
 }
+
+const DEFAULT_MIN_DIST = 0.1
+const DEFAULT_TOLERANCE = 0.45
+const DEFAULT_MAX_BOND_DIST = 3.0
+
+/** Map the app's bond options (the same tolerance / max_bond_dist the CPU path
+ *  uses, driven by the existing UI sliders) into the GPU compute options. This
+ *  is what makes "custom bond distance" live-tunable on the GPU path: the
+ *  StructureScene loop re-dispatches compute with these whenever a slider
+ *  changes. */
+export function to_compute_options(opts: Record<string, number>): { tolerance: number; max_bond_dist: number; min_dist: number } {
+  return {
+    tolerance: opts.tolerance ?? DEFAULT_TOLERANCE,
+    max_bond_dist: opts.max_bond_dist ?? DEFAULT_MAX_BOND_DIST,
+    min_dist: opts.min_dist ?? DEFAULT_MIN_DIST,
+  }
+}

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -1146,8 +1146,8 @@ export function create_large_system_renderer(
   /** Fixed pixel geometry of the corner gizmo. The triad region is ~2·GIZMO_PX
    *  wide (each axis reaches GIZMO_PX from the origin), placed GIZMO_MARGIN_PX in
    *  from the bottom-left corner — matching the WebGL Gizmo's offset:{left,bottom}. */
-  const GIZMO_PX = 42
-  const GIZMO_MARGIN_PX = 12
+  const GIZMO_PX = 72
+  const GIZMO_MARGIN_PX = 20
 
   /** Pack + upload the gizmo placement uniform from the canvas backing size.
    *  - center_ndc: bottom-left corner anchor in NDC. NDC x∈[-1,1] (right), y∈

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -2020,11 +2020,6 @@ export function create_large_system_renderer(
       const h = pick_id_texture.height
       const px = Math.max(0, Math.min(w - 1, Math.floor(x)))
       const py = Math.max(0, Math.min(h - 1, Math.floor(y)))
-      // TODO(pick-debug): strip once verified. Logs the requested vs clamped
-      // device pixel against the pick id texture size + atom count.
-      // eslint-disable-next-line no-console
-      console.log(`[pick-debug] pick() in`, { x, y }, `clamped`, { px, py },
-        `pick_tex`, { w, h }, `atom_count`, atom_count)
 
       const encoder = device.createCommandEncoder({ label: `large-system-pick` })
       const pass = encoder.beginRenderPass({
@@ -2064,9 +2059,6 @@ export function create_large_system_renderer(
       }
       const id = new Uint32Array(pick_readback.getMappedRange(0, 4))[0]
       pick_readback.unmap()
-      // TODO(pick-debug): strip once verified. Logs the raw texel id read back.
-      // eslint-disable-next-line no-console
-      console.log(`[pick-debug] pick() readback id=`, id, `→ idx=`, id === 0 ? -1 : id - 1)
       // id 0 = background ⇒ -1; otherwise atom index = id - 1.
       return id === 0 ? -1 : id - 1
     },

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -661,6 +661,13 @@ export type LargeSystemRenderer = {
    *  (so the background and atoms share one color space — dark atoms keep their
    *  contrast against the viewer's normal background). Alpha stays 1 (opaque). */
   set_background(rgb: [number, number, number]): void
+  /** Gate bond detection + bond rendering. When `false`, render() skips BOTH the
+   *  GPU bond compute pass AND the bond draw (atoms + cell box still render), so
+   *  the overlay shows no bonds — mirroring the WebGL view when the viewer's
+   *  `show_bonds` setting (via should_show_bonds) resolves to hidden. Defaults to
+   *  true. Flipping it back to true re-enables the compute on the next render
+   *  (the caller should also re-push set_bond_data / mark bonds dirty). */
+  set_bonds_enabled(enabled: boolean): void
   /** Provide the unit-cell box. `lattice` is the 9-float row-major matrix (rows
    *  a,b,c — same convention as set_bond_data / pack_lattice); pass null (or an
    *  all-zero lattice) for non-periodic structures. `show` gates drawing; `color`
@@ -782,6 +789,10 @@ export function create_large_system_renderer(
   // True when the bond inputs (or atoms) changed and the compute must re-run.
   let bonds_dirty = false
   let bonds_configured = false // set once set_bond_data has provided inputs
+  // Gates the bond compute + bond draw. When false the overlay shows no bonds
+  // (atoms + cell still render), mirroring the WebGL view's should_show_bonds.
+  // Default true ⇒ unchanged behaviour until the caller threads visibility in.
+  let bonds_enabled = true
 
   // Bind groups rebuilt when the underlying buffers (re)allocate.
   let bond_compute_bg: GPUBindGroup | null = null
@@ -1229,14 +1240,24 @@ export function create_large_system_renderer(
       upload_bond_render_uniform()
       bonds_dirty = true
     },
+    set_bonds_enabled(enabled: boolean): void {
+      if (destroyed) return
+      if (enabled === bonds_enabled) return
+      bonds_enabled = enabled
+      // Turning bonds back on must re-run the compute against the current atoms
+      // (the cached pairs may be stale or were never computed while disabled).
+      if (enabled) bonds_dirty = true
+    },
     render(): void {
       if (destroyed) return
       if (!depth_view || !msaa_color_view) ensure_targets(canvas.width || 1, canvas.height || 1)
       const encoder = device.createCommandEncoder({ label: `large-system-frame` })
 
-      // Whether bonds are renderable this frame (inputs present + atoms).
+      // Whether bonds are renderable this frame (visible + inputs present +
+      // atoms). bonds_enabled gates BOTH the compute pass below AND the bond
+      // draw, so a hidden show_bonds setting skips all bond work entirely.
       const bonds_ready =
-        bonds_configured && atom_count > 0 && bond_n > 0 &&
+        bonds_enabled && bonds_configured && atom_count > 0 && bond_n > 0 &&
         !!bond_compute_bg && !!indirect_bg && !!bond_render_bg && !!pairs_buffer
 
       // ── Bond compute (only when dirty) ───────────────────────────────────

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -1962,6 +1962,11 @@ export function create_large_system_renderer(
       const h = pick_id_texture.height
       const px = Math.max(0, Math.min(w - 1, Math.floor(x)))
       const py = Math.max(0, Math.min(h - 1, Math.floor(y)))
+      // TODO(pick-debug): strip once verified. Logs the requested vs clamped
+      // device pixel against the pick id texture size + atom count.
+      // eslint-disable-next-line no-console
+      console.log(`[pick-debug] pick() in`, { x, y }, `clamped`, { px, py },
+        `pick_tex`, { w, h }, `atom_count`, atom_count)
 
       const encoder = device.createCommandEncoder({ label: `large-system-pick` })
       const pass = encoder.beginRenderPass({
@@ -2001,6 +2006,9 @@ export function create_large_system_renderer(
       }
       const id = new Uint32Array(pick_readback.getMappedRange(0, 4))[0]
       pick_readback.unmap()
+      // TODO(pick-debug): strip once verified. Logs the raw texel id read back.
+      // eslint-disable-next-line no-console
+      console.log(`[pick-debug] pick() readback id=`, id, `→ idx=`, id === 0 ? -1 : id - 1)
       // id 0 = background ⇒ -1; otherwise atom index = id - 1.
       return id === 0 ? -1 : id - 1
     },

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -49,6 +49,76 @@ const CLEAR_COLOR: GPUColor = { r: 0.02, g: 0.03, b: 0.05, a: 1 }
 
 const DEPTH_FORMAT: GPUTextureFormat = `depth24plus`
 
+/** WGSL cell-box line shader. Draws the 12 edges of the parallelepiped spanned
+ *  by lattice vectors a,b,c as a `line-list` (24 vertices = 12 edges × 2 ends).
+ *  Corners are generated in the vertex shader from a lattice uniform: the cell
+ *  spans from origin 0 to a+b+c, in the SAME coordinate space as the atom
+ *  positions (atoms render at raw site.xyz; the WebGL Lattice box likewise spans
+ *  origin→a+b+c within the shared scene group — see Lattice.svelte's
+ *  lattice_center = 0.5·(a+b+c) applied to an origin-centered box), so no extra
+ *  centering offset is needed.
+ *  Lattice convention: lat0/lat1/lat2 are rows a/b/c of the row-major 9-float
+ *  matrix (same as the bond render uniform), so corner(i) = bit0·a + bit1·b +
+ *  bit2·c. Depth uses the SAME GL→WebGPU clip-z remap as the atom impostor so the
+ *  box shares the depth buffer and is occluded by atoms in front. */
+const CELL_LINE_WGSL = `
+struct Camera {
+  view : mat4x4<f32>,
+  proj : mat4x4<f32>,
+  cam_pos : vec4<f32>,
+};
+// Cell uniform: lattice rows a,b,c (vec3+pad each) + color (rgb + pad).
+struct CellU {
+  lat0 : vec4<f32>,
+  lat1 : vec4<f32>,
+  lat2 : vec4<f32>,
+  color : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<uniform> cell : CellU;
+
+struct VsOut {
+  @builtin(position) clip : vec4<f32>,
+  @location(0) color : vec3<f32>,
+};
+
+// 12 edges as corner-index pairs. Corner i = bit0·a + bit1·b + bit2·c.
+const EDGES = array<vec2<u32>, 12>(
+  vec2<u32>(0u, 1u), vec2<u32>(0u, 2u), vec2<u32>(0u, 4u),
+  vec2<u32>(1u, 3u), vec2<u32>(1u, 5u), vec2<u32>(2u, 3u),
+  vec2<u32>(2u, 6u), vec2<u32>(4u, 5u), vec2<u32>(4u, 6u),
+  vec2<u32>(3u, 7u), vec2<u32>(5u, 7u), vec2<u32>(6u, 7u),
+);
+
+fn corner(i : u32) -> vec3<f32> {
+  let fa = f32(i & 1u);
+  let fb = f32((i >> 1u) & 1u);
+  let fc = f32((i >> 2u) & 1u);
+  return fa * cell.lat0.xyz + fb * cell.lat1.xyz + fc * cell.lat2.xyz;
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi : u32) -> VsOut {
+  let edge = EDGES[vi / 2u];
+  let ci = select(edge.x, edge.y, (vi & 1u) == 1u);
+  let world = corner(ci);
+  var clip = camera.proj * (camera.view * vec4<f32>(world, 1.0));
+  // SAME GL->WebGPU NDC z remap as the atom impostor shader.
+  clip.z = (clip.z + clip.w) * 0.5;
+
+  var out : VsOut;
+  out.clip = clip;
+  out.color = cell.color.xyz;
+  return out;
+}
+
+@fragment
+fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
+  return vec4<f32>(in.color, 1.0);
+}
+`
+
 /** WGSL impostor-sphere shader. View-space billboard + per-fragment ray-sphere.
  *  - storage buffers: positions (3N), radii (N), colors (3N linear rgb)
  *  - camera uniform: view + proj (separate) + camPos
@@ -392,6 +462,18 @@ export type LargeSystemRenderer = {
    *  (so the background and atoms share one color space — dark atoms keep their
    *  contrast against the viewer's normal background). Alpha stays 1 (opaque). */
   set_background(rgb: [number, number, number]): void
+  /** Provide the unit-cell box. `lattice` is the 9-float row-major matrix (rows
+   *  a,b,c — same convention as set_bond_data / pack_lattice); pass null (or an
+   *  all-zero lattice) for non-periodic structures. `show` gates drawing; `color`
+   *  is the linear-RGB cell edge color (alpha is forced to 1). When `show` is true
+   *  AND the lattice is non-zero, render() draws the 12 cell edges as thin lines
+   *  (WebGPU core line width is 1px) sharing the atom depth buffer (occluded by
+   *  atoms in front). */
+  set_cell(
+    lattice: Float32Array | null,
+    show: boolean,
+    color: [number, number, number],
+  ): void
   /** Run one render pass: clear + (if bonds dirty) bond compute + indirect-args
    *  build, then (if atoms present) impostor sphere draw + (if bonds present)
    *  instanced cylinder draw, all sharing one depth attachment. */
@@ -466,6 +548,19 @@ export function create_large_system_renderer(
     size: 64, // 4 × vec4
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   })
+  // Cell-box render uniform: lattice rows a,b,c (3×vec4) + color (vec4).
+  const cell_uniform = device.createBuffer({
+    label: `large-system-cell-uniform`,
+    size: 64, // 4 × vec4
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  // Cached cell inputs (uploaded only when set_cell changes them).
+  let cell_lattice = new Float32Array(9)
+  let cell_show = false
+  let cell_color: [number, number, number] = [0.5, 0.5, 0.5]
+  // True once the lattice is non-zero (a periodic structure has been provided).
+  let cell_has_lattice = false
+
   // cfg for the indirect-args build: (verts_per_cylinder, bond capacity). The
   // build shader clamps the bond count to capacity then doubles it, so the draw
   // issues instance_count = 2*min(count,capacity) (two half-cylinders per bond).
@@ -570,6 +665,51 @@ export function create_large_system_renderer(
       depthCompare: `less`,
     },
   })
+
+  // Cell-box render: 12 edges as a thin line-list. Binds camera + cell uniform.
+  const cell_module = device.createShaderModule({
+    label: `large-system-cell-line`,
+    code: CELL_LINE_WGSL,
+  })
+  const cell_bgl = device.createBindGroupLayout({
+    label: `large-system-cell-bgl`,
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `uniform` } },
+      { binding: 1, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `uniform` } },
+    ],
+  })
+  const cell_pipeline = device.createRenderPipeline({
+    label: `large-system-cell-line-pipeline`,
+    layout: device.createPipelineLayout({ bindGroupLayouts: [cell_bgl] }),
+    vertex: { module: cell_module, entryPoint: `vs_main` },
+    fragment: { module: cell_module, entryPoint: `fs_main`, targets: [{ format }] },
+    primitive: { topology: `line-list` },
+    depthStencil: {
+      format: DEPTH_FORMAT,
+      depthWriteEnabled: true,
+      depthCompare: `less`,
+    },
+  })
+  const cell_bind_group = device.createBindGroup({
+    label: `large-system-cell-bg`,
+    layout: cell_bgl,
+    entries: [
+      { binding: 0, resource: { buffer: camera_buffer } },
+      { binding: 1, resource: { buffer: cell_uniform } },
+    ],
+  })
+
+  /** Pack + upload the cell render uniform: lattice rows a,b,c (each a vec3 + pad)
+   *  then color (rgb + pad). Same row convention as the bond render uniform. */
+  function upload_cell_uniform(): void {
+    const u = new Float32Array(16)
+    const L = cell_lattice
+    u[0] = L[0]; u[1] = L[1]; u[2] = L[2]; u[3] = 0
+    u[4] = L[3]; u[5] = L[4]; u[6] = L[5]; u[7] = 0
+    u[8] = L[6]; u[9] = L[7]; u[10] = L[8]; u[11] = 0
+    u[12] = cell_color[0]; u[13] = cell_color[1]; u[14] = cell_color[2]; u[15] = 1
+    device.queue.writeBuffer(cell_uniform, 0, u.buffer, u.byteOffset, 64)
+  }
 
   // Static indirect-args cfg: (verts_per_cylinder, capacity) — capacity is
   // refreshed when the pairs buffer (re)allocates.
@@ -693,6 +833,28 @@ export function create_large_system_renderer(
       clear_color.g = rgb[1]
       clear_color.b = rgb[2]
       clear_color.a = 1
+    },
+    set_cell(
+      lattice: Float32Array | null,
+      show: boolean,
+      color: [number, number, number],
+    ): void {
+      if (destroyed) return
+      cell_show = show
+      cell_color = [color[0], color[1], color[2]]
+      // A null lattice (non-periodic structure) ⇒ no box. Otherwise detect a
+      // degenerate all-zero lattice (also no box) so molecules never draw one.
+      let nonzero = false
+      if (lattice && lattice.length >= 9) {
+        cell_lattice = lattice.slice(0, 9)
+        for (let i = 0; i < 9; i++) {
+          if (Math.abs(cell_lattice[i]) > 1e-12) { nonzero = true; break }
+        }
+      } else {
+        cell_lattice = new Float32Array(9)
+      }
+      cell_has_lattice = nonzero
+      upload_cell_uniform()
     },
     set_camera(uniform: Float32Array): void {
       if (destroyed) return
@@ -895,6 +1057,14 @@ export function create_large_system_renderer(
         pass.setBindGroup(0, bond_render_bg as GPUBindGroup)
         pass.drawIndirect(indirect_buffer, 0)
       }
+      // Cell box: 12 edges as a thin line-list. Drawn only when toggled on AND a
+      // non-zero lattice is present (periodic structure). Shares the depth
+      // attachment so atoms in front occlude the wireframe.
+      if (cell_show && cell_has_lattice) {
+        pass.setPipeline(cell_pipeline)
+        pass.setBindGroup(0, cell_bind_group)
+        pass.draw(24) // 12 edges × 2 line endpoints
+      }
       pass.end()
       device.queue.submit([encoder.finish()])
     },
@@ -924,6 +1094,7 @@ export function create_large_system_renderer(
       indirect_buffer.destroy()
       bond_params_buffer.destroy()
       bond_render_uniform.destroy()
+      cell_uniform.destroy()
       indirect_cfg_buffer.destroy()
       positions_buffer = null
       radii_buffer = null

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -240,6 +240,10 @@ struct Camera {
 @group(0) @binding(1) var<storage, read> positions : array<f32>;
 @group(0) @binding(2) var<storage, read> radii : array<f32>;
 @group(0) @binding(3) var<storage, read> colors : array<f32>;
+// Per-atom selection flag (1 = selected). Read in the fragment stage so selected
+// atoms get a visible highlight (brighten + rim ring). Always bound (a 4-byte
+// placeholder when nothing is selected), so 0 ⇒ unchanged appearance.
+@group(0) @binding(4) var<storage, read> selected : array<u32>;
 
 struct VsOut {
   @builtin(position) clip : vec4<f32>,
@@ -247,6 +251,7 @@ struct VsOut {
   @location(1) radius : f32,
   @location(2) color : vec3<f32>,
   @location(3) vpos : vec3<f32>,    // view-space position of this quad corner
+  @location(4) @interpolate(flat) sel : u32, // 1 = this atom is selected
 };
 
 struct FsOut {
@@ -293,6 +298,7 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   out.radius = r;
   out.color = col;
   out.vpos = vpos;
+  out.sel = selected[inst];
   return out;
 }
 
@@ -338,11 +344,118 @@ fn fs_main(in : VsOut) -> FsOut {
   let clip_h = camera.proj * vec4<f32>(p, 1.0);
   let remapped_z = (clip_h.z + clip_h.w) * 0.5;
 
+  var shaded = in.color * lighting;
+  // ── Selection highlight ──────────────────────────────────────────────────
+  // Selected atoms (sel == 1) get a clearly-distinct look: brighten the body and
+  // add a bright cyan-tinted RIM where the eye ray grazes the silhouette (rim is
+  // strong when the surface normal is near-perpendicular to the view direction —
+  // i.e. 1 - |n·view|). This reads as a glowing outline ring on the sphere,
+  // matching the "this atom is selected" affordance of the WebGL view. Non-
+  // selected atoms (sel == 0) are untouched.
+  if (in.sel == 1u) {
+    let view_dir = normalize(-p);            // toward the eye (eye at origin)
+    let rim = pow(1.0 - clamp(dot(n, view_dir), 0.0, 1.0), 2.0);
+    let highlight_tint = vec3<f32>(0.25, 0.95, 1.0); // bright cyan
+    // Brighten the body and mix toward the tint at the rim.
+    shaded = mix(shaded * 1.35 + highlight_tint * 0.25, highlight_tint, rim * 0.85);
+  }
+
   var out : FsOut;
   out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
   // alpha = coverage feeds alpha-to-coverage; no alpha blending is enabled, so
   // the color target stays opaque.
-  out.color = vec4<f32>(in.color * lighting, coverage);
+  out.color = vec4<f32>(shaded, coverage);
+  return out;
+}
+`
+
+/** WGSL atom PICK shader. Re-runs the SAME impostor sphere ray-trace as
+ *  IMPOSTOR_WGSL, but writes the atom INDEX (instance_index + 1, so 0 stays free
+ *  for "background") into an R32Uint id buffer instead of a shaded color. Renders
+ *  single-sampled (no MSAA) with its own single-sample depth, so the front-most
+ *  atom at each pixel wins the depth test and its id is what gets read back. Only
+ *  the disk interior is written (the analytic AA band is skipped — a hard discard
+ *  is correct for picking, no fractional ids). The fragment writes the same
+ *  corrected sphere depth as the color pass so overlapping atoms resolve by true
+ *  depth, not draw order. */
+const PICK_WGSL = `
+struct Camera {
+  view : mat4x4<f32>,
+  proj : mat4x4<f32>,
+  cam_pos : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<storage, read> positions : array<f32>;
+@group(0) @binding(2) var<storage, read> radii : array<f32>;
+
+struct VsOut {
+  @builtin(position) clip : vec4<f32>,
+  @location(0) vc : vec3<f32>,
+  @location(1) radius : f32,
+  @location(2) vpos : vec3<f32>,
+  @location(3) @interpolate(flat) id : u32, // instance_index + 1
+};
+
+struct FsOut {
+  @builtin(frag_depth) depth : f32,
+  @location(0) id : u32,
+};
+
+fn corner_for(vi : u32) -> vec2<f32> {
+  let x = select(-1.0, 1.0, (vi & 1u) == 1u);
+  let y = select(-1.0, 1.0, (vi & 2u) == 2u);
+  return vec2<f32>(x, y);
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi : u32,
+           @builtin(instance_index) inst : u32) -> VsOut {
+  let center = vec3<f32>(
+    positions[inst * 3u + 0u],
+    positions[inst * 3u + 1u],
+    positions[inst * 3u + 2u],
+  );
+  let r = radii[inst];
+
+  let vc4 = camera.view * vec4<f32>(center, 1.0);
+  let vc = vc4.xyz;
+
+  let c = corner_for(vi);
+  let vpos = vc + vec3<f32>(c * r * 1.5, 0.0);
+  var clip = camera.proj * vec4<f32>(vpos, 1.0);
+  clip.z = (clip.z + clip.w) * 0.5;
+
+  var out : VsOut;
+  out.clip = clip;
+  out.vc = vc;
+  out.radius = r;
+  out.vpos = vpos;
+  out.id = inst + 1u;
+  return out;
+}
+
+@fragment
+fn fs_main(in : VsOut) -> FsOut {
+  let ro = vec3<f32>(0.0, 0.0, 0.0);
+  let rd = normalize(in.vpos);
+
+  let oc = ro - in.vc;
+  let b = dot(oc, rd);
+  let c = dot(oc, oc) - in.radius * in.radius;
+  let disc = b * b - c;
+  // Hard silhouette for picking — no AA band (an id can't be fractional).
+  if (disc < 0.0) { discard; }
+  let t = -b - sqrt(disc);
+  if (t < 0.0) { discard; }
+  let p = ro + t * rd;
+
+  let clip_h = camera.proj * vec4<f32>(p, 1.0);
+  let remapped_z = (clip_h.z + clip_h.w) * 0.5;
+
+  var out : FsOut;
+  out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
+  out.id = in.id;
   return out;
 }
 `
@@ -821,6 +934,19 @@ export type LargeSystemRenderer = {
     show: boolean,
     color: [number, number, number],
   ): void
+  /** Set which atoms are highlighted as "selected". `indices` is the list of atom
+   *  indices (same indexing as the uploaded positions / structure.sites order) to
+   *  highlight; pass an empty array to clear. Uploads a per-atom u32 flag buffer
+   *  (1 = selected) bound to the atom impostor fragment shader, so selected atoms
+   *  render with a distinct highlight (brighten + rim ring) on the next render.
+   *  Cheap; safe to call every frame the selection might have changed. */
+  set_selection(indices: Uint32Array | number[]): void
+  /** GPU atom picking. Renders the atoms once into an offscreen R32Uint id buffer
+   *  (single-sampled, depth-tested so the front atom wins), then copies the single
+   *  texel at the given DEVICE-pixel (x,y) to a readback buffer and returns the
+   *  atom index under that pixel, or -1 for background. (x,y) are in device pixels
+   *  (CSS px × devicePixelRatio); the caller maps cursor→canvas→device. */
+  pick(x: number, y: number): Promise<number>
   /** Run one render pass: clear + (if bonds dirty) bond compute + indirect-args
    *  build, then (if atoms present) impostor sphere draw + (if bonds present)
    *  instanced cylinder draw, all sharing one depth attachment. */
@@ -857,6 +983,12 @@ export function create_large_system_renderer(
   let colors_buffer: GPUBuffer | null = null
   let atom_capacity = 0 // instances the current buffers can hold
   let atom_count = 0 // instances to draw this frame
+  // Per-atom selection flag buffer (u32 per atom, 1 = selected), bound to the
+  // impostor fragment (binding 4). Grows with the atom buffers; a 4-byte minimum
+  // keeps the binding valid (and reads as "nothing selected") before any
+  // selection is set. Re-created alongside positions when capacity grows.
+  let selected_buffer: GPUBuffer | null = null
+  let selected_capacity = 0
 
   // MSAA render targets, sized to the canvas backing store; recreated on resize.
   // - msaa_color: 4× multisampled COLOR target (canvas format). The render pass
@@ -995,6 +1127,8 @@ export function create_large_system_renderer(
       { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      // binding 4: per-atom selection flag, read by the FRAGMENT stage (highlight).
+      { binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: `read-only-storage` } },
     ],
   })
 
@@ -1016,6 +1150,55 @@ export function create_large_system_renderer(
     // sphere edge — defined by ray-miss discard — gets antialiased. The color
     // target stays opaque (no blend); alpha is consumed ONLY as coverage.
     multisample: { count: SAMPLE_COUNT, alphaToCoverageEnabled: true },
+  })
+
+  // ── Atom PICK pipeline (id-buffer) ───────────────────────────────────────
+  // Re-renders the atoms single-sampled into an R32Uint id texture (atom_index+1)
+  // with its own single-sample depth so the front atom wins. Reuses the camera +
+  // positions + radii buffers (a subset of the color pass's bind group), with its
+  // OWN bind group layout (no colors / selected). pick() runs this pass on demand
+  // and copies one texel back to the CPU.
+  const PICK_ID_FORMAT: GPUTextureFormat = `r32uint`
+  const pick_module = device.createShaderModule({
+    label: `large-system-pick`,
+    code: PICK_WGSL,
+  })
+  const pick_bgl = device.createBindGroupLayout({
+    label: `large-system-pick-bgl`,
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+      { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+    ],
+  })
+  const pick_pipeline = device.createRenderPipeline({
+    label: `large-system-pick-pipeline`,
+    layout: device.createPipelineLayout({ bindGroupLayouts: [pick_bgl] }),
+    vertex: { module: pick_module, entryPoint: `vs_main` },
+    fragment: { module: pick_module, entryPoint: `fs_main`, targets: [{ format: PICK_ID_FORMAT }] },
+    primitive: { topology: `triangle-strip`, cullMode: `none` },
+    depthStencil: {
+      format: DEPTH_FORMAT,
+      depthWriteEnabled: true,
+      depthCompare: `less`,
+    },
+    // Single-sampled — picking needs exact per-pixel ids, no MSAA resolve.
+    multisample: { count: 1 },
+  })
+  // Pick render targets (single-sample), sized to the canvas backing store and
+  // recreated on resize alongside the MSAA targets.
+  let pick_id_texture: GPUTexture | null = null
+  let pick_id_view: GPUTextureView | null = null
+  let pick_depth_texture: GPUTexture | null = null
+  let pick_depth_view: GPUTextureView | null = null
+  let pick_bind_group: GPUBindGroup | null = null
+  // 256-byte-aligned readback staging buffer for a single R32Uint texel. WebGPU
+  // requires bytesPerRow be a multiple of 256 for texture→buffer copies, so we
+  // copy a 1×1 region into a 256-byte buffer and read the first 4 bytes.
+  const pick_readback = device.createBuffer({
+    label: `large-system-pick-readback`,
+    size: 256,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
   })
 
   // Bond-detect compute (BOND_COMPUTE_WGSL). Three entry points share ONE explicit
@@ -1271,15 +1454,51 @@ export function create_large_system_renderer(
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     })
     depth_view = depth_texture.createView()
+
+    // Single-sample PICK targets at the SAME device-pixel size so a (x,y) read
+    // maps 1:1 to the color view. The id texture needs COPY_SRC for the readback.
+    pick_id_texture?.destroy()
+    pick_depth_texture?.destroy()
+    pick_id_texture = device.createTexture({
+      label: `large-system-pick-id`,
+      size: { width, height },
+      format: PICK_ID_FORMAT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    })
+    pick_id_view = pick_id_texture.createView()
+    pick_depth_texture = device.createTexture({
+      label: `large-system-pick-depth`,
+      size: { width, height },
+      format: DEPTH_FORMAT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    })
+    pick_depth_view = pick_depth_texture.createView()
   }
   ensure_targets(canvas.width || 1, canvas.height || 1)
   upload_gizmo_uniform() // seed corner placement from the initial canvas size
+
+  /** Ensure the per-atom selection buffer (binding 4) holds at least `cap`
+   *  entries. Created/grown with a 4-byte minimum so the binding is always valid
+   *  (reads 0 = nothing selected) before any selection is pushed. */
+  function ensure_selected_capacity(cap: number): void {
+    const want = Math.max(cap, 1)
+    if (want <= selected_capacity && selected_buffer) return
+    selected_buffer?.destroy()
+    selected_capacity = Math.max(want, Math.ceil(selected_capacity * 2), 1)
+    selected_buffer = device.createBuffer({
+      label: `large-system-selected`,
+      size: Math.max(selected_capacity * 4, 4),
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    })
+  }
 
   function rebuild_bind_group(): void {
     if (!positions_buffer || !radii_buffer || !colors_buffer) {
       bind_group = null
       return
     }
+    // binding 4 must exist for the layout; lazily create the placeholder.
+    if (!selected_buffer) ensure_selected_capacity(atom_capacity)
     bind_group = device.createBindGroup({
       label: `large-system-impostor-bg`,
       layout: bind_group_layout,
@@ -1288,6 +1507,17 @@ export function create_large_system_renderer(
         { binding: 1, resource: { buffer: positions_buffer } },
         { binding: 2, resource: { buffer: radii_buffer } },
         { binding: 3, resource: { buffer: colors_buffer } },
+        { binding: 4, resource: { buffer: selected_buffer as GPUBuffer } },
+      ],
+    })
+    // Pick pass reuses camera + positions + radii (no colors/selected).
+    pick_bind_group = device.createBindGroup({
+      label: `large-system-pick-bg`,
+      layout: pick_bgl,
+      entries: [
+        { binding: 0, resource: { buffer: camera_buffer } },
+        { binding: 1, resource: { buffer: positions_buffer } },
+        { binding: 2, resource: { buffer: radii_buffer } },
       ],
     })
   }
@@ -1555,6 +1785,9 @@ export function create_large_system_renderer(
           usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         })
         atom_capacity = new_cap
+        // Grow the selection buffer in lockstep so binding 4 covers every atom.
+        // (Newly-grown slots default to 0 = unselected; set_selection re-uploads.)
+        ensure_selected_capacity(new_cap)
         rebuild_bind_group()
         // positions_buffer just reallocated ⇒ rebuild the bond bind groups that
         // reference it (they may have been null before, that's fine).
@@ -1682,6 +1915,80 @@ export function create_large_system_renderer(
       // Turning bonds back on must re-run the compute against the current atoms
       // (the cached pairs may be stale or were never computed while disabled).
       if (enabled) bonds_dirty = true
+    },
+    set_selection(indices: Uint32Array | number[]): void {
+      if (destroyed) return
+      // Build a dense per-atom flag array (1 = selected) over the current atom
+      // capacity, then upload. We always rewrite the whole buffer (clearing old
+      // selections), so an empty `indices` clears the highlight. Sized to the
+      // atom buffer; out-of-range indices are ignored.
+      ensure_selected_capacity(Math.max(atom_capacity, 1))
+      // rebuild the bind group if the buffer was (re)created without atoms yet.
+      if (!bind_group && positions_buffer && radii_buffer && colors_buffer) {
+        rebuild_bind_group()
+      }
+      const n = Math.max(atom_capacity, 1)
+      const flags = new Uint32Array(n)
+      for (let k = 0; k < indices.length; k++) {
+        const i = indices[k]
+        if (i >= 0 && i < n) flags[i] = 1
+      }
+      if (selected_buffer) {
+        device.queue.writeBuffer(selected_buffer, 0, flags.buffer, flags.byteOffset, n * 4)
+      }
+    },
+    async pick(x: number, y: number): Promise<number> {
+      if (destroyed) return -1
+      if (atom_count <= 0 || !pick_bind_group || !pick_id_view || !pick_depth_view) {
+        return -1
+      }
+      if (!pick_id_texture) return -1
+      // Clamp the requested device pixel to the texture bounds.
+      const w = pick_id_texture.width
+      const h = pick_id_texture.height
+      const px = Math.max(0, Math.min(w - 1, Math.floor(x)))
+      const py = Math.max(0, Math.min(h - 1, Math.floor(y)))
+
+      const encoder = device.createCommandEncoder({ label: `large-system-pick` })
+      const pass = encoder.beginRenderPass({
+        label: `large-system-pick-pass`,
+        colorAttachments: [
+          {
+            view: pick_id_view,
+            // 0 = background (no atom). Atom ids are instance_index + 1.
+            clearValue: { r: 0, g: 0, b: 0, a: 0 },
+            loadOp: `clear`,
+            storeOp: `store`,
+          },
+        ],
+        depthStencilAttachment: {
+          view: pick_depth_view,
+          depthClearValue: 1.0,
+          depthLoadOp: `clear`,
+          depthStoreOp: `store`,
+        },
+      })
+      pass.setPipeline(pick_pipeline)
+      pass.setBindGroup(0, pick_bind_group)
+      pass.draw(4, atom_count)
+      pass.end()
+      // Copy the single picked texel into the 256-byte readback buffer.
+      encoder.copyTextureToBuffer(
+        { texture: pick_id_texture, origin: { x: px, y: py, z: 0 } },
+        { buffer: pick_readback, bytesPerRow: 256, rowsPerImage: 1 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      )
+      device.queue.submit([encoder.finish()])
+
+      await pick_readback.mapAsync(GPUMapMode.READ, 0, 4)
+      if (destroyed) {
+        try { pick_readback.unmap() } catch { /* already torn down */ }
+        return -1
+      }
+      const id = new Uint32Array(pick_readback.getMappedRange(0, 4))[0]
+      pick_readback.unmap()
+      // id 0 = background ⇒ -1; otherwise atom index = id - 1.
+      return id === 0 ? -1 : id - 1
     },
     render(): void {
       if (destroyed) return
@@ -1830,8 +2137,12 @@ export function create_large_system_renderer(
       positions_buffer?.destroy()
       radii_buffer?.destroy()
       colors_buffer?.destroy()
+      selected_buffer?.destroy()
       msaa_color_texture?.destroy()
       depth_texture?.destroy()
+      pick_id_texture?.destroy()
+      pick_depth_texture?.destroy()
+      pick_readback.destroy()
       // Bond resources.
       covalent_buffer?.destroy()
       elem_ids_buffer?.destroy()
@@ -1850,6 +2161,12 @@ export function create_large_system_renderer(
       positions_buffer = null
       radii_buffer = null
       colors_buffer = null
+      selected_buffer = null
+      pick_id_texture = null
+      pick_id_view = null
+      pick_depth_texture = null
+      pick_depth_view = null
+      pick_bind_group = null
       covalent_buffer = null
       elem_ids_buffer = null
       rules_buffer = null

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -154,7 +154,11 @@ fn fs_main(in : VsOut) -> FsOut {
 
 /** Tiny 1-thread compute: read the atomic bond `count`, clamp to capacity, and
  *  write draw-indirect args [vertex_count, instance_count, first_vertex,
- *  first_instance] so the bond draw uses drawIndirect with zero CPU readback. */
+ *  first_instance] so the bond draw uses drawIndirect with zero CPU readback.
+ *  Each detected bond renders as TWO half-cylinder instances (half 0 rooted at
+ *  atom A, half 1 rooted at atom B), so instance_count = 2 * clamped_bond_count.
+ *  The pairs buffer is unchanged (one entry per bond); the bond vertex shader
+ *  maps instance_index -> (bond_index = inst>>1, half = inst&1). */
 const INDIRECT_ARGS_WGSL = `
 struct Args {
   vertex_count : u32,
@@ -173,19 +177,29 @@ fn build_args() {
   let raw = count[0];
   let inst = min(raw, cfg.y);
   args.vertex_count = cfg.x;
-  args.instance_count = inst;
+  args.instance_count = inst * 2u; // two half-cylinders per bond
   args.first_vertex = 0u;
   args.first_instance = 0u;
 }
 `
 
-/** Instanced procedural-cylinder bond shader. One instance per detected bond.
- *  Per instance reads (a, b, jimage_packed) from the pairs buffer; endpoint B is
- *  shifted by jimage·lattice (min-image PBC partner) using the SAME lattice the
- *  compute used. Verts trace a unit side-wall triangle-strip that is oriented to
- *  the bond axis and scaled to span A→B with a fixed radius. Depth uses the SAME
- *  GL→WebGPU clip-z remap as the atom impostor so bonds share the depth buffer
- *  and occlude / are occluded correctly. */
+/** Instanced procedural-cylinder bond shader. Each detected bond renders as TWO
+ *  half-cylinder instances that meet at the bond midpoint, so PBC (cross-cell)
+ *  bonds become two short stubs each rooted at a REAL atom instead of one long
+ *  cylinder jutting out of the cell. Instance mapping: bond_index = inst>>1,
+ *  half = inst&1. Per bond reads (a, b, jimage_packed) from the pairs buffer
+ *  (unchanged — one entry per bond); the imaged partner is shifted by
+ *  jimage·lattice using the SAME lattice the compute used.
+ *    Let A = pos[a], partnerB = pos[b] + jimage·lattice (A's imaged partner),
+ *        B = pos[b], partnerA = pos[a] - jimage·lattice (B's imaged partner).
+ *    half 0: cylinder A      -> M0 = (A + partnerB) * 0.5
+ *    half 1: cylinder B      -> M1 = (B + partnerA) * 0.5
+ *  For intra-cell bonds (jimage = 0) partnerB = B and partnerA = A, so
+ *  M0 = M1 = (A+B)/2 and the two halves join into a seamless full cylinder.
+ *  Verts trace a unit side-wall triangle-strip oriented to the half's axis and
+ *  scaled to span start→end with a fixed radius. Depth uses the SAME GL→WebGPU
+ *  clip-z remap as the atom impostor so bonds share the depth buffer and occlude
+ *  / are occluded correctly. */
 const BOND_RENDER_WGSL = `
 struct Camera {
   view : mat4x4<f32>,
@@ -221,9 +235,13 @@ fn atom_pos(i : u32) -> vec3<f32> {
 @vertex
 fn vs_main(@builtin(vertex_index) vi : u32,
            @builtin(instance_index) inst : u32) -> VsOut {
-  let a = pairs[inst*3u + 0u];
-  let b = pairs[inst*3u + 1u];
-  let jp = pairs[inst*3u + 2u];
+  // Two half-cylinder instances per bond: bond_index = inst>>1, half = inst&1.
+  let bond_index = inst >> 1u;
+  let half = inst & 1u;
+
+  let a = pairs[bond_index*3u + 0u];
+  let b = pairs[bond_index*3u + 1u];
+  let jp = pairs[bond_index*3u + 2u];
 
   // Unpack jimage {-1,0,1} from (na+1)|((nb+1)<<2)|((nc+1)<<4).
   let na = f32(i32(jp & 3u) - 1);
@@ -231,11 +249,21 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let nc = f32(i32((jp >> 4u) & 3u) - 1);
   let shift = na * bond.lat0.xyz + nb * bond.lat1.xyz + nc * bond.lat2.xyz;
 
-  let pa = atom_pos(a);
-  let pb = atom_pos(b) + shift;
+  let A = atom_pos(a);
+  let B = atom_pos(b);
+  // A's imaged partner is B + jimage·lattice; B's imaged partner is A - jimage·lattice.
+  let partnerB = B + shift;
+  let partnerA = A - shift;
 
-  // Orthonormal basis around the bond axis A->B.
-  let axis = pb - pa;
+  // half 0: A -> midpoint of (A, partnerB);  half 1: B -> midpoint of (B, partnerA).
+  // Intra-cell (jimage=0): partnerB=B, partnerA=A => both midpoints = (A+B)/2,
+  // so the two halves join into a seamless full cylinder.
+  let start = select(B, A, half == 0u);
+  let mid = select((B + partnerA) * 0.5, (A + partnerB) * 0.5, half == 0u);
+  let end = mid;
+
+  // Orthonormal basis around this half's axis start->end.
+  let axis = end - start;
   let len = length(axis);
   let dir = select(vec3<f32>(0.0, 0.0, 1.0), axis / max(len, 1e-6), len > 1e-6);
   let up = select(vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(1.0, 0.0, 0.0), abs(dir.y) > 0.9);
@@ -247,7 +275,7 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let is_top = (vi & 1u) == 1u;   // alternate bottom/top
   let ang = f32(seg) / f32(SEG) * PI2;
   let radial = cos(ang) * tangent + sin(ang) * bitangent;
-  let base = select(pa, pb, is_top);
+  let base = select(start, end, is_top);
   let world = base + radial * bond.radius_color.x;
 
   let vpos4 = camera.view * vec4<f32>(world, 1.0);
@@ -378,7 +406,9 @@ export function create_large_system_renderer(
     size: 64, // 4 × vec4
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   })
-  // cfg for the indirect-args build: (verts_per_cylinder, capacity).
+  // cfg for the indirect-args build: (verts_per_cylinder, bond capacity). The
+  // build shader clamps the bond count to capacity then doubles it, so the draw
+  // issues instance_count = 2*min(count,capacity) (two half-cylinders per bond).
   const indirect_cfg_buffer = device.createBuffer({
     label: `large-system-indirect-cfg`,
     size: 8, // vec2<u32>

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -683,6 +683,15 @@ export type LargeSystemRenderer = {
     options: { tolerance: number; max_bond_dist: number; min_dist: number },
     periodic: boolean,
   ): void
+  /** Provide the per-element-pair bond_distance_rules POST-FILTER inputs (matches
+   *  src/lib/structure/scene/visibility.ts). `elem_ids` is the per-atom element id
+   *  (N entries) and `rules` is the packed rule buffer (4 floats per rule:
+   *  id_a, id_b, min, max with id_a ≤ id_b), both produced by
+   *  encode_bond_rules (bond-rules.ts) so their id mapping agrees. Empty `rules`
+   *  ⇒ rule_count 0 ⇒ no filtering (behaviour identical to no rules). Marks bonds
+   *  dirty so the next render re-runs the compute with the new rules — LIVE update
+   *  when the viewer edits a bond distance rule. */
+  set_bond_rules(elem_ids: Uint32Array, rules: Float32Array): void
   /** Set the clear (background) color the render pass uses. `rgb` is LINEAR
    *  float [r,g,b] in the SAME space as the atom colors uploaded via set_atoms
    *  (so the background and atoms share one color space — dark atoms keep their
@@ -761,6 +770,21 @@ export function create_large_system_renderer(
   // Covalent radii (N) for bond detection — distinct from the display radii.
   let covalent_buffer: GPUBuffer | null = null
   let covalent_capacity = 0
+  // Per-atom element ids (N, binding 5) + packed element-pair distance rules
+  // (binding 6) for the per-pair bond_distance_rules POST-FILTER in the compute
+  // (matches src/lib/structure/scene/visibility.ts). Both default to a 4-byte
+  // placeholder so the auto-layout bind group is always complete even before any
+  // rules are pushed; with rule_count 0 the shader applies no filtering. The
+  // elem-ids buffer grows with the atom count; the rules buffer is re-created on
+  // each set_bond_rules (rule arrays are tiny — a few entries).
+  let elem_ids_buffer: GPUBuffer | null = null
+  let elem_ids_capacity = 0
+  let rules_buffer: GPUBuffer | null = null
+  let rules_capacity_bytes = 0
+  // Packed rules last pushed; read at dispatch to repack Params.rule_count
+  // (rules.length / 4). The actual rule floats also live in rules_buffer
+  // (binding 6); this cache only drives the Params count + the upload.
+  let bond_rules: Float32Array = new Float32Array(0)
   // GPU-resident bond outputs. `pairs` holds capacity*3 u32 (a,b,jimage); the
   // atomic count + indirect-args are tiny fixed buffers.
   let pairs_buffer: GPUBuffer | null = null
@@ -1047,14 +1071,69 @@ export function create_large_system_renderer(
     rebuild_bond_bind_groups()
   }
 
+  /** Ensure the per-atom element-id buffer (binding 5) can hold at least `cap`
+   *  ids. Created/grown like the covalent buffer; a 4-byte minimum keeps the
+   *  binding valid before any ids are pushed. Rebuilds the bond bind groups when
+   *  it reallocates (the compute bind group references it). */
+  function ensure_elem_ids_capacity(cap: number): void {
+    const want = Math.max(cap, 1)
+    if (want <= elem_ids_capacity && elem_ids_buffer) return
+    elem_ids_buffer?.destroy()
+    elem_ids_capacity = Math.max(want, Math.ceil(elem_ids_capacity * 2), 1)
+    elem_ids_buffer = device.createBuffer({
+      label: `large-system-bond-elem-ids`,
+      size: Math.max(elem_ids_capacity * 4, 4),
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    })
+    rebuild_bond_bind_groups()
+  }
+
+  /** Ensure the packed-rules buffer (binding 6) can hold at least `bytes` bytes.
+   *  Re-created (never shrunk) when the rule set grows; a 4-byte minimum keeps
+   *  the read-only storage binding non-empty when there are no rules. Rebuilds
+   *  the bond bind groups when it reallocates. */
+  function ensure_rules_capacity(bytes: number): void {
+    const want = Math.max(bytes, 4)
+    if (want <= rules_capacity_bytes && rules_buffer) return
+    rules_buffer?.destroy()
+    rules_capacity_bytes = Math.max(want, Math.ceil(rules_capacity_bytes * 2), 4)
+    rules_buffer = device.createBuffer({
+      label: `large-system-bond-rules`,
+      size: rules_capacity_bytes,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    })
+    rebuild_bond_bind_groups()
+  }
+
   /** (Re)build the three bond bind groups. Depends on positions_buffer (atom
-   *  realloc), covalent_buffer, and pairs_buffer — any of which may reallocate.
-   *  No-op until all are present. */
+   *  realloc), covalent_buffer, pairs_buffer, and the elem-ids / rules buffers
+   *  (bindings 5/6) — any of which may reallocate. The elem-ids / rules buffers
+   *  are auto-created here (with a placeholder if never set) so the auto-layout
+   *  compute bind group is always complete (bindings 5/6 are declared in the
+   *  WGSL). No-op until positions/covalent/pairs are present. */
   function rebuild_bond_bind_groups(): void {
     bond_compute_bg = null
     indirect_bg = null
     bond_render_bg = null
     if (!positions_buffer || !covalent_buffer || !pairs_buffer) return
+    // Bindings 5/6 must exist for the auto-layout bind group; lazily create the
+    // placeholders the first time (and avoid recursing back into this fn).
+    if (!elem_ids_buffer) {
+      elem_ids_capacity = 1
+      elem_ids_buffer = device.createBuffer({
+        label: `large-system-bond-elem-ids`,
+        size: 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+    }
+    if (!rules_buffer) {
+      rules_capacity_bytes = 4
+      rules_buffer = device.createBuffer({
+        label: `large-system-bond-rules`,
+        size: 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+    }
 
     bond_compute_bg = device.createBindGroup({
       label: `large-system-bond-compute-bg`,
@@ -1065,6 +1144,8 @@ export function create_large_system_renderer(
         { binding: 2, resource: { buffer: bond_params_buffer } },
         { binding: 3, resource: { buffer: pairs_buffer } },
         { binding: 4, resource: { buffer: count_buffer } },
+        { binding: 5, resource: { buffer: elem_ids_buffer } },
+        { binding: 6, resource: { buffer: rules_buffer } },
       ],
     })
     indirect_bg = device.createBindGroup({
@@ -1267,6 +1348,39 @@ export function create_large_system_renderer(
       upload_bond_render_uniform()
       bonds_dirty = true
     },
+    set_bond_rules(elem_ids: Uint32Array, rules: Float32Array): void {
+      if (destroyed) return
+      bond_rules = rules
+
+      // Per-atom element ids (binding 5). Grow + upload N entries. When elem_ids
+      // is shorter than the atom count the tail keeps its previous/zero id; that
+      // can only mis-key atoms with no element (none in practice). Empty elem_ids
+      // is fine — with rule_count 0 the buffer is never read.
+      if (elem_ids.length > 0) {
+        ensure_elem_ids_capacity(elem_ids.length)
+        if (elem_ids_buffer) {
+          device.queue.writeBuffer(
+            elem_ids_buffer, 0,
+            elem_ids.buffer, elem_ids.byteOffset, elem_ids.length * 4,
+          )
+        }
+      }
+
+      // Packed rules (binding 6). Grow + upload; empty ⇒ leave the placeholder
+      // buffer (rule_count 0 ⇒ the shader skips the scan entirely).
+      if (rules.length > 0) {
+        ensure_rules_capacity(rules.byteLength)
+        if (rules_buffer) {
+          device.queue.writeBuffer(
+            rules_buffer, 0,
+            rules.buffer, rules.byteOffset, rules.byteLength,
+          )
+        }
+      }
+
+      // Rules changed ⇒ re-run the compute so the post-filter is reapplied LIVE.
+      bonds_dirty = true
+    },
     set_bonds_enabled(enabled: boolean): void {
       if (destroyed) return
       if (enabled === bonds_enabled) return
@@ -1305,6 +1419,10 @@ export function create_large_system_renderer(
             radii: new Float32Array(0), // unused by pack_params
             lattice: bond_lattice,
             periodic: bond_periodic,
+            // rules drives Params.rule_count (rules.length / 4). Empty ⇒ 0 ⇒ the
+            // shader's rules_keep returns early (no post-filter), identical to no
+            // rules. The actual rule data lives in the binding-6 storage buffer.
+            rules: bond_rules,
           }),
           0, PARAMS_BYTES,
         )
@@ -1387,6 +1505,8 @@ export function create_large_system_renderer(
       depth_texture?.destroy()
       // Bond resources.
       covalent_buffer?.destroy()
+      elem_ids_buffer?.destroy()
+      rules_buffer?.destroy()
       pairs_buffer?.destroy()
       count_buffer.destroy()
       indirect_buffer.destroy()
@@ -1398,6 +1518,8 @@ export function create_large_system_renderer(
       radii_buffer = null
       colors_buffer = null
       covalent_buffer = null
+      elem_ids_buffer = null
+      rules_buffer = null
       pairs_buffer = null
       msaa_color_texture = null
       msaa_color_view = null

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -289,6 +289,13 @@ export type LargeSystemRenderer = {
     colors: Float32Array,
     count: number,
   ): void
+  /** Re-upload ONLY the atom xyz positions for the current trajectory frame.
+   *  `count` must match the previously uploaded atom count (same topology). No
+   *  radii/colors re-upload, no buffer realloc — the lightweight per-frame path.
+   *  Marks bonds dirty so the next render re-runs the GPU bond compute against
+   *  the moved atoms. No-op if the buffers haven't been allocated yet (call
+   *  set_atoms first to establish topology). */
+  set_positions(positions: Float32Array, count: number): void
   /** Provide bond-detection inputs. `covalent_radii` is the per-atom COVALENT
    *  radius (N entries, from build_atom_radii — distinct from the display radii
    *  used for sphere size). `lattice` is the 9-float row-major matrix (rows
@@ -648,6 +655,26 @@ export function create_large_system_renderer(
         colors.buffer, colors.byteOffset, atom_count * 3 * 4,
       )
       // Positions moved ⇒ bonds must be recomputed next render.
+      bonds_dirty = true
+    },
+    set_positions(positions: Float32Array, count: number): void {
+      if (destroyed) return
+      // Per-frame fast path: requires an existing positions buffer (topology
+      // already established by set_atoms). If the count somehow grew past
+      // capacity, bail — the caller should re-run set_atoms to reallocate.
+      const n = Math.max(0, count)
+      if (n === 0 || !positions_buffer || n > atom_capacity) return
+      // Never read past the supplied array: the caller guarantees length>=3n in
+      // the normal path, but clamp defensively so a short frame can't make
+      // writeBuffer throw (it would just upload the atoms it does have).
+      const floats = Math.min(n * 3, positions.length)
+      if (floats === 0) return
+      atom_count = n
+      device.queue.writeBuffer(
+        positions_buffer, 0,
+        positions.buffer, positions.byteOffset, floats * 4,
+      )
+      // Atoms moved ⇒ bonds must be recomputed against the new positions.
       bonds_dirty = true
     },
     set_bond_data(

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -26,14 +26,25 @@ const CAMERA_FULL_BYTES = 144
 /** Bond Params uniform (BOND_COMPUTE_WGSL): 80 bytes, packed via pack_params. */
 const BOND_PARAMS_BYTES = 80
 
-/** Vertices per bond half. Each half is now an IMPOSTOR cylinder: a single
- *  camera-facing billboard quad (4 verts, triangle-STRIP) whose fragment shader
- *  ray-traces a mathematically smooth, capped finite cylinder. Constant low
- *  vertex count regardless of curvature (no facets), matching the atom impostor
- *  approach. This is the single source of truth for the indirect-args
- *  vertex_count (`cfg.x`) and MUST stay in sync with the render pipeline
- *  topology (triangle-strip ⇒ 4 verts). */
-const BOND_VERTS_PER_CYLINDER = 4
+/** Vertices per bond half. Each half is an IMPOSTOR cylinder: a camera-facing
+ *  billboard whose fragment shader ray-traces a mathematically smooth, capped
+ *  finite cylinder. Constant low vertex count regardless of curvature (no
+ *  facets), matching the atom impostor approach.
+ *
+ *  The billboard is a 6-vertex triangle-STRIP "hull" of two screen-aligned
+ *  squares (one per endpoint, each side ~2r) — a capsule-bounding hexagon. This
+ *  ALWAYS covers the full projected capsule silhouette from any view angle:
+ *  - end-on (axis pointing at the eye, v0≈v1 in screen XY): each square is still
+ *    a full 2r×2r screen quad, so the cap disk (radius r) is fully rasterized —
+ *    no hollow ring. A degenerate single-vertex ribbon could not do this.
+ *  - side / oblique long bonds: each endpoint square is anchored at that
+ *    endpoint's OWN view-space depth, so perspective foreshortening can't clip
+ *    the silhouette at grazing angles (a single-depth screen quad would).
+ *
+ *  This is the single source of truth for the indirect-args vertex_count
+ *  (`cfg.x`) and MUST stay in sync with the render pipeline topology
+ *  (triangle-strip ⇒ this many verts). */
+const BOND_VERTS_PER_CYLINDER = 6
 
 /** Fixed bond cylinder radius (Å). Small constant; tunable. Uploaded to the
  *  bond render shader as part of its uniform so it can be retuned without a
@@ -366,36 +377,59 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let v0 = (camera.view * vec4<f32>(start, 1.0)).xyz;
   let v1 = (camera.view * vec4<f32>(end, 1.0)).xyz;
 
-  // Camera-facing ribbon quad covering the finite capsule. axis = â (view space);
-  // a degenerate (zero-length) half falls back to a fixed axis so normalize never
-  // produces NaN — the fragment shader discards it anyway.
-  let av = v1 - v0;
-  let alen = length(av);
-  let axis = select(vec3<f32>(0.0, 0.0, 1.0), av / max(alen, 1e-6), alen > 1e-6);
-  // Toward the eye from the segment midpoint (eye at view-space origin).
-  let mid_v = (v0 + v1) * 0.5;
-  let to_eye = -mid_v;
-  // Camera-facing perpendicular; fall back if axis ∥ to_eye (segment pointing at
-  // the eye) so the cross product can't collapse to zero.
-  var side = cross(axis, to_eye);
-  if (length(side) < 1e-6) {
-    side = cross(axis, vec3<f32>(0.0, 1.0, 0.0));
-    if (length(side) < 1e-6) {
-      side = cross(axis, vec3<f32>(1.0, 0.0, 0.0));
-    }
-  }
-  side = normalize(side) * r;
-  // Extend the quad past both ends by r along the axis so the round caps are
-  // covered, with a little extra slack (1.5) on the width so the perspective
-  // silhouette of the cylinder is never clipped at grazing/foreshortened angles.
-  let cap_ext = axis * r;
-  let widen = side * 1.5;
+  // SCREEN-ALIGNED capsule-bounding hull. The old camera-facing ribbon was
+  // built from side = cross(axis, to_eye); when the bond axis points at the eye
+  // (end-on) that cross product collapses and the quad turns edge-on, leaving
+  // the projected cap disk uncovered -> hollow ring. Instead we wrap BOTH
+  // endpoint disks with a 6-vertex hull of two screen-aligned squares (each side
+  // 2r, in the view-space XY plane the camera looks down -Z). Whatever the bond
+  // orientation, each square keeps its full 2r×2r screen footprint, so the cap
+  // circle is always fully rasterized; the fragment ray-test discards the slack.
+  //
+  // The hull is laid out along the bond's SCREEN-PROJECTED direction (so it
+  // hugs the capsule for long side-on bonds), with each endpoint's billboard
+  // corners anchored at that endpoint's OWN view-space depth -> no perspective
+  // clipping of the silhouette at oblique/foreshortened angles.
+  let w = r * 1.5; // half-extent per square; slack so grazing silhouette never clips.
 
-  // 4 triangle-strip corners: (vi&1) -> ±side, (vi&2) -> v0/v1 end.
-  let s_sign = select(-1.0, 1.0, (vi & 1u) == 1u);
-  let is_end = (vi & 2u) == 2u;
-  let base = select(v0 - cap_ext, v1 + cap_ext, is_end);
-  let vpos = base + s_sign * widen;
+  // Screen-space (view XY) direction from v0 to v1. End-on bonds project to a
+  // ~zero-length 2D segment -> fall back to +X so the perp axis is well defined;
+  // the two squares simply stack into one 2r×2r quad, which is exactly what an
+  // end-on cap needs.
+  let d2 = v1.xy - v0.xy;
+  let d2len = length(d2);
+  let sdir = select(vec2<f32>(1.0, 0.0), d2 / max(d2len, 1e-6), d2len > 1e-6);
+  let sperp = vec2<f32>(-sdir.y, sdir.x);
+  // View-space screen offsets: along the projected axis (so caps extend past the
+  // endpoints by w) and across it (capsule width). Both live in the XY plane.
+  let off_axis = vec3<f32>(sdir * w, 0.0);
+  let off_perp = vec3<f32>(sperp * w, 0.0);
+
+  // 6-vertex triangle-STRIP hull of the two endpoint squares (a capsule-bounding
+  // hexagon). The strip's 4 triangles — (0,1,2),(1,2,3),(2,3,4),(3,4,5) — tile a
+  // convex hexagon whose 6 corners wrap both squares:
+  //   0: v0 - axis - perp        (v0 far-cap, perp -)
+  //   1: v0 - axis + perp        (v0 far-cap, perp +)
+  //   2: v1       - perp         (v1 body edge, perp -)   [shares v0's near side
+  //   3: v0       + perp          via the strip's quad coverage]
+  //   4: v1 + axis - perp        (v1 far-cap, perp -)
+  //   5: v1 + axis + perp        (v1 far-cap, perp +)
+  // Each corner is anchored at its OWN endpoint's view-space depth (v0 vs v1) so
+  // perspective foreshortening never clips the silhouette of an oblique long
+  // bond. End-on (off_axis along the +X fallback) every corner still sits at
+  // ±w, so the union is a full 2w×2w screen square over the cap — solid, no ring.
+  var anchor = v0;
+  var ax_sign = 0.0;
+  var p_sign = -1.0;
+  switch vi % 6u {
+    case 0u: { anchor = v0; ax_sign = -1.0; p_sign = -1.0; }
+    case 1u: { anchor = v0; ax_sign = -1.0; p_sign =  1.0; }
+    case 2u: { anchor = v1; ax_sign =  0.0; p_sign = -1.0; }
+    case 3u: { anchor = v0; ax_sign =  0.0; p_sign =  1.0; }
+    case 4u: { anchor = v1; ax_sign =  1.0; p_sign = -1.0; }
+    default: { anchor = v1; ax_sign =  1.0; p_sign =  1.0; }
+  }
+  let vpos = anchor + ax_sign * off_axis + p_sign * off_perp;
 
   var clip = camera.proj * vec4<f32>(vpos, 1.0);
   // SAME GL->WebGPU NDC z remap as the atom impostor shader.
@@ -749,10 +783,10 @@ export function create_large_system_renderer(
     layout: device.createPipelineLayout({ bindGroupLayouts: [bond_render_bgl] }),
     vertex: { module: bond_render_module, entryPoint: `vs_main` },
     fragment: { module: bond_render_module, entryPoint: `fs_main`, targets: [{ format }] },
-    // Impostor cylinder is a single camera-facing billboard (4-vert triangle-
-    // STRIP, matching BOND_VERTS_PER_CYLINDER); the fragment shader ray-traces
-    // the smooth capped finite cylinder. cullMode none — billboard winding flips
-    // with view, and the impostor is one-sided per-fragment regardless.
+    // Impostor cylinder is a screen-aligned capsule-bounding billboard (6-vert
+    // triangle-STRIP hull, matching BOND_VERTS_PER_CYLINDER); the fragment shader
+    // ray-traces the smooth capped finite cylinder. cullMode none — the hull
+    // winding flips with view, and the impostor is one-sided per-fragment regardless.
     primitive: { topology: `triangle-strip`, cullMode: `none` },
     depthStencil: {
       format: DEPTH_FORMAT,

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -139,6 +139,93 @@ fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
 }
 `
 
+/** WGSL axis-orientation gizmo shader. Draws a small camera-oriented XYZ triad
+ *  (X=red, Y=green, Z=blue) pinned to a fixed SCREEN CORNER, sized in constant
+ *  pixels, independent of zoom / structure scale. It replaces the WebGL Gizmo
+ *  widget (which is gone when WebGL is suspended in overlay mode).
+ *
+ *  Geometry: a line-list of 6 vertices = 3 axes × 2 endpoints. Per vertex the
+ *  axis index = vi/2 selects the unit axis (+X/+Y/+Z); the low bit picks origin
+ *  vs. the axis tip. Orientation uses ONLY the camera view ROTATION (upper-3×3 of
+ *  camera.view, NOT its translation), so the triad spins with the camera like an
+ *  orientation indicator. The rotated axis' XY (screen plane; camera looks down
+ *  -Z in view space) is scaled to a small NDC region and offset to the corner.
+ *  The corner center + per-pixel NDC scale (aspect-corrected so the region is
+ *  square in pixels) come from a uniform the renderer fills from the canvas size.
+ *
+ *  Depth: the gizmo must ALWAYS be visible (never occluded by atoms/bonds). Its
+ *  pipeline runs with depthCompare:`always` + depthWriteEnabled:false, and it is
+ *  drawn LAST in the pass, so it overwrites the corner regardless of scene depth.
+ *  Colored per-axis; no labels (text is out of scope). */
+const GIZMO_WGSL = `
+struct Camera {
+  view : mat4x4<f32>,
+  proj : mat4x4<f32>,
+  cam_pos : vec4<f32>,
+};
+// Gizmo placement uniform:
+//   center_ndc : corner anchor in clip/NDC space (xy), z/w unused.
+//   scale_ndc  : per-unit-axis NDC half-extent (x,y) — y carries the aspect
+//                correction so the triad is square in pixels.
+struct GizmoU {
+  center_ndc : vec4<f32>,
+  scale_ndc : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<uniform> giz : GizmoU;
+
+struct VsOut {
+  @builtin(position) clip : vec4<f32>,
+  @location(0) color : vec3<f32>,
+};
+
+// Axis unit vectors and their (linear-ish) colors. X red, Y green, Z blue.
+const AXES = array<vec3<f32>, 3>(
+  vec3<f32>(1.0, 0.0, 0.0),
+  vec3<f32>(0.0, 1.0, 0.0),
+  vec3<f32>(0.0, 0.0, 1.0),
+);
+const AXIS_COLORS = array<vec3<f32>, 3>(
+  vec3<f32>(0.85, 0.10, 0.10),
+  vec3<f32>(0.10, 0.70, 0.10),
+  vec3<f32>(0.10, 0.10, 0.85),
+);
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi : u32) -> VsOut {
+  let axis_i = vi / 2u;            // 0=X, 1=Y, 2=Z
+  let is_tip = (vi & 1u) == 1u;    // segment: origin -> tip
+  let unit = AXES[axis_i];
+
+  // Camera view ROTATION only (upper-3x3 of camera.view). Drop translation so
+  // the triad rotates with the camera but stays pinned to the corner.
+  let rot = mat3x3<f32>(
+    camera.view[0].xyz,
+    camera.view[1].xyz,
+    camera.view[2].xyz,
+  );
+  let dir = rot * unit;            // rotated axis in view space (camera looks -Z)
+
+  // Endpoint: origin at the corner, tip offset by the rotated axis' screen XY.
+  // Output clip space with w=1 so these are already NDC (no perspective divide);
+  // depthCompare always ignores z, so z is parked at 0.
+  let tip_off = vec2<f32>(dir.x * giz.scale_ndc.x, dir.y * giz.scale_ndc.y);
+  let off = select(vec2<f32>(0.0, 0.0), tip_off, is_tip);
+  let pos = giz.center_ndc.xy + off;
+
+  var out : VsOut;
+  out.clip = vec4<f32>(pos, 0.0, 1.0);
+  out.color = AXIS_COLORS[axis_i];
+  return out;
+}
+
+@fragment
+fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
+  return vec4<f32>(in.color, 1.0);
+}
+`
+
 /** WGSL impostor-sphere shader. View-space billboard + per-fragment ray-sphere.
  *  - storage buffers: positions (3N), radii (N), colors (3N linear rgb)
  *  - camera uniform: view + proj (separate) + camPos
@@ -356,6 +443,11 @@ struct VsOut {
   @location(2) radius : f32,        // cylinder radius (flat)
   @location(3) color : vec3<f32>,
   @location(4) vpos : vec3<f32>,    // view-space position of this quad corner
+  // 1.0 for CROSS-cell stubs, 0.0 for INTRA-cell full cylinders. Flat-interp.
+  // The fragment shader pushes cross-cell stubs slightly BACKWARD in depth so a
+  // stub coincident with an intra-cell bond at a shared atom loses the depth tie
+  // (intra always wins) — kills the faint alpha-to-coverage dotted seam.
+  @location(5) is_stub : f32,
 };
 
 struct FsOut {
@@ -477,6 +569,7 @@ fn vs_main(@builtin(vertex_index) vi : u32,
     out_deg.radius = r;
     out_deg.color = bond.radius_color.yzw;
     out_deg.vpos = vpos;
+    out_deg.is_stub = 0.0; // degenerate (discarded) — value irrelevant
     return out_deg;
   }
 
@@ -491,6 +584,8 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   out.radius = r;
   out.color = bond.radius_color.yzw;
   out.vpos = vpos;
+  // Cross-cell stubs (jimage != 0, !is_intra) get the fragment depth bias.
+  out.is_stub = select(1.0, 0.0, is_intra);
   return out;
 }
 
@@ -640,8 +735,19 @@ fn fs_main(in : VsOut) -> FsOut {
   let clip_h = camera.proj * vec4<f32>(hit_p, 1.0);
   let remapped_z = (clip_h.z + clip_h.w) * 0.5;
 
+  var depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
+  // Cross-cell stub depth bias: where a stub overlaps the START of an intra-cell
+  // full cylinder at a shared atom, the two grey surfaces are coincident -> a
+  // depth tie -> alpha-to-coverage stipple (faint dotted seam). Push the stub
+  // slightly BACKWARD (larger depth) so the intra-cell bond consistently wins the
+  // depth test there. Epsilon is tiny enough to be invisible elsewhere but breaks
+  // the tie at typical near/far. Intra-cell bonds (is_stub == 0) are NOT biased.
+  if (in.is_stub > 0.5) {
+    depth = clamp(depth + 1e-4, 0.0, 1.0);
+  }
+
   var out : FsOut;
-  out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
+  out.depth = depth;
   // alpha = coverage feeds alpha-to-coverage; no alpha blending is enabled.
   out.color = vec4<f32>(in.color * lighting, cov);
   return out;
@@ -817,6 +923,13 @@ export function create_large_system_renderer(
     size: 64, // 4 × vec4
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   })
+  // Gizmo placement uniform: center_ndc (vec4) + scale_ndc (vec4). Filled from
+  // the canvas backing size so the triad sits in a fixed pixel-sized corner.
+  const gizmo_uniform = device.createBuffer({
+    label: `large-system-gizmo-uniform`,
+    size: 32, // 2 × vec4
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
   // Cached cell inputs (uploaded only when set_cell changes them).
   let cell_lattice = new Float32Array(9)
   let cell_show = false
@@ -989,6 +1102,75 @@ export function create_large_system_renderer(
     ],
   })
 
+  // Axis-orientation gizmo: a small corner XYZ triad as a line-list (6 verts).
+  // Binds the camera (for the view rotation) + the gizmo placement uniform. Runs
+  // with depthCompare:`always` + no depth write, drawn LAST, so it is ALWAYS
+  // visible (never occluded by atoms/bonds) and never disturbs scene depth.
+  const gizmo_module = device.createShaderModule({
+    label: `large-system-gizmo`,
+    code: GIZMO_WGSL,
+  })
+  const gizmo_bgl = device.createBindGroupLayout({
+    label: `large-system-gizmo-bgl`,
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+      { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+    ],
+  })
+  const gizmo_pipeline = device.createRenderPipeline({
+    label: `large-system-gizmo-pipeline`,
+    layout: device.createPipelineLayout({ bindGroupLayouts: [gizmo_bgl] }),
+    vertex: { module: gizmo_module, entryPoint: `vs_main` },
+    fragment: { module: gizmo_module, entryPoint: `fs_main`, targets: [{ format }] },
+    primitive: { topology: `line-list` },
+    depthStencil: {
+      format: DEPTH_FORMAT,
+      // Always visible: never write depth, never fail the depth test. The gizmo
+      // overwrites its corner regardless of what atoms/bonds drew there.
+      depthWriteEnabled: false,
+      depthCompare: `always`,
+    },
+    // Share the multisampled targets (count must match). No alpha-to-coverage —
+    // opaque colored lines.
+    multisample: { count: SAMPLE_COUNT },
+  })
+  const gizmo_bind_group = device.createBindGroup({
+    label: `large-system-gizmo-bg`,
+    layout: gizmo_bgl,
+    entries: [
+      { binding: 0, resource: { buffer: camera_buffer } },
+      { binding: 1, resource: { buffer: gizmo_uniform } },
+    ],
+  })
+
+  /** Fixed pixel geometry of the corner gizmo. The triad region is ~2·GIZMO_PX
+   *  wide (each axis reaches GIZMO_PX from the origin), placed GIZMO_MARGIN_PX in
+   *  from the bottom-left corner — matching the WebGL Gizmo's offset:{left,bottom}. */
+  const GIZMO_PX = 42
+  const GIZMO_MARGIN_PX = 12
+
+  /** Pack + upload the gizmo placement uniform from the canvas backing size.
+   *  - center_ndc: bottom-left corner anchor in NDC. NDC x∈[-1,1] (right), y∈
+   *    [-1,1] (UP). Pixel→NDC: dx_ndc = 2·px/width, dy_ndc = 2·px/height. We seat
+   *    the triad ORIGIN one (margin + axis reach) in from the bottom-left so the
+   *    whole triad stays on-screen whatever its rotation.
+   *  - scale_ndc: per-unit-axis half-extent. x = 2·GIZMO_PX/width; y =
+   *    2·GIZMO_PX/height (independent per-axis pixel scale ⇒ square in pixels,
+   *    aspect-corrected — a unit axis reaches exactly GIZMO_PX pixels either way). */
+  function upload_gizmo_uniform(): void {
+    const w = Math.max(1, canvas.width)
+    const h = Math.max(1, canvas.height)
+    const inset = GIZMO_MARGIN_PX + GIZMO_PX
+    const cx = -1 + (2 * inset) / w // from the LEFT edge
+    const cy = -1 + (2 * inset) / h // from the BOTTOM edge (NDC y up)
+    const sx = (2 * GIZMO_PX) / w
+    const sy = (2 * GIZMO_PX) / h
+    const u = new Float32Array(8)
+    u[0] = cx; u[1] = cy; u[2] = 0; u[3] = 0
+    u[4] = sx; u[5] = sy; u[6] = 0; u[7] = 0
+    device.queue.writeBuffer(gizmo_uniform, 0, u.buffer, u.byteOffset, 32)
+  }
+
   /** Pack + upload the cell render uniform: lattice rows a,b,c (each a vec3 + pad)
    *  then color (rgb + pad). Same row convention as the bond render uniform. */
   function upload_cell_uniform(): void {
@@ -1038,6 +1220,7 @@ export function create_large_system_renderer(
     depth_view = depth_texture.createView()
   }
   ensure_targets(canvas.width || 1, canvas.height || 1)
+  upload_gizmo_uniform() // seed corner placement from the initial canvas size
 
   function rebuild_bind_group(): void {
     if (!positions_buffer || !radii_buffer || !colors_buffer) {
@@ -1480,6 +1663,14 @@ export function create_large_system_renderer(
         pass.setBindGroup(0, cell_bind_group)
         pass.draw(24) // 12 edges × 2 line endpoints
       }
+      // Axis-orientation gizmo: drawn LAST with depthCompare:`always` + no depth
+      // write so the corner XYZ triad is ALWAYS visible (atoms/bonds never occlude
+      // it). Reuses the camera uniform (the shader extracts the view rotation), so
+      // it spins with the camera. Always drawn while the overlay is active — no
+      // toggle/prop needed; it lives in the corner away from the structure.
+      pass.setPipeline(gizmo_pipeline)
+      pass.setBindGroup(0, gizmo_bind_group)
+      pass.draw(6) // 3 axes × 2 line endpoints
       pass.end()
       device.queue.submit([encoder.finish()])
     },
@@ -1488,6 +1679,9 @@ export function create_large_system_renderer(
       canvas.width = Math.max(1, Math.floor(w))
       canvas.height = Math.max(1, Math.floor(h))
       ensure_targets(canvas.width, canvas.height)
+      // Re-derive the corner gizmo placement for the new canvas size so it stays
+      // a constant pixel size in the corner (not stretched by the aspect change).
+      upload_gizmo_uniform()
     },
     destroy(): void {
       if (destroyed) return
@@ -1513,6 +1707,7 @@ export function create_large_system_renderer(
       bond_params_buffer.destroy()
       bond_render_uniform.destroy()
       cell_uniform.destroy()
+      gizmo_uniform.destroy()
       indirect_cfg_buffer.destroy()
       positions_buffer = null
       radii_buffer = null

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -143,9 +143,15 @@ fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
  *  pixels, independent of zoom / structure scale. It replaces the WebGL Gizmo
  *  widget (which is gone when WebGL is suspended in overlay mode).
  *
- *  Geometry: a line-list of 6 vertices = 3 axes × 2 endpoints. Per vertex the
- *  axis index = vi/2 selects the unit axis (+X/+Y/+Z); the low bit picks origin
- *  vs. the axis tip. Orientation uses ONLY the camera view ROTATION (upper-3×3 of
+ *  Geometry: a line-list of 22 vertices.
+ *    - verts 0..5  = the 3 axis lines (3 axes × 2 endpoints): axis index = vi/2
+ *      selects the unit axis (+X/+Y/+Z); the low bit picks origin vs. axis tip.
+ *    - verts 6..21 = 16 LETTER-GLYPH endpoints (8 line segments × 2): tiny X/Y/Z
+ *      letters drawn at each axis tip, color-matched to the axis. X=2 segments,
+ *      Y=3, Z=3. Each glyph vertex offsets from its axis' PROJECTED tip by a 2D
+ *      template coordinate scaled to a small constant pixel size — the letters
+ *      stay SCREEN-FLAT (no 3D rotation), facing the viewer at the tip.
+ *  Orientation of the AXES uses ONLY the camera view ROTATION (upper-3×3 of
  *  camera.view, NOT its translation), so the triad spins with the camera like an
  *  orientation indicator. The rotated axis' XY (screen plane; camera looks down
  *  -Z in view space) is scaled to a small NDC region and offset to the corner.
@@ -154,8 +160,7 @@ fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
  *
  *  Depth: the gizmo must ALWAYS be visible (never occluded by atoms/bonds). Its
  *  pipeline runs with depthCompare:`always` + depthWriteEnabled:false, and it is
- *  drawn LAST in the pass, so it overwrites the corner regardless of scene depth.
- *  Colored per-axis; no labels (text is out of scope). */
+ *  drawn LAST in the pass, so it overwrites the corner regardless of scene depth. */
 const GIZMO_WGSL = `
 struct Camera {
   view : mat4x4<f32>,
@@ -191,12 +196,40 @@ const AXIS_COLORS = array<vec3<f32>, 3>(
   vec3<f32>(0.10, 0.10, 0.85),
 );
 
+// Letter-glyph templates as 2D line segments on a [-1,1] square, screen-aligned.
+// 8 segments = 16 endpoints (glyph verts 0..15 = gizmo verts 6..21):
+//   X (axis 0): segs 0,1 -> two crossing diagonals.
+//   Y (axis 1): segs 2,3,4 -> two upper arms to center + stem down.
+//   Z (axis 2): segs 5,6,7 -> top bar, diagonal, bottom bar.
+const GLYPH_PTS = array<vec2<f32>, 16>(
+  // X: (-1,-1)->(1,1), (-1,1)->(1,-1)
+  vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, 1.0),
+  vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0),
+  // Y: (-1,1)->(0,0), (1,1)->(0,0), (0,0)->(0,-1)
+  vec2<f32>(-1.0, 1.0), vec2<f32>(0.0, 0.0),
+  vec2<f32>(1.0, 1.0), vec2<f32>(0.0, 0.0),
+  vec2<f32>(0.0, 0.0), vec2<f32>(0.0, -1.0),
+  // Z: (-1,1)->(1,1), (1,1)->(-1,-1), (-1,-1)->(1,-1)
+  vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, 1.0),
+  vec2<f32>(1.0, 1.0), vec2<f32>(-1.0, -1.0),
+  vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0),
+);
+// Which axis (tip + color) each of the 16 glyph endpoints belongs to.
+const GLYPH_AXIS = array<u32, 16>(
+  0u, 0u, 0u, 0u,                 // X: 2 segs
+  1u, 1u, 1u, 1u, 1u, 1u,         // Y: 3 segs
+  2u, 2u, 2u, 2u, 2u, 2u,         // Z: 3 segs
+);
+// Glyph half-size in pixels (the template [-1,1] maps to +-GLYPH_PX). Sat past
+// the axis tip by GLYPH_TIP_SCALE so the letter clears the arrow end.
+const GLYPH_PX : f32 = 9.0;
+const GLYPH_TIP_SCALE : f32 = 1.18;
+// Mirrors the TS-side GIZMO_PX: scale_ndc spans GIZMO_PX pixels per unit axis, so
+// dividing GLYPH_PX by it converts the glyph half-size into the same NDC scale.
+const GIZMO_PX_F : f32 = 120.0;
+
 @vertex
 fn vs_main(@builtin(vertex_index) vi : u32) -> VsOut {
-  let axis_i = vi / 2u;            // 0=X, 1=Y, 2=Z
-  let is_tip = (vi & 1u) == 1u;    // segment: origin -> tip
-  let unit = AXES[axis_i];
-
   // Camera view ROTATION only (upper-3x3 of camera.view). Drop translation so
   // the triad rotates with the camera but stays pinned to the corner.
   let rot = mat3x3<f32>(
@@ -204,16 +237,40 @@ fn vs_main(@builtin(vertex_index) vi : u32) -> VsOut {
     camera.view[1].xyz,
     camera.view[2].xyz,
   );
-  let dir = rot * unit;            // rotated axis in view space (camera looks -Z)
 
-  // Endpoint: origin at the corner, tip offset by the rotated axis' screen XY.
-  // Output clip space with w=1 so these are already NDC (no perspective divide);
-  // depthCompare always ignores z, so z is parked at 0.
-  let tip_off = vec2<f32>(dir.x * giz.scale_ndc.x, dir.y * giz.scale_ndc.y);
-  let off = select(vec2<f32>(0.0, 0.0), tip_off, is_tip);
-  let pos = giz.center_ndc.xy + off;
+  // The glyph half-size in NDC reuses the per-axis pixel scale (scale_ndc spans
+  // GIZMO_PX), so a GLYPH_PX template is square in pixels and not skewed.
+  let glyph_ndc = vec2<f32>(
+    giz.scale_ndc.x * (GLYPH_PX / GIZMO_PX_F),
+    giz.scale_ndc.y * (GLYPH_PX / GIZMO_PX_F),
+  );
 
   var out : VsOut;
+
+  if (vi < 6u) {
+    // --- Axis lines: 3 axes x 2 endpoints (origin -> rotated tip). ---
+    let axis_i = vi / 2u;            // 0=X, 1=Y, 2=Z
+    let is_tip = (vi & 1u) == 1u;    // segment: origin -> tip
+    let dir = rot * AXES[axis_i];    // rotated axis in view space (camera looks -Z)
+    let tip_off = vec2<f32>(dir.x * giz.scale_ndc.x, dir.y * giz.scale_ndc.y);
+    let off = select(vec2<f32>(0.0, 0.0), tip_off, is_tip);
+    let pos = giz.center_ndc.xy + off;
+    out.clip = vec4<f32>(pos, 0.0, 1.0);
+    out.color = AXIS_COLORS[axis_i];
+    return out;
+  }
+
+  // --- Letter glyphs: verts 6..21 -> glyph endpoints 0..15. ---
+  let gvi = vi - 6u;
+  let axis_i = GLYPH_AXIS[gvi];
+  // Projected axis tip in NDC, pushed slightly BEYOND the tip so the letter sits
+  // past the arrow end (along the rotated axis' screen direction).
+  let dir = rot * AXES[axis_i];
+  let tip_off = vec2<f32>(dir.x * giz.scale_ndc.x, dir.y * giz.scale_ndc.y);
+  let tip_pos = giz.center_ndc.xy + tip_off * GLYPH_TIP_SCALE;
+  // Screen-flat template offset (NO 3D rotation): the letter faces the viewer.
+  let t = GLYPH_PTS[gvi];
+  let pos = tip_pos + vec2<f32>(t.x * glyph_ndc.x, t.y * glyph_ndc.y);
   out.clip = vec4<f32>(pos, 0.0, 1.0);
   out.color = AXIS_COLORS[axis_i];
   return out;
@@ -1352,7 +1409,8 @@ export function create_large_system_renderer(
     ],
   })
 
-  // Axis-orientation gizmo: a small corner XYZ triad as a line-list (6 verts).
+  // Axis-orientation gizmo: a small corner XYZ triad as a line-list (22 verts:
+  // 6 axis + 16 letter-glyph endpoints).
   // Binds the camera (for the view rotation) + the gizmo placement uniform. Runs
   // with depthCompare:`always` + no depth write, drawn LAST, so it is ALWAYS
   // visible (never occluded by atoms/bonds) and never disturbs scene depth.
@@ -1396,8 +1454,8 @@ export function create_large_system_renderer(
   /** Fixed pixel geometry of the corner gizmo. The triad region is ~2·GIZMO_PX
    *  wide (each axis reaches GIZMO_PX from the origin), placed GIZMO_MARGIN_PX in
    *  from the bottom-left corner — matching the WebGL Gizmo's offset:{left,bottom}. */
-  const GIZMO_PX = 72
-  const GIZMO_MARGIN_PX = 20
+  const GIZMO_PX = 120
+  const GIZMO_MARGIN_PX = 28
 
   /** Pack + upload the gizmo placement uniform from the canvas backing size.
    *  - center_ndc: bottom-left corner anchor in NDC. NDC x∈[-1,1] (right), y∈
@@ -2134,7 +2192,7 @@ export function create_large_system_renderer(
       // toggle/prop needed; it lives in the corner away from the structure.
       pass.setPipeline(gizmo_pipeline)
       pass.setBindGroup(0, gizmo_bind_group)
-      pass.draw(6) // 3 axes × 2 line endpoints
+      pass.draw(22) // 6 axis verts (3 axes × 2) + 16 letter-glyph verts (8 segs × 2)
       pass.end()
       device.queue.submit([encoder.finish()])
     },

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -26,10 +26,12 @@ const CAMERA_FULL_BYTES = 144
 /** Bond Params uniform (BOND_COMPUTE_WGSL): 80 bytes, packed via pack_params. */
 const BOND_PARAMS_BYTES = 80
 
-/** Radial segments of the procedural cylinder. The side wall is a closed
- *  triangle-strip: 2 verts per segment boundary, (SEG+1) boundaries. */
+/** Radial segments of the procedural cylinder. The cylinder is a triangle-LIST
+ *  (no strip): SEG side-wall quads (2 tris = 6 verts each) plus two flat end-cap
+ *  fans (SEG tris = 3 verts each) so the cut ends are solid, not hollow tubes.
+ *  Side wall: SEG*6, each cap: SEG*3, two caps: SEG*6 => SEG*12 total. */
 const BOND_SEGMENTS = 12
-const BOND_VERTS_PER_CYLINDER = (BOND_SEGMENTS + 1) * 2
+const BOND_VERTS_PER_CYLINDER = BOND_SEGMENTS * 12
 
 /** Fixed bond cylinder radius (Å). Small constant; tunable. Uploaded to the
  *  bond render shader as part of its uniform so it can be retuned without a
@@ -198,8 +200,9 @@ fn build_args() {
  *    half 1: cylinder B      -> M1 = (B + partnerA) * 0.5
  *  For intra-cell bonds (jimage = 0) partnerB = B and partnerA = A, so
  *  M0 = M1 = (A+B)/2 and the two halves join into a seamless full cylinder.
- *  Verts trace a unit side-wall triangle-strip oriented to the half's axis and
- *  scaled to span start→end with a fixed radius. Depth uses the SAME GL→WebGPU
+ *  Verts trace a unit side-wall (triangle-list quads) plus two flat end-cap fans
+ *  oriented to the half's axis and scaled to span start→end with a fixed radius
+ *  so the cut ends read as solid disks, not hollow tubes. Depth uses the SAME GL→WebGPU
  *  clip-z remap as the atom impostor so bonds share the depth buffer and occlude
  *  / are occluded correctly. */
 const BOND_RENDER_WGSL = `
@@ -272,21 +275,67 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let tangent = normalize(cross(up, dir));
   let bitangent = cross(dir, tangent);
 
-  // Side-wall triangle-strip: pairs of (bottom, top) ring verts.
-  let seg = vi >> 1u;             // 0..SEG
-  let is_top = (vi & 1u) == 1u;   // alternate bottom/top
-  let ang = f32(seg) / f32(SEG) * PI2;
-  let radial = cos(ang) * tangent + sin(ang) * bitangent;
-  let base = select(start, end, is_top);
-  let world = base + radial * bond.radius_color.x;
+  // Triangle-LIST cylinder (no strip): SEG side-wall quads then two cap fans.
+  //   verts [0,             SEG*6)  -> side wall, 6 verts per segment quad
+  //   verts [SEG*6,         SEG*9)  -> start-end cap fan (faces -dir, toward atom)
+  //   verts [SEG*9,         SEG*12) -> end-end   cap fan (faces +dir, the midpoint)
+  let SIDE_END : u32 = SEG * 6u;
+  let CAP0_END : u32 = SEG * 9u;
+
+  var world : vec3<f32>;
+  var world_normal : vec3<f32>; // object-space normal at this vertex
+
+  if (vi < SIDE_END) {
+    // Side wall. Each segment is a quad (seg .. seg+1) split into 2 triangles:
+    //   tri layout per quad (6 verts): (b0,t0,b1)(b1,t0,t1)
+    //   b=bottom(start ring), t=top(end ring); 0=this angle, 1=next angle.
+    let seg = vi / 6u;            // 0..SEG-1
+    let k = vi % 6u;              // vertex within the quad's two triangles
+    // corner index ci in {0=b0,1=t0,2=b1,3=t1}
+    var ci : u32 = 0u;
+    if (k == 0u) { ci = 0u; }      // b0
+    else if (k == 1u) { ci = 1u; } // t0
+    else if (k == 2u) { ci = 2u; } // b1
+    else if (k == 3u) { ci = 2u; } // b1
+    else if (k == 4u) { ci = 1u; } // t0
+    else { ci = 3u; }              // t1
+    let next_ang = (ci == 2u) || (ci == 3u);
+    let is_top = (ci == 1u) || (ci == 3u);
+    let s = select(seg, seg + 1u, next_ang);
+    let ang = f32(s) / f32(SEG) * PI2;
+    let radial = cos(ang) * tangent + sin(ang) * bitangent;
+    let base = select(start, end, is_top);
+    world = base + radial * bond.radius_color.x;
+    world_normal = radial; // side-wall normal points radially outward
+  } else {
+    // Cap fan. Pick which end + facing direction, then build a triangle fan
+    // from the end-center to consecutive ring vertices.
+    let is_end_cap = vi >= CAP0_END;
+    let local = select(vi - SIDE_END, vi - CAP0_END, is_end_cap);
+    let center = select(start, end, is_end_cap);
+    // Cap normal is the axis direction: start cap faces -dir (toward atom),
+    // end cap faces +dir (the midpoint). Front-face winding handled by cullMode none.
+    let cap_normal = select(-dir, dir, is_end_cap);
+    let seg = local / 3u;          // 0..SEG-1
+    let corner = local % 3u;       // 0=center, 1=ring(seg), 2=ring(seg+1)
+    if (corner == 0u) {
+      world = center;
+    } else {
+      let s = select(seg, seg + 1u, corner == 2u);
+      let ang = f32(s) / f32(SEG) * PI2;
+      let radial = cos(ang) * tangent + sin(ang) * bitangent;
+      world = center + radial * bond.radius_color.x;
+    }
+    world_normal = cap_normal;
+  }
 
   let vpos4 = camera.view * vec4<f32>(world, 1.0);
   var clip = camera.proj * vpos4;
   // SAME GL->WebGPU NDC z remap as the atom impostor shader.
   clip.z = (clip.z + clip.w) * 0.5;
 
-  // View-space normal for lambert shading (radial direction in view space).
-  let vn4 = camera.view * vec4<f32>(radial, 0.0);
+  // View-space normal for lambert shading.
+  let vn4 = camera.view * vec4<f32>(world_normal, 0.0);
 
   var out : VsOut;
   out.clip = clip;
@@ -512,8 +561,9 @@ export function create_large_system_renderer(
     layout: device.createPipelineLayout({ bindGroupLayouts: [bond_render_bgl] }),
     vertex: { module: bond_render_module, entryPoint: `vs_main` },
     fragment: { module: bond_render_module, entryPoint: `fs_main`, targets: [{ format }] },
-    // Closed side-wall strip; cull nothing so thin cylinders never vanish.
-    primitive: { topology: `triangle-strip`, cullMode: `none` },
+    // Capped cylinder is an explicit triangle-LIST (side-wall quads + 2 cap
+    // fans); cull nothing so caps render regardless of winding/view.
+    primitive: { topology: `triangle-list`, cullMode: `none` },
     depthStencil: {
       format: DEPTH_FORMAT,
       depthWriteEnabled: true,

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -62,6 +62,13 @@ const CLEAR_COLOR: GPUColor = { r: 0.02, g: 0.03, b: 0.05, a: 1 }
 
 const DEPTH_FORMAT: GPUTextureFormat = `depth24plus`
 
+/** MSAA sample count for the overlay. 4× MSAA + alpha-to-coverage gives the
+ *  impostor silhouettes (defined by fragment discard / ray-miss) smooth,
+ *  analytically-AA'd edges that match the WebGL view's `antialias:true`. Both
+ *  the color and depth render targets are multisampled at this count; the color
+ *  target resolves into the swapchain texture each frame. */
+const SAMPLE_COUNT = 4
+
 /** WGSL cell-box line shader. Draws the 12 edges of the parallelepiped spanned
  *  by lattice vectors a,b,c as a `line-list` (24 vertices = 12 edges × 2 ends).
  *  Corners are generated in the vertex shader from a lattice uniform: the cell
@@ -214,10 +221,23 @@ fn fs_main(in : VsOut) -> FsOut {
   let b = dot(oc, rd);
   let c = dot(oc, oc) - in.radius * in.radius;
   let disc = b * b - c;
-  if (disc < 0.0) {
+
+  // ── Analytic silhouette coverage (alpha-to-coverage AA) ────────────────────
+  // disc = r^2 - d_perp^2 where d_perp is the eye-ray's perpendicular distance
+  // to the center: >0 inside the disk, =0 exactly on the silhouette. This is a
+  // SMOOTH varying of the interpolated ray (in.vpos), so fwidth() gives the
+  // screen-space width of the silhouette band. coverage ramps 0->1 across that
+  // ~1px band; output as alpha so alpha-to-coverage turns it into fractional
+  // MSAA sample coverage -> smooth curved edges (plain MSAA can't smooth a
+  // hard discard edge).
+  let fw = fwidth(disc);
+  let coverage = clamp(disc / max(fw, 1e-8) + 0.5, 0.0, 1.0);
+  if (coverage <= 0.0) {
     discard;
   }
-  let t = -b - sqrt(disc); // near hit
+  // Near hit. In the thin edge band disc may be ~0 (sqrt≈0), so the hit point
+  // sits on the silhouette — its depth is the right value for that band.
+  let t = -b - sqrt(max(disc, 0.0)); // near hit
   if (t < 0.0) {
     discard;
   }
@@ -234,7 +254,9 @@ fn fs_main(in : VsOut) -> FsOut {
 
   var out : FsOut;
   out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
-  out.color = vec4<f32>(in.color * lighting, 1.0);
+  // alpha = coverage feeds alpha-to-coverage; no alpha blending is enabled, so
+  // the color target stays opaque.
+  out.color = vec4<f32>(in.color * lighting, coverage);
   return out;
 }
 `
@@ -524,7 +546,64 @@ fn fs_main(in : VsOut) -> FsOut {
     }
   }
 
-  if (!found) { discard; }
+  // ── Analytic capsule silhouette coverage (alpha-to-coverage AA) ─────────────
+  // The exact body/cap ray-test above sets found (a binary edge); plain MSAA
+  // can't smooth that. We deliberately do NOT discard on !found yet — a fragment
+  // just outside the solid still lies in the thin silhouette band below and must
+  // survive to receive fractional coverage. Build a SMOOTH signed inside-measure
+  // of the finite-capsule silhouette and convert it to fractional coverage so
+  // alpha-to-coverage AAs the body and cap edges.
+  //
+  // For the eye ray (origin 0, dir rd) we measure perpendicular distance to the
+  // axis SEGMENT [pa,pb] and combine with the two cap planes:
+  //   body_inside = r - dist(ray, axis-line)              (radial silhouette)
+  //   cap-axial   = clamp the closest-approach axial coord into [0,clen]
+  // We sample the ray at its closest approach to the axis line, clamp that
+  // point onto the segment, and take measure = r - |closest point on ray to the
+  // segment|. This is the standard ray↔segment capsule distance and is a smooth
+  // varying of the interpolated rd, so fwidth() yields the screen-space edge
+  // width. measure>0 inside the projected capsule, =0 on the silhouette.
+  //
+  // Closest approach between the eye ray (P=rd*t, t>=0) and the axis line
+  // (Q=pa+axis*s): solve the 2x2 least-squares for (t,s) using rd·rd=1.
+  let rda = dot(rd, axis);          // = rd_a, reuse-friendly
+  let denom_cl = 1.0 - rda * rda;   // = |rd x axis|^2 (rd is unit)
+  let w0 = -pa;                     // O - pa, O=0
+  let d_w = dot(rd, w0);
+  let e_w = dot(axis, w0);
+  // t along the ray, s along the axis line, at mutual closest approach.
+  var t_cl = 0.0;
+  var s_cl = 0.0;
+  if (denom_cl > 1e-7) {
+    t_cl = (rda * e_w - d_w) / denom_cl;
+    s_cl = (e_w - rda * d_w) / denom_cl;
+  } else {
+    // Ray ~parallel to axis (end-on): project onto the ray.
+    t_cl = -d_w;
+    s_cl = 0.0;
+  }
+  t_cl = max(t_cl, 0.0);            // ray only extends forward
+  s_cl = clamp(s_cl, 0.0, clen);    // clamp onto the finite axis SEGMENT
+  let p_ray = rd * t_cl;            // closest ray point
+  let p_seg = pa + axis * s_cl;     // closest segment point
+  let gap = length(p_ray - p_seg);  // capsule surface distance proxy
+  let measure = r - gap;            // >0 inside silhouette, =0 on edge
+  let fw = fwidth(measure);
+  let coverage = clamp(measure / max(fw, 1e-8) + 0.5, 0.0, 1.0);
+
+  // Inside the solid (found) → full coverage; only the thin silhouette band gets
+  // fractional coverage. If neither the exact solid test nor the analytic band
+  // covers this fragment, discard.
+  let cov = select(coverage, 1.0, found);
+  if (cov <= 0.0) { discard; }
+
+  // For the thin AA band where the exact ray-test missed, fall back to the
+  // capsule-surface point for normal + depth so the edge band shades/depths
+  // consistently with the solid body.
+  if (!found) {
+    hit_p = p_ray;
+    hit_n = normalize(p_ray - p_seg);
+  }
 
   let light_dir = normalize(vec3<f32>(0.3, 0.5, 0.8));
   let lighting = 0.35 + 0.65 * max(dot(hit_n, light_dir), 0.0);
@@ -536,7 +615,8 @@ fn fs_main(in : VsOut) -> FsOut {
 
   var out : FsOut;
   out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
-  out.color = vec4<f32>(in.color * lighting, 1.0);
+  // alpha = coverage feeds alpha-to-coverage; no alpha blending is enabled.
+  out.color = vec4<f32>(in.color * lighting, cov);
   return out;
 }
 `
@@ -630,7 +710,13 @@ export function create_large_system_renderer(
   let atom_capacity = 0 // instances the current buffers can hold
   let atom_count = 0 // instances to draw this frame
 
-  // Depth texture, sized to the canvas; recreated on resize.
+  // MSAA render targets, sized to the canvas backing store; recreated on resize.
+  // - msaa_color: 4× multisampled COLOR target (canvas format). The render pass
+  //   draws into this and RESOLVES into the swapchain texture each frame.
+  // - depth_texture: 4× multisampled DEPTH target (depth24plus). Must match the
+  //   color sampleCount so the pipelines (multisample.count = 4) are valid.
+  let msaa_color_texture: GPUTexture | null = null
+  let msaa_color_view: GPUTextureView | null = null
   let depth_texture: GPUTexture | null = null
   let depth_view: GPUTextureView | null = null
 
@@ -730,6 +816,11 @@ export function create_large_system_renderer(
       depthWriteEnabled: true,
       depthCompare: `less`,
     },
+    // 4× MSAA. alphaToCoverageEnabled turns the fragment's alpha (= analytic
+    // silhouette coverage) into fractional MSAA sample coverage, so the curved
+    // sphere edge — defined by ray-miss discard — gets antialiased. The color
+    // target stays opaque (no blend); alpha is consumed ONLY as coverage.
+    multisample: { count: SAMPLE_COUNT, alphaToCoverageEnabled: true },
   })
 
   // Bond-detect compute (the already-validated BOND_COMPUTE_WGSL). auto layout
@@ -793,6 +884,10 @@ export function create_large_system_renderer(
       depthWriteEnabled: true,
       depthCompare: `less`,
     },
+    // 4× MSAA + alpha-to-coverage: same as the atom impostor. The capsule
+    // silhouette (body + caps), defined by ray-miss discard, outputs fractional
+    // coverage as alpha so the curved/grazing bond edges are smoothly AA'd.
+    multisample: { count: SAMPLE_COUNT, alphaToCoverageEnabled: true },
   })
 
   // Cell-box render: 12 edges as a thin line-list. Binds camera + cell uniform.
@@ -818,6 +913,10 @@ export function create_large_system_renderer(
       depthWriteEnabled: true,
       depthCompare: `less`,
     },
+    // 4× MSAA so the opaque cell lines share the multisampled targets and get
+    // geometric edge AA. No alpha-to-coverage — lines aren't silhouette-discard
+    // impostors, and the fragment alpha stays 1 (fully opaque).
+    multisample: { count: SAMPLE_COUNT },
   })
   const cell_bind_group = device.createBindGroup({
     label: `large-system-cell-bg`,
@@ -849,17 +948,34 @@ export function create_large_system_renderer(
     )
   }
 
-  function ensure_depth(w: number, h: number): void {
+  // (Re)create both MSAA render targets (color + depth) at the canvas backing
+  // size. Destroy the old textures first so resize never leaks. Both are
+  // multisampled at SAMPLE_COUNT — the color resolves into the swapchain, the
+  // depth is transient (storeOp:`discard` is fine but we keep `store` for
+  // simplicity; nothing reads it after the pass).
+  function ensure_targets(w: number, h: number): void {
+    const width = Math.max(1, w)
+    const height = Math.max(1, h)
+    msaa_color_texture?.destroy()
     depth_texture?.destroy()
+    msaa_color_texture = device.createTexture({
+      label: `large-system-msaa-color`,
+      size: { width, height },
+      format,
+      sampleCount: SAMPLE_COUNT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    })
+    msaa_color_view = msaa_color_texture.createView()
     depth_texture = device.createTexture({
       label: `large-system-depth`,
-      size: { width: Math.max(1, w), height: Math.max(1, h) },
+      size: { width, height },
       format: DEPTH_FORMAT,
+      sampleCount: SAMPLE_COUNT,
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     })
     depth_view = depth_texture.createView()
   }
-  ensure_depth(canvas.width || 1, canvas.height || 1)
+  ensure_targets(canvas.width || 1, canvas.height || 1)
 
   function rebuild_bind_group(): void {
     if (!positions_buffer || !radii_buffer || !colors_buffer) {
@@ -1115,7 +1231,7 @@ export function create_large_system_renderer(
     },
     render(): void {
       if (destroyed) return
-      if (!depth_view) ensure_depth(canvas.width || 1, canvas.height || 1)
+      if (!depth_view || !msaa_color_view) ensure_targets(canvas.width || 1, canvas.height || 1)
       const encoder = device.createCommandEncoder({ label: `large-system-frame` })
 
       // Whether bonds are renderable this frame (inputs present + atoms).
@@ -1156,11 +1272,15 @@ export function create_large_system_renderer(
         bonds_dirty = false
       }
 
-      const view = context.getCurrentTexture().createView()
+      // Draw into the multisampled color target, RESOLVE into the swapchain
+      // texture. storeOp:`store` performs the MSAA→single-sample resolve into
+      // resolveTarget at the end of the pass.
+      const swapchain_view = context.getCurrentTexture().createView()
       const pass = encoder.beginRenderPass({
         colorAttachments: [
           {
-            view,
+            view: msaa_color_view as GPUTextureView,
+            resolveTarget: swapchain_view,
             clearValue: clear_color,
             loadOp: `clear`,
             storeOp: `store`,
@@ -1201,7 +1321,7 @@ export function create_large_system_renderer(
       if (destroyed) return
       canvas.width = Math.max(1, Math.floor(w))
       canvas.height = Math.max(1, Math.floor(h))
-      ensure_depth(canvas.width, canvas.height)
+      ensure_targets(canvas.width, canvas.height)
     },
     destroy(): void {
       if (destroyed) return
@@ -1215,6 +1335,7 @@ export function create_large_system_renderer(
       positions_buffer?.destroy()
       radii_buffer?.destroy()
       colors_buffer?.destroy()
+      msaa_color_texture?.destroy()
       depth_texture?.destroy()
       // Bond resources.
       covalent_buffer?.destroy()
@@ -1230,6 +1351,8 @@ export function create_large_system_renderer(
       colors_buffer = null
       covalent_buffer = null
       pairs_buffer = null
+      msaa_color_texture = null
+      msaa_color_view = null
       depth_texture = null
       depth_view = null
       bind_group = null

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -758,11 +758,23 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   // jimage shift IS one cell step — so reuse partnerB as the real adjacent atom.
   let B_real = partnerB;
 
+  // show_images flag (viewer's show_image_atoms) packed into lat0.w by the TS
+  // upload (1=on). When ON and we are in the NON-supercell path (ncells==1), a
+  // cross-cell bond's imaged partner B+jimage·lattice coincides with a DISPLAYED
+  // PBC image atom → upgrade the boundary STUB to a FULL cylinder reaching it, so
+  // image atoms gain bonds (matching the WebGL view). Supercell mode (ncells>1)
+  // is left to the Phase-2 partner-cell-in-range logic untouched.
+  let ncells = nx * ny * nz;
+  let show_images = supercell.lat0.w > 0.5;
+  let image_full = (!inside) && ncells == 1u && show_images;
+
   // Render as ONE full cylinder when the partner is a real in-range atom (half 0:
   // A→B_real, half 1 degenerate) — same single-full-cylinder path the Phase-1
   // single-cell code used for intra-cell (jimage=0) bonds. When ncells=1, only
   // jimage=0 is ever inside [0,1)³, so this is exactly the old is_intra branch.
-  let is_full = inside;
+  // image_full upgrades a ncells==1 cross-cell boundary stub to that same full
+  // path (endpoint partnerB = the displayed image atom) when show_images is on.
+  let is_full = inside || image_full;
 
   // FULL: half 0 spans A→B_real; half 1 is collapsed offscreen below.
   // STUB (boundary): half 0 = A→mid(A,partnerB); half 1 = B→mid(B,partnerA) — the
@@ -1066,6 +1078,16 @@ export type LargeSystemRenderer = {
    *  identical to the non-supercell path. The CPU stays at the base cell; this is
    *  what scales the rendered atom count WITHOUT building N× Site objects. */
   set_supercell(dims: [number, number, number], base_lattice: Float32Array): void
+  /** Toggle whether DISPLAYED PBC image atoms exist (the viewer's
+   *  `show_image_atoms`, non-supercell only). When true, cross-cell bonds
+   *  (jimage != 0) in the ncells==1 path are drawn as FULL cylinders reaching the
+   *  imaged partner (B + jimage·lattice) — exactly where the displayed image atom
+   *  sits — so image atoms gain bonds (matching the WebGL view). When false (the
+   *  default) those bonds stay HALF-stubs (the "PBC bond too long, show half"
+   *  behaviour). NEVER affects supercell mode (ncells>1) — there the Phase-2
+   *  partner-cell-in-range logic is authoritative. Marks bonds dirty so the next
+   *  render re-emits with the new flag. */
+  set_show_images(show: boolean): void
   /** Provide bond-detection inputs. `covalent_radii` is the per-atom COVALENT
    *  radius (N entries, from build_atom_radii — distinct from the display radii
    *  used for sphere size). `lattice` is the 9-float row-major matrix (rows
@@ -1169,6 +1191,12 @@ export function create_large_system_renderer(
   let supercell_ncells = 1
   // Cached base lattice rows (9 floats, rows a,b,c) for the per-cell offset.
   let supercell_lattice = new Float32Array(9)
+  // Whether DISPLAYED PBC image atoms exist (viewer's show_image_atoms). Packed
+  // into the Supercell uniform's lat0.w pad slot (the atom impostor reads only
+  // .xyz, so this never perturbs it). Read in BOND_RENDER_WGSL to upgrade the
+  // ncells==1 cross-cell STUB to a FULL cylinder reaching the displayed image
+  // atom. Default false ⇒ stubs ⇒ zero change.
+  let show_image_atoms = false
 
   // Atom storage buffers — lazily (re)created when the atom count grows.
   let positions_buffer: GPUBuffer | null = null
@@ -1958,8 +1986,10 @@ export function create_large_system_renderer(
     // decoded as inst % base_count). 0 atoms ⇒ no draw, value is irrelevant.
     u32[3] = Math.max(0, atom_count)
     const L = supercell_lattice
-    // Row a -> lat0.xyz, row b -> lat1.xyz, row c -> lat2.xyz (w = 0 pad).
-    f32[0] = L[0]; f32[1] = L[1]; f32[2] = L[2]; f32[3] = 0
+    // Row a -> lat0.xyz, row b -> lat1.xyz, row c -> lat2.xyz. The lat0.w pad
+    // slot carries show_image_atoms (1=on) for the bond render's ncells==1 full-
+    // to-image-atom path; the atom impostor reads only .xyz so it is unaffected.
+    f32[0] = L[0]; f32[1] = L[1]; f32[2] = L[2]; f32[3] = show_image_atoms ? 1 : 0
     f32[4] = L[3]; f32[5] = L[4]; f32[6] = L[5]; f32[7] = 0
     f32[8] = L[6]; f32[9] = L[7]; f32[10] = L[8]; f32[11] = 0
     device.queue.writeBuffer(supercell_buffer, 0, buf, 0, SUPERCELL_BYTES)
@@ -2216,6 +2246,16 @@ export function create_large_system_renderer(
       // re-runs the indirect-args build with the new ncells (and re-emits the per-
       // cell bond replicas). A static scene would otherwise keep the old count.
       write_indirect_cfg()
+      bonds_dirty = true
+    },
+    set_show_images(show: boolean): void {
+      if (destroyed) return
+      const next = !!show
+      if (next === show_image_atoms) return
+      show_image_atoms = next
+      // Re-pack the Supercell uniform (lat0.w flag) and re-emit bonds so the
+      // ncells==1 cross-cell halves switch between stub and full-to-image.
+      upload_supercell_uniform()
       bonds_dirty = true
     },
     set_selection(indices: Uint32Array | number[]): void {

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -5,8 +5,16 @@
  *  Milestone 9.2 — render the current frame's ATOMS as impostor spheres.
  *  A single instanced draw paints one screen-facing quad per atom; the fragment
  *  shader ray-traces a sphere inside the quad and writes correct clip-space depth
- *  so spheres occlude each other properly. No bonds / trajectory / picking yet —
- *  those arrive in later milestones. */
+ *  so spheres occlude each other properly.
+ *  Milestone 9.3 — GPU bond detection + bond rendering. The bond-detect compute
+ *  (BOND_COMPUTE_WGSL) runs over the SAME positions buffer plus a separate
+ *  COVALENT-radii buffer, writing a GPU-resident `pairs` buffer + atomic count.
+ *  A tiny 1-thread compute then writes draw-indirect args from that count so the
+ *  bond draw never stalls the CPU (trajectory-ready for 9.4). Bonds render as
+ *  instanced procedural cylinders, sharing the atom depth buffer so they occlude
+ *  correctly. No trajectory / picking yet — those arrive in later milestones. */
+import { BOND_COMPUTE_WGSL } from '$lib/structure/gpu/bond-compute.wgsl'
+import { pack_params, PARAMS_BYTES } from '$lib/structure/gpu/bond-compute'
 
 /** Camera uniform (legacy 9.1): 20 floats (proj*view + camPos + pad) = 80 bytes. */
 const CAMERA_UNIFORM_BYTES = 80
@@ -14,6 +22,22 @@ const CAMERA_UNIFORM_BYTES = 80
 /** Camera uniform (9.2 impostor): view(16) + proj(16) + camPos vec3 + pad = 36
  *  floats = 144 bytes. Matches pack_camera_full's layout. */
 const CAMERA_FULL_BYTES = 144
+
+/** Bond Params uniform (BOND_COMPUTE_WGSL): 80 bytes, packed via pack_params. */
+const BOND_PARAMS_BYTES = 80
+
+/** Radial segments of the procedural cylinder. The side wall is a closed
+ *  triangle-strip: 2 verts per segment boundary, (SEG+1) boundaries. */
+const BOND_SEGMENTS = 12
+const BOND_VERTS_PER_CYLINDER = (BOND_SEGMENTS + 1) * 2
+
+/** Fixed bond cylinder radius (Å). Small constant; tunable. Uploaded to the
+ *  bond render shader as part of its uniform so it can be retuned without a
+ *  shader edit. */
+const BOND_RADIUS = 0.16
+
+/** Neutral bond color (linear rgb). Half-A/half-B coloring is a later milestone. */
+const BOND_COLOR: [number, number, number] = [0.7, 0.7, 0.7]
 
 /** A distinct dark background so flipping the toggle visibly swaps which canvas
  *  paints. Near-black with a faint blue tint. */
@@ -128,6 +152,127 @@ fn fs_main(in : VsOut) -> FsOut {
 }
 `
 
+/** Tiny 1-thread compute: read the atomic bond `count`, clamp to capacity, and
+ *  write draw-indirect args [vertex_count, instance_count, first_vertex,
+ *  first_instance] so the bond draw uses drawIndirect with zero CPU readback. */
+const INDIRECT_ARGS_WGSL = `
+struct Args {
+  vertex_count : u32,
+  instance_count : u32,
+  first_vertex : u32,
+  first_instance : u32,
+};
+@group(0) @binding(0) var<storage, read> count : array<u32>;
+@group(0) @binding(1) var<storage, read_write> args : Args;
+
+// uniforms: x = vertex_count_per_cylinder, y = capacity (clamp)
+@group(0) @binding(2) var<uniform> cfg : vec2<u32>;
+
+@compute @workgroup_size(1)
+fn build_args() {
+  let raw = count[0];
+  let inst = min(raw, cfg.y);
+  args.vertex_count = cfg.x;
+  args.instance_count = inst;
+  args.first_vertex = 0u;
+  args.first_instance = 0u;
+}
+`
+
+/** Instanced procedural-cylinder bond shader. One instance per detected bond.
+ *  Per instance reads (a, b, jimage_packed) from the pairs buffer; endpoint B is
+ *  shifted by jimage·lattice (min-image PBC partner) using the SAME lattice the
+ *  compute used. Verts trace a unit side-wall triangle-strip that is oriented to
+ *  the bond axis and scaled to span A→B with a fixed radius. Depth uses the SAME
+ *  GL→WebGPU clip-z remap as the atom impostor so bonds share the depth buffer
+ *  and occlude / are occluded correctly. */
+const BOND_RENDER_WGSL = `
+struct Camera {
+  view : mat4x4<f32>,
+  proj : mat4x4<f32>,
+  cam_pos : vec4<f32>,
+};
+// Bond uniform: lattice columns a,b,c (transposed, vec3+pad each) + radius.
+struct BondU {
+  lat0 : vec4<f32>,
+  lat1 : vec4<f32>,
+  lat2 : vec4<f32>,
+  radius_color : vec4<f32>, // x=radius, yzw=color
+};
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<storage, read> positions : array<f32>;
+@group(0) @binding(2) var<storage, read> pairs : array<u32>;
+@group(0) @binding(3) var<uniform> bond : BondU;
+
+struct VsOut {
+  @builtin(position) clip : vec4<f32>,
+  @location(0) vnormal : vec3<f32>, // view-space surface normal for shading
+  @location(1) color : vec3<f32>,
+};
+
+const SEG : u32 = ${BOND_SEGMENTS}u;
+const PI2 : f32 = 6.28318530718;
+
+fn atom_pos(i : u32) -> vec3<f32> {
+  return vec3<f32>(positions[i*3u], positions[i*3u+1u], positions[i*3u+2u]);
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi : u32,
+           @builtin(instance_index) inst : u32) -> VsOut {
+  let a = pairs[inst*3u + 0u];
+  let b = pairs[inst*3u + 1u];
+  let jp = pairs[inst*3u + 2u];
+
+  // Unpack jimage {-1,0,1} from (na+1)|((nb+1)<<2)|((nc+1)<<4).
+  let na = f32(i32(jp & 3u) - 1);
+  let nb = f32(i32((jp >> 2u) & 3u) - 1);
+  let nc = f32(i32((jp >> 4u) & 3u) - 1);
+  let shift = na * bond.lat0.xyz + nb * bond.lat1.xyz + nc * bond.lat2.xyz;
+
+  let pa = atom_pos(a);
+  let pb = atom_pos(b) + shift;
+
+  // Orthonormal basis around the bond axis A->B.
+  let axis = pb - pa;
+  let len = length(axis);
+  let dir = select(vec3<f32>(0.0, 0.0, 1.0), axis / max(len, 1e-6), len > 1e-6);
+  let up = select(vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(1.0, 0.0, 0.0), abs(dir.y) > 0.9);
+  let tangent = normalize(cross(up, dir));
+  let bitangent = cross(dir, tangent);
+
+  // Side-wall triangle-strip: pairs of (bottom, top) ring verts.
+  let seg = vi >> 1u;             // 0..SEG
+  let is_top = (vi & 1u) == 1u;   // alternate bottom/top
+  let ang = f32(seg) / f32(SEG) * PI2;
+  let radial = cos(ang) * tangent + sin(ang) * bitangent;
+  let base = select(pa, pb, is_top);
+  let world = base + radial * bond.radius_color.x;
+
+  let vpos4 = camera.view * vec4<f32>(world, 1.0);
+  var clip = camera.proj * vpos4;
+  // SAME GL->WebGPU NDC z remap as the atom impostor shader.
+  clip.z = (clip.z + clip.w) * 0.5;
+
+  // View-space normal for lambert shading (radial direction in view space).
+  let vn4 = camera.view * vec4<f32>(radial, 0.0);
+
+  var out : VsOut;
+  out.clip = clip;
+  out.vnormal = normalize(vn4.xyz);
+  out.color = bond.radius_color.yzw;
+  return out;
+}
+
+@fragment
+fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
+  let light_dir = normalize(vec3<f32>(0.3, 0.5, 0.8));
+  let lighting = 0.35 + 0.65 * max(dot(normalize(in.vnormal), light_dir), 0.0);
+  return vec4<f32>(in.color * lighting, 1.0);
+}
+`
+
 export type LargeSystemRenderer = {
   /** Upload a packed camera uniform (Float32Array(20), proj*view layout).
    *  Legacy 9.1 entry point; kept for back-compat. Not used by the impostor
@@ -144,7 +289,21 @@ export type LargeSystemRenderer = {
     colors: Float32Array,
     count: number,
   ): void
-  /** Run one render pass: clear + (if atoms present) impostor sphere draw. */
+  /** Provide bond-detection inputs. `covalent_radii` is the per-atom COVALENT
+   *  radius (N entries, from build_atom_radii — distinct from the display radii
+   *  used for sphere size). `lattice` is the 9-float row-major matrix (rows
+   *  a,b,c), the SAME one the compute + bond render use. `options` carries the
+   *  bond cutoffs; `periodic` toggles min-image PBC. Marks bonds dirty so the
+   *  next render re-runs the compute dispatch — NOT every frame. */
+  set_bond_data(
+    covalent_radii: Float32Array,
+    lattice: Float32Array,
+    options: { tolerance: number; max_bond_dist: number; min_dist: number },
+    periodic: boolean,
+  ): void
+  /** Run one render pass: clear + (if bonds dirty) bond compute + indirect-args
+   *  build, then (if atoms present) impostor sphere draw + (if bonds present)
+   *  instanced cylinder draw, all sharing one depth attachment. */
   render(): void
   /** Resize the backing canvas + depth texture to device-pixel dimensions. */
   resize(w: number, h: number): void
@@ -182,6 +341,56 @@ export function create_large_system_renderer(
   // Bind group depends on the storage buffers, so rebuild whenever they change.
   let bind_group: GPUBindGroup | null = null
 
+  // ── Bond resources (milestone 9.3) ──────────────────────────────────────
+  // Covalent radii (N) for bond detection — distinct from the display radii.
+  let covalent_buffer: GPUBuffer | null = null
+  let covalent_capacity = 0
+  // GPU-resident bond outputs. `pairs` holds capacity*3 u32 (a,b,jimage); the
+  // atomic count + indirect-args are tiny fixed buffers.
+  let pairs_buffer: GPUBuffer | null = null
+  let bond_capacity = 0 // pairs the current pairs buffer can hold
+  const count_buffer = device.createBuffer({
+    label: `large-system-bond-count`,
+    size: 4,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+  })
+  const indirect_buffer = device.createBuffer({
+    label: `large-system-bond-indirect`,
+    // draw args: vertex_count, instance_count, first_vertex, first_instance.
+    size: 16,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST,
+  })
+  const bond_params_buffer = device.createBuffer({
+    label: `large-system-bond-params`,
+    size: BOND_PARAMS_BYTES,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  // Bond render uniform: lattice columns (transposed, 3×vec4) + (radius,color).
+  const bond_render_uniform = device.createBuffer({
+    label: `large-system-bond-render-uniform`,
+    size: 64, // 4 × vec4
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  // cfg for the indirect-args build: (verts_per_cylinder, capacity).
+  const indirect_cfg_buffer = device.createBuffer({
+    label: `large-system-indirect-cfg`,
+    size: 8, // vec2<u32>
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  // Cached bond inputs, re-uploaded only when set_bond_data changes them.
+  let bond_lattice = new Float32Array(9)
+  let bond_options = { tolerance: 0, max_bond_dist: 0, min_dist: 0 }
+  let bond_periodic = false
+  let bond_n = 0 // atom count the detection should range over
+  // True when the bond inputs (or atoms) changed and the compute must re-run.
+  let bonds_dirty = false
+  let bonds_configured = false // set once set_bond_data has provided inputs
+
+  // Bind groups rebuilt when the underlying buffers (re)allocate.
+  let bond_compute_bg: GPUBindGroup | null = null
+  let indirect_bg: GPUBindGroup | null = null
+  let bond_render_bg: GPUBindGroup | null = null
+
   const shader = device.createShaderModule({
     label: `large-system-impostor`,
     code: IMPOSTOR_WGSL,
@@ -212,6 +421,67 @@ export function create_large_system_renderer(
     },
   })
 
+  // Bond-detect compute (the already-validated BOND_COMPUTE_WGSL). auto layout
+  // matches bond-compute.ts: 0 positions, 1 radii, 2 params, 3 out_pairs,
+  // 4 out_count.
+  const bond_compute_module = device.createShaderModule({
+    label: `large-system-bond-compute`,
+    code: BOND_COMPUTE_WGSL,
+  })
+  const bond_compute_pipeline = device.createComputePipeline({
+    label: `large-system-bond-compute-pipeline`,
+    layout: `auto`,
+    compute: { module: bond_compute_module, entryPoint: `detect_bonds` },
+  })
+
+  // Indirect-args build: read atomic count, write drawIndirect args.
+  const indirect_module = device.createShaderModule({
+    label: `large-system-indirect-args`,
+    code: INDIRECT_ARGS_WGSL,
+  })
+  const indirect_pipeline = device.createComputePipeline({
+    label: `large-system-indirect-args-pipeline`,
+    layout: `auto`,
+    compute: { module: indirect_module, entryPoint: `build_args` },
+  })
+
+  // Bond render: instanced procedural cylinders.
+  const bond_render_module = device.createShaderModule({
+    label: `large-system-bond-render`,
+    code: BOND_RENDER_WGSL,
+  })
+  const bond_render_bgl = device.createBindGroupLayout({
+    label: `large-system-bond-render-bgl`,
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+      { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+    ],
+  })
+  const bond_render_pipeline = device.createRenderPipeline({
+    label: `large-system-bond-render-pipeline`,
+    layout: device.createPipelineLayout({ bindGroupLayouts: [bond_render_bgl] }),
+    vertex: { module: bond_render_module, entryPoint: `vs_main` },
+    fragment: { module: bond_render_module, entryPoint: `fs_main`, targets: [{ format }] },
+    // Closed side-wall strip; cull nothing so thin cylinders never vanish.
+    primitive: { topology: `triangle-strip`, cullMode: `none` },
+    depthStencil: {
+      format: DEPTH_FORMAT,
+      depthWriteEnabled: true,
+      depthCompare: `less`,
+    },
+  })
+
+  // Static indirect-args cfg: (verts_per_cylinder, capacity) — capacity is
+  // refreshed when the pairs buffer (re)allocates.
+  function write_indirect_cfg(): void {
+    device.queue.writeBuffer(
+      indirect_cfg_buffer, 0,
+      new Uint32Array([BOND_VERTS_PER_CYLINDER, bond_capacity]),
+    )
+  }
+
   function ensure_depth(w: number, h: number): void {
     depth_texture?.destroy()
     depth_texture = device.createTexture({
@@ -239,6 +509,76 @@ export function create_large_system_renderer(
         { binding: 3, resource: { buffer: colors_buffer } },
       ],
     })
+  }
+
+  /** Grow the GPU-resident pairs buffer to hold at least `cap` bonds. Heuristic
+   *  capacity is chosen by the caller (set_atoms): max(1024, n_atoms*16). */
+  function ensure_pairs_capacity(cap: number): void {
+    if (cap <= bond_capacity && pairs_buffer) return
+    pairs_buffer?.destroy()
+    bond_capacity = Math.max(cap, 1024)
+    pairs_buffer = device.createBuffer({
+      label: `large-system-bond-pairs`,
+      size: bond_capacity * 3 * 4,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    })
+    write_indirect_cfg()
+    rebuild_bond_bind_groups()
+  }
+
+  /** (Re)build the three bond bind groups. Depends on positions_buffer (atom
+   *  realloc), covalent_buffer, and pairs_buffer — any of which may reallocate.
+   *  No-op until all are present. */
+  function rebuild_bond_bind_groups(): void {
+    bond_compute_bg = null
+    indirect_bg = null
+    bond_render_bg = null
+    if (!positions_buffer || !covalent_buffer || !pairs_buffer) return
+
+    bond_compute_bg = device.createBindGroup({
+      label: `large-system-bond-compute-bg`,
+      layout: bond_compute_pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: positions_buffer } },
+        { binding: 1, resource: { buffer: covalent_buffer } },
+        { binding: 2, resource: { buffer: bond_params_buffer } },
+        { binding: 3, resource: { buffer: pairs_buffer } },
+        { binding: 4, resource: { buffer: count_buffer } },
+      ],
+    })
+    indirect_bg = device.createBindGroup({
+      label: `large-system-indirect-bg`,
+      layout: indirect_pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: count_buffer } },
+        { binding: 1, resource: { buffer: indirect_buffer } },
+        { binding: 2, resource: { buffer: indirect_cfg_buffer } },
+      ],
+    })
+    bond_render_bg = device.createBindGroup({
+      label: `large-system-bond-render-bg`,
+      layout: bond_render_bgl,
+      entries: [
+        { binding: 0, resource: { buffer: camera_buffer } },
+        { binding: 1, resource: { buffer: positions_buffer } },
+        { binding: 2, resource: { buffer: pairs_buffer } },
+        { binding: 3, resource: { buffer: bond_render_uniform } },
+      ],
+    })
+  }
+
+  /** Pack + upload the bond render uniform: lattice columns (TRANSPOSED to match
+   *  the compute's column layout) + (radius, color). */
+  function upload_bond_render_uniform(): void {
+    const u = new Float32Array(16)
+    const L = bond_lattice
+    // Same transpose pack_params uses: column k = lattice row k.
+    u[0] = L[0]; u[1] = L[1]; u[2] = L[2]; u[3] = 0
+    u[4] = L[3]; u[5] = L[4]; u[6] = L[5]; u[7] = 0
+    u[8] = L[6]; u[9] = L[7]; u[10] = L[8]; u[11] = 0
+    u[12] = BOND_RADIUS
+    u[13] = BOND_COLOR[0]; u[14] = BOND_COLOR[1]; u[15] = BOND_COLOR[2]
+    device.queue.writeBuffer(bond_render_uniform, 0, u.buffer, u.byteOffset, 64)
   }
 
   let destroyed = false
@@ -290,6 +630,9 @@ export function create_large_system_renderer(
         })
         atom_capacity = new_cap
         rebuild_bind_group()
+        // positions_buffer just reallocated ⇒ rebuild the bond bind groups that
+        // reference it (they may have been null before, that's fine).
+        rebuild_bond_bind_groups()
       }
 
       device.queue.writeBuffer(
@@ -304,11 +647,94 @@ export function create_large_system_renderer(
         colors_buffer as GPUBuffer, 0,
         colors.buffer, colors.byteOffset, atom_count * 3 * 4,
       )
+      // Positions moved ⇒ bonds must be recomputed next render.
+      bonds_dirty = true
+    },
+    set_bond_data(
+      covalent_radii: Float32Array,
+      lattice: Float32Array,
+      options: { tolerance: number; max_bond_dist: number; min_dist: number },
+      periodic: boolean,
+    ): void {
+      if (destroyed) return
+      bonds_configured = true
+      bond_n = covalent_radii.length
+      bond_lattice = lattice.slice(0, 9)
+      bond_options = { ...options }
+      bond_periodic = periodic
+
+      // Capacity heuristic: max(1024, n_atoms * 16). Pairs buffer + indirect cfg
+      // grow with the atom count; never shrink (avoids churn on tweaks).
+      ensure_pairs_capacity(Math.max(1024, bond_n * 16))
+
+      // (Re)allocate the covalent-radii buffer when the atom count grows. It is
+      // SEPARATE from the display radii buffer (different radius semantics).
+      if (bond_n > covalent_capacity) {
+        const new_cap = Math.max(bond_n, Math.ceil(covalent_capacity * 2), 1)
+        covalent_buffer?.destroy()
+        covalent_buffer = device.createBuffer({
+          label: `large-system-covalent-radii`,
+          size: new_cap * 4,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        covalent_capacity = new_cap
+        rebuild_bond_bind_groups()
+      }
+      if (bond_n > 0 && covalent_buffer) {
+        device.queue.writeBuffer(
+          covalent_buffer, 0,
+          covalent_radii.buffer, covalent_radii.byteOffset, bond_n * 4,
+        )
+      }
+
+      // Upload the bond render uniform (lattice + radius/color) now; the compute
+      // Params is repacked at dispatch time (it also needs capacity).
+      upload_bond_render_uniform()
+      bonds_dirty = true
     },
     render(): void {
       if (destroyed) return
       if (!depth_view) ensure_depth(canvas.width || 1, canvas.height || 1)
       const encoder = device.createCommandEncoder({ label: `large-system-frame` })
+
+      // Whether bonds are renderable this frame (inputs present + atoms).
+      const bonds_ready =
+        bonds_configured && atom_count > 0 && bond_n > 0 &&
+        !!bond_compute_bg && !!indirect_bg && !!bond_render_bg && !!pairs_buffer
+
+      // ── Bond compute (only when dirty) ───────────────────────────────────
+      // Runs as a compute pass in THIS encoder, before the render pass, so the
+      // pairs/indirect writes are visible to the bond draw in the same submit.
+      // Cached by `bonds_dirty`: structure/option/atom changes flip it; a static
+      // scene re-uses last frame's GPU-resident pairs with no recompute.
+      if (bonds_ready && bonds_dirty) {
+        // Reset the atomic counter, then repack Params (n, capacity vary).
+        device.queue.writeBuffer(count_buffer, 0, new Uint32Array([0]))
+        device.queue.writeBuffer(
+          bond_params_buffer, 0,
+          pack_params(bond_n, bond_capacity, {
+            tolerance: bond_options.tolerance,
+            max_bond_dist: bond_options.max_bond_dist,
+            min_dist: bond_options.min_dist,
+            positions: new Float32Array(0), // unused by pack_params
+            radii: new Float32Array(0), // unused by pack_params
+            lattice: bond_lattice,
+            periodic: bond_periodic,
+          }),
+          0, PARAMS_BYTES,
+        )
+        const cpass = encoder.beginComputePass({ label: `large-system-bond-compute` })
+        cpass.setPipeline(bond_compute_pipeline)
+        cpass.setBindGroup(0, bond_compute_bg as GPUBindGroup)
+        cpass.dispatchWorkgroups(Math.max(1, Math.ceil(bond_n / 64)))
+        // Build draw-indirect args from the atomic count (no CPU readback).
+        cpass.setPipeline(indirect_pipeline)
+        cpass.setBindGroup(0, indirect_bg as GPUBindGroup)
+        cpass.dispatchWorkgroups(1)
+        cpass.end()
+        bonds_dirty = false
+      }
+
       const view = context.getCurrentTexture().createView()
       const pass = encoder.beginRenderPass({
         colorAttachments: [
@@ -330,6 +756,14 @@ export function create_large_system_renderer(
         pass.setPipeline(pipeline)
         pass.setBindGroup(0, bind_group)
         pass.draw(4, atom_count) // triangle-strip quad, one instance per atom
+      }
+      // Bonds: instanced procedural cylinders, instance count supplied by the
+      // indirect buffer the compute wrote (this same submit, or last frame's).
+      // Shares the depth attachment with the atom draw ⇒ correct occlusion.
+      if (bonds_ready) {
+        pass.setPipeline(bond_render_pipeline)
+        pass.setBindGroup(0, bond_render_bg as GPUBindGroup)
+        pass.drawIndirect(indirect_buffer, 0)
       }
       pass.end()
       device.queue.submit([encoder.finish()])
@@ -353,12 +787,25 @@ export function create_large_system_renderer(
       radii_buffer?.destroy()
       colors_buffer?.destroy()
       depth_texture?.destroy()
+      // Bond resources.
+      covalent_buffer?.destroy()
+      pairs_buffer?.destroy()
+      count_buffer.destroy()
+      indirect_buffer.destroy()
+      bond_params_buffer.destroy()
+      bond_render_uniform.destroy()
+      indirect_cfg_buffer.destroy()
       positions_buffer = null
       radii_buffer = null
       colors_buffer = null
+      covalent_buffer = null
+      pairs_buffer = null
       depth_texture = null
       depth_view = null
       bind_group = null
+      bond_compute_bg = null
+      indirect_bg = null
+      bond_render_bg = null
     },
   }
 }

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -570,17 +570,28 @@ struct Args {
 @group(0) @binding(0) var<storage, read> count : array<u32>;
 @group(0) @binding(1) var<storage, read_write> args : Args;
 
-// uniforms: x = vertex_count_per_cylinder, y = capacity (clamp)
-@group(0) @binding(2) var<uniform> cfg : vec2<u32>;
+// cfg: x = vertex_count_per_cylinder, y = capacity (clamp), z = ncells (supercell
+// tiling product nx·ny·nz). GPU supercell Phase 2 replicates each bond into every
+// cell, so the bond draw issues 2 · bond_count · ncells instances (two half-
+// cylinders per bond per cell). ncells defaults to 1 ⇒ 2·bond_count, the Phase-1
+// single-cell count (byte-identical).
+@group(0) @binding(2) var<uniform> cfg : vec3<u32>;
+// Clamped bond_count, written here so the bond RENDER vertex shader can decode
+// inst → (cell, bond_index, half) without reading the atomic count buffer. The
+// render shader needs the SAME clamped value used for instance_count below.
+@group(0) @binding(3) var<storage, read_write> bond_meta : array<u32>;
 
 @compute @workgroup_size(1)
 fn build_args() {
   let raw = count[0];
   let inst = min(raw, cfg.y);
+  let ncells = max(cfg.z, 1u);
   args.vertex_count = cfg.x;
-  args.instance_count = inst * 2u; // two half-cylinders per bond
+  // two half-cylinders per bond, replicated into every supercell cell.
+  args.instance_count = inst * 2u * ncells;
   args.first_vertex = 0u;
   args.first_instance = 0u;
+  bond_meta[0] = inst; // clamped bond_count for the render-side decode
 }
 `
 
@@ -636,10 +647,26 @@ struct BondU {
   radius_color : vec4<f32>, // x=radius, yzw=color
 };
 
+// GPU supercell uniform (Phase 2). Same layout as the atom impostor's Supercell:
+// dims = [nx,ny,nz,base_count] (base_count unused here — bond_count comes from
+// bond_meta), lat0/1/2 = base lattice ROWS a,b,c. The per-cell offset is
+// ix·a + iy·b + iz·c. Read ONLY in vs_main (cell decode + partner-cell test).
+struct Supercell {
+  dims : vec4<u32>,
+  lat0 : vec4<f32>,
+  lat1 : vec4<f32>,
+  lat2 : vec4<f32>,
+};
+
 @group(0) @binding(0) var<uniform> camera : Camera;
 @group(0) @binding(1) var<storage, read> positions : array<f32>;
 @group(0) @binding(2) var<storage, read> pairs : array<u32>;
 @group(0) @binding(3) var<uniform> bond : BondU;
+// Clamped bond_count (written by the indirect-args build). Drives the inst decode
+// cell = inst / (2·bond_count). Read ONLY in vs_main.
+@group(0) @binding(4) var<storage, read> bond_meta : array<u32>;
+// GPU supercell instancing params (dims + base lattice). Read ONLY in vs_main.
+@group(0) @binding(5) var<uniform> supercell : Supercell;
 
 struct VsOut {
   @builtin(position) clip : vec4<f32>,
@@ -667,39 +694,88 @@ fn atom_pos(i : u32) -> vec3<f32> {
 @vertex
 fn vs_main(@builtin(vertex_index) vi : u32,
            @builtin(instance_index) inst : u32) -> VsOut {
-  // Two half instances per bond: bond_index = inst>>1, half = inst&1.
-  let bond_index = inst >> 1u;
-  let half = inst & 1u;
+  // ── GPU supercell Phase 2 bond decode ──────────────────────────────────────
+  // Bonds are computed ONCE on the base cell (pairs = (a,b,jimage)). Each base
+  // bond is replicated into every cell (ix,iy,iz) of the nx·ny·nz supercell, each
+  // as TWO half instances (matching the Phase-1 atom replication). Instance
+  // layout: inst = cell·(2·bond_count) + bond_index·2 + half.
+  //   cell       = inst / (2·bond_count)
+  //   local      = inst % (2·bond_count)
+  //   bond_index = local >> 1
+  //   half       = local & 1
+  // When ncells = 1 (dims 1,1,1) cell = 0 and this collapses to the Phase-1
+  // mapping bond_index = inst>>1, half = inst&1 — byte-identical.
+  let bond_count = max(bond_meta[0], 1u);
+  let per_cell = bond_count * 2u;
+  let cell = inst / per_cell;
+  let local = inst % per_cell;
+  let bond_index = local >> 1u;
+  let half = local & 1u;
+
+  // Decode the cell index → (ix,iy,iz) and its lattice offset ix·a+iy·b+iz·c.
+  let nx = max(supercell.dims.x, 1u);
+  let ny = max(supercell.dims.y, 1u);
+  let nz = max(supercell.dims.z, 1u);
+  let ix = cell % nx;
+  let iy = (cell / nx) % ny;
+  let iz = cell / (nx * ny);
+  let cell_offset = f32(ix) * supercell.lat0.xyz
+                  + f32(iy) * supercell.lat1.xyz
+                  + f32(iz) * supercell.lat2.xyz;
 
   let a = pairs[bond_index*3u + 0u];
   let b = pairs[bond_index*3u + 1u];
   let jp = pairs[bond_index*3u + 2u];
 
   // Unpack jimage {-1,0,1} from (na+1)|((nb+1)<<2)|((nc+1)<<4).
-  let na = f32(i32(jp & 3u) - 1);
-  let nb = f32(i32((jp >> 2u) & 3u) - 1);
-  let nc = f32(i32((jp >> 4u) & 3u) - 1);
+  let ji = i32(jp & 3u) - 1;
+  let jj = i32((jp >> 2u) & 3u) - 1;
+  let jk = i32((jp >> 4u) & 3u) - 1;
+  let na = f32(ji);
+  let nb = f32(jj);
+  let nc = f32(jk);
   let shift = na * bond.lat0.xyz + nb * bond.lat1.xyz + nc * bond.lat2.xyz;
 
-  let A = atom_pos(a);
-  let B = atom_pos(b);
-  // A's imaged partner is B + jimage·lattice; B's imaged partner is A - jimage·lattice.
-  let partnerB = B + shift;
-  let partnerA = A - shift;
+  // A is atom a in THIS cell; partnerB is atom b imaged by jimage (still relative
+  // to this cell). Both carry the per-cell offset so every replica is positioned.
+  let A = atom_pos(a) + cell_offset;
+  let B = atom_pos(b) + cell_offset;
+  let partnerB = B + shift;       // A's imaged partner
+  let partnerA = A - shift;       // (unused when inside; kept for the stub path)
 
-  // INTRA-cell bonds (jimage = 0,0,0) pack to (0+1)|((0+1)<<2)|((0+1)<<4) = 21u.
-  // For those we render ONE full cylinder (half 0: A->B) and collapse half 1 to a
-  // degenerate offscreen billboard, so there is no coincident midpoint cap plane
-  // (which z-fights / shows as a dotted alpha-to-coverage seam across the surface).
-  let is_intra = jp == 21u;
+  // Partner cell = this cell + jimage. If it lies INSIDE [0,nx)×[0,ny)×[0,nz) the
+  // partner is a REAL replica atom one cell over → draw a FULL cylinder A→B_real
+  // (no spike, it's an actual adjacent atom). Otherwise (true outer boundary) draw
+  // the boundary STUB exactly as the single-cell path does.
+  let px = i32(ix) + ji;
+  let py = i32(iy) + jj;
+  let pz = i32(iz) + jk;
+  let inside = px >= 0 && px < i32(nx)
+            && py >= 0 && py < i32(ny)
+            && pz >= 0 && pz < i32(nz);
+  // B_real: atom b in the partner cell = base_pos[b] + (px·a + py·b + pz·c). This
+  // equals B + shift (= partnerB) whenever the partner cell is in range — the
+  // jimage shift IS one cell step — so reuse partnerB as the real adjacent atom.
+  let B_real = partnerB;
 
-  // half 0: A -> midpoint of (A, partnerB);  half 1: B -> midpoint of (B, partnerA).
-  // Cross-cell (jimage != 0) keeps the two A->M0 / B->M1 stubs (the gap is intended).
-  // Intra-cell half 0 spans the whole bond A->B; half 1 is discarded below.
+  // Render as ONE full cylinder when the partner is a real in-range atom (half 0:
+  // A→B_real, half 1 degenerate) — same single-full-cylinder path the Phase-1
+  // single-cell code used for intra-cell (jimage=0) bonds. When ncells=1, only
+  // jimage=0 is ever inside [0,1)³, so this is exactly the old is_intra branch.
+  let is_full = inside;
+
+  // FULL: half 0 spans A→B_real; half 1 is collapsed offscreen below.
+  // STUB (boundary): half 0 = A→mid(A,partnerB); half 1 = B→mid(B,partnerA) — the
+  // two short stubs of the single-cell cross-cell path, shifted by cell_offset.
   let cross_start = select(B, A, half == 0u);
   let cross_mid = select((B + partnerA) * 0.5, (A + partnerB) * 0.5, half == 0u);
-  let start = select(cross_start, A, is_intra);
-  let end = select(cross_mid, B, is_intra);
+  let start = select(cross_start, A, is_full);
+  let end = select(cross_mid, B_real, is_full);
+
+  // Keep the downstream variable name the rest of vs_main uses (is_intra) so the
+  // degenerate-half collapse + is_stub flag below are untouched: a full cylinder
+  // behaves exactly like an intra-cell bond (half 1 redundant, no depth bias).
+  let is_intra = is_full;
 
   let r = bond.radius_color.x;
 
@@ -1211,13 +1287,24 @@ export function create_large_system_renderer(
   // True once the lattice is non-zero (a periodic structure has been provided).
   let cell_has_lattice = false
 
-  // cfg for the indirect-args build: (verts_per_cylinder, bond capacity). The
-  // build shader clamps the bond count to capacity then doubles it, so the draw
-  // issues instance_count = 2*min(count,capacity) (two half-cylinders per bond).
+  // cfg for the indirect-args build: (verts_per_cylinder, bond capacity, ncells).
+  // The build shader clamps the bond count to capacity, doubles it (two half-
+  // cylinders per bond), then multiplies by ncells (GPU supercell Phase 2 bond
+  // replication) ⇒ instance_count = 2·min(count,capacity)·ncells. ncells defaults
+  // to 1 ⇒ the Phase-1 single-cell count. A vec3<u32> uniform is 12 bytes; round
+  // the buffer to 16 (uniform buffers bind in 16-byte granularity anyway).
   const indirect_cfg_buffer = device.createBuffer({
     label: `large-system-indirect-cfg`,
-    size: 8, // vec2<u32>
+    size: 16, // vec3<u32> (12 bytes, padded to 16)
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  // bond_meta: clamped bond_count written by the indirect-args build, read by the
+  // bond RENDER vertex shader to decode inst → (cell, bond_index, half). A tiny
+  // 4-byte storage buffer.
+  const bond_meta_buffer = device.createBuffer({
+    label: `large-system-bond-meta`,
+    size: 4,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
   })
   // Cached bond inputs, re-uploaded only when set_bond_data changes them.
   let bond_lattice = new Float32Array(9)
@@ -1420,6 +1507,13 @@ export function create_large_system_renderer(
       { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+      // binding 4 = bond_meta (clamped bond_count) and binding 5 = the GPU
+      // supercell uniform (dims + base lattice). Both are read ONLY in vs_main
+      // (the Phase-2 inst → cell/bond/half decode + partner-cell test); fs_main
+      // never touches them. Per the project's recurrence-proof bind-group rule,
+      // grant EXACTLY the reading stage — VERTEX only.
+      { binding: 4, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      { binding: 5, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
     ],
   })
   const bond_render_pipeline = device.createRenderPipeline({
@@ -1562,12 +1656,17 @@ export function create_large_system_renderer(
     device.queue.writeBuffer(cell_uniform, 0, u.buffer, u.byteOffset, 64)
   }
 
-  // Static indirect-args cfg: (verts_per_cylinder, capacity) — capacity is
-  // refreshed when the pairs buffer (re)allocates.
+  // Indirect-args cfg: (verts_per_cylinder, capacity, ncells). capacity is
+  // refreshed when the pairs buffer (re)allocates; ncells when set_supercell
+  // changes the tiling. ncells defaults to 1 ⇒ the single-cell instance count.
   function write_indirect_cfg(): void {
     device.queue.writeBuffer(
       indirect_cfg_buffer, 0,
-      new Uint32Array([BOND_VERTS_PER_CYLINDER, bond_capacity]),
+      new Uint32Array([
+        BOND_VERTS_PER_CYLINDER,
+        bond_capacity,
+        Math.max(1, supercell_ncells),
+      ]),
     )
   }
 
@@ -1819,6 +1918,8 @@ export function create_large_system_renderer(
         { binding: 0, resource: { buffer: count_buffer } },
         { binding: 1, resource: { buffer: indirect_buffer } },
         { binding: 2, resource: { buffer: indirect_cfg_buffer } },
+        // binding 3: bond_meta — the build writes the clamped bond_count here.
+        { binding: 3, resource: { buffer: bond_meta_buffer } },
       ],
     })
     bond_render_bg = device.createBindGroup({
@@ -1829,6 +1930,10 @@ export function create_large_system_renderer(
         { binding: 1, resource: { buffer: positions_buffer } },
         { binding: 2, resource: { buffer: pairs_buffer } },
         { binding: 3, resource: { buffer: bond_render_uniform } },
+        // binding 4: clamped bond_count (Phase-2 inst decode). binding 5: the GPU
+        // supercell uniform (dims + base lattice) for the per-cell offset.
+        { binding: 4, resource: { buffer: bond_meta_buffer } },
+        { binding: 5, resource: { buffer: supercell_buffer } },
       ],
     })
   }
@@ -2106,6 +2211,12 @@ export function create_large_system_renderer(
         supercell_lattice = padded
       }
       upload_supercell_uniform()
+      // ncells changed ⇒ the bond draw's instance count (2·bond_count·ncells) must
+      // be rebuilt. Refresh the cfg uniform and mark bonds dirty so the next render
+      // re-runs the indirect-args build with the new ncells (and re-emits the per-
+      // cell bond replicas). A static scene would otherwise keep the old count.
+      write_indirect_cfg()
+      bonds_dirty = true
     },
     set_selection(indices: Uint32Array | number[]): void {
       if (destroyed) return
@@ -2347,6 +2458,7 @@ export function create_large_system_renderer(
       overflow_buffer.destroy()
       count_buffer.destroy()
       indirect_buffer.destroy()
+      bond_meta_buffer.destroy()
       bond_params_buffer.destroy()
       bond_render_uniform.destroy()
       cell_uniform.destroy()

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -463,14 +463,18 @@ fn fs_main(in : VsOut) -> FsOut {
 `
 
 /** WGSL atom PICK shader. Re-runs the SAME impostor sphere ray-trace as
- *  IMPOSTOR_WGSL, but writes the atom INDEX (instance_index + 1, so 0 stays free
- *  for "background") into an R32Uint id buffer instead of a shaded color. Renders
- *  single-sampled (no MSAA) with its own single-sample depth, so the front-most
- *  atom at each pixel wins the depth test and its id is what gets read back. Only
- *  the disk interior is written (the analytic AA band is skipped — a hard discard
- *  is correct for picking, no fractional ids). The fragment writes the same
- *  corrected sphere depth as the color pass so overlapping atoms resolve by true
- *  depth, not draw order. */
+ *  IMPOSTOR_WGSL, INCLUDING the identical GPU-supercell instance decode (Phase 4):
+ *  the pass is instanced exactly like the atom draw (atom_count·ncells instances),
+ *  so a click in supercell mode hits the right replica. It writes the GLOBAL
+ *  instance index + 1 (so 0 stays free for "background") into an R32Uint id buffer
+ *  instead of a shaded color; pick() decodes that raw id back to the BASE atom
+ *  index. Renders single-sampled (no MSAA) with its own single-sample depth, so
+ *  the front-most atom at each pixel wins the depth test and its id is what gets
+ *  read back. Only the disk interior is written (the analytic AA band is skipped —
+ *  a hard discard is correct for picking, no fractional ids). The fragment writes
+ *  the same corrected sphere depth as the color pass so overlapping atoms resolve
+ *  by true depth, not draw order. When dims = (1,1,1) the decode collapses to
+ *  atom = inst / id = inst + 1 ⇒ byte-identical to the pre-Phase-4 pick. */
 const PICK_WGSL = `
 struct Camera {
   view : mat4x4<f32>,
@@ -478,16 +482,29 @@ struct Camera {
   cam_pos : vec4<f32>,
 };
 
+// GPU supercell uniform (Phase 4). SAME layout as the atom impostor's Supercell:
+// dims = [nx,ny,nz,base_count]; lat0/1/2 = base lattice rows a,b,c (xyz + pad).
+// Read ONLY in vs_main (decode of instance_index into atom + cell offset), so the
+// BGL grants it VERTEX visibility only. Default dims (1,1,1) + base_count = the
+// instance count ⇒ atom = inst, cell = 0, zero offset ⇒ identical pick.
+struct Supercell {
+  dims : vec4<u32>,    // x=nx, y=ny, z=nz, w=base_count
+  lat0 : vec4<f32>,
+  lat1 : vec4<f32>,
+  lat2 : vec4<f32>,
+};
+
 @group(0) @binding(0) var<uniform> camera : Camera;
 @group(0) @binding(1) var<storage, read> positions : array<f32>;
 @group(0) @binding(2) var<storage, read> radii : array<f32>;
+@group(0) @binding(3) var<uniform> supercell : Supercell;
 
 struct VsOut {
   @builtin(position) clip : vec4<f32>,
   @location(0) vc : vec3<f32>,
   @location(1) radius : f32,
   @location(2) vpos : vec3<f32>,
-  @location(3) @interpolate(flat) id : u32, // instance_index + 1
+  @location(3) @interpolate(flat) id : u32, // global instance_index + 1
 };
 
 struct FsOut {
@@ -504,12 +521,29 @@ fn corner_for(vi : u32) -> vec2<f32> {
 @vertex
 fn vs_main(@builtin(vertex_index) vi : u32,
            @builtin(instance_index) inst : u32) -> VsOut {
+  // SAME GPU supercell decode as IMPOSTOR_WGSL.vs_main: instance = atom-within-
+  // base-cell + cell tiling index. base_count = supercell.dims.w; the per-cell
+  // integer (ix,iy,iz) gives the lattice offset ix·a + iy·b + iz·c. When dims =
+  // (1,1,1) and base_count = the instance count, atom = inst, cell = 0, offset =
+  // 0 ⇒ center = positions[inst], byte-identical to the pre-Phase-4 pick.
+  let base_count = max(supercell.dims.w, 1u);
+  let atom = inst % base_count;
+  let cell = inst / base_count;
+  let nx = max(supercell.dims.x, 1u);
+  let ny = max(supercell.dims.y, 1u);
+  let ix = cell % nx;
+  let iy = (cell / nx) % ny;
+  let iz = cell / (nx * ny);
+  let offset = f32(ix) * supercell.lat0.xyz
+             + f32(iy) * supercell.lat1.xyz
+             + f32(iz) * supercell.lat2.xyz;
+
   let center = vec3<f32>(
-    positions[inst * 3u + 0u],
-    positions[inst * 3u + 1u],
-    positions[inst * 3u + 2u],
-  );
-  let r = radii[inst];
+    positions[atom * 3u + 0u],
+    positions[atom * 3u + 1u],
+    positions[atom * 3u + 2u],
+  ) + offset;
+  let r = radii[atom];
 
   let vc4 = camera.view * vec4<f32>(center, 1.0);
   let vc = vc4.xyz;
@@ -1365,7 +1399,9 @@ export function create_large_system_renderer(
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       // binding 4: per-atom selection flag `selected`. The BUFFER is indexed in
-      // vs_main (`selected[inst]` -> flat varying `out.sel`); fs_main reads only
+      // vs_main by the DECODED base atom (`selected[atom]`, atom = inst %
+      // base_count) -> flat varying `out.sel`, so EVERY supercell replica of a
+      // selected base atom glows (the buffer stays BASE-sized). fs_main reads only
       // that varying, never the buffer. So the binding's referencing stage is
       // VERTEX. (A prior layout granted FRAGMENT-only, mismatching vs_main and
       // invalidating the pipeline -> blank overlay.) Granted VERTEX|FRAGMENT —
@@ -1426,6 +1462,11 @@ export function create_large_system_renderer(
       // off interpolated VsOut varyings — so VERTEX-only.
       { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      // binding 3 = GPU supercell uniform (Phase 4). Read ONLY in vs_main (instance
+      // decode → atom + cell offset), so VERTEX-only — granting FRAGMENT here would
+      // mismatch the shader and invalidate the pick pipeline (the same bind-group-
+      // visibility rule that bit binding 0 above).
+      { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
     ],
   })
   const pick_pipeline = device.createRenderPipeline({
@@ -1781,7 +1822,9 @@ export function create_large_system_renderer(
         { binding: 5, resource: { buffer: supercell_buffer } },
       ],
     })
-    // Pick pass reuses camera + positions + radii (no colors/selected).
+    // Pick pass reuses camera + positions + radii (no colors/selected) PLUS the
+    // GPU supercell uniform (Phase 4) so the pick vs decodes the cell identically
+    // to the atom draw and clicks hit the right replica.
     pick_bind_group = device.createBindGroup({
       label: `large-system-pick-bg`,
       layout: pick_bgl,
@@ -1789,6 +1832,7 @@ export function create_large_system_renderer(
         { binding: 0, resource: { buffer: camera_buffer } },
         { binding: 1, resource: { buffer: positions_buffer } },
         { binding: 2, resource: { buffer: radii_buffer } },
+        { binding: 3, resource: { buffer: supercell_buffer } },
       ],
     })
   }
@@ -2312,7 +2356,10 @@ export function create_large_system_renderer(
       })
       pass.setPipeline(pick_pipeline)
       pass.setBindGroup(0, pick_bind_group)
-      pass.draw(4, atom_count)
+      // GPU supercell (Phase 4): draw atom_count × ncells instances, exactly like
+      // the atom render draw, so every replica is pickable. ncells 1 (default /
+      // 1×1×1) ⇒ atom_count instances ⇒ inst = atom, byte-identical to before.
+      pass.draw(4, atom_count * Math.max(1, supercell_ncells))
       pass.end()
       // Copy the single picked texel into the 256-byte readback buffer.
       encoder.copyTextureToBuffer(
@@ -2329,8 +2376,17 @@ export function create_large_system_renderer(
       }
       const id = new Uint32Array(pick_readback.getMappedRange(0, 4))[0]
       pick_readback.unmap()
-      // id 0 = background ⇒ -1; otherwise atom index = id - 1.
-      return id === 0 ? -1 : id - 1
+      // id 0 = background ⇒ -1. Otherwise the raw id is GLOBAL instance + 1; the
+      // global instance is atom + cell·base_count, so the BASE atom index is
+      // (id - 1) % base_count. The CPU holds the BASE cell (displayed_structure IS
+      // the base cell in supercell mode), so base_atom indexes displayed_structure
+      // .sites directly — the caller (handle_overlay_pick) needs no change. With
+      // 1×1×1 (ncells 1) base_count = atom_count and g < atom_count, so base_atom =
+      // g — byte-identical to the pre-Phase-4 `id - 1`.
+      if (id === 0) return -1
+      const g = id - 1
+      const base_count = Math.max(1, atom_count)
+      return g % base_count
     },
     render(): void {
       if (destroyed) return

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -1,0 +1,88 @@
+/// <reference types="@webgpu/types" />
+/** WebGPU large-system render path (Task 9).
+ *
+ *  Milestone 9.1 — de-risking skeleton: configures a webgpu canvas context,
+ *  holds the camera uniform buffer (proving the upload path), and renders a
+ *  single clear pass to a distinct dark-blue so the overlay canvas is visibly
+ *  the one painting. No atom / bond geometry yet; this module grows in later
+ *  milestones (atoms, then bonds via the existing bond-compute pipeline). */
+
+/** Camera uniform: 20 floats (proj*view 4x4 + camera world pos vec3 + pad),
+ *  matching Task 7's pack_camera_uniform layout. 20 * 4 bytes = 80. */
+const CAMERA_UNIFORM_BYTES = 80
+
+/** A distinct dark blue, intentionally different from the normal viewer
+ *  background, so flipping the toggle visibly swaps which canvas paints. */
+const CLEAR_COLOR: GPUColor = { r: 0.06, g: 0.1, b: 0.16, a: 1 }
+
+export type LargeSystemRenderer = {
+  /** Upload a packed camera uniform (Float32Array(20)). Stored only for now. */
+  set_camera(uniform: Float32Array): void
+  /** Run one render pass (clear-only this milestone). */
+  render(): void
+  /** Resize the backing canvas to the given device-pixel dimensions. */
+  resize(w: number, h: number): void
+  /** Tear down GPU resources and unconfigure the context. */
+  destroy(): void
+}
+
+export function create_large_system_renderer(
+  device: GPUDevice,
+  canvas: HTMLCanvasElement,
+): LargeSystemRenderer {
+  const context = canvas.getContext(`webgpu`)
+  if (!context) throw new Error(`WebGPU canvas context unavailable`)
+  const format = navigator.gpu.getPreferredCanvasFormat()
+  context.configure({ device, format, alphaMode: `premultiplied` })
+
+  // Camera uniform buffer — written by set_camera, not yet bound for drawing.
+  const camera_buffer = device.createBuffer({
+    label: `large-system-camera-uniform`,
+    size: CAMERA_UNIFORM_BYTES,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+
+  let destroyed = false
+
+  return {
+    set_camera(uniform: Float32Array): void {
+      if (destroyed) return
+      // Upload exactly CAMERA_UNIFORM_BYTES; guard against a short/long array.
+      const bytes = Math.min(uniform.byteLength, CAMERA_UNIFORM_BYTES)
+      device.queue.writeBuffer(camera_buffer, 0, uniform.buffer, uniform.byteOffset, bytes)
+    },
+    render(): void {
+      if (destroyed) return
+      const encoder = device.createCommandEncoder({ label: `large-system-frame` })
+      const view = context.getCurrentTexture().createView()
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view,
+            clearValue: CLEAR_COLOR,
+            loadOp: `clear`,
+            storeOp: `store`,
+          },
+        ],
+      })
+      // No geometry yet — clear-only pass.
+      pass.end()
+      device.queue.submit([encoder.finish()])
+    },
+    resize(w: number, h: number): void {
+      if (destroyed) return
+      canvas.width = Math.max(1, Math.floor(w))
+      canvas.height = Math.max(1, Math.floor(h))
+    },
+    destroy(): void {
+      if (destroyed) return
+      destroyed = true
+      try {
+        context.unconfigure()
+      } catch {
+        // some implementations / already-lost contexts may throw — ignore
+      }
+      camera_buffer.destroy()
+    },
+  }
+}

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -24,6 +24,10 @@ const CAMERA_UNIFORM_BYTES = 80
  *  floats = 144 bytes. Matches pack_camera_full's layout. */
 const CAMERA_FULL_BYTES = 144
 
+/** GPU supercell uniform (Phase 1): dims vec4<u32> (nx,ny,nz,base_count) + base
+ *  lattice rows a,b,c as 3×vec4<f32> = 4 vec4 = 64 bytes. */
+const SUPERCELL_BYTES = 64
+
 
 /** Vertices per bond half. Each half is an IMPOSTOR cylinder: a camera-facing
  *  billboard whose fragment shader ray-traces a mathematically smooth, capped
@@ -293,6 +297,17 @@ struct Camera {
   cam_pos : vec4<f32>,
 };
 
+// GPU supercell uniform (Phase 1). dims = [nx,ny,nz] tiling counts; base_count =
+// atoms in the BASE cell. lat0/lat1/lat2 are the base lattice rows a,b,c (xyz in
+// .xyz, w pad) — the per-cell offset is ix·a + iy·b + iz·c. Default dims (1,1,1)
+// + base_count = the instance count ⇒ atom = inst, zero offset ⇒ identical draw.
+struct Supercell {
+  dims : vec4<u32>,    // x=nx, y=ny, z=nz, w=base_count
+  lat0 : vec4<f32>,
+  lat1 : vec4<f32>,
+  lat2 : vec4<f32>,
+};
+
 @group(0) @binding(0) var<uniform> camera : Camera;
 @group(0) @binding(1) var<storage, read> positions : array<f32>;
 @group(0) @binding(2) var<storage, read> radii : array<f32>;
@@ -301,6 +316,9 @@ struct Camera {
 // atoms get a visible highlight (brighten + rim ring). Always bound (a 4-byte
 // placeholder when nothing is selected), so 0 ⇒ unchanged appearance.
 @group(0) @binding(4) var<storage, read> selected : array<u32>;
+// GPU supercell instancing params. Read ONLY in the vertex stage (decode of
+// instance_index into atom + cell offset), so the BGL grants it VERTEX only.
+@group(0) @binding(5) var<uniform> supercell : Supercell;
 
 struct VsOut {
   @builtin(position) clip : vec4<f32>,
@@ -326,16 +344,34 @@ fn corner_for(vi : u32) -> vec2<f32> {
 @vertex
 fn vs_main(@builtin(vertex_index) vi : u32,
            @builtin(instance_index) inst : u32) -> VsOut {
+  // GPU supercell decode: instance = atom-within-base-cell + cell tiling index.
+  // base_count = supercell.dims.w; cell = inst / base_count; the per-cell integer
+  // (ix,iy,iz) gives the lattice offset ix·a + iy·b + iz·c. When dims = (1,1,1)
+  // and base_count = the instance count, atom = inst, cell = 0, offset = 0 ⇒
+  // byte-identical to the non-supercell path. Per-atom radii/colors/selected are
+  // indexed by atom (NOT inst) so every replica shares the base atom's look.
+  let base_count = max(supercell.dims.w, 1u);
+  let atom = inst % base_count;
+  let cell = inst / base_count;
+  let nx = max(supercell.dims.x, 1u);
+  let ny = max(supercell.dims.y, 1u);
+  let ix = cell % nx;
+  let iy = (cell / nx) % ny;
+  let iz = cell / (nx * ny);
+  let offset = f32(ix) * supercell.lat0.xyz
+             + f32(iy) * supercell.lat1.xyz
+             + f32(iz) * supercell.lat2.xyz;
+
   let center = vec3<f32>(
-    positions[inst * 3u + 0u],
-    positions[inst * 3u + 1u],
-    positions[inst * 3u + 2u],
-  );
-  let r = radii[inst];
+    positions[atom * 3u + 0u],
+    positions[atom * 3u + 1u],
+    positions[atom * 3u + 2u],
+  ) + offset;
+  let r = radii[atom];
   let col = vec3<f32>(
-    colors[inst * 3u + 0u],
-    colors[inst * 3u + 1u],
-    colors[inst * 3u + 2u],
+    colors[atom * 3u + 0u],
+    colors[atom * 3u + 1u],
+    colors[atom * 3u + 2u],
   );
 
   let vc4 = camera.view * vec4<f32>(center, 1.0);
@@ -355,7 +391,7 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   out.radius = r;
   out.color = col;
   out.vpos = vpos;
-  out.sel = selected[inst];
+  out.sel = selected[atom];
   return out;
 }
 
@@ -946,6 +982,14 @@ export type LargeSystemRenderer = {
    *  the moved atoms. No-op if the buffers haven't been allocated yet (call
    *  set_atoms first to establish topology). */
   set_positions(positions: Float32Array, count: number): void
+  /** Set the GPU supercell instancing params (Phase 1). `dims` = [nx,ny,nz]
+   *  tiling counts; the atom draw issues `atom_count × nx·ny·nz` sphere instances,
+   *  each offset by ix·a + iy·b + iz·c. `base_lattice` is the 9-float row-major
+   *  BASE-cell lattice (rows a,b,c — same convention as pack_lattice / set_cell).
+   *  dims [1,1,1] (the default) ⇒ ncells 1, zero offset ⇒ the draw is byte-
+   *  identical to the non-supercell path. The CPU stays at the base cell; this is
+   *  what scales the rendered atom count WITHOUT building N× Site objects. */
+  set_supercell(dims: [number, number, number], base_lattice: Float32Array): void
   /** Provide bond-detection inputs. `covalent_radii` is the per-atom COVALENT
    *  radius (N entries, from build_atom_radii — distinct from the display radii
    *  used for sphere size). `lattice` is the 9-float row-major matrix (rows
@@ -1033,6 +1077,26 @@ export function create_large_system_renderer(
     size: CAMERA_FULL_BYTES,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   })
+
+  // GPU supercell uniform (Phase 1), bound to the impostor vertex (binding 5).
+  // Defaults to dims (1,1,1) + base_count 0 + zero lattice ⇒ ncells 1, zero
+  // offset; the renderer fills base_count from the atom count when atoms upload
+  // and overwrites dims/lattice via set_supercell. Initialised to the identity
+  // (1,1,1) below so an un-configured overlay draws exactly as before.
+  const supercell_buffer = device.createBuffer({
+    label: `large-system-supercell`,
+    size: SUPERCELL_BYTES,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  // Cached supercell dims; ncells = product. Default [1,1,1] ⇒ ncells 1.
+  let supercell_dims: [number, number, number] = [1, 1, 1]
+  let supercell_ncells = 1
+  // Cached base lattice rows (9 floats, rows a,b,c) for the per-cell offset.
+  let supercell_lattice = new Float32Array(9)
+  // Initialise the supercell uniform to identity (dims 1,1,1 / zero lattice) so
+  // the binding is valid before any set_supercell/set_atoms — ncells 1, zero
+  // offset ⇒ the draw is identical to the non-supercell path.
+  upload_supercell_uniform()
 
   // Atom storage buffers — lazily (re)created when the atom count grows.
   let positions_buffer: GPUBuffer | null = null
@@ -1192,6 +1256,12 @@ export function create_large_system_renderer(
       // VERTEX is required; FRAGMENT is the highlight stage that plausibly reads
       // it, so OR both per the project's recurrence-proof rule.
       { binding: 4, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `read-only-storage` } },
+      // binding 5: GPU supercell uniform. Read ONLY in vs_main (decode of
+      // instance_index → atom + lattice offset); fs_main never touches it. Per the
+      // project's recurrence-proof rule, grant EXACTLY the stage that reads it —
+      // VERTEX only. (A spurious FRAGMENT here would not break, but VERTEX is the
+      // precise + minimal visibility the binding requires.)
+      { binding: 5, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
     ],
   })
 
@@ -1580,6 +1650,7 @@ export function create_large_system_renderer(
         { binding: 2, resource: { buffer: radii_buffer } },
         { binding: 3, resource: { buffer: colors_buffer } },
         { binding: 4, resource: { buffer: selected_buffer as GPUBuffer } },
+        { binding: 5, resource: { buffer: supercell_buffer } },
       ],
     })
     // Pick pass reuses camera + positions + radii (no colors/selected).
@@ -1763,6 +1834,31 @@ export function create_large_system_renderer(
 
   /** Pack + upload the bond render uniform: lattice columns (TRANSPOSED to match
    *  the compute's column layout) + (radius, color). */
+  /** Upload the GPU supercell uniform: dims (nx,ny,nz,base_count) as u32 + base
+   *  lattice rows a,b,c as 3×vec4<f32>. base_count = the current atom_count (the
+   *  BASE cell's atom count, since the CPU stays base-cell when GPU-supercell is
+   *  active). Stored as ROWS a/b/c (matching pack_lattice's row convention) — the
+   *  vertex offset reads supercell.lat{0,1,2}.xyz directly as a/b/c. Re-called by
+   *  set_supercell AND set_atoms/set_positions (so base_count tracks the atom
+   *  count). The 64-byte buffer: u32×4 (dims) then f32×12 (3 padded rows). */
+  function upload_supercell_uniform(): void {
+    const buf = new ArrayBuffer(SUPERCELL_BYTES)
+    const u32 = new Uint32Array(buf, 0, 4)
+    const f32 = new Float32Array(buf, 16, 12)
+    u32[0] = Math.max(1, supercell_dims[0] | 0)
+    u32[1] = Math.max(1, supercell_dims[1] | 0)
+    u32[2] = Math.max(1, supercell_dims[2] | 0)
+    // base_count = atoms in the base cell (the instance count is atom_count*ncells,
+    // decoded as inst % base_count). 0 atoms ⇒ no draw, value is irrelevant.
+    u32[3] = Math.max(0, atom_count)
+    const L = supercell_lattice
+    // Row a -> lat0.xyz, row b -> lat1.xyz, row c -> lat2.xyz (w = 0 pad).
+    f32[0] = L[0]; f32[1] = L[1]; f32[2] = L[2]; f32[3] = 0
+    f32[4] = L[3]; f32[5] = L[4]; f32[6] = L[5]; f32[7] = 0
+    f32[8] = L[6]; f32[9] = L[7]; f32[10] = L[8]; f32[11] = 0
+    device.queue.writeBuffer(supercell_buffer, 0, buf, 0, SUPERCELL_BYTES)
+  }
+
   function upload_bond_render_uniform(): void {
     const u = new Float32Array(16)
     const L = bond_lattice
@@ -1880,6 +1976,9 @@ export function create_large_system_renderer(
       )
       // Cache positions for the non-periodic AABB grid plan (see last_positions).
       last_positions = positions
+      // base_count in the supercell uniform tracks the atom count (= base cell
+      // atoms while GPU-supercell is active). Re-upload so inst decode stays valid.
+      upload_supercell_uniform()
       // Positions moved ⇒ bonds must be recomputed next render.
       bonds_dirty = true
     },
@@ -1902,6 +2001,8 @@ export function create_large_system_renderer(
       )
       // Cache positions for the non-periodic AABB grid plan (see last_positions).
       last_positions = positions
+      // Keep base_count in sync if the count changed on the fast path.
+      upload_supercell_uniform()
       // Atoms moved ⇒ bonds must be recomputed against the new positions.
       bonds_dirty = true
     },
@@ -1987,6 +2088,23 @@ export function create_large_system_renderer(
       // Turning bonds back on must re-run the compute against the current atoms
       // (the cached pairs may be stale or were never computed while disabled).
       if (enabled) bonds_dirty = true
+    },
+    set_supercell(dims: [number, number, number], base_lattice: Float32Array): void {
+      if (destroyed) return
+      supercell_dims = [
+        Math.max(1, Math.floor(dims[0])),
+        Math.max(1, Math.floor(dims[1])),
+        Math.max(1, Math.floor(dims[2])),
+      ]
+      supercell_ncells = supercell_dims[0] * supercell_dims[1] * supercell_dims[2]
+      // Copy the 9-float base lattice (rows a,b,c) — never alias the caller's array.
+      supercell_lattice = base_lattice.slice(0, 9)
+      if (supercell_lattice.length < 9) {
+        const padded = new Float32Array(9)
+        padded.set(supercell_lattice)
+        supercell_lattice = padded
+      }
+      upload_supercell_uniform()
     },
     set_selection(indices: Uint32Array | number[]): void {
       if (destroyed) return
@@ -2159,7 +2277,10 @@ export function create_large_system_renderer(
       if (atom_count > 0 && bind_group) {
         pass.setPipeline(pipeline)
         pass.setBindGroup(0, bind_group)
-        pass.draw(4, atom_count) // triangle-strip quad, one instance per atom
+        // GPU supercell: atom_count × ncells instances (ncells = nx·ny·nz). The
+        // vertex decodes inst → atom (inst % base_count) + cell offset. ncells 1
+        // ⇒ atom_count instances, identical to the non-supercell draw.
+        pass.draw(4, atom_count * Math.max(1, supercell_ncells))
       }
       // Bonds: instanced procedural cylinders, instance count supplied by the
       // indirect buffer the compute wrote (this same submit, or last frame's).

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -1093,10 +1093,6 @@ export function create_large_system_renderer(
   let supercell_ncells = 1
   // Cached base lattice rows (9 floats, rows a,b,c) for the per-cell offset.
   let supercell_lattice = new Float32Array(9)
-  // Initialise the supercell uniform to identity (dims 1,1,1 / zero lattice) so
-  // the binding is valid before any set_supercell/set_atoms — ncells 1, zero
-  // offset ⇒ the draw is identical to the non-supercell path.
-  upload_supercell_uniform()
 
   // Atom storage buffers — lazily (re)created when the atom count grows.
   let positions_buffer: GPUBuffer | null = null
@@ -1104,6 +1100,11 @@ export function create_large_system_renderer(
   let colors_buffer: GPUBuffer | null = null
   let atom_capacity = 0 // instances the current buffers can hold
   let atom_count = 0 // instances to draw this frame
+  // Initialise the supercell uniform to identity (dims 1,1,1 / zero lattice) so
+  // the binding is valid before any set_supercell/set_atoms — ncells 1, zero
+  // offset ⇒ the draw is identical to the non-supercell path. Must run AFTER
+  // `atom_count` is declared (upload_supercell_uniform reads it) — else TDZ.
+  upload_supercell_uniform()
   // Per-atom selection flag buffer (u32 per atom, 1 = selected), bound to the
   // impostor fragment (binding 4). Grows with the atom buffers; a 4-byte minimum
   // keeps the binding valid (and reads as "nothing selected") before any

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -353,7 +353,11 @@ export function create_large_system_renderer(
   const context = canvas.getContext(`webgpu`)
   if (!context) throw new Error(`WebGPU canvas context unavailable`)
   const format = navigator.gpu.getPreferredCanvasFormat()
-  context.configure({ device, format, alphaMode: `premultiplied` })
+  // `opaque` (not `premultiplied`) forces opaque compositing and ignores the
+  // canvas alpha, so the overlay fully covers the WebGL canvas beneath it with
+  // no bleed-through. Combined with clearValue a=1 + alpha=1 in both fragment
+  // shaders, the overlay is a fully opaque replacement when active.
+  context.configure({ device, format, alphaMode: `opaque` })
 
   // Full camera uniform (view + proj + camPos), bound by the impostor pipeline.
   const camera_buffer = device.createBuffer({

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -26,12 +26,14 @@ const CAMERA_FULL_BYTES = 144
 /** Bond Params uniform (BOND_COMPUTE_WGSL): 80 bytes, packed via pack_params. */
 const BOND_PARAMS_BYTES = 80
 
-/** Radial segments of the procedural cylinder. The cylinder is a triangle-LIST
- *  (no strip): SEG side-wall quads (2 tris = 6 verts each) plus two flat end-cap
- *  fans (SEG tris = 3 verts each) so the cut ends are solid, not hollow tubes.
- *  Side wall: SEG*6, each cap: SEG*3, two caps: SEG*6 => SEG*12 total. */
-const BOND_SEGMENTS = 12
-const BOND_VERTS_PER_CYLINDER = BOND_SEGMENTS * 12
+/** Vertices per bond half. Each half is now an IMPOSTOR cylinder: a single
+ *  camera-facing billboard quad (4 verts, triangle-STRIP) whose fragment shader
+ *  ray-traces a mathematically smooth, capped finite cylinder. Constant low
+ *  vertex count regardless of curvature (no facets), matching the atom impostor
+ *  approach. This is the single source of truth for the indirect-args
+ *  vertex_count (`cfg.x`) and MUST stay in sync with the render pipeline
+ *  topology (triangle-strip ⇒ 4 verts). */
+const BOND_VERTS_PER_CYLINDER = 4
 
 /** Fixed bond cylinder radius (Å). Small constant; tunable. Uploaded to the
  *  bond render shader as part of its uniform so it can be retuned without a
@@ -257,24 +259,39 @@ fn build_args() {
 }
 `
 
-/** Instanced procedural-cylinder bond shader. Each detected bond renders as TWO
- *  half-cylinder instances that meet at the bond midpoint, so PBC (cross-cell)
- *  bonds become two short stubs each rooted at a REAL atom instead of one long
- *  cylinder jutting out of the cell. Instance mapping: bond_index = inst>>1,
- *  half = inst&1. Per bond reads (a, b, jimage_packed) from the pairs buffer
- *  (unchanged — one entry per bond); the imaged partner is shifted by
- *  jimage·lattice using the SAME lattice the compute used.
+/** Instanced IMPOSTOR-cylinder bond shader. Each detected bond renders as TWO
+ *  half instances that meet at the bond midpoint, so PBC (cross-cell) bonds
+ *  become two short stubs each rooted at a REAL atom instead of one long cylinder
+ *  jutting out of the cell. Instance mapping: bond_index = inst>>1, half = inst&1.
+ *  Per bond reads (a, b, jimage_packed) from the pairs buffer (unchanged — one
+ *  entry per bond); the imaged partner is shifted by jimage·lattice using the
+ *  SAME lattice the compute used.
  *    Let A = pos[a], partnerB = pos[b] + jimage·lattice (A's imaged partner),
  *        B = pos[b], partnerA = pos[a] - jimage·lattice (B's imaged partner).
  *    half 0: cylinder A      -> M0 = (A + partnerB) * 0.5
  *    half 1: cylinder B      -> M1 = (B + partnerA) * 0.5
  *  For intra-cell bonds (jimage = 0) partnerB = B and partnerA = A, so
  *  M0 = M1 = (A+B)/2 and the two halves join into a seamless full cylinder.
- *  Verts trace a unit side-wall (triangle-list quads) plus two flat end-cap fans
- *  oriented to the half's axis and scaled to span start→end with a fixed radius
- *  so the cut ends read as solid disks, not hollow tubes. Depth uses the SAME GL→WebGPU
- *  clip-z remap as the atom impostor so bonds share the depth buffer and occlude
- *  / are occluded correctly. */
+ *
+ *  GEOMETRY (impostor, NGL/3Dmol-style — no facets, constant 4 verts/half):
+ *  Each half's segment endpoints P0=start, P1=end are transformed to VIEW space
+ *  (v0,v1). A camera-facing ribbon quad is built that fully covers the finite
+ *  capsule: the quad's long edge runs along the view-space axis â=normalize(v1-v0),
+ *  extended past BOTH ends by the radius r so the round caps are inside the quad;
+ *  the quad's width is ±r along a camera-facing perpendicular
+ *  side=normalize(cross(â, toEye)) (toEye = -mid, eye at origin), with a small
+ *  blow-up so the silhouette of the perspective-projected cylinder is never
+ *  clipped. The 4 triangle-strip corners map (vi&1)->±side, (vi&2)->P0/P1 end.
+ *
+ *  The fragment shader ray-traces the FINITE cylinder: eye ray O=0, d=normalize(vpos);
+ *  solve the infinite-cylinder quadratic, clamp the body hit's axial projection to
+ *  [0,len]; if out of range, intersect the two END-CAP disks (planes at v0,v1 with
+ *  normal ∓â, |radial|<=r) so the cylinder is SOLID (no hollow ends — caps are free
+ *  from the disk test). No hit anywhere => discard. Lambert shading like the atoms
+ *  (0.35 + 0.65·max(dot(N,L),0), same light dir) × grey color. Depth: project the
+ *  view-space hit Pv and apply the SAME GL→WebGPU clip-z remap + perspective divide
+ *  as the sphere impostor, so bonds share the depth buffer and occlude / are
+ *  occluded consistently with atoms. Degenerate (zero-length) halves discard cleanly. */
 const BOND_RENDER_WGSL = `
 struct Camera {
   view : mat4x4<f32>,
@@ -296,12 +313,17 @@ struct BondU {
 
 struct VsOut {
   @builtin(position) clip : vec4<f32>,
-  @location(0) vnormal : vec3<f32>, // view-space surface normal for shading
-  @location(1) color : vec3<f32>,
+  @location(0) v0 : vec3<f32>,      // view-space cylinder start (flat)
+  @location(1) v1 : vec3<f32>,      // view-space cylinder end   (flat)
+  @location(2) radius : f32,        // cylinder radius (flat)
+  @location(3) color : vec3<f32>,
+  @location(4) vpos : vec3<f32>,    // view-space position of this quad corner
 };
 
-const SEG : u32 = ${BOND_SEGMENTS}u;
-const PI2 : f32 = 6.28318530718;
+struct FsOut {
+  @builtin(frag_depth) depth : f32,
+  @location(0) color : vec4<f32>,
+};
 
 fn atom_pos(i : u32) -> vec3<f32> {
   return vec3<f32>(positions[i*3u], positions[i*3u+1u], positions[i*3u+2u]);
@@ -310,7 +332,7 @@ fn atom_pos(i : u32) -> vec3<f32> {
 @vertex
 fn vs_main(@builtin(vertex_index) vi : u32,
            @builtin(instance_index) inst : u32) -> VsOut {
-  // Two half-cylinder instances per bond: bond_index = inst>>1, half = inst&1.
+  // Two half instances per bond: bond_index = inst>>1, half = inst&1.
   let bond_index = inst >> 1u;
   let half = inst & 1u;
 
@@ -337,88 +359,151 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let mid = select((B + partnerA) * 0.5, (A + partnerB) * 0.5, half == 0u);
   let end = mid;
 
-  // Orthonormal basis around this half's axis start->end.
-  let axis = end - start;
-  let len = length(axis);
-  let dir = select(vec3<f32>(0.0, 0.0, 1.0), axis / max(len, 1e-6), len > 1e-6);
-  let up = select(vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(1.0, 0.0, 0.0), abs(dir.y) > 0.9);
-  let tangent = normalize(cross(up, dir));
-  let bitangent = cross(dir, tangent);
+  let r = bond.radius_color.x;
 
-  // Triangle-LIST cylinder (no strip): SEG side-wall quads then two cap fans.
-  //   verts [0,             SEG*6)  -> side wall, 6 verts per segment quad
-  //   verts [SEG*6,         SEG*9)  -> start-end cap fan (faces -dir, toward atom)
-  //   verts [SEG*9,         SEG*12) -> end-end   cap fan (faces +dir, the midpoint)
-  let SIDE_END : u32 = SEG * 6u;
-  let CAP0_END : u32 = SEG * 9u;
+  // Endpoints in VIEW space (eye at origin). The impostor ray-trace + depth all
+  // happen in this space.
+  let v0 = (camera.view * vec4<f32>(start, 1.0)).xyz;
+  let v1 = (camera.view * vec4<f32>(end, 1.0)).xyz;
 
-  var world : vec3<f32>;
-  var world_normal : vec3<f32>; // object-space normal at this vertex
-
-  if (vi < SIDE_END) {
-    // Side wall. Each segment is a quad (seg .. seg+1) split into 2 triangles:
-    //   tri layout per quad (6 verts): (b0,t0,b1)(b1,t0,t1)
-    //   b=bottom(start ring), t=top(end ring); 0=this angle, 1=next angle.
-    let seg = vi / 6u;            // 0..SEG-1
-    let k = vi % 6u;              // vertex within the quad's two triangles
-    // corner index ci in {0=b0,1=t0,2=b1,3=t1}
-    var ci : u32 = 0u;
-    if (k == 0u) { ci = 0u; }      // b0
-    else if (k == 1u) { ci = 1u; } // t0
-    else if (k == 2u) { ci = 2u; } // b1
-    else if (k == 3u) { ci = 2u; } // b1
-    else if (k == 4u) { ci = 1u; } // t0
-    else { ci = 3u; }              // t1
-    let next_ang = (ci == 2u) || (ci == 3u);
-    let is_top = (ci == 1u) || (ci == 3u);
-    let s = select(seg, seg + 1u, next_ang);
-    let ang = f32(s) / f32(SEG) * PI2;
-    let radial = cos(ang) * tangent + sin(ang) * bitangent;
-    let base = select(start, end, is_top);
-    world = base + radial * bond.radius_color.x;
-    world_normal = radial; // side-wall normal points radially outward
-  } else {
-    // Cap fan. Pick which end + facing direction, then build a triangle fan
-    // from the end-center to consecutive ring vertices.
-    let is_end_cap = vi >= CAP0_END;
-    let local = select(vi - SIDE_END, vi - CAP0_END, is_end_cap);
-    let center = select(start, end, is_end_cap);
-    // Cap normal is the axis direction: start cap faces -dir (toward atom),
-    // end cap faces +dir (the midpoint). Front-face winding handled by cullMode none.
-    let cap_normal = select(-dir, dir, is_end_cap);
-    let seg = local / 3u;          // 0..SEG-1
-    let corner = local % 3u;       // 0=center, 1=ring(seg), 2=ring(seg+1)
-    if (corner == 0u) {
-      world = center;
-    } else {
-      let s = select(seg, seg + 1u, corner == 2u);
-      let ang = f32(s) / f32(SEG) * PI2;
-      let radial = cos(ang) * tangent + sin(ang) * bitangent;
-      world = center + radial * bond.radius_color.x;
+  // Camera-facing ribbon quad covering the finite capsule. axis = â (view space);
+  // a degenerate (zero-length) half falls back to a fixed axis so normalize never
+  // produces NaN — the fragment shader discards it anyway.
+  let av = v1 - v0;
+  let alen = length(av);
+  let axis = select(vec3<f32>(0.0, 0.0, 1.0), av / max(alen, 1e-6), alen > 1e-6);
+  // Toward the eye from the segment midpoint (eye at view-space origin).
+  let mid_v = (v0 + v1) * 0.5;
+  let to_eye = -mid_v;
+  // Camera-facing perpendicular; fall back if axis ∥ to_eye (segment pointing at
+  // the eye) so the cross product can't collapse to zero.
+  var side = cross(axis, to_eye);
+  if (length(side) < 1e-6) {
+    side = cross(axis, vec3<f32>(0.0, 1.0, 0.0));
+    if (length(side) < 1e-6) {
+      side = cross(axis, vec3<f32>(1.0, 0.0, 0.0));
     }
-    world_normal = cap_normal;
   }
+  side = normalize(side) * r;
+  // Extend the quad past both ends by r along the axis so the round caps are
+  // covered, with a little extra slack (1.5) on the width so the perspective
+  // silhouette of the cylinder is never clipped at grazing/foreshortened angles.
+  let cap_ext = axis * r;
+  let widen = side * 1.5;
 
-  let vpos4 = camera.view * vec4<f32>(world, 1.0);
-  var clip = camera.proj * vpos4;
+  // 4 triangle-strip corners: (vi&1) -> ±side, (vi&2) -> v0/v1 end.
+  let s_sign = select(-1.0, 1.0, (vi & 1u) == 1u);
+  let is_end = (vi & 2u) == 2u;
+  let base = select(v0 - cap_ext, v1 + cap_ext, is_end);
+  let vpos = base + s_sign * widen;
+
+  var clip = camera.proj * vec4<f32>(vpos, 1.0);
   // SAME GL->WebGPU NDC z remap as the atom impostor shader.
   clip.z = (clip.z + clip.w) * 0.5;
 
-  // View-space normal for lambert shading.
-  let vn4 = camera.view * vec4<f32>(world_normal, 0.0);
-
   var out : VsOut;
   out.clip = clip;
-  out.vnormal = normalize(vn4.xyz);
+  out.v0 = v0;
+  out.v1 = v1;
+  out.radius = r;
   out.color = bond.radius_color.yzw;
+  out.vpos = vpos;
   return out;
 }
 
 @fragment
-fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
+fn fs_main(in : VsOut) -> FsOut {
+  let r = in.radius;
+  let pa = in.v0;            // cylinder axis point 0 (view space)
+  let ca = in.v1 - in.v0;    // axis vector
+  let clen = length(ca);
+  // Degenerate (coincident) half: nothing to draw, no NaN.
+  if (clen < 1e-6) { discard; }
+  let axis = ca / clen;      // unit axis
+
+  // Eye ray: origin at view-space 0, direction toward the interpolated corner.
+  let rd = normalize(in.vpos);
+
+  // Infinite-cylinder intersection. Project ray + origin offset off the axis.
+  // d_perp = rd - (rd·axis)axis ; oc = O - pa = -pa.
+  let oc = -pa;
+  let rd_a = dot(rd, axis);
+  let oc_a = dot(oc, axis);
+  let d_perp = rd - rd_a * axis;
+  let oc_perp = oc - oc_a * axis;
+  let qa = dot(d_perp, d_perp);
+  let qb = 2.0 * dot(d_perp, oc_perp);
+  let qc = dot(oc_perp, oc_perp) - r * r;
+
+  var best_t = 1e30;
+  var hit_p = vec3<f32>(0.0);
+  var hit_n = vec3<f32>(0.0);
+  var found = false;
+
+  // Body: solve quadratic, take the nearer positive root whose axial projection
+  // lands within [0, clen].
+  if (qa > 1e-12) {
+    let disc = qb * qb - 4.0 * qa * qc;
+    if (disc >= 0.0) {
+      let sq = sqrt(disc);
+      let inv = 1.0 / (2.0 * qa);
+      let t0 = (-qb - sq) * inv;
+      let t1 = (-qb + sq) * inv;
+      // Try the near root, then the far root (we may be inside the cylinder).
+      for (var k = 0; k < 2; k = k + 1) {
+        let t = select(t1, t0, k == 0);
+        if (t > 0.0 && t < best_t) {
+          let p = rd * t;
+          let h = dot(p - pa, axis); // axial coordinate along the cylinder
+          if (h >= 0.0 && h <= clen) {
+            best_t = t;
+            hit_p = p;
+            let axis_point = pa + axis * h;
+            hit_n = normalize(p - axis_point); // radial outward
+            found = true;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // End-cap disks: planes at pa (normal -axis) and pb (normal +axis), |radial|<=r.
+  // Tested independently so a body miss (or a cap-on view) still reads as solid.
+  let pb = in.v1;
+  for (var c = 0; c < 2; c = c + 1) {
+    let cap_center = select(pa, pb, c == 1);
+    let cap_n = select(-axis, axis, c == 1);
+    let denom = dot(rd, cap_n);
+    if (abs(denom) > 1e-6) {
+      let t = dot(cap_center, cap_n) / denom; // (cap_center - O)·n / (rd·n), O=0
+      if (t > 0.0 && t < best_t) {
+        let p = rd * t;
+        let radial = p - cap_center;
+        if (dot(radial, radial) <= r * r) {
+          best_t = t;
+          hit_p = p;
+          hit_n = cap_n;
+          found = true;
+        }
+      }
+    }
+  }
+
+  if (!found) { discard; }
+
   let light_dir = normalize(vec3<f32>(0.3, 0.5, 0.8));
-  let lighting = 0.35 + 0.65 * max(dot(normalize(in.vnormal), light_dir), 0.0);
-  return vec4<f32>(in.color * lighting, 1.0);
+  let lighting = 0.35 + 0.65 * max(dot(hit_n, light_dir), 0.0);
+
+  // Correct depth: project the view-space hit point, apply the SAME GL->WebGPU z
+  // remap as the vertex stage, then perspective-divide into NDC z (range 0..1).
+  let clip_h = camera.proj * vec4<f32>(hit_p, 1.0);
+  let remapped_z = (clip_h.z + clip_h.w) * 0.5;
+
+  var out : FsOut;
+  out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
+  out.color = vec4<f32>(in.color * lighting, 1.0);
+  return out;
 }
 `
 
@@ -656,9 +741,11 @@ export function create_large_system_renderer(
     layout: device.createPipelineLayout({ bindGroupLayouts: [bond_render_bgl] }),
     vertex: { module: bond_render_module, entryPoint: `vs_main` },
     fragment: { module: bond_render_module, entryPoint: `fs_main`, targets: [{ format }] },
-    // Capped cylinder is an explicit triangle-LIST (side-wall quads + 2 cap
-    // fans); cull nothing so caps render regardless of winding/view.
-    primitive: { topology: `triangle-list`, cullMode: `none` },
+    // Impostor cylinder is a single camera-facing billboard (4-vert triangle-
+    // STRIP, matching BOND_VERTS_PER_CYLINDER); the fragment shader ray-traces
+    // the smooth capped finite cylinder. cullMode none — billboard winding flips
+    // with view, and the impostor is one-sided per-fragment regardless.
+    primitive: { topology: `triangle-strip`, cullMode: `none` },
     depthStencil: {
       format: DEPTH_FORMAT,
       depthWriteEnabled: true,

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -24,8 +24,6 @@ const CAMERA_UNIFORM_BYTES = 80
  *  floats = 144 bytes. Matches pack_camera_full's layout. */
 const CAMERA_FULL_BYTES = 144
 
-/** Bond Params uniform (BOND_COMPUTE_WGSL): 80 bytes, packed via pack_params. */
-const BOND_PARAMS_BYTES = 80
 
 /** Vertices per bond half. Each half is an IMPOSTOR cylinder: a camera-facing
  *  billboard whose fragment shader ray-traces a mathematically smooth, capped
@@ -930,7 +928,7 @@ export function create_large_system_renderer(
   })
   const bond_params_buffer = device.createBuffer({
     label: `large-system-bond-params`,
-    size: BOND_PARAMS_BYTES,
+    size: PARAMS_BYTES,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   })
   // Bond render uniform: lattice columns (transposed, 3×vec4) + (radius,color).

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -1,26 +1,147 @@
 /// <reference types="@webgpu/types" />
 /** WebGPU large-system render path (Task 9).
  *
- *  Milestone 9.1 — de-risking skeleton: configures a webgpu canvas context,
- *  holds the camera uniform buffer (proving the upload path), and renders a
- *  single clear pass to a distinct dark-blue so the overlay canvas is visibly
- *  the one painting. No atom / bond geometry yet; this module grows in later
- *  milestones (atoms, then bonds via the existing bond-compute pipeline). */
+ *  Milestone 9.1 — de-risking skeleton: clear-only pass + camera uniform upload.
+ *  Milestone 9.2 — render the current frame's ATOMS as impostor spheres.
+ *  A single instanced draw paints one screen-facing quad per atom; the fragment
+ *  shader ray-traces a sphere inside the quad and writes correct clip-space depth
+ *  so spheres occlude each other properly. No bonds / trajectory / picking yet —
+ *  those arrive in later milestones. */
 
-/** Camera uniform: 20 floats (proj*view 4x4 + camera world pos vec3 + pad),
- *  matching Task 7's pack_camera_uniform layout. 20 * 4 bytes = 80. */
+/** Camera uniform (legacy 9.1): 20 floats (proj*view + camPos + pad) = 80 bytes. */
 const CAMERA_UNIFORM_BYTES = 80
 
-/** A distinct dark blue, intentionally different from the normal viewer
- *  background, so flipping the toggle visibly swaps which canvas paints. */
-const CLEAR_COLOR: GPUColor = { r: 0.06, g: 0.1, b: 0.16, a: 1 }
+/** Camera uniform (9.2 impostor): view(16) + proj(16) + camPos vec3 + pad = 36
+ *  floats = 144 bytes. Matches pack_camera_full's layout. */
+const CAMERA_FULL_BYTES = 144
+
+/** A distinct dark background so flipping the toggle visibly swaps which canvas
+ *  paints. Near-black with a faint blue tint. */
+const CLEAR_COLOR: GPUColor = { r: 0.02, g: 0.03, b: 0.05, a: 1 }
+
+const DEPTH_FORMAT: GPUTextureFormat = `depth24plus`
+
+/** WGSL impostor-sphere shader. View-space billboard + per-fragment ray-sphere.
+ *  - storage buffers: positions (3N), radii (N), colors (3N linear rgb)
+ *  - camera uniform: view + proj (separate) + camPos
+ *  Camera sits at the view-space origin, so the eye ray is just normalize(vpos). */
+const IMPOSTOR_WGSL = `
+struct Camera {
+  view : mat4x4<f32>,
+  proj : mat4x4<f32>,
+  cam_pos : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<storage, read> positions : array<f32>;
+@group(0) @binding(2) var<storage, read> radii : array<f32>;
+@group(0) @binding(3) var<storage, read> colors : array<f32>;
+
+struct VsOut {
+  @builtin(position) clip : vec4<f32>,
+  @location(0) vc : vec3<f32>,      // view-space sphere center
+  @location(1) radius : f32,
+  @location(2) color : vec3<f32>,
+  @location(3) vpos : vec3<f32>,    // view-space position of this quad corner
+};
+
+struct FsOut {
+  @builtin(frag_depth) depth : f32,
+  @location(0) color : vec4<f32>,
+};
+
+// Quad corners as a triangle-strip (4 verts): (-1,-1) (1,-1) (-1,1) (1,1)
+fn corner_for(vi : u32) -> vec2<f32> {
+  let x = select(-1.0, 1.0, (vi & 1u) == 1u);
+  let y = select(-1.0, 1.0, (vi & 2u) == 2u);
+  return vec2<f32>(x, y);
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi : u32,
+           @builtin(instance_index) inst : u32) -> VsOut {
+  let center = vec3<f32>(
+    positions[inst * 3u + 0u],
+    positions[inst * 3u + 1u],
+    positions[inst * 3u + 2u],
+  );
+  let r = radii[inst];
+  let col = vec3<f32>(
+    colors[inst * 3u + 0u],
+    colors[inst * 3u + 1u],
+    colors[inst * 3u + 2u],
+  );
+
+  let vc4 = camera.view * vec4<f32>(center, 1.0);
+  let vc = vc4.xyz;
+
+  let c = corner_for(vi);
+  // Billboard in view space; bump radius slightly so the silhouette isn't clipped.
+  let vpos = vc + vec3<f32>(c * r * 1.5, 0.0);
+  let clip = camera.proj * vec4<f32>(vpos, 1.0);
+
+  var out : VsOut;
+  out.clip = clip;
+  out.vc = vc;
+  out.radius = r;
+  out.color = col;
+  out.vpos = vpos;
+  return out;
+}
+
+@fragment
+fn fs_main(in : VsOut) -> FsOut {
+  // Eye at view-space origin; ray through the interpolated view-space position.
+  let ro = vec3<f32>(0.0, 0.0, 0.0);
+  let rd = normalize(in.vpos);
+
+  // Ray-sphere intersection: |ro + t*rd - vc|^2 = radius^2
+  let oc = ro - in.vc;
+  let b = dot(oc, rd);
+  let c = dot(oc, oc) - in.radius * in.radius;
+  let disc = b * b - c;
+  if (disc < 0.0) {
+    discard;
+  }
+  let t = -b - sqrt(disc); // near hit
+  if (t < 0.0) {
+    discard;
+  }
+  let p = ro + t * rd;            // view-space hit point
+  let n = normalize(p - in.vc);   // surface normal
+
+  let light_dir = normalize(vec3<f32>(0.3, 0.5, 0.8));
+  let lighting = 0.35 + 0.65 * max(dot(n, light_dir), 0.0);
+
+  // Correct depth: project the hit point and write NDC z (WebGPU range 0..1).
+  let clip_h = camera.proj * vec4<f32>(p, 1.0);
+
+  var out : FsOut;
+  out.depth = clip_h.z / clip_h.w;
+  out.color = vec4<f32>(in.color * lighting, 1.0);
+  return out;
+}
+`
 
 export type LargeSystemRenderer = {
-  /** Upload a packed camera uniform (Float32Array(20)). Stored only for now. */
+  /** Upload a packed camera uniform (Float32Array(20), proj*view layout).
+   *  Legacy 9.1 entry point; kept for back-compat. Not used by the impostor
+   *  draw (which reads view+proj separately via set_camera_full). */
   set_camera(uniform: Float32Array): void
-  /** Run one render pass (clear-only this milestone). */
+  /** Upload the full camera uniform (Float32Array(36): view + proj + camPos).
+   *  This is what the impostor pipeline binds. */
+  set_camera_full(uniform: Float32Array): void
+  /** (Re)upload atom storage buffers. positions=3N, radii=N, colors=3N linear
+   *  rgb. Buffers grow as needed; count drives the instanced draw. */
+  set_atoms(
+    positions: Float32Array,
+    radii: Float32Array,
+    colors: Float32Array,
+    count: number,
+  ): void
+  /** Run one render pass: clear + (if atoms present) impostor sphere draw. */
   render(): void
-  /** Resize the backing canvas to the given device-pixel dimensions. */
+  /** Resize the backing canvas + depth texture to device-pixel dimensions. */
   resize(w: number, h: number): void
   /** Tear down GPU resources and unconfigure the context. */
   destroy(): void
@@ -35,24 +156,151 @@ export function create_large_system_renderer(
   const format = navigator.gpu.getPreferredCanvasFormat()
   context.configure({ device, format, alphaMode: `premultiplied` })
 
-  // Camera uniform buffer — written by set_camera, not yet bound for drawing.
+  // Full camera uniform (view + proj + camPos), bound by the impostor pipeline.
   const camera_buffer = device.createBuffer({
-    label: `large-system-camera-uniform`,
-    size: CAMERA_UNIFORM_BYTES,
+    label: `large-system-camera-full`,
+    size: CAMERA_FULL_BYTES,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   })
+
+  // Atom storage buffers — lazily (re)created when the atom count grows.
+  let positions_buffer: GPUBuffer | null = null
+  let radii_buffer: GPUBuffer | null = null
+  let colors_buffer: GPUBuffer | null = null
+  let atom_capacity = 0 // instances the current buffers can hold
+  let atom_count = 0 // instances to draw this frame
+
+  // Depth texture, sized to the canvas; recreated on resize.
+  let depth_texture: GPUTexture | null = null
+  let depth_view: GPUTextureView | null = null
+
+  // Bind group depends on the storage buffers, so rebuild whenever they change.
+  let bind_group: GPUBindGroup | null = null
+
+  const shader = device.createShaderModule({
+    label: `large-system-impostor`,
+    code: IMPOSTOR_WGSL,
+  })
+
+  const bind_group_layout = device.createBindGroupLayout({
+    label: `large-system-impostor-bgl`,
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `uniform` } },
+      { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+      { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
+    ],
+  })
+
+  const pipeline = device.createRenderPipeline({
+    label: `large-system-impostor-pipeline`,
+    layout: device.createPipelineLayout({ bindGroupLayouts: [bind_group_layout] }),
+    vertex: { module: shader, entryPoint: `vs_main` },
+    fragment: { module: shader, entryPoint: `fs_main`, targets: [{ format }] },
+    primitive: { topology: `triangle-strip` },
+    depthStencil: {
+      format: DEPTH_FORMAT,
+      depthWriteEnabled: true,
+      depthCompare: `less`,
+    },
+  })
+
+  function ensure_depth(w: number, h: number): void {
+    depth_texture?.destroy()
+    depth_texture = device.createTexture({
+      label: `large-system-depth`,
+      size: { width: Math.max(1, w), height: Math.max(1, h) },
+      format: DEPTH_FORMAT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    })
+    depth_view = depth_texture.createView()
+  }
+  ensure_depth(canvas.width || 1, canvas.height || 1)
+
+  function rebuild_bind_group(): void {
+    if (!positions_buffer || !radii_buffer || !colors_buffer) {
+      bind_group = null
+      return
+    }
+    bind_group = device.createBindGroup({
+      label: `large-system-impostor-bg`,
+      layout: bind_group_layout,
+      entries: [
+        { binding: 0, resource: { buffer: camera_buffer } },
+        { binding: 1, resource: { buffer: positions_buffer } },
+        { binding: 2, resource: { buffer: radii_buffer } },
+        { binding: 3, resource: { buffer: colors_buffer } },
+      ],
+    })
+  }
 
   let destroyed = false
 
   return {
     set_camera(uniform: Float32Array): void {
       if (destroyed) return
-      // Upload exactly CAMERA_UNIFORM_BYTES; guard against a short/long array.
+      // Legacy 80-byte (proj*view) upload into the first bytes; harmless — the
+      // impostor draw uses set_camera_full. Guard against short/long arrays.
       const bytes = Math.min(uniform.byteLength, CAMERA_UNIFORM_BYTES)
       device.queue.writeBuffer(camera_buffer, 0, uniform.buffer, uniform.byteOffset, bytes)
     },
+    set_camera_full(uniform: Float32Array): void {
+      if (destroyed) return
+      const bytes = Math.min(uniform.byteLength, CAMERA_FULL_BYTES)
+      device.queue.writeBuffer(camera_buffer, 0, uniform.buffer, uniform.byteOffset, bytes)
+    },
+    set_atoms(
+      positions: Float32Array,
+      radii: Float32Array,
+      colors: Float32Array,
+      count: number,
+    ): void {
+      if (destroyed) return
+      atom_count = Math.max(0, count)
+      if (atom_count === 0) return
+
+      // (Re)allocate when capacity is insufficient. Storage buffers must be at
+      // least the byte length we write; grow with headroom to avoid churn.
+      if (atom_count > atom_capacity) {
+        const new_cap = Math.max(atom_count, Math.ceil(atom_capacity * 2), 1)
+        positions_buffer?.destroy()
+        radii_buffer?.destroy()
+        colors_buffer?.destroy()
+        positions_buffer = device.createBuffer({
+          label: `large-system-positions`,
+          size: new_cap * 3 * 4,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        radii_buffer = device.createBuffer({
+          label: `large-system-radii`,
+          size: new_cap * 4,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        colors_buffer = device.createBuffer({
+          label: `large-system-colors`,
+          size: new_cap * 3 * 4,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        })
+        atom_capacity = new_cap
+        rebuild_bind_group()
+      }
+
+      device.queue.writeBuffer(
+        positions_buffer as GPUBuffer, 0,
+        positions.buffer, positions.byteOffset, atom_count * 3 * 4,
+      )
+      device.queue.writeBuffer(
+        radii_buffer as GPUBuffer, 0,
+        radii.buffer, radii.byteOffset, atom_count * 4,
+      )
+      device.queue.writeBuffer(
+        colors_buffer as GPUBuffer, 0,
+        colors.buffer, colors.byteOffset, atom_count * 3 * 4,
+      )
+    },
     render(): void {
       if (destroyed) return
+      if (!depth_view) ensure_depth(canvas.width || 1, canvas.height || 1)
       const encoder = device.createCommandEncoder({ label: `large-system-frame` })
       const view = context.getCurrentTexture().createView()
       const pass = encoder.beginRenderPass({
@@ -64,8 +312,18 @@ export function create_large_system_renderer(
             storeOp: `store`,
           },
         ],
+        depthStencilAttachment: {
+          view: depth_view as GPUTextureView,
+          depthClearValue: 1.0,
+          depthLoadOp: `clear`,
+          depthStoreOp: `store`,
+        },
       })
-      // No geometry yet — clear-only pass.
+      if (atom_count > 0 && bind_group) {
+        pass.setPipeline(pipeline)
+        pass.setBindGroup(0, bind_group)
+        pass.draw(4, atom_count) // triangle-strip quad, one instance per atom
+      }
       pass.end()
       device.queue.submit([encoder.finish()])
     },
@@ -73,6 +331,7 @@ export function create_large_system_renderer(
       if (destroyed) return
       canvas.width = Math.max(1, Math.floor(w))
       canvas.height = Math.max(1, Math.floor(h))
+      ensure_depth(canvas.width, canvas.height)
     },
     destroy(): void {
       if (destroyed) return
@@ -83,6 +342,16 @@ export function create_large_system_renderer(
         // some implementations / already-lost contexts may throw — ignore
       }
       camera_buffer.destroy()
+      positions_buffer?.destroy()
+      radii_buffer?.destroy()
+      colors_buffer?.destroy()
+      depth_texture?.destroy()
+      positions_buffer = null
+      radii_buffer = null
+      colors_buffer = null
+      depth_texture = null
+      depth_view = null
+      bind_group = null
     },
   }
 }

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -78,7 +78,10 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let c = corner_for(vi);
   // Billboard in view space; bump radius slightly so the silhouette isn't clipped.
   let vpos = vc + vec3<f32>(c * r * 1.5, 0.0);
-  let clip = camera.proj * vec4<f32>(vpos, 1.0);
+  var clip = camera.proj * vec4<f32>(vpos, 1.0);
+  // three.js projectionMatrix uses GL NDC z in [-1,1]; WebGPU clip space needs
+  // 0 <= z <= w (NDC z in [0,1]). Remap before returning @builtin(position).
+  clip.z = (clip.z + clip.w) * 0.5;
 
   var out : VsOut;
   out.clip = clip;
@@ -113,11 +116,13 @@ fn fs_main(in : VsOut) -> FsOut {
   let light_dir = normalize(vec3<f32>(0.3, 0.5, 0.8));
   let lighting = 0.35 + 0.65 * max(dot(n, light_dir), 0.0);
 
-  // Correct depth: project the hit point and write NDC z (WebGPU range 0..1).
+  // Correct depth: project the hit point, apply the same GL->WebGPU z remap as
+  // the vertex stage, then perspective-divide into NDC z (WebGPU range 0..1).
   let clip_h = camera.proj * vec4<f32>(p, 1.0);
+  let remapped_z = (clip_h.z + clip_h.w) * 0.5;
 
   var out : FsOut;
-  out.depth = clip_h.z / clip_h.w;
+  out.depth = clamp(remapped_z / clip_h.w, 0.0, 1.0);
   out.color = vec4<f32>(in.color * lighting, 1.0);
   return out;
 }
@@ -197,7 +202,9 @@ export function create_large_system_renderer(
     layout: device.createPipelineLayout({ bindGroupLayouts: [bind_group_layout] }),
     vertex: { module: shader, entryPoint: `vs_main` },
     fragment: { module: shader, entryPoint: `fs_main`, targets: [{ format }] },
-    primitive: { topology: `triangle-strip` },
+    // Camera-facing billboards must never be back-face culled — winding flips
+    // depending on view, so cull nothing.
+    primitive: { topology: `triangle-strip`, cullMode: `none` },
     depthStencil: {
       format: DEPTH_FORMAT,
       depthWriteEnabled: true,
@@ -236,6 +243,10 @@ export function create_large_system_renderer(
 
   let destroyed = false
 
+  // TODO(9.2-debug) remove — capture the last full camera uniform + log once.
+  let _dbg_last_cam: Float32Array | null = null
+  let _dbg_logged_cam = false
+
   return {
     set_camera(uniform: Float32Array): void {
       if (destroyed) return
@@ -246,6 +257,7 @@ export function create_large_system_renderer(
     },
     set_camera_full(uniform: Float32Array): void {
       if (destroyed) return
+      _dbg_last_cam = uniform // TODO(9.2-debug) remove
       const bytes = Math.min(uniform.byteLength, CAMERA_FULL_BYTES)
       device.queue.writeBuffer(camera_buffer, 0, uniform.buffer, uniform.byteOffset, bytes)
     },
@@ -256,6 +268,8 @@ export function create_large_system_renderer(
       count: number,
     ): void {
       if (destroyed) return
+      // TODO(9.2-debug) remove
+      console.log(`[lsr] set_atoms count=`, count, `pos0=`, Array.from(positions.slice(0, 3)), `r0=`, radii[0], `col0=`, Array.from(colors.slice(0, 3)))
       atom_count = Math.max(0, count)
       if (atom_count === 0) return
 
@@ -300,6 +314,16 @@ export function create_large_system_renderer(
     },
     render(): void {
       if (destroyed) return
+      // TODO(9.2-debug) remove — log the camera uniform sample on the first frame.
+      if (!_dbg_logged_cam && _dbg_last_cam) {
+        _dbg_logged_cam = true
+        const u = _dbg_last_cam
+        console.log(
+          `[lsr] cam uniform view0..3=`, Array.from(u.slice(0, 4)),
+          `proj0..3=`, Array.from(u.slice(16, 20)),
+          `camPos=`, Array.from(u.slice(32, 35)),
+        )
+      }
       if (!depth_view) ensure_depth(canvas.width || 1, canvas.height || 1)
       const encoder = device.createCommandEncoder({ label: `large-system-frame` })
       const view = context.getCurrentTexture().createView()

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -303,8 +303,13 @@ fn build_args() {
  *        B = pos[b], partnerA = pos[a] - jimage·lattice (B's imaged partner).
  *    half 0: cylinder A      -> M0 = (A + partnerB) * 0.5
  *    half 1: cylinder B      -> M1 = (B + partnerA) * 0.5
- *  For intra-cell bonds (jimage = 0) partnerB = B and partnerA = A, so
- *  M0 = M1 = (A+B)/2 and the two halves join into a seamless full cylinder.
+ *  For CROSS-cell bonds (jimage != 0) this yields the two short stubs above.
+ *  For INTRA-cell bonds (jimage = 0) the two halves would be collinear and their
+ *  flat midpoint cap planes coincide -> coincident depth -> alpha-to-coverage
+ *  z-fight that shows as a faint dotted seam across the cylinder. To avoid it,
+ *  intra-cell bonds instead draw ONE full cylinder (half 0: A -> B) and collapse
+ *  half 1 to a degenerate offscreen billboard (zero fragments). Detection:
+ *  jimage (0,0,0) packs to (0+1)|((0+1)<<2)|((0+1)<<4) = 21u.
  *
  *  GEOMETRY (impostor, NGL/3Dmol-style — no facets, constant 4 verts/half):
  *  Each half's segment endpoints P0=start, P1=end are transformed to VIEW space
@@ -385,12 +390,19 @@ fn vs_main(@builtin(vertex_index) vi : u32,
   let partnerB = B + shift;
   let partnerA = A - shift;
 
+  // INTRA-cell bonds (jimage = 0,0,0) pack to (0+1)|((0+1)<<2)|((0+1)<<4) = 21u.
+  // For those we render ONE full cylinder (half 0: A->B) and collapse half 1 to a
+  // degenerate offscreen billboard, so there is no coincident midpoint cap plane
+  // (which z-fights / shows as a dotted alpha-to-coverage seam across the surface).
+  let is_intra = jp == 21u;
+
   // half 0: A -> midpoint of (A, partnerB);  half 1: B -> midpoint of (B, partnerA).
-  // Intra-cell (jimage=0): partnerB=B, partnerA=A => both midpoints = (A+B)/2,
-  // so the two halves join into a seamless full cylinder.
-  let start = select(B, A, half == 0u);
-  let mid = select((B + partnerA) * 0.5, (A + partnerB) * 0.5, half == 0u);
-  let end = mid;
+  // Cross-cell (jimage != 0) keeps the two A->M0 / B->M1 stubs (the gap is intended).
+  // Intra-cell half 0 spans the whole bond A->B; half 1 is discarded below.
+  let cross_start = select(B, A, half == 0u);
+  let cross_mid = select((B + partnerA) * 0.5, (A + partnerB) * 0.5, half == 0u);
+  let start = select(cross_start, A, is_intra);
+  let end = select(cross_mid, B, is_intra);
 
   let r = bond.radius_color.x;
 
@@ -452,6 +464,21 @@ fn vs_main(@builtin(vertex_index) vi : u32,
     default: { anchor = v1; ax_sign =  1.0; p_sign =  1.0; }
   }
   let vpos = anchor + ax_sign * off_axis + p_sign * off_perp;
+
+  // Intra-cell half 1 is redundant (half 0 already draws the full A->B cylinder):
+  // collapse ALL 6 strip vertices to the same offscreen clip position so the
+  // billboard has zero area and rasterizes no fragments (don't rely on fragment
+  // discard alone). Cross-cell halves are untouched.
+  if (is_intra && half == 1u) {
+    var out_deg : VsOut;
+    out_deg.clip = vec4<f32>(2.0, 2.0, 2.0, 1.0); // outside the [-w,w] clip cube
+    out_deg.v0 = v0;
+    out_deg.v1 = v1;
+    out_deg.radius = r;
+    out_deg.color = bond.radius_color.yzw;
+    out_deg.vpos = vpos;
+    return out_deg;
+  }
 
   var clip = camera.proj * vec4<f32>(vpos, 1.0);
   // SAME GL->WebGPU NDC z remap as the atom impostor shader.

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -243,10 +243,6 @@ export function create_large_system_renderer(
 
   let destroyed = false
 
-  // TODO(9.2-debug) remove — capture the last full camera uniform + log once.
-  let _dbg_last_cam: Float32Array | null = null
-  let _dbg_logged_cam = false
-
   return {
     set_camera(uniform: Float32Array): void {
       if (destroyed) return
@@ -257,7 +253,6 @@ export function create_large_system_renderer(
     },
     set_camera_full(uniform: Float32Array): void {
       if (destroyed) return
-      _dbg_last_cam = uniform // TODO(9.2-debug) remove
       const bytes = Math.min(uniform.byteLength, CAMERA_FULL_BYTES)
       device.queue.writeBuffer(camera_buffer, 0, uniform.buffer, uniform.byteOffset, bytes)
     },
@@ -268,8 +263,6 @@ export function create_large_system_renderer(
       count: number,
     ): void {
       if (destroyed) return
-      // TODO(9.2-debug) remove
-      console.log(`[lsr] set_atoms count=`, count, `pos0=`, Array.from(positions.slice(0, 3)), `r0=`, radii[0], `col0=`, Array.from(colors.slice(0, 3)))
       atom_count = Math.max(0, count)
       if (atom_count === 0) return
 
@@ -314,16 +307,6 @@ export function create_large_system_renderer(
     },
     render(): void {
       if (destroyed) return
-      // TODO(9.2-debug) remove — log the camera uniform sample on the first frame.
-      if (!_dbg_logged_cam && _dbg_last_cam) {
-        _dbg_logged_cam = true
-        const u = _dbg_last_cam
-        console.log(
-          `[lsr] cam uniform view0..3=`, Array.from(u.slice(0, 4)),
-          `proj0..3=`, Array.from(u.slice(16, 20)),
-          `camPos=`, Array.from(u.slice(32, 35)),
-        )
-      }
       if (!depth_view) ensure_depth(canvas.width || 1, canvas.height || 1)
       const encoder = device.createCommandEncoder({ label: `large-system-frame` })
       const view = context.getCurrentTexture().createView()

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -730,7 +730,15 @@ export function create_large_system_renderer(
   const bond_render_bgl = device.createBindGroupLayout({
     label: `large-system-bond-render-bgl`,
     entries: [
-      { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+      // binding 0 = camera: read by BOTH vs_main (view+proj billboard) AND
+      // fs_main (camera.proj for the frag_depth projection of the ray-traced hit
+      // point). The impostor-cylinder rewrite moved that projection into the
+      // fragment stage, so this binding MUST be visible to FRAGMENT too —
+      // otherwise the pipeline is invalid ("entry point's stage is not in the
+      // binding visibility") and the whole frame submit fails (blank overlay).
+      { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `uniform` } },
+      // bindings 1-3 (positions, pairs, bond uniform) are read only by vs_main —
+      // fs_main works entirely off interpolated VsOut varyings — so VERTEX-only.
       { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -15,6 +15,7 @@
  *  correctly. No trajectory / picking yet — those arrive in later milestones. */
 import { BOND_COMPUTE_WGSL } from '$lib/structure/gpu/bond-compute.wgsl'
 import { pack_params, PARAMS_BYTES } from '$lib/structure/gpu/bond-compute'
+import { plan_grid, type GridPlan } from '$lib/structure/gpu/bond-grid'
 
 /** Camera uniform (legacy 9.1): 20 floats (proj*view + camPos + pad) = 80 bytes. */
 const CAMERA_UNIFORM_BYTES = 80
@@ -895,6 +896,27 @@ export function create_large_system_renderer(
   // atomic count + indirect-args are tiny fixed buffers.
   let pairs_buffer: GPUBuffer | null = null
   let bond_capacity = 0 // pairs the current pairs buffer can hold
+  // ── Uniform-grid (cell-list) buffers (bindings 7/8/9). cell_count tallies atoms
+  // per cell (n_cells u32), cell_atoms holds up to max_per_cell atom ids per cell
+  // (n_cells*max u32), overflow is a single u32 flag. Sized from the grid plan;
+  // grown when the plan needs more cells/atoms. A 4-byte minimum keeps the
+  // bindings valid in the fallback (use_grid=0) path. ──
+  let cell_count_buffer: GPUBuffer | null = null
+  let cell_atoms_buffer: GPUBuffer | null = null
+  let cell_count_cells = 0 // cells the cell_count buffer can hold
+  let cell_atoms_slots = 0 // total (cells*max) slots cell_atoms can hold
+  const overflow_buffer = device.createBuffer({
+    label: `large-system-bond-overflow`,
+    size: 4,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+  })
+  // Last grid plan (recomputed at dispatch from the current bond inputs).
+  let grid_plan: GridPlan | null = null
+  // CPU copy of the current frame's atom xyz (3N), kept ONLY so the non-periodic
+  // grid plan can compute the atom AABB on the CPU (the periodic plan needs no
+  // positions). Updated by set_atoms / set_positions. For periodic structures this
+  // is still cached but never read by plan_grid.
+  let last_positions: Float32Array | null = null
   const count_buffer = device.createBuffer({
     label: `large-system-bond-count`,
     size: 4,
@@ -998,17 +1020,50 @@ export function create_large_system_renderer(
     multisample: { count: SAMPLE_COUNT, alphaToCoverageEnabled: true },
   })
 
-  // Bond-detect compute (the already-validated BOND_COMPUTE_WGSL). auto layout
-  // matches bond-compute.ts: 0 positions, 1 radii, 2 params, 3 out_pairs,
-  // 4 out_count.
+  // Bond-detect compute (BOND_COMPUTE_WGSL). Three entry points share ONE explicit
+  // bind-group layout (clear_grid / bin_atoms / detect_bonds) so a single bond
+  // compute bind group binds all three pipelines. Bindings: 0 positions, 1 radii,
+  // 2 params, 3 out_pairs, 4 out_count, 5 elem_ids, 6 rules, 7 cell_count,
+  // 8 cell_atoms, 9 overflow.
   const bond_compute_module = device.createShaderModule({
     label: `large-system-bond-compute`,
     code: BOND_COMPUTE_WGSL,
   })
+  const bc_storage = (rw: boolean): GPUBindGroupLayoutEntry[`buffer`] => ({
+    type: rw ? `storage` : `read-only-storage`,
+  })
+  const bond_compute_bgl = device.createBindGroupLayout({
+    label: `large-system-bond-compute-bgl`,
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(false) },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(false) },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: `uniform` } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(true) },
+      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(true) },
+      { binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(false) },
+      { binding: 6, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(false) },
+      { binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(true) },
+      { binding: 8, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(true) },
+      { binding: 9, visibility: GPUShaderStage.COMPUTE, buffer: bc_storage(true) },
+    ],
+  })
+  const bond_compute_layout = device.createPipelineLayout({
+    bindGroupLayouts: [bond_compute_bgl],
+  })
   const bond_compute_pipeline = device.createComputePipeline({
     label: `large-system-bond-compute-pipeline`,
-    layout: `auto`,
+    layout: bond_compute_layout,
     compute: { module: bond_compute_module, entryPoint: `detect_bonds` },
+  })
+  const bond_clear_pipeline = device.createComputePipeline({
+    label: `large-system-bond-clear-pipeline`,
+    layout: bond_compute_layout,
+    compute: { module: bond_compute_module, entryPoint: `clear_grid` },
+  })
+  const bond_bin_pipeline = device.createComputePipeline({
+    label: `large-system-bond-bin-pipeline`,
+    layout: bond_compute_layout,
+    compute: { module: bond_compute_module, entryPoint: `bin_atoms` },
   })
 
   // Indirect-args build: read atomic count, write drawIndirect args.
@@ -1288,6 +1343,39 @@ export function create_large_system_renderer(
     rebuild_bond_bind_groups()
   }
 
+  /** Ensure the uniform-grid storage buffers (bindings 7/8) can hold `n_cells`
+   *  cells and `n_cells * max_per_cell` atom slots. Re-created (never shrunk) when
+   *  the grid grows; rebuilds the bond bind groups when they reallocate (the
+   *  compute bind group references them). Returns true when a reallocation
+   *  happened (so the caller re-fetches the rebuilt bind group). */
+  function ensure_grid_capacity(n_cells: number, max_per_cell: number): boolean {
+    const want_cells = Math.max(n_cells, 1)
+    const want_slots = Math.max(n_cells * max_per_cell, 1)
+    let grew = false
+    if (want_cells > cell_count_cells || !cell_count_buffer) {
+      cell_count_buffer?.destroy()
+      cell_count_cells = Math.max(want_cells, Math.ceil(cell_count_cells * 2), 1)
+      cell_count_buffer = device.createBuffer({
+        label: `large-system-bond-cell-count`,
+        size: Math.max(cell_count_cells * 4, 4),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+      grew = true
+    }
+    if (want_slots > cell_atoms_slots || !cell_atoms_buffer) {
+      cell_atoms_buffer?.destroy()
+      cell_atoms_slots = Math.max(want_slots, Math.ceil(cell_atoms_slots * 2), 1)
+      cell_atoms_buffer = device.createBuffer({
+        label: `large-system-bond-cell-atoms`,
+        size: Math.max(cell_atoms_slots * 4, 4),
+        usage: GPUBufferUsage.STORAGE,
+      })
+      grew = true
+    }
+    if (grew) rebuild_bond_bind_groups()
+    return grew
+  }
+
   /** (Re)build the three bond bind groups. Depends on positions_buffer (atom
    *  realloc), covalent_buffer, pairs_buffer, and the elem-ids / rules buffers
    *  (bindings 5/6) — any of which may reallocate. The elem-ids / rules buffers
@@ -1317,10 +1405,28 @@ export function create_large_system_renderer(
         usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
       })
     }
+    // Grid buffers (bindings 7/8): lazily create placeholders so the bind group
+    // is complete even before the first dispatch sizes them.
+    if (!cell_count_buffer) {
+      cell_count_cells = 1
+      cell_count_buffer = device.createBuffer({
+        label: `large-system-bond-cell-count`,
+        size: 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+    }
+    if (!cell_atoms_buffer) {
+      cell_atoms_slots = 1
+      cell_atoms_buffer = device.createBuffer({
+        label: `large-system-bond-cell-atoms`,
+        size: 4,
+        usage: GPUBufferUsage.STORAGE,
+      })
+    }
 
     bond_compute_bg = device.createBindGroup({
       label: `large-system-bond-compute-bg`,
-      layout: bond_compute_pipeline.getBindGroupLayout(0),
+      layout: bond_compute_bgl,
       entries: [
         { binding: 0, resource: { buffer: positions_buffer } },
         { binding: 1, resource: { buffer: covalent_buffer } },
@@ -1329,6 +1435,9 @@ export function create_large_system_renderer(
         { binding: 4, resource: { buffer: count_buffer } },
         { binding: 5, resource: { buffer: elem_ids_buffer } },
         { binding: 6, resource: { buffer: rules_buffer } },
+        { binding: 7, resource: { buffer: cell_count_buffer } },
+        { binding: 8, resource: { buffer: cell_atoms_buffer } },
+        { binding: 9, resource: { buffer: overflow_buffer } },
       ],
     })
     indirect_bg = device.createBindGroup({
@@ -1466,6 +1575,8 @@ export function create_large_system_renderer(
         colors_buffer as GPUBuffer, 0,
         colors.buffer, colors.byteOffset, atom_count * 3 * 4,
       )
+      // Cache positions for the non-periodic AABB grid plan (see last_positions).
+      last_positions = positions
       // Positions moved ⇒ bonds must be recomputed next render.
       bonds_dirty = true
     },
@@ -1486,6 +1597,8 @@ export function create_large_system_renderer(
         positions_buffer, 0,
         positions.buffer, positions.byteOffset, floats * 4,
       )
+      // Cache positions for the non-periodic AABB grid plan (see last_positions).
+      last_positions = positions
       // Atoms moved ⇒ bonds must be recomputed against the new positions.
       bonds_dirty = true
     },
@@ -1590,8 +1703,24 @@ export function create_large_system_renderer(
       // Cached by `bonds_dirty`: structure/option/atom changes flip it; a static
       // scene re-uses last frame's GPU-resident pairs with no recompute.
       if (bonds_ready && bonds_dirty) {
-        // Reset the atomic counter, then repack Params (n, capacity vary).
+        // Plan the uniform grid from the current bond inputs + this frame's atom
+        // positions (non-periodic AABB needs them). For periodic small cells the
+        // plan's use_grid is false ⇒ the shader takes the O(N²) fallback.
+        grid_plan = plan_grid({
+          periodic: bond_periodic,
+          lattice: bond_lattice,
+          max_bond_dist: bond_options.max_bond_dist,
+          positions: last_positions ?? new Float32Array(0),
+          n: bond_n,
+        })
+        // Grow the grid buffers if this plan needs more cells/atom slots. If they
+        // reallocate, the bond compute bind group was rebuilt — re-fetch it below.
+        ensure_grid_capacity(grid_plan.n_cells, grid_plan.max_per_cell)
+
+        // Reset the atomic counter + overflow flag, then repack Params (n,
+        // capacity, and the grid block vary).
         device.queue.writeBuffer(count_buffer, 0, new Uint32Array([0]))
+        device.queue.writeBuffer(overflow_buffer, 0, new Uint32Array([0]))
         device.queue.writeBuffer(
           bond_params_buffer, 0,
           pack_params(bond_n, bond_capacity, {
@@ -1606,12 +1735,20 @@ export function create_large_system_renderer(
             // shader's rules_keep returns early (no post-filter), identical to no
             // rules. The actual rule data lives in the binding-6 storage buffer.
             rules: bond_rules,
-          }),
+          }, grid_plan),
           0, PARAMS_BYTES,
         )
         const cpass = encoder.beginComputePass({ label: `large-system-bond-compute` })
-        cpass.setPipeline(bond_compute_pipeline)
         cpass.setBindGroup(0, bond_compute_bg as GPUBindGroup)
+        // Grid path: clear the per-cell counts, then bin atoms, then detect. The
+        // clear/bin passes are skipped on the fallback (detect ignores the grid).
+        if (grid_plan.use_grid) {
+          cpass.setPipeline(bond_clear_pipeline)
+          cpass.dispatchWorkgroups(Math.max(1, Math.ceil(grid_plan.n_cells / 64)))
+          cpass.setPipeline(bond_bin_pipeline)
+          cpass.dispatchWorkgroups(Math.max(1, Math.ceil(bond_n / 64)))
+        }
+        cpass.setPipeline(bond_compute_pipeline)
         cpass.dispatchWorkgroups(Math.max(1, Math.ceil(bond_n / 64)))
         // Build draw-indirect args from the atomic count (no CPU readback).
         cpass.setPipeline(indirect_pipeline)
@@ -1702,6 +1839,9 @@ export function create_large_system_renderer(
       elem_ids_buffer?.destroy()
       rules_buffer?.destroy()
       pairs_buffer?.destroy()
+      cell_count_buffer?.destroy()
+      cell_atoms_buffer?.destroy()
+      overflow_buffer.destroy()
       count_buffer.destroy()
       indirect_buffer.destroy()
       bond_params_buffer.destroy()
@@ -1716,6 +1856,9 @@ export function create_large_system_renderer(
       elem_ids_buffer = null
       rules_buffer = null
       pairs_buffer = null
+      cell_count_buffer = null
+      cell_atoms_buffer = null
+      last_positions = null
       msaa_color_texture = null
       msaa_color_view = null
       depth_texture = null

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -1127,8 +1127,14 @@ export function create_large_system_renderer(
       { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 3, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
-      // binding 4: per-atom selection flag, read by the FRAGMENT stage (highlight).
-      { binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: `read-only-storage` } },
+      // binding 4: per-atom selection flag `selected`. The BUFFER is indexed in
+      // vs_main (`selected[inst]` -> flat varying `out.sel`); fs_main reads only
+      // that varying, never the buffer. So the binding's referencing stage is
+      // VERTEX. (A prior layout granted FRAGMENT-only, mismatching vs_main and
+      // invalidating the pipeline -> blank overlay.) Granted VERTEX|FRAGMENT —
+      // VERTEX is required; FRAGMENT is the highlight stage that plausibly reads
+      // it, so OR both per the project's recurrence-proof rule.
+      { binding: 4, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `read-only-storage` } },
     ],
   })
 
@@ -1166,7 +1172,15 @@ export function create_large_system_renderer(
   const pick_bgl = device.createBindGroupLayout({
     label: `large-system-pick-bgl`,
     entries: [
-      { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: `uniform` } },
+      // binding 0 = camera: read by BOTH vs_main (view+proj billboard) AND
+      // fs_main (camera.proj projects the ray-traced view-space hit point for
+      // frag_depth). A prior layout granted VERTEX-only, mismatching fs_main and
+      // invalidating the pick pipeline ("fragment stage is not in binding
+      // visibility") -> the whole frame submit failed (blank overlay). Must be
+      // VERTEX|FRAGMENT.
+      { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: `uniform` } },
+      // bindings 1-2 (positions, radii) are read only by vs_main — fs_main works
+      // off interpolated VsOut varyings — so VERTEX-only.
       { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
       { binding: 2, visibility: GPUShaderStage.VERTEX, buffer: { type: `read-only-storage` } },
     ],

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -39,8 +39,10 @@ const BOND_RADIUS = 0.16
 /** Neutral bond color (linear rgb). Half-A/half-B coloring is a later milestone. */
 const BOND_COLOR: [number, number, number] = [0.7, 0.7, 0.7]
 
-/** A distinct dark background so flipping the toggle visibly swaps which canvas
- *  paints. Near-black with a faint blue tint. */
+/** Default clear color when no background is threaded in: a distinct dark
+ *  background (near-black, faint blue tint) so flipping the toggle visibly
+ *  swaps which canvas paints. Overridden by set_background to match the WebGL
+ *  viewer's actual canvas background (so dark atoms keep their contrast). */
 const CLEAR_COLOR: GPUColor = { r: 0.02, g: 0.03, b: 0.05, a: 1 }
 
 const DEPTH_FORMAT: GPUTextureFormat = `depth24plus`
@@ -336,6 +338,11 @@ export type LargeSystemRenderer = {
     options: { tolerance: number; max_bond_dist: number; min_dist: number },
     periodic: boolean,
   ): void
+  /** Set the clear (background) color the render pass uses. `rgb` is LINEAR
+   *  float [r,g,b] in the SAME space as the atom colors uploaded via set_atoms
+   *  (so the background and atoms share one color space — dark atoms keep their
+   *  contrast against the viewer's normal background). Alpha stays 1 (opaque). */
+  set_background(rgb: [number, number, number]): void
   /** Run one render pass: clear + (if bonds dirty) bond compute + indirect-args
    *  build, then (if atoms present) impostor sphere draw + (if bonds present)
    *  instanced cylinder draw, all sharing one depth attachment. */
@@ -624,7 +631,19 @@ export function create_large_system_renderer(
 
   let destroyed = false
 
+  // Mutable clear color, defaulting to the near-black constant until the caller
+  // threads the viewer's background via set_background. Typed as the dict form
+  // (not the GPUColor union) so the .r/.g/.b/.a fields are writable.
+  const clear_color: GPUColorDict = { ...(CLEAR_COLOR as GPUColorDict) }
+
   return {
+    set_background(rgb: [number, number, number]): void {
+      if (destroyed) return
+      clear_color.r = rgb[0]
+      clear_color.g = rgb[1]
+      clear_color.b = rgb[2]
+      clear_color.a = 1
+    },
     set_camera(uniform: Float32Array): void {
       if (destroyed) return
       // Legacy 80-byte (proj*view) upload into the first bytes; harmless — the
@@ -801,7 +820,7 @@ export function create_large_system_renderer(
         colorAttachments: [
           {
             view,
-            clearValue: CLEAR_COLOR,
+            clearValue: clear_color,
             loadOp: `clear`,
             storeOp: `store`,
           },

--- a/src/lib/structure/gpu/radius-lut.ts
+++ b/src/lib/structure/gpu/radius-lut.ts
@@ -1,4 +1,5 @@
-import type { Site } from '$lib/structure'
+import type { ElementSymbol, Site } from '$lib/structure'
+import { atomic_radii } from '$lib/structure'
 import element_data from '$lib/element/data'
 
 const DEFAULT_RADIUS = 1.0 // Å, fallback for elements with no covalent radius
@@ -12,12 +13,55 @@ const covalent_radius_by_symbol = new Map<string, number>(
 )
 
 /** Per-atom covalent radius (Å), one entry per site, from the site's primary
- *  species. Used as the GPU radius lookup for atom_radii bond detection. */
+ *  species. This is the BOND-CUTOFF radius (used by milestone 9.3 bond
+ *  detection), NOT the visual sphere size. Do not repurpose for rendering —
+ *  use build_display_radii for the impostor sphere radius. */
 export function build_atom_radii(sites: readonly Site[]): Float32Array {
   const out = new Float32Array(sites.length)
   for (let i = 0; i < sites.length; i++) {
     const elem = sites[i].species[0]?.element
     out[i] = (elem != null ? covalent_radius_by_symbol.get(elem) : undefined) ?? DEFAULT_RADIUS
+  }
+  return out
+}
+
+/** Per-atom DISPLAY radius (Å) for the impostor spheres, matching the WebGL
+ *  ball-and-stick view's sizing as closely as practical. Mirrors the radius
+ *  resolution in StructureScene.svelte:
+ *    site_override > same_size_atoms > occu-weighted (element_override | atomic_radii)
+ *  all multiplied by the global atom_radius scale. `atomic_radii` here is the
+ *  half-covalent-radius LUT exported from $lib/structure (covalent/2), the same
+ *  base the WebGL path uses — distinct from build_atom_radii's full covalent
+ *  radius used for bond cutoffs. */
+export function build_display_radii(
+  sites: readonly Site[],
+  opts: {
+    atom_radius?: number
+    same_size_atoms?: boolean
+    element_radius_overrides?: Partial<Record<ElementSymbol, number>>
+    site_radius_overrides?: Map<number, number> | { get(k: number): number | undefined }
+  } = {},
+): Float32Array {
+  const scale = opts.atom_radius ?? 1
+  const same_size = opts.same_size_atoms ?? false
+  const ero = opts.element_radius_overrides
+  const sro = opts.site_radius_overrides
+  const out = new Float32Array(sites.length)
+  for (let i = 0; i < sites.length; i++) {
+    const site_override = sro?.get(i)
+    if (site_override !== undefined) {
+      out[i] = site_override * scale
+    } else if (same_size) {
+      out[i] = scale
+    } else {
+      // occupancy-weighted sum of per-species radii, matching the WebGL reduce.
+      let base = 0
+      for (const spec of sites[i].species) {
+        const elem = spec.element as ElementSymbol
+        base += spec.occu * (ero?.[elem] ?? atomic_radii[elem] ?? 1)
+      }
+      out[i] = base * scale
+    }
   }
   return out
 }

--- a/src/lib/structure/gpu/radius-lut.ts
+++ b/src/lib/structure/gpu/radius-lut.ts
@@ -1,0 +1,23 @@
+import type { Site } from '$lib/structure'
+import element_data from '$lib/element/data'
+
+const DEFAULT_RADIUS = 1.0 // Å, fallback for elements with no covalent radius
+
+// element symbol -> covalent radius (Å). Mirrors src/lib/structure/bonding.ts
+// so GPU bond radii match the CPU bond path.
+const covalent_radius_by_symbol = new Map<string, number>(
+  element_data
+    .filter((el) => el.covalent_radius != null)
+    .map((el) => [el.symbol, el.covalent_radius as number]),
+)
+
+/** Per-atom covalent radius (Å), one entry per site, from the site's primary
+ *  species. Used as the GPU radius lookup for atom_radii bond detection. */
+export function build_atom_radii(sites: readonly Site[]): Float32Array {
+  const out = new Float32Array(sites.length)
+  for (let i = 0; i < sites.length; i++) {
+    const elem = sites[i].species[0]?.element
+    out[i] = (elem != null ? covalent_radius_by_symbol.get(elem) : undefined) ?? DEFAULT_RADIUS
+  }
+  return out
+}

--- a/src/lib/structure/gpu/webgpu-context.ts
+++ b/src/lib/structure/gpu/webgpu-context.ts
@@ -15,7 +15,14 @@ export async function acquire_webgpu_device(): Promise<GPUDevice | null> {
   try {
     const adapter = await navigator.gpu.requestAdapter({ powerPreference: `high-performance` })
     if (!adapter) return null
-    const device = await adapter.requestDevice()
+    // The spatial-grid bond compute pipeline binds 9 storage buffers; the default
+    // maxStorageBuffersPerShaderStage is 8. Raise it to what the adapter supports
+    // (capped at 16, plenty for 9). If an adapter reports < 9 (rare) the device
+    // still gets the max it can — we'd need to merge buffers to fully support it.
+    const want = Math.min(16, adapter.limits.maxStorageBuffersPerShaderStage)
+    const device = await adapter.requestDevice({
+      requiredLimits: { maxStorageBuffersPerShaderStage: want },
+    })
     cached_device = device
     return device
   } catch {

--- a/src/lib/structure/gpu/webgpu-context.ts
+++ b/src/lib/structure/gpu/webgpu-context.ts
@@ -1,0 +1,27 @@
+/// <reference types="@webgpu/types" />
+/** WebGPU device acquisition + capability detection. No rendering logic here. */
+
+export function is_webgpu_supported(): boolean {
+  return typeof navigator !== `undefined` && `gpu` in navigator && navigator.gpu != null
+}
+
+let cached_device: GPUDevice | null = null
+
+/** Acquire a GPUDevice, or null if WebGPU is unavailable / acquisition fails.
+ *  Result is cached for the process lifetime. */
+export async function acquire_webgpu_device(): Promise<GPUDevice | null> {
+  if (cached_device !== null) return cached_device
+  if (!is_webgpu_supported()) return null
+  try {
+    const adapter = await navigator.gpu.requestAdapter({ powerPreference: `high-performance` })
+    if (!adapter) return null
+    const device = await adapter.requestDevice()
+    cached_device = device
+    return device
+  } catch {
+    return null
+  }
+}
+
+/** Test-only: reset the cached device. */
+export function __reset_device_cache(): void { cached_device = null }

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -178,11 +178,15 @@ export function make_supercell(
 // instances the base cell), so this threshold does NOT apply.
 export const CPU_SUPERCELL_CELL_WARN_THRESHOLD = 64
 
-// Soft cap on the EFFECTIVE GPU instance count (base atom count × number of
-// cells). Beyond this the GPU instancing path can hang on weaker hardware, so
-// the caller should warn and/or clamp. ~10M instances is a sane ceiling for a
-// single InstancedMesh on current WebGPU.
-export const GPU_SUPERCELL_MAX_INSTANCES = 10_000_000
+// Hard ceiling on the EFFECTIVE GPU instance count (base atom count × number of
+// cells) — a guard against pathological factors (e.g. a fat-fingered
+// 1000×1000×1000), NOT a perf budget. The GPU supercell path is pure
+// instancing: bonds are detected on the BASE cell only and GPU memory stays
+// base-cell-sized, so only the draw instance count grows — which GPUs handle
+// into the hundreds of millions (OVITO-class). 200M is comfortably above
+// 100M-atom visualization while still catching absurd input. Frame rate may
+// drop near the top (fill rate), but it degrades gracefully — it never freezes.
+export const GPU_SUPERCELL_MAX_INSTANCES = 200_000_000
 
 // Product of the [nx,ny,nz] factors parsed from a scaling input = number of
 // cells. Returns 1 (no supercell) for malformed input so callers can treat a

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -170,6 +170,32 @@ export function make_supercell(
   } as SupercellType
 }
 
+// Threshold (in number of cells = nx·ny·nz) beyond which a CPU-side supercell
+// build (WASM `create_supercell` / TS `make_supercell`) is considered too large
+// to expand without freezing the main thread. When the WebGPU large-system
+// overlay is OFF and a requested factor exceeds this, the UI warns / guards
+// instead of building. With the overlay ON the build is skipped entirely (GPU
+// instances the base cell), so this threshold does NOT apply.
+export const CPU_SUPERCELL_CELL_WARN_THRESHOLD = 64
+
+// Soft cap on the EFFECTIVE GPU instance count (base atom count × number of
+// cells). Beyond this the GPU instancing path can hang on weaker hardware, so
+// the caller should warn and/or clamp. ~10M instances is a sane ceiling for a
+// single InstancedMesh on current WebGPU.
+export const GPU_SUPERCELL_MAX_INSTANCES = 10_000_000
+
+// Product of the [nx,ny,nz] factors parsed from a scaling input = number of
+// cells. Returns 1 (no supercell) for malformed input so callers can treat a
+// bad string as "no expansion" rather than throwing.
+export function supercell_cell_count(scaling: string | number | Vec3): number {
+  try {
+    const [nx, ny, nz] = parse_supercell_scaling(scaling)
+    return nx * ny * nz
+  } catch {
+    return 1
+  }
+}
+
 // Validate supercell input string
 // Takes user input string and returns true if valid, false otherwise
 export function is_valid_supercell_input(input: string): boolean {

--- a/src/lib/structure/trajectory-bond-cache.svelte.ts
+++ b/src/lib/structure/trajectory-bond-cache.svelte.ts
@@ -216,6 +216,13 @@ export function wire_trajectory_bond_cache(
     /** Optional. When the positions-version bump represents an edit-all
      *  fan-out, drop EVERY frame's bond cache rather than just `idx`. */
     get_positions_invalidate_all?: () => boolean
+    /** Optional. When true (WebGPU large-system overlay active), the WebGL
+     *  path is idle and the overlay computes its own GPU bonds — so the
+     *  per-frame async bond recompute here is wasted work. The driver effect
+     *  early-returns while suspended. Read reactively, so flipping back to
+     *  false re-fires the effect and re-primes the current frame's bonds
+     *  (cache may be stale: frames advanced under suspension were skipped). */
+    get_suspended?: () => boolean
   },
 ): void {
   // Reset cache on actual value changes (not parent-render proxy churn).
@@ -295,14 +302,49 @@ export function wire_trajectory_bond_cache(
   // bond-worker request, which spreads again, and Svelte 5's flush
   // overflow guard kicks in.
   let last_pos_version = -1
+  let was_suspended = false
   $effect(() => {
     const idx = deps.get_step_idx()
     const pv = deps.get_positions_version?.() ?? 0
-    if (idx < 0) return
+    // Read suspend reactively so toggle-OFF (true→false) re-fires this effect.
+    const suspended = deps.get_suspended?.() ?? false
+    if (idx < 0) {
+      was_suspended = suspended
+      return
+    }
+    if (suspended) {
+      // WebGPU overlay active: do NO per-frame bond compute. Keep the trackers
+      // in sync with the frames that advanced under the overlay so we don't
+      // replay stale work on resume; the resume branch below recomputes the
+      // landing frame. Read getter/base etc. is unnecessary here.
+      was_suspended = true
+      untrack(() => {
+        last_idx = idx
+        last_pos_version = pv
+      })
+      return
+    }
+    const resuming = was_suspended
+    was_suspended = false
     const idx_moved = idx !== last_idx
     const pos_changed = pv !== last_pos_version
-    if (!idx_moved && !pos_changed) return
+    // On resume the frame may not have moved since we last tracked it (we kept
+    // last_idx synced while suspended), so the normal guard would skip and the
+    // current frame's bonds would be stale/absent. Force a recompute on resume.
+    if (!idx_moved && !pos_changed && !resuming) return
     untrack(() => {
+      if (resuming && !idx_moved && !pos_changed) {
+        // Pure resume on a settled frame: re-prime just the current frame
+        // (and neighbours) so the WebGL bonds are correct for what's onscreen.
+        const getter = deps.get_positions()
+        const base = deps.get_base()
+        if (!getter || !base) return
+        last_idx = idx
+        last_pos_version = pv
+        cache.invalidate(idx)
+        cache.on_frame_change(idx, getter, base, deps.get_strategy(), deps.get_options())
+        return
+      }
       const getter = deps.get_positions()
       const base = deps.get_base()
       if (!getter || !base) return

--- a/tests/vitest/structure/gpu/bond-compute-pack.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute-pack.test.ts
@@ -13,10 +13,11 @@ const make_run = (over: Partial<BondComputeRun> = {}): BondComputeRun => ({
 })
 
 describe(`pack_params`, () => {
-  it(`PARAMS_BYTES is 80 and the buffer is 80 bytes`, () => {
-    expect(PARAMS_BYTES).toBe(80)
+  it(`PARAMS_BYTES is 128 and the buffer is 128 bytes`, () => {
+    // 80 bytes (header + transposed lattice) + 48 bytes uniform-grid block.
+    expect(PARAMS_BYTES).toBe(128)
     const buf = pack_params(3, 1024, make_run())
-    expect(buf.byteLength).toBe(80)
+    expect(buf.byteLength).toBe(128)
   })
 
   it(`u32 header lands at word offsets 0..3`, () => {
@@ -62,6 +63,29 @@ describe(`pack_params`, () => {
     expect(dv.getFloat32(32, true)).toBe(1) // column0.x at byte 32
     expect(dv.getFloat32(48, true)).toBe(4) // column1.x at byte 48
     expect(dv.getFloat32(64, true)).toBe(7) // column2.x at byte 64
+  })
+
+  it(`grid block (words 20..28) defaults to use_grid 0 when no plan passed`, () => {
+    const u32 = new Uint32Array(pack_params(1, 8, make_run()))
+    expect(u32[23]).toBe(0) // use_grid = 0 ⇒ shader takes the O(N²) fallback
+  })
+
+  it(`packs the uniform-grid plan into words 20..28`, () => {
+    const buf = pack_params(1, 8, make_run({ periodic: false }), {
+      use_grid: true,
+      dims: [4, 5, 6],
+      n_cells: 120,
+      aabb_min: [-1, 2, -3],
+      inv_h: 0.5,
+      max_per_cell: 64,
+    })
+    const u32 = new Uint32Array(buf)
+    const f32 = new Float32Array(buf)
+    expect([u32[20], u32[21], u32[22]]).toEqual([4, 5, 6]) // grid_dims
+    expect(u32[23]).toBe(1) // use_grid
+    expect([f32[24], f32[25], f32[26]]).toEqual([-1, 2, -3]) // aabb_min
+    expect(u32[27]).toBe(64) // max_per_cell
+    expect(f32[28]).toBeCloseTo(0.5, 6) // inv_h
   })
 })
 

--- a/tests/vitest/structure/gpu/bond-compute-pack.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute-pack.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { pack_params, unpack_jimage, PARAMS_BYTES, type BondComputeRun } from '$lib/structure/gpu/bond-compute'
+
+const make_run = (over: Partial<BondComputeRun> = {}): BondComputeRun => ({
+  tolerance: 0.45,
+  max_bond_dist: 3,
+  min_dist: 0.1,
+  positions: new Float32Array([0, 0, 0]),
+  radii: new Float32Array([0.76]),
+  lattice: new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+  periodic: true,
+  ...over,
+})
+
+describe(`pack_params`, () => {
+  it(`PARAMS_BYTES is 80 and the buffer is 80 bytes`, () => {
+    expect(PARAMS_BYTES).toBe(80)
+    const buf = pack_params(3, 1024, make_run())
+    expect(buf.byteLength).toBe(80)
+  })
+
+  it(`u32 header lands at word offsets 0..3`, () => {
+    const buf = pack_params(7, 1024, make_run({ periodic: true }))
+    const u32 = new Uint32Array(buf)
+    expect(u32[0]).toBe(7) // n
+    expect(u32[1]).toBe(1024) // capacity
+    expect(u32[2]).toBe(1) // periodic
+    expect(u32[3]).toBe(0) // _pad0
+  })
+
+  it(`periodic=false packs 0`, () => {
+    const u32 = new Uint32Array(pack_params(1, 8, make_run({ periodic: false })))
+    expect(u32[2]).toBe(0)
+  })
+
+  it(`f32 scalars land at word offsets 4..7`, () => {
+    const buf = pack_params(1, 8, make_run({ tolerance: 0.45, max_bond_dist: 3, min_dist: 0.1 }))
+    const f32 = new Float32Array(buf)
+    expect(f32[4]).toBeCloseTo(0.45, 6) // tolerance
+    expect(f32[5]).toBeCloseTo(3, 6) // max_bond_dist
+    expect(f32[6]).toBeCloseTo(0.1, 6) // min_dist
+    expect(f32[7]).toBe(0) // _pad1
+  })
+
+  it(`TRANSPOSES the lattice: WGSL column k = row-major row k, pads are 0`, () => {
+    // rows a=(1,2,3), b=(4,5,6), c=(7,8,9)
+    const lattice = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const f32 = new Float32Array(pack_params(1, 8, make_run({ lattice })))
+    // column 0 = row a at f32 8..10
+    expect([f32[8], f32[9], f32[10]]).toEqual([1, 2, 3])
+    // column 1 = row b at f32 12..14
+    expect([f32[12], f32[13], f32[14]]).toEqual([4, 5, 6])
+    // column 2 = row c at f32 16..18
+    expect([f32[16], f32[17], f32[18]]).toEqual([7, 8, 9])
+    // mat3x3 column pads (f32 11, 15, 19) are 0
+    expect([f32[11], f32[15], f32[19]]).toEqual([0, 0, 0])
+  })
+
+  it(`reads back transposed lattice via DataView little-endian`, () => {
+    const lattice = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const dv = new DataView(pack_params(1, 8, make_run({ lattice })))
+    expect(dv.getFloat32(32, true)).toBe(1) // column0.x at byte 32
+    expect(dv.getFloat32(48, true)).toBe(4) // column1.x at byte 48
+    expect(dv.getFloat32(64, true)).toBe(7) // column2.x at byte 64
+  })
+})
+
+describe(`unpack_jimage`, () => {
+  it(`round-trips every (na,nb,nc) in {-1,0,1}^3`, () => {
+    for (let na = -1; na <= 1; na++) {
+      for (let nb = -1; nb <= 1; nb++) {
+        for (let nc = -1; nc <= 1; nc++) {
+          const packed = (na + 1) | ((nb + 1) << 2) | ((nc + 1) << 4)
+          expect(unpack_jimage(packed)).toEqual([na, nb, nc])
+        }
+      }
+    }
+  })
+
+  it(`[0,0,0] packs to 0b010101 = 21`, () => {
+    expect(unpack_jimage(21)).toEqual([0, 0, 0])
+  })
+})

--- a/tests/vitest/structure/gpu/bond-compute.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { acquire_webgpu_device } from '$lib/structure/gpu/webgpu-context'
+import { create_bond_compute } from '$lib/structure/gpu/bond-compute'
+import { detect_bonds_reference } from '$lib/structure/gpu/bond-detect-reference'
+
+let device: GPUDevice | null = null
+beforeAll(async () => { device = await acquire_webgpu_device() })
+const pair_set = (bonds: { a: number; b: number }[]) =>
+  new Set(bonds.map((b) => `${Math.min(b.a, b.b)}-${Math.max(b.a, b.b)}`))
+
+describe.skipIf(!globalThis.navigator?.gpu)(`bond-compute (GPU)`, () => {
+  it(`matches the JS reference on a small periodic cell`, async () => {
+    if (!device) return
+    const positions = new Float32Array([0.2, 0, 0, 4.9, 0, 0, 0.2, 1.2, 0])
+    const radii = new Float32Array([0.76, 0.76, 0.76])
+    const lattice = new Float32Array([5, 0, 0, 0, 5, 0, 0, 0, 5])
+    const opts = { tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 }
+    const ref = detect_bonds_reference(positions, lattice, radii, opts)
+    const compute = create_bond_compute(device, { capacity: 1024 })
+    const gpu = await compute.run({ positions, radii, lattice, periodic: true, ...opts })
+    expect(gpu.count).toBe(ref.length)
+    expect(pair_set(gpu.pairs)).toEqual(pair_set(ref))
+  })
+})

--- a/tests/vitest/structure/gpu/bond-compute.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute.test.ts
@@ -9,8 +9,10 @@ const pair_set = (bonds: { a: number; b: number }[]) =>
   new Set(bonds.map((b) => `${Math.min(b.a, b.b)}-${Math.max(b.a, b.b)}`))
 
 describe.skipIf(!globalThis.navigator?.gpu)(`bond-compute (GPU)`, () => {
-  it(`matches the JS reference on a small periodic cell`, async () => {
+  it(`matches the JS reference on a small periodic cell (O(N²) fallback path)`, async () => {
     if (!device) return
+    // 5 Å cell with max_bond_dist 3 ⇒ floor(5/3)=1 grid dim < 3 ⇒ use_grid=false ⇒
+    // the shader takes the exact O(N²) 27-image fallback. Exercises that path.
     const positions = new Float32Array([0.2, 0, 0, 4.9, 0, 0, 0.2, 1.2, 0])
     const radii = new Float32Array([0.76, 0.76, 0.76])
     const lattice = new Float32Array([5, 0, 0, 0, 5, 0, 0, 0, 5])
@@ -21,5 +23,57 @@ describe.skipIf(!globalThis.navigator?.gpu)(`bond-compute (GPU)`, () => {
     expect(gpu.count).toBe(ref.length)
     expect(pair_set(gpu.pairs)).toEqual(pair_set(ref))
     expect(gpu.overflowed).toBe(false)
+  })
+
+  it(`matches the JS reference on a MEDIUM periodic cell (uniform-grid path)`, async () => {
+    if (!device) return
+    // An 11.2 Å cubic cell with max_bond_dist 3 ⇒ floor(11.2/3)=3 grid dims (≥3) ⇒
+    // use_grid=true: the candidate search runs through the cell-list. Fill it with
+    // a 4×4×4 simple-cubic lattice of carbons at 2.8 Å spacing so nearest neighbors
+    // (2.8 Å) sit comfortably inside the 3 Å cutoff (no float-boundary ties) and
+    // bond across grid cells + PBC faces.
+    const lat = 11.2
+    const lattice = new Float32Array([lat, 0, 0, 0, lat, 0, 0, 0, lat])
+    const opts = { tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 }
+    const coords: number[] = []
+    const radii_arr: number[] = []
+    for (let i = 0; i < 4; i++)
+      for (let j = 0; j < 4; j++)
+        for (let k = 0; k < 4; k++) {
+          coords.push(i * 2.8 + 0.05, j * 2.8 + 0.05, k * 2.8 + 0.05)
+          radii_arr.push(0.76)
+        }
+    const positions = new Float32Array(coords)
+    const radii = new Float32Array(radii_arr)
+    const ref = detect_bonds_reference(positions, lattice, radii, opts)
+    const compute = create_bond_compute(device, { capacity: 65536 })
+    const gpu = await compute.run({ positions, radii, lattice, periodic: true, ...opts })
+    expect(gpu.overflowed).toBe(false)
+    expect(gpu.count).toBe(ref.length)
+    expect(pair_set(gpu.pairs)).toEqual(pair_set(ref))
+  })
+
+  it(`matches the JS reference on a NON-PERIODIC cluster (AABB grid path)`, async () => {
+    if (!device) return
+    // Non-periodic always grids (over the atom AABB). A 3×3×3 cubic blob of atoms
+    // at 2.4 Å spacing, jittered, so neighbors bond across AABB cells.
+    const opts = { tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 }
+    const coords: number[] = []
+    const radii_arr: number[] = []
+    for (let i = 0; i < 3; i++)
+      for (let j = 0; j < 3; j++)
+        for (let k = 0; k < 3; k++) {
+          coords.push(i * 2.4 + 0.1, j * 2.4 - 0.05, k * 2.4 + 0.07)
+          radii_arr.push(0.76)
+        }
+    const positions = new Float32Array(coords)
+    const radii = new Float32Array(radii_arr)
+    const zero = new Float32Array(9) // non-periodic ⇒ all-zero lattice in the ref
+    const ref = detect_bonds_reference(positions, zero, radii, opts)
+    const compute = create_bond_compute(device, { capacity: 65536 })
+    const gpu = await compute.run({ positions, radii, lattice: zero, periodic: false, ...opts })
+    expect(gpu.overflowed).toBe(false)
+    expect(gpu.count).toBe(ref.length)
+    expect(pair_set(gpu.pairs)).toEqual(pair_set(ref))
   })
 })

--- a/tests/vitest/structure/gpu/bond-compute.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute.test.ts
@@ -20,5 +20,6 @@ describe.skipIf(!globalThis.navigator?.gpu)(`bond-compute (GPU)`, () => {
     const gpu = await compute.run({ positions, radii, lattice, periodic: true, ...opts })
     expect(gpu.count).toBe(ref.length)
     expect(pair_set(gpu.pairs)).toEqual(pair_set(ref))
+    expect(gpu.overflowed).toBe(false)
   })
 })

--- a/tests/vitest/structure/gpu/bond-compute.wgsl.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute.wgsl.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { BOND_COMPUTE_WGSL } from '$lib/structure/gpu/bond-compute.wgsl'
+
+describe('BOND_COMPUTE_WGSL', () => {
+  it('is a non-empty WGSL string with the expected entry points', () => {
+    expect(typeof BOND_COMPUTE_WGSL).toBe('string')
+    expect(BOND_COMPUTE_WGSL).toContain('@compute')
+    expect(BOND_COMPUTE_WGSL).toContain('fn detect_bonds')
+    expect(BOND_COMPUTE_WGSL).toContain('atomicAdd')
+  })
+})

--- a/tests/vitest/structure/gpu/bond-compute.wgsl.test.ts
+++ b/tests/vitest/structure/gpu/bond-compute.wgsl.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { BOND_COMPUTE_WGSL } from '$lib/structure/gpu/bond-compute.wgsl'
 
-describe('BOND_COMPUTE_WGSL', () => {
-  it('is a non-empty WGSL string with the expected entry points', () => {
-    expect(typeof BOND_COMPUTE_WGSL).toBe('string')
-    expect(BOND_COMPUTE_WGSL).toContain('@compute')
-    expect(BOND_COMPUTE_WGSL).toContain('fn detect_bonds')
-    expect(BOND_COMPUTE_WGSL).toContain('atomicAdd')
+describe(`BOND_COMPUTE_WGSL`, () => {
+  it(`is a non-empty WGSL string with the expected entry points`, () => {
+    expect(typeof BOND_COMPUTE_WGSL).toBe(`string`)
+    expect(BOND_COMPUTE_WGSL).toContain(`@compute`)
+    expect(BOND_COMPUTE_WGSL).toContain(`fn detect_bonds`)
+    expect(BOND_COMPUTE_WGSL).toContain(`atomicAdd`)
   })
 })

--- a/tests/vitest/structure/gpu/bond-detect-reference.test.ts
+++ b/tests/vitest/structure/gpu/bond-detect-reference.test.ts
@@ -40,6 +40,8 @@ describe(`detect_bonds_reference`, () => {
     // b at 4.9, a at 0.2: dx = b-a = 4.7; shifting b by -a (na=-1 -> -5) gives
     // displacement -0.3, the shortest. So jimage = [-1,0,0].
     expect(bonds[0].jimage).toEqual([-1, 0, 0])
+    // Lock the minimum-image distance the WGSL shader must reproduce: 5 - 4.7 = 0.3 Å.
+    expect(bonds[0].dist).toBeCloseTo(0.3)
   })
 
   it(`drops coincident atoms (below min_dist)`, () => {
@@ -65,6 +67,10 @@ describe(`detect_bonds_reference`, () => {
       { tolerance: 0.45, max_bond_dist: 3, min_dist: 0.1 },
     )
 
+    // NOTE: the lower bound (min_dist) is NOT parity-checked here. The JS side
+    // passes min_dist: 0.1 while compute_bonds_sync uses Rust's default (0.4),
+    // and this fixture has no pair landing in the (0.1, 0.4) gap, so the
+    // divergence is invisible to this cross-check.
     const key = (a: number, b: number) => `${Math.min(a, b)}-${Math.max(a, b)}`
     const cpu_set = new Set(cpu.map((b) => key(b.site_idx_1, b.site_idx_2)))
     const ref_set = new Set(ref.map((b) => key(b.a, b.b)))

--- a/tests/vitest/structure/gpu/bond-detect-reference.test.ts
+++ b/tests/vitest/structure/gpu/bond-detect-reference.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { detect_bonds_reference, type RefBondOptions } from '$lib/structure/gpu/bond-detect-reference'
+import { compute_bonds_sync } from '$lib/structure/workers/bond-worker-api'
+import { pack_positions, pack_lattice } from '$lib/structure/gpu/frame-buffers'
+import { build_atom_radii } from '$lib/structure/gpu/radius-lut'
+import type { PymatgenStructure } from '$lib/structure'
+
+const OPTS: RefBondOptions = { tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 }
+
+describe(`detect_bonds_reference`, () => {
+  it(`finds a single bond between two close atoms (non-periodic)`, () => {
+    const pos = new Float32Array([0, 0, 0, 1.0, 0, 0])
+    const radii = new Float32Array([0.76, 0.76])
+    const bonds = detect_bonds_reference(pos, new Float32Array(9), radii, OPTS)
+    expect(bonds).toHaveLength(1)
+    expect(bonds[0]).toMatchObject({ a: 0, b: 1, jimage: [0, 0, 0] })
+  })
+
+  it(`rejects atoms beyond radius sum + tolerance`, () => {
+    const pos = new Float32Array([0, 0, 0, 2.5, 0, 0])
+    const radii = new Float32Array([0.76, 0.76])
+    expect(detect_bonds_reference(pos, new Float32Array(9), radii, OPTS)).toHaveLength(0)
+  })
+
+  it(`rejects beyond max_bond_dist even if within radius sum`, () => {
+    const pos = new Float32Array([0, 0, 0, 2.9, 0, 0])
+    const radii = new Float32Array([2.0, 2.0])
+    const opts = { ...OPTS, max_bond_dist: 2.0 }
+    expect(detect_bonds_reference(pos, new Float32Array(9), radii, opts)).toHaveLength(0)
+  })
+
+  it(`finds a minimum-image bond across a periodic boundary`, () => {
+    // cubic 5 Å cell; x=0.2 and x=4.9 are 4.7 apart direct, 0.3 across boundary
+    const pos = new Float32Array([0.2, 0, 0, 4.9, 0, 0])
+    const radii = new Float32Array([0.76, 0.76])
+    const lat = new Float32Array([5, 0, 0, 0, 5, 0, 0, 0, 5])
+    const bonds = detect_bonds_reference(pos, lat, radii, OPTS)
+    expect(bonds).toHaveLength(1)
+    // Convention: jimage applied to b (b + jimage·L) reaches the min image of a.
+    // b at 4.9, a at 0.2: dx = b-a = 4.7; shifting b by -a (na=-1 -> -5) gives
+    // displacement -0.3, the shortest. So jimage = [-1,0,0].
+    expect(bonds[0].jimage).toEqual([-1, 0, 0])
+  })
+
+  it(`drops coincident atoms (below min_dist)`, () => {
+    const pos = new Float32Array([0, 0, 0, 0.01, 0, 0])
+    const radii = new Float32Array([0.76, 0.76])
+    expect(detect_bonds_reference(pos, new Float32Array(9), radii, OPTS)).toHaveLength(0)
+  })
+
+  it(`matches the production CPU detector on a small periodic structure (oracle cross-check)`, () => {
+    // Cubic 6 Å cell with a few common (C/H/O/N) atoms so build_atom_radii's
+    // 1.0 Å fallback never triggers (which would diverge from the CPU path).
+    const struct = make_test_structure()
+
+    const cpu = compute_bonds_sync(struct, `atom_radii`, { max_bond_dist: 3, tolerance: 0.45 })
+    // compute_bonds_sync returns null when Rust WASM is not initialized in the
+    // vitest env. Skip the comparison but keep the test in place.
+    if (cpu == null) return
+
+    const ref = detect_bonds_reference(
+      pack_positions(struct.sites),
+      pack_lattice(struct.lattice),
+      build_atom_radii(struct.sites),
+      { tolerance: 0.45, max_bond_dist: 3, min_dist: 0.1 },
+    )
+
+    const key = (a: number, b: number) => `${Math.min(a, b)}-${Math.max(a, b)}`
+    const cpu_set = new Set(cpu.map((b) => key(b.site_idx_1, b.site_idx_2)))
+    const ref_set = new Set(ref.map((b) => key(b.a, b.b)))
+
+    expect([...ref_set].sort()).toEqual([...cpu_set].sort())
+  })
+})
+
+function make_test_structure(): PymatgenStructure {
+  const a = 6
+  const matrix: [[number, number, number], [number, number, number], [number, number, number]] = [
+    [a, 0, 0],
+    [0, a, 0],
+    [0, 0, a],
+  ]
+  // A small molecule-like cluster (C, O, two H, N) with realistic bond lengths.
+  const coords: Array<{ el: string; xyz: [number, number, number] }> = [
+    { el: `C`, xyz: [1.0, 1.0, 1.0] },
+    { el: `O`, xyz: [2.2, 1.0, 1.0] }, // C-O ~1.2
+    { el: `H`, xyz: [1.0, 2.0, 1.0] }, // C-H ~1.0 (close to C)
+    { el: `N`, xyz: [1.0, 1.0, 2.45] }, // C-N ~1.45
+  ]
+  const sites = coords.map(({ el, xyz }) => ({
+    species: [{ element: el as never, occu: 1 }],
+    abc: [xyz[0] / a, xyz[1] / a, xyz[2] / a] as [number, number, number],
+    xyz,
+    label: el,
+    properties: {},
+  }))
+  return {
+    lattice: {
+      matrix,
+      pbc: [true, true, true],
+      volume: a * a * a,
+      a,
+      b: a,
+      c: a,
+      alpha: 90,
+      beta: 90,
+      gamma: 90,
+    },
+    sites,
+  } as PymatgenStructure
+}

--- a/tests/vitest/structure/gpu/bond-grid.test.ts
+++ b/tests/vitest/structure/gpu/bond-grid.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_PER_CELL,
+  MIN_GRID_DIM,
+  periodic_grid_dims,
+  compute_aabb,
+  aabb_grid_dims,
+  plan_grid,
+} from '$lib/structure/gpu/bond-grid'
+
+const ortho = (a: number, b: number, c: number) =>
+  new Float32Array([a, 0, 0, 0, b, 0, 0, 0, c])
+
+describe(`periodic_grid_dims`, () => {
+  it(`dim = floor(|v| / h) per axis`, () => {
+    // 12 / 3 = 4; 9 / 3 = 3; 30 / 3 = 10
+    expect(periodic_grid_dims(ortho(12, 9, 30), 3)).toEqual([4, 3, 10])
+  })
+
+  it(`clamps each dim to at least 1`, () => {
+    // 2 / 3 = 0.66 → floor 0 → clamped to 1
+    expect(periodic_grid_dims(ortho(2, 2, 2), 3)).toEqual([1, 1, 1])
+  })
+
+  it(`uses lattice VECTOR LENGTHS (works for non-orthogonal rows)`, () => {
+    // row a = (3,4,0) ⇒ |a| = 5 ⇒ 5/2.5 = 2; row b = (0,10,0) ⇒ 10/2.5 = 4;
+    // row c = (0,0,10) ⇒ 4.
+    const lat = new Float32Array([3, 4, 0, 0, 10, 0, 0, 0, 10])
+    expect(periodic_grid_dims(lat, 2.5)).toEqual([2, 4, 4])
+  })
+
+  it(`h <= 0 collapses to all-ones`, () => {
+    expect(periodic_grid_dims(ortho(12, 12, 12), 0)).toEqual([1, 1, 1])
+  })
+})
+
+describe(`compute_aabb`, () => {
+  it(`finds the min/max corner over interleaved xyz`, () => {
+    const p = new Float32Array([1, 2, 3, -4, 5, -6, 0, 0, 9])
+    const { min, max } = compute_aabb(p, 3)
+    expect(min).toEqual([-4, 0, -6])
+    expect(max).toEqual([1, 5, 9])
+  })
+
+  it(`n = 0 returns a zero box`, () => {
+    expect(compute_aabb(new Float32Array(0), 0)).toEqual({
+      min: [0, 0, 0],
+      max: [0, 0, 0],
+    })
+  })
+})
+
+describe(`aabb_grid_dims`, () => {
+  it(`dim = ceil(extent / h), at least 1`, () => {
+    // extents 10,3,0 with h=3 ⇒ ceil(10/3)=4, ceil(3/3)=1, ceil(0/3)=0→1
+    expect(aabb_grid_dims([0, 0, 0], [10, 3, 0], 3)).toEqual([4, 1, 1])
+  })
+})
+
+describe(`plan_grid`, () => {
+  it(`periodic large cell ⇒ use_grid true, dims ≥ ${MIN_GRID_DIM}`, () => {
+    const plan = plan_grid({
+      periodic: true,
+      lattice: ortho(12, 12, 12),
+      max_bond_dist: 3,
+      positions: new Float32Array(0),
+      n: 0,
+    })
+    expect(plan.use_grid).toBe(true)
+    expect(plan.dims).toEqual([4, 4, 4])
+    expect(plan.n_cells).toBe(64)
+    expect(plan.aabb_min).toEqual([0, 0, 0])
+    expect(plan.max_per_cell).toBe(MAX_PER_CELL)
+    expect(plan.inv_h).toBeCloseTo(1 / 3, 6)
+  })
+
+  it(`periodic SMALL cell (any dim < 3) ⇒ use_grid false (O(N²) fallback)`, () => {
+    // 12 / 3 = 4, but 5 / 3 = 1 < 3 ⇒ fall back.
+    const plan = plan_grid({
+      periodic: true,
+      lattice: ortho(12, 5, 12),
+      max_bond_dist: 3,
+      positions: new Float32Array(0),
+      n: 0,
+    })
+    expect(plan.use_grid).toBe(false)
+    expect(plan.dims).toEqual([4, 1, 4])
+  })
+
+  it(`non-periodic ⇒ use_grid always true, dims from AABB`, () => {
+    // atoms span x:[0,9], y:[0,0], z:[0,6]; h=3 ⇒ ceil(9/3)=3, 1, ceil(6/3)=2.
+    const positions = new Float32Array([0, 0, 0, 9, 0, 6])
+    const plan = plan_grid({
+      periodic: false,
+      lattice: new Float32Array(9),
+      max_bond_dist: 3,
+      positions,
+      n: 2,
+    })
+    expect(plan.use_grid).toBe(true)
+    expect(plan.dims).toEqual([3, 1, 2])
+    expect(plan.n_cells).toBe(6)
+    expect(plan.aabb_min).toEqual([0, 0, 0])
+  })
+})

--- a/tests/vitest/structure/gpu/bond-rules.test.ts
+++ b/tests/vitest/structure/gpu/bond-rules.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { encode_bond_rules, type BondDistanceRuleLike } from '$lib/structure/gpu/bond-rules'
+import type { Site } from '$lib/structure'
+
+// Minimal Site factory: only species[0].element is read by encode_bond_rules.
+const site = (element: string): Site =>
+  ({ species: [{ element, occu: 1, oxidation_state: 0 }], xyz: [0, 0, 0], abc: [0, 0, 0], label: element }) as unknown as Site
+
+describe(`encode_bond_rules`, () => {
+  it(`no rules ⇒ rule_count 0 and an empty rules buffer (no filtering)`, () => {
+    const out = encode_bond_rules([site(`Ti`), site(`O`)], [])
+    expect(out.rule_count).toBe(0)
+    expect(out.rules.length).toBe(0)
+    // One element id per site.
+    expect(out.elem_ids.length).toBe(2)
+  })
+
+  it(`per-atom ids share the mapping with the rule ids`, () => {
+    const sites = [site(`Ti`), site(`O`), site(`Ti`)]
+    const rules: BondDistanceRuleLike[] = [
+      { element_1: `O`, element_2: `Ti`, min_dist: 1.5, max_dist: 2.2 },
+    ]
+    const out = encode_bond_rules(sites, rules)
+    // Ti and O each get a stable id; the two Ti sites share one id.
+    expect(out.elem_ids[0]).toBe(out.elem_ids[2]) // both Ti
+    expect(out.elem_ids[0]).not.toBe(out.elem_ids[1]) // Ti != O
+    expect(out.rule_count).toBe(1)
+    // Rule pair is SORTED (id_a ≤ id_b), matching [e1,e2].sort() in visibility.ts.
+    const id_a = out.rules[0]
+    const id_b = out.rules[1]
+    expect(id_a).toBeLessThanOrEqual(id_b)
+    // The two rule ids are exactly the Ti and O atom ids (order-independent).
+    const ti = out.elem_ids[0]
+    const o = out.elem_ids[1]
+    expect(new Set([id_a, id_b])).toEqual(new Set([ti, o]))
+    // min/max preserved.
+    expect(out.rules[2]).toBeCloseTo(1.5, 6)
+    expect(out.rules[3]).toBeCloseTo(2.2, 6)
+  })
+
+  it(`sorts the pair regardless of element_1/element_2 order`, () => {
+    const sites = [site(`Ti`), site(`O`)]
+    const fwd = encode_bond_rules(sites, [
+      { element_1: `Ti`, element_2: `O`, min_dist: 1, max_dist: 2 },
+    ])
+    const rev = encode_bond_rules(sites, [
+      { element_1: `O`, element_2: `Ti`, min_dist: 1, max_dist: 2 },
+    ])
+    // Same site order ⇒ same id mapping ⇒ identical sorted (id_a,id_b).
+    expect([fwd.rules[0], fwd.rules[1]]).toEqual([rev.rules[0], rev.rules[1]])
+    expect(fwd.rules[0]).toBeLessThanOrEqual(fwd.rules[1])
+  })
+
+  it(`a rule element absent from the structure still encodes (just never matches)`, () => {
+    const out = encode_bond_rules([site(`Ti`), site(`O`)], [
+      { element_1: `Fe`, element_2: `O`, min_dist: 1, max_dist: 2 },
+    ])
+    expect(out.rule_count).toBe(1)
+    // Fe gets an id; since no atom carries it, the rule's id pair contains an id
+    // that's NOT among the per-atom ids ⇒ no atom pair ever keys to this rule.
+    const atom_ids = new Set(out.elem_ids)
+    const rule_ids = [out.rules[0], out.rules[1]]
+    expect(rule_ids.some((id) => !atom_ids.has(id))).toBe(true)
+    expect(out.elem_ids.length).toBe(2)
+  })
+})

--- a/tests/vitest/structure/gpu/camera-uniform.test.ts
+++ b/tests/vitest/structure/gpu/camera-uniform.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { PerspectiveCamera, Matrix4 } from 'three'
-import { pack_camera_uniform } from '$lib/structure/gpu/camera-uniform'
+import { pack_camera_uniform, pack_camera_full } from '$lib/structure/gpu/camera-uniform'
 
 describe(`pack_camera_uniform`, () => {
   it(`packs proj*view (16 floats) then camera world position (vec3 + pad) = 20 floats`, () => {
@@ -27,5 +27,37 @@ describe(`pack_camera_uniform`, () => {
     // recompute expected with three (column-major .elements)
     const vp = new Matrix4().multiplyMatrices(cam.projectionMatrix, cam.matrixWorldInverse)
     for (let i = 0; i < 16; i++) expect(out[i]).toBeCloseTo(vp.elements[i])
+  })
+})
+
+describe(`pack_camera_full`, () => {
+  it(`packs view (16) + proj (16) + cam_pos (vec3 + pad) = 36 floats`, () => {
+    const cam = new PerspectiveCamera(50, 1.5, 0.1, 1000)
+    cam.position.set(1, 2, 3)
+    cam.updateMatrixWorld(true)
+    const out = pack_camera_full(cam)
+    expect(out).toBeInstanceOf(Float32Array)
+    expect(out.length).toBe(36)
+    // view block == matrixWorldInverse.elements (column-major)
+    for (let i = 0; i < 16; i++) expect(out[i]).toBeCloseTo(cam.matrixWorldInverse.elements[i])
+    // proj block == projectionMatrix.elements
+    for (let i = 0; i < 16; i++) expect(out[16 + i]).toBeCloseTo(cam.projectionMatrix.elements[i])
+    // cam_pos
+    expect(out[32]).toBeCloseTo(1)
+    expect(out[33]).toBeCloseTo(2)
+    expect(out[34]).toBeCloseTo(3)
+    expect(out[35]).toBe(0) // pad
+  })
+
+  it(`view and proj blocks are distinct (not the multiplied product)`, () => {
+    const cam = new PerspectiveCamera(60, 2, 0.5, 500)
+    cam.position.set(0, 0, 8)
+    cam.updateMatrixWorld(true)
+    const out = pack_camera_full(cam)
+    const vp = new Matrix4().multiplyMatrices(cam.projectionMatrix, cam.matrixWorldInverse)
+    // the separated view block should NOT equal the combined proj*view product
+    let differs = false
+    for (let i = 0; i < 16; i++) if (Math.abs(out[i] - vp.elements[i]) > 1e-4) differs = true
+    expect(differs).toBe(true)
   })
 })

--- a/tests/vitest/structure/gpu/camera-uniform.test.ts
+++ b/tests/vitest/structure/gpu/camera-uniform.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { PerspectiveCamera, Matrix4 } from 'three'
+import { pack_camera_uniform } from '$lib/structure/gpu/camera-uniform'
+
+describe(`pack_camera_uniform`, () => {
+  it(`packs proj*view (16 floats) then camera world position (vec3 + pad) = 20 floats`, () => {
+    const cam = new PerspectiveCamera(50, 1.5, 0.1, 1000)
+    cam.position.set(1, 2, 3)
+    cam.updateMatrixWorld(true) // refreshes matrixWorldInverse
+    const out = pack_camera_uniform(cam)
+    expect(out).toBeInstanceOf(Float32Array)
+    expect(out.length).toBe(20)
+    // last vec3 = camera world position
+    expect(out[16]).toBeCloseTo(1)
+    expect(out[17]).toBeCloseTo(2)
+    expect(out[18]).toBeCloseTo(3)
+    expect(out[19]).toBe(0) // pad
+    // all matrix entries finite
+    for (let i = 0; i < 16; i++) expect(Number.isFinite(out[i])).toBe(true)
+  })
+
+  it(`first 16 floats equal projectionMatrix * matrixWorldInverse (column-major)`, () => {
+    const cam = new PerspectiveCamera(50, 1.5, 0.1, 1000)
+    cam.position.set(5, 0, 10)
+    cam.updateMatrixWorld(true)
+    const out = pack_camera_uniform(cam)
+    // recompute expected with three (column-major .elements)
+    const vp = new Matrix4().multiplyMatrices(cam.projectionMatrix, cam.matrixWorldInverse)
+    for (let i = 0; i < 16; i++) expect(out[i]).toBeCloseTo(vp.elements[i])
+  })
+})

--- a/tests/vitest/structure/gpu/frame-buffers.test.ts
+++ b/tests/vitest/structure/gpu/frame-buffers.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { pack_positions, pack_lattice } from '$lib/structure/gpu/frame-buffers'
+import type { Site, PymatgenLattice } from '$lib/structure'
+
+function site(xyz: [number, number, number]): Site {
+  return { species: [{ element: 'C', occu: 1 } as never], abc: [0, 0, 0], xyz } as Site
+}
+
+describe('pack_positions', () => {
+  it('packs site xyz into a flat Float32Array(3N)', () => {
+    const out = pack_positions([site([1, 2, 3]), site([4, 5, 6])])
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6])
+  })
+  it('returns a raw Float32Array frame unchanged (already 3N)', () => {
+    const frame = new Float32Array([7, 8, 9])
+    expect(pack_positions(frame)).toBe(frame)
+  })
+})
+
+describe('pack_lattice', () => {
+  it('flattens a 3x3 lattice matrix row-major into Float32Array(9)', () => {
+    const lat: PymatgenLattice = { matrix: [[1, 0, 0], [0, 2, 0], [0, 0, 3]] } as PymatgenLattice
+    expect(Array.from(pack_lattice(lat))).toEqual([1, 0, 0, 0, 2, 0, 0, 0, 3])
+  })
+  it('returns a zero matrix for a non-periodic (no-lattice) structure', () => {
+    expect(Array.from(pack_lattice(undefined))).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0])
+  })
+})

--- a/tests/vitest/structure/gpu/frame-buffers.test.ts
+++ b/tests/vitest/structure/gpu/frame-buffers.test.ts
@@ -3,26 +3,26 @@ import { pack_positions, pack_lattice } from '$lib/structure/gpu/frame-buffers'
 import type { Site, PymatgenLattice } from '$lib/structure'
 
 function site(xyz: [number, number, number]): Site {
-  return { species: [{ element: 'C', occu: 1 } as never], abc: [0, 0, 0], xyz } as Site
+  return { species: [{ element: `C`, occu: 1 } as never], abc: [0, 0, 0], xyz } as Site
 }
 
-describe('pack_positions', () => {
-  it('packs site xyz into a flat Float32Array(3N)', () => {
+describe(`pack_positions`, () => {
+  it(`packs site xyz into a flat Float32Array(3N)`, () => {
     const out = pack_positions([site([1, 2, 3]), site([4, 5, 6])])
     expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6])
   })
-  it('returns a raw Float32Array frame unchanged (already 3N)', () => {
+  it(`returns a raw Float32Array frame unchanged (already 3N)`, () => {
     const frame = new Float32Array([7, 8, 9])
     expect(pack_positions(frame)).toBe(frame)
   })
 })
 
-describe('pack_lattice', () => {
-  it('flattens a 3x3 lattice matrix row-major into Float32Array(9)', () => {
+describe(`pack_lattice`, () => {
+  it(`flattens a 3x3 lattice matrix row-major into Float32Array(9)`, () => {
     const lat: PymatgenLattice = { matrix: [[1, 0, 0], [0, 2, 0], [0, 0, 3]] } as PymatgenLattice
     expect(Array.from(pack_lattice(lat))).toEqual([1, 0, 0, 0, 2, 0, 0, 0, 3])
   })
-  it('returns a zero matrix for a non-periodic (no-lattice) structure', () => {
+  it(`returns a zero matrix for a non-periodic (no-lattice) structure`, () => {
     expect(Array.from(pack_lattice(undefined))).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0])
   })
 })

--- a/tests/vitest/structure/gpu/large-system-mode.test.ts
+++ b/tests/vitest/structure/gpu/large-system-mode.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { result_to_connectivity, create_large_system_mode } from '$lib/structure/gpu/large-system-mode.svelte'
+
+describe(`result_to_connectivity`, () => {
+  it(`translates compute pairs into bond_connectivity entries`, () => {
+    const conn = result_to_connectivity({
+      count: 2,
+      raw_count: 2,
+      overflowed: false,
+      pairs: [
+        { a: 0, b: 1, jimage: [0, 0, 0] },
+        { a: 1, b: 2, jimage: [1, 0, 0] },
+      ],
+    })
+    expect(conn).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, strength: 1, jimage: [0, 0, 0] },
+      { site_idx_1: 1, site_idx_2: 2, strength: 1, jimage: [1, 0, 0] },
+    ])
+  })
+  it(`only emits 'count' entries even if pairs array is longer`, () => {
+    const conn = result_to_connectivity({
+      count: 1, raw_count: 5, overflowed: true,
+      pairs: [ { a: 0, b: 1, jimage: [0, 0, 0] }, { a: 2, b: 3, jimage: [0, 0, 0] } ],
+    })
+    expect(conn).toHaveLength(1)
+  })
+})
+
+describe(`create_large_system_mode`, () => {
+  it(`refuses to enable when WebGPU is unavailable and signals fallback`, () => {
+    const on_fallback = vi.fn()
+    const mode = create_large_system_mode({ has_webgpu: false, on_fallback })
+    expect(mode.available).toBe(false)
+    expect(mode.enable()).toBe(false)
+    expect(mode.enabled).toBe(false)
+    expect(on_fallback).toHaveBeenCalledOnce()
+  })
+  it(`enables when WebGPU is available`, () => {
+    const on_fallback = vi.fn()
+    const mode = create_large_system_mode({ has_webgpu: true, on_fallback })
+    expect(mode.enable()).toBe(true)
+    expect(mode.enabled).toBe(true)
+    mode.disable()
+    expect(mode.enabled).toBe(false)
+    expect(on_fallback).not.toHaveBeenCalled()
+  })
+})

--- a/tests/vitest/structure/gpu/large-system-mode.test.ts
+++ b/tests/vitest/structure/gpu/large-system-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { result_to_connectivity, create_large_system_mode } from '$lib/structure/gpu/large-system-mode.svelte'
+import { result_to_connectivity, create_large_system_mode, to_compute_options } from '$lib/structure/gpu/large-system-mode.svelte'
 
 describe(`result_to_connectivity`, () => {
   it(`translates compute pairs into bond_connectivity entries`, () => {
@@ -43,5 +43,18 @@ describe(`create_large_system_mode`, () => {
     mode.disable()
     expect(mode.enabled).toBe(false)
     expect(on_fallback).not.toHaveBeenCalled()
+  })
+})
+
+describe(`to_compute_options`, () => {
+  it(`maps bond options to compute params (custom bond distance)`, () => {
+    expect(to_compute_options({ max_bond_dist: 2.6, tolerance: 0.3 }))
+      .toEqual({ tolerance: 0.3, max_bond_dist: 2.6, min_dist: 0.1 })
+  })
+  it(`fills defaults when options are missing`, () => {
+    expect(to_compute_options({})).toEqual({ tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.1 })
+  })
+  it(`honors a custom min_dist when provided`, () => {
+    expect(to_compute_options({ min_dist: 0.2 })).toEqual({ tolerance: 0.45, max_bond_dist: 3.0, min_dist: 0.2 })
   })
 })

--- a/tests/vitest/structure/gpu/large-system-renderer.test.ts
+++ b/tests/vitest/structure/gpu/large-system-renderer.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { acquire_webgpu_device } from '$lib/structure/gpu/webgpu-context'
+import { create_large_system_renderer } from '$lib/structure/gpu/large-system-renderer'
+
+// Device-gated: SKIPS in node (no navigator.gpu). Runs only where a real
+// WebGPU device is available (e.g. a browser test runner with WebGPU enabled).
+describe.skipIf(!globalThis.navigator?.gpu)(`create_large_system_renderer`, () => {
+  it(`constructs, uploads a camera uniform, renders a clear pass without throwing`, async () => {
+    const device = await acquire_webgpu_device()
+    expect(device).not.toBeNull()
+    if (!device) return
+
+    const canvas = (typeof OffscreenCanvas !== `undefined`
+      ? new OffscreenCanvas(64, 64)
+      : document.createElement(`canvas`)) as unknown as HTMLCanvasElement
+
+    const renderer = create_large_system_renderer(device, canvas)
+    expect(() => {
+      renderer.resize(64, 64)
+      renderer.set_camera(new Float32Array(20))
+      renderer.render()
+      renderer.destroy()
+    }).not.toThrow()
+  })
+})

--- a/tests/vitest/structure/gpu/radius-lut.test.ts
+++ b/tests/vitest/structure/gpu/radius-lut.test.ts
@@ -6,17 +6,17 @@ function site(element: string, xyz: [number, number, number]): Site {
   return { species: [{ element, occu: 1, oxidation_state: 0 } as never], abc: [0, 0, 0], xyz } as Site
 }
 
-describe('build_atom_radii', () => {
-  it('returns one finite radius per site, using the primary species', () => {
-    const sites = [site('H', [0, 0, 0]), site('O', [1, 0, 0]), site('C', [2, 0, 0])]
+describe(`build_atom_radii`, () => {
+  it(`returns one finite radius per site, using the primary species`, () => {
+    const sites = [site(`H`, [0, 0, 0]), site(`O`, [1, 0, 0]), site(`C`, [2, 0, 0])]
     const radii = build_atom_radii(sites)
     expect(radii).toBeInstanceOf(Float32Array)
     expect(radii.length).toBe(3)
     for (const r of radii) expect(r).toBeGreaterThan(0)
     expect(radii[1]).toBeLessThan(radii[2]) // O covalent radius (0.66) < C (0.76)
   })
-  it('falls back to a default radius for unknown elements', () => {
-    const radii = build_atom_radii([site('Xx', [0, 0, 0])])
+  it(`falls back to a default radius for unknown elements`, () => {
+    const radii = build_atom_radii([site(`Xx`, [0, 0, 0])])
     expect(radii[0]).toBeGreaterThan(0)
   })
 })

--- a/tests/vitest/structure/gpu/radius-lut.test.ts
+++ b/tests/vitest/structure/gpu/radius-lut.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { build_atom_radii } from '$lib/structure/gpu/radius-lut'
+import type { Site } from '$lib/structure'
+
+function site(element: string, xyz: [number, number, number]): Site {
+  return { species: [{ element, occu: 1, oxidation_state: 0 } as never], abc: [0, 0, 0], xyz } as Site
+}
+
+describe('build_atom_radii', () => {
+  it('returns one finite radius per site, using the primary species', () => {
+    const sites = [site('H', [0, 0, 0]), site('O', [1, 0, 0]), site('C', [2, 0, 0])]
+    const radii = build_atom_radii(sites)
+    expect(radii).toBeInstanceOf(Float32Array)
+    expect(radii.length).toBe(3)
+    for (const r of radii) expect(r).toBeGreaterThan(0)
+    expect(radii[1]).toBeLessThan(radii[2]) // O covalent radius (0.66) < C (0.76)
+  })
+  it('falls back to a default radius for unknown elements', () => {
+    const radii = build_atom_radii([site('Xx', [0, 0, 0])])
+    expect(radii[0]).toBeGreaterThan(0)
+  })
+})

--- a/tests/vitest/structure/gpu/webgpu-context.test.ts
+++ b/tests/vitest/structure/gpu/webgpu-context.test.ts
@@ -3,24 +3,24 @@ import { is_webgpu_supported, acquire_webgpu_device, __reset_device_cache } from
 
 afterEach(() => { vi.unstubAllGlobals(); __reset_device_cache() })
 
-describe('webgpu-context', () => {
-  it('is_webgpu_supported reflects navigator.gpu presence', () => {
-    vi.stubGlobal('navigator', {})
+describe(`webgpu-context`, () => {
+  it(`is_webgpu_supported reflects navigator.gpu presence`, () => {
+    vi.stubGlobal(`navigator`, {})
     expect(is_webgpu_supported()).toBe(false)
-    vi.stubGlobal('navigator', { gpu: {} })
+    vi.stubGlobal(`navigator`, { gpu: {} })
     expect(is_webgpu_supported()).toBe(true)
   })
-  it('acquire_webgpu_device returns null when unsupported', async () => {
-    vi.stubGlobal('navigator', {})
+  it(`acquire_webgpu_device returns null when unsupported`, async () => {
+    vi.stubGlobal(`navigator`, {})
     expect(await acquire_webgpu_device()).toBeNull()
   })
-  it('acquire_webgpu_device returns null when adapter unavailable', async () => {
-    vi.stubGlobal('navigator', { gpu: { requestAdapter: async () => null } })
+  it(`acquire_webgpu_device returns null when adapter unavailable`, async () => {
+    vi.stubGlobal(`navigator`, { gpu: { requestAdapter: async () => null } })
     expect(await acquire_webgpu_device()).toBeNull()
   })
-  it('acquire_webgpu_device returns the device on success', async () => {
-    const fake_device = { label: 'd' }
-    vi.stubGlobal('navigator', { gpu: { requestAdapter: async () => ({ requestDevice: async () => fake_device }) } })
+  it(`acquire_webgpu_device returns the device on success`, async () => {
+    const fake_device = { label: `d` }
+    vi.stubGlobal(`navigator`, { gpu: { requestAdapter: async () => ({ requestDevice: async () => fake_device }) } })
     expect(await acquire_webgpu_device()).toBe(fake_device)
   })
 })

--- a/tests/vitest/structure/gpu/webgpu-context.test.ts
+++ b/tests/vitest/structure/gpu/webgpu-context.test.ts
@@ -20,7 +20,7 @@ describe(`webgpu-context`, () => {
   })
   it(`acquire_webgpu_device returns the device on success`, async () => {
     const fake_device = { label: `d` }
-    vi.stubGlobal(`navigator`, { gpu: { requestAdapter: async () => ({ requestDevice: async () => fake_device }) } })
+    vi.stubGlobal(`navigator`, { gpu: { requestAdapter: async () => ({ limits: { maxStorageBuffersPerShaderStage: 16 }, requestDevice: async () => fake_device }) } })
     expect(await acquire_webgpu_device()).toBe(fake_device)
   })
 })

--- a/tests/vitest/structure/gpu/webgpu-context.test.ts
+++ b/tests/vitest/structure/gpu/webgpu-context.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { is_webgpu_supported, acquire_webgpu_device, __reset_device_cache } from '$lib/structure/gpu/webgpu-context'
+
+afterEach(() => { vi.unstubAllGlobals(); __reset_device_cache() })
+
+describe('webgpu-context', () => {
+  it('is_webgpu_supported reflects navigator.gpu presence', () => {
+    vi.stubGlobal('navigator', {})
+    expect(is_webgpu_supported()).toBe(false)
+    vi.stubGlobal('navigator', { gpu: {} })
+    expect(is_webgpu_supported()).toBe(true)
+  })
+  it('acquire_webgpu_device returns null when unsupported', async () => {
+    vi.stubGlobal('navigator', {})
+    expect(await acquire_webgpu_device()).toBeNull()
+  })
+  it('acquire_webgpu_device returns null when adapter unavailable', async () => {
+    vi.stubGlobal('navigator', { gpu: { requestAdapter: async () => null } })
+    expect(await acquire_webgpu_device()).toBeNull()
+  })
+  it('acquire_webgpu_device returns the device on success', async () => {
+    const fake_device = { label: 'd' }
+    vi.stubGlobal('navigator', { gpu: { requestAdapter: async () => ({ requestDevice: async () => fake_device }) } })
+    expect(await acquire_webgpu_device()).toBe(fake_device)
+  })
+})

--- a/tests/vitest/structure/supercell-export-core.test.ts
+++ b/tests/vitest/structure/supercell-export-core.test.ts
@@ -1,0 +1,118 @@
+import {
+  type CoreStructure,
+  EXPORT_ATOM_CONFIRM_THRESHOLD,
+  expand_and_serialize,
+  expand_supercell,
+  expanded_atom_count,
+  serialize_poscar,
+  serialize_xyz,
+} from '$lib/structure/export/supercell-export-core'
+import { describe, expect, test } from 'vitest'
+
+// 2-atom orthorhombic base cell (4 Å cube) — H at origin, He at the body centre.
+const base: CoreStructure = {
+  id: `H2He`,
+  lattice: {
+    matrix: [[4, 0, 0], [0, 4, 0], [0, 0, 4]],
+    pbc: [true, true, true],
+  },
+  sites: [
+    { species: [{ element: `H` }], xyz: [0, 0, 0], abc: [0, 0, 0], label: `H1` },
+    { species: [{ element: `He` }], xyz: [2, 2, 2], abc: [0.5, 0.5, 0.5], label: `He1` },
+  ],
+}
+
+describe(`expanded_atom_count`, () => {
+  test(`multiplies site count by the cell product`, () => {
+    expect(expanded_atom_count(base, [2, 1, 1])).toBe(4)
+    expect(expanded_atom_count(base, [2, 2, 2])).toBe(16)
+    expect(expanded_atom_count(base, [10, 10, 10])).toBe(2000)
+  })
+})
+
+describe(`expand_supercell`, () => {
+  test(`2-atom base ×2×1×1 → 4 atoms with scaled lattice + correct positions`, () => {
+    const sc = expand_supercell(base, [2, 1, 1])
+
+    // 2 atoms × 2 cells = 4 sites.
+    expect(sc.sites.length).toBe(4)
+
+    // Lattice scaled by [2,1,1] along a only.
+    expect(sc.lattice!.matrix).toEqual([[8, 0, 0], [0, 4, 0], [0, 0, 4]])
+
+    // Cell (0,0,0): H@(0,0,0), He@(2,2,2). Cell (1,0,0): +a(4,0,0).
+    const xyz = sc.sites.map((s) => s.xyz)
+    expect(xyz[0]).toEqual([0, 0, 0]) // H, cell 0
+    expect(xyz[1]).toEqual([2, 2, 2]) // He, cell 0
+    expect(xyz[2]).toEqual([4, 0, 0]) // H, cell (1,0,0)
+    expect(xyz[3]).toEqual([6, 2, 2]) // He, cell (1,0,0)
+
+    // Fractional coords are in the SCALED cell (a doubled → x halves).
+    expect(sc.sites[2].abc![0]).toBeCloseTo(0.5, 10) // H replica at a-edge
+    expect(sc.sites[0].abc).toEqual([0, 0, 0])
+
+    // Elements preserved.
+    expect(sc.sites.map((s) => s.species[0].element)).toEqual([`H`, `He`, `H`, `He`])
+  })
+
+  test(`charge scales by the cell count`, () => {
+    const charged: CoreStructure = { ...base, charge: -2 }
+    expect(expand_supercell(charged, [2, 2, 1]).charge).toBe(-8)
+  })
+
+  test(`throws without a lattice`, () => {
+    expect(() => expand_supercell({ sites: base.sites }, [2, 1, 1])).toThrow(/lattice/)
+  })
+})
+
+describe(`serialize_poscar`, () => {
+  test(`expand ×2×1×1 then serialize to a valid POSCAR`, () => {
+    const sc = expand_supercell(base, [2, 1, 1])
+    const text = serialize_poscar(sc)
+    const lines = text.trim().split(`\n`)
+
+    // line 0: comment (id), line 1: scale.
+    expect(lines[1].trim()).toBe(`1.0`)
+    // Lattice a-vector doubled.
+    expect(lines[2].trim().split(/\s+/).map(Number)[0]).toBeCloseTo(8, 6)
+    // Element symbols + counts (grouped: 2 H, 2 He).
+    expect(lines[5].trim().split(/\s+/)).toEqual([`H`, `He`])
+    expect(lines[6].trim().split(/\s+/)).toEqual([`2`, `2`])
+    expect(lines[7].trim()).toBe(`Direct`)
+    // 4 coordinate lines follow.
+    expect(lines.length).toBe(8 + 4)
+  })
+})
+
+describe(`serialize_xyz`, () => {
+  test(`plain xyz has atom count + element/coord lines`, () => {
+    const sc = expand_supercell(base, [2, 1, 1])
+    const lines = serialize_xyz(sc, false).trim().split(`\n`)
+    expect(lines[0]).toBe(`4`)
+    // First atom: H at origin.
+    expect(lines[2].split(/\s+/)[0]).toBe(`H`)
+    expect(lines.length).toBe(2 + 4)
+  })
+
+  test(`extxyz embeds Lattice + Properties in the comment line`, () => {
+    const sc = expand_supercell(base, [2, 1, 1])
+    const lines = serialize_xyz(sc, true).trim().split(`\n`)
+    expect(lines[1]).toContain(`Lattice="`)
+    expect(lines[1]).toContain(`Properties="species:S:1:pos:R:3"`)
+    expect(lines[1]).toContain(`pbc="T T T"`)
+  })
+})
+
+describe(`expand_and_serialize`, () => {
+  test(`routes each format`, () => {
+    expect(expand_and_serialize(base, [2, 1, 1], `poscar`)).toContain(`Direct`)
+    expect(expand_and_serialize(base, [2, 1, 1], `xyz`).startsWith(`4\n`)).toBe(true)
+    expect(expand_and_serialize(base, [2, 1, 1], `extxyz`)).toContain(`Lattice="`)
+  })
+})
+
+describe(`EXPORT_ATOM_CONFIRM_THRESHOLD`, () => {
+  test(`is a sane multi-million guard`, () => {
+    expect(EXPORT_ATOM_CONFIRM_THRESHOLD).toBeGreaterThanOrEqual(1_000_000)
+  })
+})


### PR DESCRIPTION
## Summary
Adds an opt-in **Large-system performance mode** (toolbar gauge toggle) that renders very large structures/trajectories through a dedicated **WebGPU** overlay, far beyond what the Three.js/WebGL path handles. The existing WebGL viewer is untouched when the mode is off.

- **GPU overlay** (`src/lib/structure/gpu/`): impostor-sphere atoms + ray-traced impostor-cylinder bonds (half-bonds at PBC boundaries, capped, 4× MSAA + alpha-to-coverage), unit-cell box, camera-oriented XYZ gizmo with labels, click-to-pick + selection highlight. Renders on demand (idle-suspends → quiet).
- **GPU bond detection**: WGSL compute, atom_radii + minimum-image PBC, per-element-pair `bond_distance_rules` post-filter (matches the CPU path), uniform-grid (cell-list) neighbour search — **O(N)**, with an O(N²) fallback for tiny cells. Validated against a JS reference oracle (device-gated golden test).
- **GPU supercell instancing**: corner *Cell type & supercell* (incl. a custom nx×ny×nz input) and Build Tools diagonal supercells route, when the overlay is on, to a **logical** supercell — the CPU keeps only the base cell, the GPU instances atoms+bonds `base × nx·ny·nz` (bonds detected on the base cell, replicated per cell). **Verified: ~140M atoms render without freezing.** Trajectories animate the base cell; replicas follow.
- **Worker export**: POSCAR/xyz/extxyz export of a logical supercell expands + serialises in a Web Worker (off-thread, no freeze), with a >20M-atom confirm guard.
- When the overlay is active, the WebGL path's per-frame render + bond/mesh compute are suspended (single active render path); camera/OrbitControls stay shared.

## Layered foundation (TDD)
Pure helpers under `src/lib/structure/gpu/` (device acquisition, radius LUT, frame/lattice packing, JS reference detector, WGSL pack/unpack, camera uniform, bond-rules encoding, supercell-export core) with colocated unit tests in `tests/vitest/structure/gpu/`.

## Notes
- WebGPU on some Linux/Chrome setups needs `--enable-unsafe-webgpu --enable-features=Vulkan`; the mode falls back to the standard viewer when no adapter.
- No "WebGPU" jargon in user-facing UI (toggle = "Large-system performance mode").

## Test Plan
- [x] `vitest run tests/vitest/structure tests/vitest/trajectory` — 1364 passed / 51 skipped, 0 failed
- [x] `svelte-check` — 0 errors
- [x] New gpu/ modules eslint-clean; device-gated GPU golden tests skip in CI (no adapter), run on a real GPU
- [x] Manual (GPU): atoms/bonds/cell/gizmo/AA, trajectory playback, click-pick, supercell 1×1×1→large, 140M-atom render, POSCAR export of a supercell, toggle on/off returns cleanly to WebGL
- [ ] Reviewer: verify WebGL/default-off path is unchanged (mode is opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)