### PR TITLE
test(export): client-side contract tests for Gaussian/ORCA/GROMACS/ABACUS/AMBER

### DIFF
--- a/tests/vitest/structure/abacus-export.test.ts
+++ b/tests/vitest/structure/abacus-export.test.ts
@@ -1,0 +1,203 @@
+import { gen_abacus_input } from '$lib/structure/export/abacus-export'
+import type { AbacusParams } from '$lib/structure/export/abacus-export'
+import type { FixAtomParams } from '$lib/structure/export/common-export'
+import { describe, expect, it } from 'vitest'
+
+// Contract / smoke tests for the client-side ABACUS generator. gen_abacus_input is
+// fully client-side and returns a Record<string, string> with keys INPUT, STRU, KPT.
+// These tests guard that every calculation type still produces all three well-formed
+// files and exercise the main branches (pw vs lcao, relax/cell-relax extras, md block).
+
+const A = 4.065 // fcc Al lattice constant (Å)
+const M = [[A, 0, 0], [0, A, 0], [0, 0, A]]
+function nacl_cubic() {
+  const frac = [[0, 0, 0], [0, 0.5, 0.5], [0.5, 0, 0.5], [0.5, 0.5, 0], [0.5, 0.5, 0.5], [0.5, 0, 0], [0, 0.5, 0], [0, 0, 0.5]]
+  const el = [`Na`, `Na`, `Na`, `Na`, `Cl`, `Cl`, `Cl`, `Cl`]
+  return {
+    lattice: { matrix: M },
+    sites: frac.map((f, i) => ({
+      species: [{ element: el[i] }],
+      abc: f,
+      xyz: [0, 1, 2].map((c) => f[0] * M[0][c] + f[1] * M[1][c] + f[2] * M[2][c]),
+    })),
+  }
+}
+
+const BASE: AbacusParams = {
+  prefix: `nacl`,
+  calculation: `scf`,
+  basis_type: `pw`,
+  ecutwfc: 100,
+  kpoints_auto: true,
+  kpoints: [4, 4, 4],
+  kspacing: 0.1,
+  scf_nmax: 100,
+  scf_thr: 1e-7,
+  smearing_method: `gauss`,
+  smearing_sigma: 0.015,
+  nspin: 1,
+  dft_functional: `PBE`,
+  mixing_type: `pulay`,
+  mixing_beta: 0.4,
+  force_thr: 1e-3,
+  stress_thr: 0.5,
+  relax_nmax: 50,
+  symmetry: 1,
+  cal_force: true,
+  cal_stress: true,
+  out_chg: false,
+  out_band: false,
+  pseudo_dir: `./`,
+  orbital_dir: `./`,
+  pseudopotentials: {},
+  orbitals: {},
+  md_type: `nvt`,
+  md_nstep: 1000,
+  md_dt: 1.0,
+  md_temp: 300,
+  unique_elements: [`Na`, `Cl`],
+}
+
+const FIX: FixAtomParams = {
+  fix_mode: `none`,
+  fix_z_threshold: 5,
+  selected_indices: [],
+  constrained_atoms_info: { count: 0, details: [] },
+}
+
+const gen = (over: Partial<AbacusParams>) =>
+  gen_abacus_input(nacl_cubic() as never, { ...BASE, ...over }, FIX as never)
+
+describe(`gen_abacus_input produces three well-formed ABACUS files`, () => {
+  it(`returns INPUT, STRU, and KPT keys`, () => {
+    const files = gen({})
+    expect(Object.keys(files).sort()).toEqual([`INPUT`, `KPT`, `STRU`])
+  })
+
+  const CALC_TYPES: AbacusParams[`calculation`][] = [`scf`, `relax`, `cell-relax`, `nscf`, `md`]
+  for (const calc of CALC_TYPES) {
+    it(`${calc} → INPUT contains required keys`, () => {
+      const { INPUT } = gen({ calculation: calc })
+      expect(INPUT).toContain(`calculation`)
+      expect(INPUT).toContain(`ecutwfc`)
+      expect(INPUT).toContain(`basis_type`)
+      expect(INPUT).toContain(`scf_thr`)
+      expect(INPUT).toContain(`scf_nmax`)
+      expect(INPUT).toContain(calc)
+    })
+  }
+
+  it(`scf INPUT contains scalar fields`, () => {
+    const { INPUT } = gen({ calculation: `scf` })
+    expect(INPUT).toContain(`INPUT_PARAMETERS`)
+    expect(INPUT).toContain(`ntype`)
+    expect(INPUT).toContain(`smearing_method`)
+    expect(INPUT).toContain(`mixing_type`)
+    expect(INPUT).toContain(`nspin`)
+    expect(INPUT).toContain(`dft_functional`)
+    expect(INPUT).toContain(`pseudo_dir`)
+  })
+
+  it(`relax INPUT emits relax_nmax and force_thr`, () => {
+    const { INPUT } = gen({ calculation: `relax` })
+    expect(INPUT).toContain(`relax_nmax`)
+    expect(INPUT).toContain(`force_thr`)
+    expect(INPUT).not.toContain(`stress_thr`)
+  })
+
+  it(`cell-relax INPUT emits relax_nmax, force_thr, and stress_thr`, () => {
+    const { INPUT } = gen({ calculation: `cell-relax` })
+    expect(INPUT).toContain(`relax_nmax`)
+    expect(INPUT).toContain(`force_thr`)
+    expect(INPUT).toContain(`stress_thr`)
+  })
+
+  it(`md INPUT emits md block`, () => {
+    const { INPUT } = gen({ calculation: `md`, md_type: `nvt`, md_nstep: 500, md_dt: 2.0, md_temp: 400 })
+    expect(INPUT).toContain(`md_type`)
+    expect(INPUT).toContain(`md_nstep`)
+    expect(INPUT).toContain(`md_dt`)
+    expect(INPUT).toContain(`md_tfirst`)
+    expect(INPUT).toContain(`md_tlast`)
+    // nvt maps to nhc in ABACUS
+    expect(INPUT).toContain(`nhc`)
+  })
+
+  it(`STRU contains ATOMIC_SPECIES block with both elements`, () => {
+    const { STRU } = gen({})
+    expect(STRU).toContain(`ATOMIC_SPECIES`)
+    expect(STRU).toContain(`Na`)
+    expect(STRU).toContain(`Cl`)
+  })
+
+  it(`STRU contains LATTICE_CONSTANT and LATTICE_VECTORS`, () => {
+    const { STRU } = gen({})
+    expect(STRU).toContain(`LATTICE_CONSTANT`)
+    expect(STRU).toContain(`LATTICE_VECTORS`)
+  })
+
+  it(`STRU contains ATOMIC_POSITIONS in Direct mode`, () => {
+    const { STRU } = gen({})
+    expect(STRU).toContain(`ATOMIC_POSITIONS`)
+    expect(STRU).toContain(`Direct`)
+  })
+
+  it(`STRU LATTICE_VECTORS are in Bohr (scaled from Å)`, () => {
+    const { STRU } = gen({})
+    // A=4.065 Å × 1.8897259886 ≈ 7.686…
+    expect(STRU).toContain(`7.6`)
+  })
+
+  it(`KPT contains K_POINTS header and a grid line`, () => {
+    const { KPT } = gen({})
+    expect(KPT).toContain(`K_POINTS`)
+    expect(KPT).toContain(`Gamma`)
+    // kpoints_auto=true → 4 4 4
+    expect(KPT).toContain(`4 4 4`)
+  })
+
+  it(`kpoints_auto=false uses explicit kpoints and emits kspacing in INPUT`, () => {
+    const { INPUT, KPT } = gen({ kpoints_auto: false, kpoints: [2, 3, 5], kspacing: 0.2 })
+    expect(INPUT).toContain(`kspacing`)
+    expect(KPT).toContain(`2 3 5`)
+  })
+
+  it(`lcao basis_type emits orbital_dir in INPUT and NUMERICAL_ORBITAL in STRU`, () => {
+    const { INPUT, STRU } = gen({ basis_type: `lcao` })
+    expect(INPUT).toContain(`orbital_dir`)
+    expect(STRU).toContain(`NUMERICAL_ORBITAL`)
+  })
+
+  it(`pw basis_type does NOT emit orbital_dir or NUMERICAL_ORBITAL`, () => {
+    const { INPUT, STRU } = gen({ basis_type: `pw` })
+    expect(INPUT).not.toContain(`orbital_dir`)
+    expect(STRU).not.toContain(`NUMERICAL_ORBITAL`)
+  })
+
+  it(`out_chg=true emits out_chg in INPUT`, () => {
+    expect(gen({ out_chg: true }).INPUT).toContain(`out_chg`)
+    expect(gen({ out_chg: false }).INPUT).not.toContain(`out_chg`)
+  })
+
+  it(`out_band=true emits out_band in INPUT`, () => {
+    expect(gen({ out_band: true }).INPUT).toContain(`out_band`)
+    expect(gen({ out_band: false }).INPUT).not.toContain(`out_band`)
+  })
+
+  it(`custom pseudopotentials appear in STRU ATOMIC_SPECIES block`, () => {
+    const { STRU } = gen({ pseudopotentials: { Na: `Na_custom.upf`, Cl: `Cl_custom.upf` } })
+    expect(STRU).toContain(`Na_custom.upf`)
+    expect(STRU).toContain(`Cl_custom.upf`)
+  })
+
+  it(`default pseudopotentials fall back to ONCV_PBE naming`, () => {
+    const { STRU } = gen({ pseudopotentials: {} })
+    expect(STRU).toContain(`Na_ONCV_PBE-1.0.upf`)
+    expect(STRU).toContain(`Cl_ONCV_PBE-1.0.upf`)
+  })
+
+  it(`returns empty object when structure is falsy`, () => {
+    const files = gen_abacus_input(null as never, BASE, FIX)
+    expect(files).toEqual({})
+  })
+})

--- a/tests/vitest/structure/amber-export.test.ts
+++ b/tests/vitest/structure/amber-export.test.ts
@@ -1,0 +1,217 @@
+import { apply_amber_preset, generate_amber_mdin } from '$lib/structure/export/amber-export'
+import type { AmberParams, AmberPreset } from '$lib/structure/export/amber-export'
+import { describe, expect, it } from 'vitest'
+
+// Contract / smoke tests for the client-side AMBER mdin generator.
+// generate_amber_mdin is pure-frontend: no structure object needed — AMBER
+// .mdin files are parameter-only; topology and coords are external files.
+// These tests guard that every preset/stage produces a well-formed namelist.
+
+const BASE: AmberParams = {
+  title: `AMBER mdin test`,
+  job_type: `md`,
+  nstlim: 10000,
+  dt: 0.002,
+  maxcyc: 1000,
+  ncyc: 500,
+  drms: 0.01,
+  irest: 0,
+  ntt: 0,
+  temp0: 300,
+  tempi: 0,
+  gamma_ln: 2.0,
+  ntb: 1,
+  cut: 10.0,
+  ntc: 2,
+  ntf: 2,
+  ntpr: 1000,
+  ntwe: 1000,
+  ntwx: 1000,
+  ntwv: 0,
+  ntwr: 1000,
+  ioutfm: 1,
+  ntxo: 2,
+  ntp: 0,
+  barostat: 2,
+  pres0: 1.0,
+  use_mlp: false,
+  mlp_model: `macepol_l`,
+  animask: ``,
+  mlp_shake: 0,
+  gpu_id: 0,
+  mlp_embedding: 0,
+  mlp_multipole: 0,
+  mlp_polar: 0,
+  adjust_q: 1,
+  extra_cntrl: ``,
+  extra_mlp: ``,
+}
+
+const gen = (over: Partial<AmberParams>) => generate_amber_mdin({ ...BASE, ...over })
+
+describe(`generate_amber_mdin produces valid AMBER mdin`, () => {
+  it(`MD mode → well-formed &cntrl with imin=0, nstlim, dt`, () => {
+    const out = gen({ job_type: `md`, nstlim: 50000, dt: 0.002 })
+    expect(out).toContain(` &cntrl`)
+    expect(out).toContain(` /`)
+    expect(out).toContain(`imin = 0,`)
+    expect(out).toContain(`nstlim = 50000,`)
+    expect(out).toContain(`dt = 0.002,`)
+    expect(out).toContain(`ntb = 1,`)
+    expect(out).toContain(`cut = 10,`)
+  })
+
+  it(`minimize mode → well-formed &cntrl with imin=1, maxcyc, ncyc`, () => {
+    const out = gen({ job_type: `minimize`, maxcyc: 2000, ncyc: 1000, drms: 0.005 })
+    expect(out).toContain(` &cntrl`)
+    expect(out).toContain(` /`)
+    expect(out).toContain(`imin = 1,`)
+    expect(out).toContain(`maxcyc = 2000,`)
+    expect(out).toContain(`ncyc = 1000,`)
+    expect(out).toContain(`drms = 0.005,`)
+    // MD-only keys must not appear
+    expect(out).not.toContain(`nstlim`)
+    expect(out).not.toContain(`dt =`)
+  })
+
+  it(`irest=1 sets ntx=5; irest=0 sets ntx=1`, () => {
+    expect(gen({ irest: 1 })).toContain(`ntx = 5,`)
+    expect(gen({ irest: 0 })).toContain(`ntx = 1,`)
+  })
+
+  it(`ntt=3 (Langevin) emits temp0, tempi, gamma_ln`, () => {
+    const out = gen({ ntt: 3, temp0: 300, tempi: 100, gamma_ln: 5.0 })
+    expect(out).toContain(`ntt = 3,`)
+    expect(out).toContain(`temp0 = 300,`)
+    expect(out).toContain(`tempi = 100,`)
+    expect(out).toContain(`gamma_ln = 5,`)
+  })
+
+  it(`ntt=0 omits temp0/tempi/gamma_ln`, () => {
+    const out = gen({ ntt: 0 })
+    expect(out).toContain(`ntt = 0,`)
+    expect(out).not.toContain(`temp0`)
+    expect(out).not.toContain(`tempi`)
+    expect(out).not.toContain(`gamma_ln`)
+  })
+
+  it(`ntp>0 emits barostat and pres0`, () => {
+    const out = gen({ ntp: 1, barostat: 2, pres0: 1.0 })
+    expect(out).toContain(`ntp = 1,`)
+    expect(out).toContain(`barostat = 2,`)
+    expect(out).toContain(`pres0 = 1,`)
+  })
+
+  it(`ntp=0 omits barostat block`, () => {
+    const out = gen({ ntp: 0 })
+    expect(out).not.toContain(`ntp =`)
+    expect(out).not.toContain(`barostat`)
+    expect(out).not.toContain(`pres0`)
+  })
+
+  it(`use_mlp=true emits ifmlp=1 and &mlp namelist`, () => {
+    const out = gen({ use_mlp: true, mlp_model: `macepol_l`, animask: ``, mlp_shake: 0, gpu_id: 0, mlp_embedding: 0, mlp_multipole: 0, mlp_polar: 0, adjust_q: 1 })
+    expect(out).toContain(`ifmlp = 1,`)
+    expect(out).toContain(`&mlp`)
+    expect(out).toContain(`mlp_model='macepol_l',`)
+    expect(out).toContain(`adjust_q=1,`)
+    // &mlp block ends with /
+    const mlp_idx = out.indexOf(`&mlp`)
+    const slash_after = out.indexOf(`/`, mlp_idx)
+    expect(slash_after).toBeGreaterThan(mlp_idx)
+  })
+
+  it(`use_mlp=false omits &mlp namelist and ifmlp`, () => {
+    const out = gen({ use_mlp: false })
+    expect(out).not.toContain(`ifmlp`)
+    expect(out).not.toContain(`&mlp`)
+  })
+
+  it(`animask is quoted in &mlp when non-empty`, () => {
+    const out = gen({ use_mlp: true, animask: `:1-100` })
+    expect(out).toContain(`animask=":1-100",`)
+  })
+
+  it(`extra_cntrl lines are appended inside &cntrl`, () => {
+    const out = gen({ extra_cntrl: `nmropt = 1` })
+    expect(out).toContain(`nmropt = 1,`)
+    const cntrl_end = out.indexOf(` /`)
+    expect(out.lastIndexOf(`nmropt`, cntrl_end)).toBeGreaterThan(-1)
+  })
+
+  it(`output ends with a trailing newline`, () => {
+    expect(gen({})).toMatch(/\n$/)
+  })
+
+  it(`title line is the first line`, () => {
+    const out = gen({ title: `My test run` })
+    expect(out.split(`\n`)[0]).toBe(`My test run`)
+  })
+})
+
+describe(`apply_amber_preset returns correct params`, () => {
+  const PRESETS: AmberPreset[] = [`mlmm_md`, `mlmm_min`, `classical_md`, `classical_min`, `nvt_langevin`, `npt_langevin`]
+
+  for (const preset of PRESETS) {
+    it(`${preset} → non-empty partial`, () => {
+      const p = apply_amber_preset(preset)
+      expect(Object.keys(p).length).toBeGreaterThan(0)
+    })
+  }
+
+  it(`mlmm_md → MD, use_mlp=true, ntb=0, large cut`, () => {
+    const p = apply_amber_preset(`mlmm_md`)
+    expect(p.job_type).toBe(`md`)
+    expect(p.use_mlp).toBe(true)
+    expect(p.ntb).toBe(0)
+    expect(p.cut).toBeGreaterThan(100)
+  })
+
+  it(`mlmm_min → minimize, use_mlp=true, ntb=0`, () => {
+    const p = apply_amber_preset(`mlmm_min`)
+    expect(p.job_type).toBe(`minimize`)
+    expect(p.use_mlp).toBe(true)
+    expect(p.ntb).toBe(0)
+  })
+
+  it(`classical_md → MD, use_mlp=false, ntt=3, periodic`, () => {
+    const p = apply_amber_preset(`classical_md`)
+    expect(p.job_type).toBe(`md`)
+    expect(p.use_mlp).toBe(false)
+    expect(p.ntt).toBe(3)
+    expect(p.ntb).toBe(1)
+  })
+
+  it(`classical_min → minimize, use_mlp=false, periodic`, () => {
+    const p = apply_amber_preset(`classical_min`)
+    expect(p.job_type).toBe(`minimize`)
+    expect(p.use_mlp).toBe(false)
+    expect(p.ntb).toBe(1)
+  })
+
+  it(`nvt_langevin → MD, ntp=0 (NVT), ntt=3`, () => {
+    const p = apply_amber_preset(`nvt_langevin`)
+    expect(p.job_type).toBe(`md`)
+    expect(p.ntp).toBe(0)
+    expect(p.ntt).toBe(3)
+  })
+
+  it(`npt_langevin → MD, ntp=1, barostat=2, pres0=1`, () => {
+    const p = apply_amber_preset(`npt_langevin`)
+    expect(p.job_type).toBe(`md`)
+    expect(p.ntp).toBe(1)
+    expect(p.barostat).toBe(2)
+    expect(p.pres0).toBe(1.0)
+  })
+
+  it(`preset applied over BASE produces valid mdin for each preset`, () => {
+    for (const preset of PRESETS) {
+      const p = apply_amber_preset(preset)
+      const out = gen(p)
+      expect(out).toContain(` &cntrl`)
+      expect(out).toContain(` /`)
+      const is_min = p.job_type === `minimize`
+      expect(out).toContain(is_min ? `imin = 1,` : `imin = 0,`)
+    }
+  })
+})

--- a/tests/vitest/structure/gaussian-export.test.ts
+++ b/tests/vitest/structure/gaussian-export.test.ts
@@ -1,0 +1,184 @@
+import { generate_gaussian_input, apply_gaussian_preset } from '$lib/structure/export/gaussian-export'
+import type { GaussianParams } from '$lib/structure/export/gaussian-export'
+import { describe, expect, it } from 'vitest'
+
+// Contract / smoke tests for the client-side Gaussian generator.
+// Gaussian is a molecular code — no periodic lattice is needed; the generator
+// only reads structure.sites (species[].element and xyz). We use a minimal
+// water molecule (H2O) throughout.
+
+function water() {
+  return {
+    sites: [
+      { species: [{ element: `O` }], xyz: [0.0, 0.0, 0.119748] },
+      { species: [{ element: `H` }], xyz: [0.0, 0.756950, -0.478993] },
+      { species: [{ element: `H` }], xyz: [0.0, -0.756950, -0.478993] },
+    ],
+  }
+}
+
+const BASE: GaussianParams = {
+  prefix: `water`,
+  job_type: `opt`,
+  method: `B3LYP`,
+  basis: `6-31G*`,
+  charge: 0,
+  multiplicity: 1,
+  nproc: 4,
+  mem: `2GB`,
+  chk: false,
+  dispersion: `none`,
+  solvation: `none`,
+  solvent: `Water`,
+  td_nstates: 10,
+  pop: `none`,
+  nosymm: false,
+  out_wfn: `none`,
+  title: `water test`,
+  extra_keywords: ``,
+}
+
+const gen = (over: Partial<GaussianParams>) => {
+  const files = generate_gaussian_input(water() as never, { ...BASE, ...over })
+  return Object.values(files)[0]
+}
+
+describe(`generate_gaussian_input produces valid Gaussian input`, () => {
+  const JOB_TYPES: Array<[GaussianParams[`job_type`], string]> = [
+    [`sp`, `SP`],
+    [`opt`, `Opt`],
+    [`opt_freq`, `Opt Freq`],
+    [`freq`, `Freq`],
+    [`td`, `TD(NStates=10)`],
+    [`ts`, `Opt=(CalcFC,TS,NoEigen)`],
+  ]
+  for (const [jt, kw] of JOB_TYPES) {
+    it(`job_type=${jt} → route contains ${kw}`, () => {
+      const inp = gen({ job_type: jt })
+      expect(inp).toContain(`#p B3LYP/6-31G*`)
+      expect(inp).toContain(kw)
+    })
+  }
+
+  it(`output file is named prefix.gjf`, () => {
+    const files = generate_gaussian_input(water() as never, BASE)
+    expect(Object.keys(files)).toEqual([`water.gjf`])
+  })
+
+  it(`contains title, charge/multiplicity line, and atom block`, () => {
+    const inp = gen({})
+    expect(inp).toContain(`water test`)
+    expect(inp).toContain(`0 1`)
+    expect(inp).toContain(`O`)
+    expect(inp).toContain(`H`)
+  })
+
+  it(`atom block has element + x y z with 8 decimal places`, () => {
+    const inp = gen({})
+    // each atom line: element padded then three fixed-point coords
+    expect(inp).toMatch(/O\s+[\d. -]+\s+[\d. -]+\s+[\d. -]+/)
+    expect(inp).toMatch(/H\s+[\d. -]+\s+[\d. -]+\s+[\d. -]+/)
+    expect(inp).toContain(`0.11974800`)
+    expect(inp).toContain(`0.75695000`)
+  })
+
+  it(`nproc and mem directives are present`, () => {
+    const inp = gen({ nproc: 8, mem: `4GB` })
+    expect(inp).toContain(`%nproc=8`)
+    expect(inp).toContain(`%mem=4GB`)
+  })
+
+  it(`chk=true adds %chk line`, () => {
+    expect(gen({ chk: true })).toContain(`%chk=water.chk`)
+    expect(gen({ chk: false })).not.toContain(`%chk=`)
+  })
+
+  it(`dispersion keyword is appended when not none`, () => {
+    const inp = gen({ dispersion: `EmpiricalDispersion=GD3BJ` })
+    expect(inp).toContain(`EmpiricalDispersion=GD3BJ`)
+  })
+
+  it(`dispersion is skipped for wB97XD method`, () => {
+    const inp = gen({ method: `wB97XD`, dispersion: `EmpiricalDispersion=GD3BJ` })
+    expect(inp).not.toContain(`EmpiricalDispersion=GD3BJ`)
+  })
+
+  it(`solvation=scrf adds SCRF keyword with solvent`, () => {
+    const inp = gen({ solvation: `scrf`, solvent: `Ethanol` })
+    expect(inp).toContain(`SCRF=(SMD,Solvent=Ethanol)`)
+  })
+
+  it(`pop keyword is added when not none`, () => {
+    const inp = gen({ pop: `Full` })
+    expect(inp).toContain(`pop=Full`)
+  })
+
+  it(`nosymm adds nosymm keyword`, () => {
+    const inp = gen({ nosymm: true })
+    expect(inp).toContain(`nosymm`)
+  })
+
+  it(`out_wfn adds output keyword and wfn filename block`, () => {
+    const inp = gen({ out_wfn: `wfn` })
+    expect(inp).toContain(`output=wfn`)
+    expect(inp).toContain(`water.wfn`)
+  })
+
+  it(`extra_keywords are appended to route`, () => {
+    const inp = gen({ extra_keywords: `scf=tight` })
+    expect(inp).toContain(`scf=tight`)
+  })
+})
+
+describe(`apply_gaussian_preset returns correct overrides`, () => {
+  it(`quick_opt → B3LYP/6-31G* Opt`, () => {
+    const p = apply_gaussian_preset(`quick_opt`)
+    expect(p.job_type).toBe(`opt`)
+    expect(p.method).toBe(`B3LYP`)
+    expect(p.basis).toBe(`6-31G*`)
+    const inp = gen({ ...p })
+    expect(inp).toContain(`B3LYP/6-31G*`)
+    expect(inp).toContain(`Opt`)
+  })
+
+  it(`accurate → B3LYP/6-311+G(d,p) Opt Freq + D3BJ`, () => {
+    const p = apply_gaussian_preset(`accurate`)
+    expect(p.job_type).toBe(`opt_freq`)
+    expect(p.basis).toBe(`6-311+G(d,p)`)
+    const inp = gen({ ...p })
+    expect(inp).toContain(`6-311+G(d,p)`)
+    expect(inp).toContain(`Opt Freq`)
+    expect(inp).toContain(`EmpiricalDispersion=GD3BJ`)
+  })
+
+  it(`td_dft → TD-DFT with NStates`, () => {
+    const p = apply_gaussian_preset(`td_dft`)
+    expect(p.job_type).toBe(`td`)
+    expect(p.td_nstates).toBe(10)
+    const inp = gen({ ...p })
+    expect(inp).toContain(`TD(NStates=10)`)
+  })
+
+  it(`freq_thermo → Freq job with D3BJ`, () => {
+    const p = apply_gaussian_preset(`freq_thermo`)
+    expect(p.job_type).toBe(`freq`)
+    const inp = gen({ ...p })
+    expect(inp).toContain(`Freq`)
+    expect(inp).toContain(`EmpiricalDispersion=GD3BJ`)
+  })
+
+  it(`solvation → scrf with Water solvent`, () => {
+    const p = apply_gaussian_preset(`solvation`)
+    expect(p.solvation).toBe(`scrf`)
+    expect(p.solvent).toBe(`Water`)
+    const inp = gen({ ...p })
+    expect(inp).toContain(`SCRF=(SMD,Solvent=Water)`)
+  })
+
+  it(`ts_search → TS optimization keywords`, () => {
+    const p = apply_gaussian_preset(`ts_search`)
+    expect(p.job_type).toBe(`ts`)
+    const inp = gen({ ...p })
+    expect(inp).toContain(`Opt=(CalcFC,TS,NoEigen)`)
+  })
+})

--- a/tests/vitest/structure/gromacs-export.test.ts
+++ b/tests/vitest/structure/gromacs-export.test.ts
@@ -1,0 +1,278 @@
+import { generate_gromacs_input, apply_gmx_preset } from '$lib/structure/export/gromacs-export'
+import type { GromacsParams, GromacsPreset } from '$lib/structure/export/gromacs-export'
+import { describe, expect, it } from 'vitest'
+
+// Contract / smoke tests for the client-side GROMACS generator. generate_gromacs_input
+// is fully client-side and returns a Record<string, string> of {mdp, gro, top} file
+// contents. These tests guard that every sim_type/preset produces well-formed output
+// so the offline export path can be relied on.
+
+const A = 4.0
+const M = [[A, 0, 0], [0, A, 0], [0, 0, A]]
+function nacl_small() {
+  // 2-atom NaCl unit cell (minimal periodic box)
+  const frac = [[0, 0, 0], [0.5, 0.5, 0.5]]
+  const el = [`Na`, `Cl`]
+  return {
+    lattice: { matrix: M },
+    sites: frac.map((f, i) => ({
+      species: [{ element: el[i] }],
+      abc: f,
+      xyz: [0, 1, 2].map((c) => f[0] * M[0][c] + f[1] * M[1][c] + f[2] * M[2][c]),
+    })),
+  }
+}
+
+// Shared base params — filled with sensible defaults; tests override per-preset as needed.
+const BASE: GromacsParams = {
+  prefix: `structure`,
+  sim_type: `em`,
+  dt: 0.002,
+  nsteps: 50000,
+  nsteps_display: `100 ps`,
+  emtol: 1000,
+  emstep: 0.01,
+  tcoupl: `V-rescale`,
+  ref_t: 300,
+  tau_t: 0.1,
+  pcoupl: `no`,
+  pcoupltype: `isotropic`,
+  ref_p: 1.0,
+  tau_p: 2.0,
+  coulombtype: `PME`,
+  rcoulomb: 1.0,
+  rvdw: 1.0,
+  pbc: `xyz`,
+  dispcorr: `EnerPres`,
+  nstlog: 1000,
+  nstenergy: 1000,
+  nstxout_compressed: 5000,
+  constraints: `none`,
+  gen_vel: `no`,
+  gen_temp: 300,
+  posres: false,
+  anneal_time: `0 100`,
+  anneal_temp: `0 298.15`,
+}
+
+const gen = (over: Partial<GromacsParams>) =>
+  generate_gromacs_input(nacl_small() as never, { ...BASE, ...over })
+
+describe(`generate_gromacs_input produces well-formed output`, () => {
+  it(`returns mdp, gro, and top files`, () => {
+    const out = gen({})
+    expect(Object.keys(out)).toContain(`structure.mdp`)
+    expect(Object.keys(out)).toContain(`structure.gro`)
+    expect(Object.keys(out)).toContain(`structure.top`)
+  })
+
+  it(`custom prefix is reflected in returned file names`, () => {
+    const out = gen({ prefix: `my_run` })
+    expect(Object.keys(out)).toContain(`my_run.mdp`)
+    expect(Object.keys(out)).toContain(`my_run.gro`)
+    expect(Object.keys(out)).toContain(`my_run.top`)
+  })
+
+  describe(`energy minimisation (em)`, () => {
+    it(`uses steep integrator`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ sim_type: `em` })
+      expect(mdp).toContain(`integrator  = steep`)
+    })
+    it(`emits emtol and emstep`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ sim_type: `em`, emtol: 500, emstep: 0.005 })
+      expect(mdp).toContain(`emtol       = 500`)
+      expect(mdp).toContain(`emstep      = 0.005`)
+    })
+    it(`emits nsteps`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ sim_type: `em`, nsteps: 20000 })
+      expect(mdp).toContain(`nsteps      = 20000`)
+    })
+    it(`does NOT emit tcoupl section`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ sim_type: `em` })
+      expect(mdp).not.toContain(`Temperature coupling`)
+    })
+  })
+
+  describe(`NVT equilibration (eq_nvt)`, () => {
+    const nvt_params = apply_gmx_preset(`eq_nvt`)
+    it(`uses md integrator`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...nvt_params })
+      expect(mdp).toContain(`integrator  = md`)
+    })
+    it(`emits dt and nsteps`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...nvt_params })
+      expect(mdp).toContain(`dt          = 0.002`)
+      expect(mdp).toContain(`nsteps      = 50000`)
+    })
+    it(`emits tcoupl section`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...nvt_params })
+      expect(mdp).toContain(`tcoupl  = V-rescale`)
+      expect(mdp).toContain(`ref_t   = 300`)
+      expect(mdp).toContain(`tau_t   = 0.1`)
+    })
+    it(`pcoupl is no (no pressure section)`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...nvt_params })
+      expect(mdp).not.toContain(`Pressure coupling`)
+    })
+    it(`emits velocity generation`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...nvt_params })
+      expect(mdp).toContain(`gen_vel  = yes`)
+      expect(mdp).toContain(`gen_temp = 300`)
+    })
+    it(`emits POSRES define when posres=true`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...nvt_params, posres: true })
+      expect(mdp).toContain(`define = -DPOSRES`)
+    })
+  })
+
+  describe(`NPT equilibration (eq_npt)`, () => {
+    const npt_params = apply_gmx_preset(`eq_npt`)
+    it(`emits tcoupl`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...npt_params })
+      expect(mdp).toContain(`tcoupl  = V-rescale`)
+    })
+    it(`emits pcoupl section`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...npt_params })
+      expect(mdp).toContain(`pcoupl      = parrinello-rahman`)
+      expect(mdp).toContain(`pcoupltype  = isotropic`)
+      expect(mdp).toContain(`ref_p       = 1`)
+      expect(mdp).toContain(`tau_p       = 2`)
+      expect(mdp).toContain(`compressibility = 4.5e-5`)
+    })
+    it(`gen_vel is no`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...npt_params })
+      expect(mdp).not.toContain(`gen_vel  = yes`)
+    })
+  })
+
+  describe(`production NPT (prod_npt)`, () => {
+    const prod_params = apply_gmx_preset(`prod_npt`)
+    it(`runs long nsteps`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...prod_params })
+      expect(mdp).toContain(`nsteps      = 1000000`)
+    })
+    it(`emits pcoupl`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...prod_params })
+      expect(mdp).toContain(`pcoupl      = parrinello-rahman`)
+    })
+    it(`no POSRES when posres=false`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...prod_params, posres: false })
+      expect(mdp).not.toContain(`-DPOSRES`)
+    })
+  })
+
+  describe(`simulated annealing / heat_npt`, () => {
+    const heat_params = apply_gmx_preset(`heat_npt`)
+    it(`emits annealing section`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...heat_params })
+      expect(mdp).toContain(`annealing       = single`)
+      expect(mdp).toContain(`annealing-time  = 0 100`)
+      expect(mdp).toContain(`annealing-temp  = 0 298.15`)
+    })
+    it(`annealing-npoints matches token count in anneal_time`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...heat_params, anneal_time: `0 50 100`, anneal_temp: `0 150 298` })
+      expect(mdp).toContain(`annealing-npoints = 3`)
+    })
+    it(`emits velocity generation from 0 K`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...heat_params })
+      expect(mdp).toContain(`gen_vel  = yes`)
+      expect(mdp).toContain(`gen_temp = 0`)
+    })
+  })
+
+  describe(`gas phase`, () => {
+    const gas_params = apply_gmx_preset(`gas_phase`)
+    it(`pbc = no`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...gas_params })
+      expect(mdp).toContain(`pbc         = no`)
+    })
+    it(`coulombtype = Cut-off`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...gas_params })
+      expect(mdp).toContain(`coulombtype = Cut-off`)
+    })
+    it(`constraints = none (omits constraints section)`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ ...gas_params })
+      expect(mdp).not.toContain(`constraint-algorithm`)
+    })
+  })
+
+  describe(`.gro coordinate file`, () => {
+    it(`header contains atom count`, () => {
+      const { [`structure.gro`]: gro } = gen({})
+      const lines = gro.split(`\n`)
+      expect(lines[1].trim()).toBe(`2`)
+    })
+    it(`atom lines contain element symbols`, () => {
+      const { [`structure.gro`]: gro } = gen({})
+      expect(gro).toContain(`Na`)
+      expect(gro).toContain(`Cl`)
+    })
+    it(`box vectors line present at end (nm conversion)`, () => {
+      const { [`structure.gro`]: gro } = gen({})
+      // Box in nm: A=4.0 Å → 0.40000 nm
+      expect(gro).toContain(`0.40000`)
+    })
+  })
+
+  describe(`.top topology file`, () => {
+    it(`contains [ defaults ] section`, () => {
+      const { [`structure.top`]: top } = gen({})
+      expect(top).toContain(`[ defaults ]`)
+    })
+    it(`contains [ atomtypes ] with Na and Cl entries`, () => {
+      const { [`structure.top`]: top } = gen({})
+      expect(top).toContain(`[ atomtypes ]`)
+      expect(top).toContain(`Na`)
+      expect(top).toContain(`Cl`)
+    })
+    it(`contains [ moleculetype ] and [ atoms ]`, () => {
+      const { [`structure.top`]: top } = gen({})
+      expect(top).toContain(`[ moleculetype ]`)
+      expect(top).toContain(`[ atoms ]`)
+    })
+    it(`contains [ system ] and [ molecules ]`, () => {
+      const { [`structure.top`]: top } = gen({})
+      expect(top).toContain(`[ system ]`)
+      expect(top).toContain(`[ molecules ]`)
+      expect(top).toContain(`MOL       1`)
+    })
+    it(`system name matches prefix`, () => {
+      const { [`my_sim.top`]: top } = gen({ prefix: `my_sim` })
+      expect(top).toContain(`my_sim`)
+    })
+  })
+
+  describe(`output control fields`, () => {
+    it(`nstlog, nstenergy, nstxout-compressed appear in mdp`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ nstlog: 500, nstenergy: 500, nstxout_compressed: 2500 })
+      expect(mdp).toContain(`nstlog              = 500`)
+      expect(mdp).toContain(`nstenergy           = 500`)
+      expect(mdp).toContain(`nstxout-compressed  = 2500`)
+    })
+    it(`electrostatics fields appear in mdp`, () => {
+      const { [`structure.mdp`]: mdp } = gen({ coulombtype: `PME`, rcoulomb: 1.2, rvdw: 1.2 })
+      expect(mdp).toContain(`coulombtype = PME`)
+      expect(mdp).toContain(`rcoulomb    = 1.2`)
+      expect(mdp).toContain(`rvdw        = 1.2`)
+    })
+  })
+
+  describe(`apply_gmx_preset returns correct partial params`, () => {
+    const PRESETS: GromacsPreset[] = [`em`, `eq_nvt`, `eq_npt`, `prod_npt`, `heat_npt`, `gas_phase`]
+    for (const preset of PRESETS) {
+      it(`${preset} → has sim_type`, () => {
+        const p = apply_gmx_preset(preset)
+        expect(p.sim_type).toBe(preset)
+      })
+    }
+    it(`em preset sets emtol = 1000`, () => {
+      expect(apply_gmx_preset(`em`).emtol).toBe(1000)
+    })
+    it(`eq_nvt preset sets posres = true`, () => {
+      expect(apply_gmx_preset(`eq_nvt`).posres).toBe(true)
+    })
+    it(`prod_npt preset sets posres = false`, () => {
+      expect(apply_gmx_preset(`prod_npt`).posres).toBe(false)
+    })
+  })
+})

--- a/tests/vitest/structure/orca-export.test.ts
+++ b/tests/vitest/structure/orca-export.test.ts
@@ -1,0 +1,159 @@
+import { gen_orca_input } from '$lib/structure/export/orca-export'
+import type { OrcaParams } from '$lib/structure/export/orca-export'
+import { describe, expect, it } from 'vitest'
+
+// Contract / smoke tests for the client-side ORCA generator. ORCA is a molecular
+// code, so we use a minimal water molecule (no periodic lattice). gen_orca_input
+// produces a well-formed ORCA input with a `!` keyword line, an optional %block
+// section, and a `* xyz charge mult` coordinate block closed by `*`.
+
+function water() {
+  return {
+    sites: [
+      { species: [{ element: `O` }], xyz: [0.000000, 0.000000, 0.119748] },
+      { species: [{ element: `H` }], xyz: [0.000000, 0.756950, -0.478993] },
+      { species: [{ element: `H` }], xyz: [0.000000, -0.756950, -0.478993] },
+    ],
+  }
+}
+
+const BASE: OrcaParams = {
+  run_type: `SP`,
+  method: `DFT`,
+  functional: `PBE`,
+  functional_custom: ``,
+  wavefunction: ``,
+  uno_enabled: false,
+  uco_enabled: false,
+  basis: `def2-SVP`,
+  charge: 0,
+  multiplicity: 1,
+  opt_convergence: `Opt`,
+  use_cartesian: false,
+  frozen_mode: `none`,
+  frozen_z: 0,
+  md_initvel: 300,
+  md_run: 500,
+  cim_method: `DLPNO-CCSD(T)`,
+  cim_thresh: 1e-4,
+  selected_indices: [],
+}
+
+const gen = (over: Partial<OrcaParams>) =>
+  gen_orca_input(water() as never, { ...BASE, ...over })
+
+describe(`gen_orca_input produces valid ORCA input`, () => {
+  const RUN_TYPES: Array<[string, string]> = [
+    [`SP`, `SP`],
+    [`Opt`, `Opt`],
+    [`Freq`, `Freq`],
+    [`MD`, `MD`],
+    [`CIM`, `CIM`],
+  ]
+
+  for (const [rt, label] of RUN_TYPES) {
+    it(`${rt} → well-formed input`, () => {
+      const inp = gen({ run_type: rt })
+      // keyword line always starts with `!`
+      expect(inp).toContain(`! `)
+      expect(inp).toContain(label)
+      // coordinate block opened with `* xyz <charge> <mult>`
+      expect(inp).toContain(`* xyz 0 1`)
+      // each element appears in the coord block
+      expect(inp).toContain(`O    `)
+      expect(inp).toContain(`H    `)
+      // coordinate block closed by bare `*`
+      const lines = inp.split(`\n`)
+      expect(lines.some((l) => l === `*`)).toBe(true)
+    })
+  }
+
+  it(`DFT run includes functional on keyword line`, () => {
+    const inp = gen({ run_type: `SP`, method: `DFT`, functional: `PBE` })
+    const kw_line = inp.split(`\n`)[0]
+    expect(kw_line).toContain(`PBE`)
+    expect(kw_line).toContain(`def2-SVP`)
+  })
+
+  it(`DFT with custom functional uses functional_custom`, () => {
+    const inp = gen({ method: `DFT`, functional: `other`, functional_custom: `wB97X-D4` })
+    expect(inp.split(`\n`)[0]).toContain(`wB97X-D4`)
+  })
+
+  it(`non-DFT method (MP2) uses method name directly`, () => {
+    const inp = gen({ run_type: `SP`, method: `MP2`, basis: `cc-pVDZ` })
+    const kw_line = inp.split(`\n`)[0]
+    expect(kw_line).toContain(`MP2`)
+    expect(kw_line).toContain(`cc-pVDZ`)
+  })
+
+  it(`wavefunction keyword appears on keyword line when set`, () => {
+    const inp = gen({ wavefunction: `RIJCOSX` })
+    expect(inp.split(`\n`)[0]).toContain(`RIJCOSX`)
+  })
+
+  it(`UNO and UCO flags appear when enabled`, () => {
+    const inp = gen({ uno_enabled: true, uco_enabled: true })
+    const kw_line = inp.split(`\n`)[0]
+    expect(kw_line).toContain(`UNO`)
+    expect(kw_line).toContain(`UCO`)
+  })
+
+  it(`Opt with non-default convergence adds convergence keyword`, () => {
+    const inp = gen({ run_type: `Opt`, opt_convergence: `TightOpt` })
+    expect(inp.split(`\n`)[0]).toContain(`TightOpt`)
+  })
+
+  it(`Opt with use_cartesian adds COpt`, () => {
+    const inp = gen({ run_type: `Opt`, use_cartesian: true })
+    expect(inp.split(`\n`)[0]).toContain(`COpt`)
+  })
+
+  it(`MD run emits %md block with Initvel and Run`, () => {
+    const inp = gen({ run_type: `MD`, md_initvel: 300, md_run: 500 })
+    expect(inp).toContain(`%md`)
+    expect(inp).toContain(`Initvel 300_K`)
+    expect(inp).toContain(`Run 500`)
+    expect(inp).toContain(`end`)
+  })
+
+  it(`CIM run emits %cim block with CIMTHRESH and cc-pVDZ basis`, () => {
+    const inp = gen({ run_type: `CIM`, cim_method: `DLPNO-CCSD(T)`, cim_thresh: 1e-4 })
+    expect(inp).toContain(`DLPNO-CCSD(T)`)
+    expect(inp).toContain(`cc-pVDZ`)
+    expect(inp).toContain(`%cim`)
+    expect(inp).toContain(`CIMTHRESH`)
+    expect(inp).toContain(`end`)
+  })
+
+  it(`charge and multiplicity appear in coordinate block header`, () => {
+    const inp = gen_orca_input(water() as never, { ...BASE, charge: -1, multiplicity: 2 })
+    expect(inp).toContain(`* xyz -1 2`)
+  })
+
+  it(`Opt with frozen selected_indices emits Constraints block`, () => {
+    const inp = gen({
+      run_type: `Opt`,
+      frozen_mode: `selected`,
+      selected_indices: [0, 2],
+    })
+    expect(inp).toContain(`> Constraints`)
+    expect(inp).toContain(`{ C 0 C }`)
+    expect(inp).toContain(`{ C 2 C }`)
+  })
+
+  it(`Opt with frozen_mode none omits Constraints block`, () => {
+    const inp = gen({ run_type: `Opt`, frozen_mode: `none` })
+    expect(inp).not.toContain(`> Constraints`)
+  })
+
+  it(`empty structure returns empty string`, () => {
+    expect(gen_orca_input(null as never, BASE)).toBe(``)
+  })
+
+  it(`coordinate values are formatted to 6 decimal places`, () => {
+    const inp = gen({ run_type: `SP` })
+    // O atom has z=0.119748 — check it appears formatted
+    expect(inp).toContain(`0.119748`)
+  })
+})


### PR DESCRIPTION
## Summary
Adds client-side contract/smoke tests for the exporters that **already generate fully client-side** (no backend call): Gaussian, ORCA, GROMACS, ABACUS, AMBER. These were already offline-capable; this PR adds test coverage so the offline export path is guarded against regressions, following the VASP/CP2K test pattern.

Pure test additions — **no runtime/behavior changes**.

| Code | Generator | Test asserts |
|---|---|---|
| Gaussian | `generate_gaussian_input` | route `#` line, charge/mult, cartesian block, presets |
| ORCA | `gen_orca_input` | `!` keyword line, `* xyz` block, MD/CIM/freeze branches |
| GROMACS | `generate_gromacs_input` | `.mdp` integrator/coupling per em/nvt/npt/anneal/gas presets |
| ABACUS | `gen_abacus_input` | INPUT/STRU/KPT across scf/relax/cell-relax/nscf/md |
| AMBER | `generate_amber_mdin` | `&cntrl` namelist, imin/ntb/barostat, ML/MM, presets |

## Validation
- **Windows vitest**: gaussian 24, orca 19, gromacs 43, abacus 23, amber 26 — **135 tests, all pass**.
- `svelte-check`: 0 errors.
- Robust substring/section assertions, not byte-parity.

## Companion
A separate PR hardens the QE + LAMMPS offline fallback (those have a server path) + adds their tests.

## Test plan
- [ ] `pnpm exec vitest run tests/vitest/structure/{gaussian,orca,gromacs,abacus,amber}-export.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
