### PR TITLE
fix(gpu): swallow AbortError when pick buffer destroyed mid-map

### DIFF
--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -2369,7 +2369,18 @@ export function create_large_system_renderer(
       )
       device.queue.submit([encoder.finish()])
 
-      await pick_readback.mapAsync(GPUMapMode.READ, 0, 4)
+      try {
+        await pick_readback.mapAsync(GPUMapMode.READ, 0, 4)
+      } catch {
+        // The buffer was destroyed before the map resolved. This happens when
+        // the overlay is torn down mid-pick — e.g. the user toggles large-system
+        // (WebGPU) mode off while a pick is in flight. WebGPU rejects the pending
+        // mapAsync with an AbortError ("Buffer was destroyed before mapping was
+        // resolved"); swallow it and abort the pick instead of leaking an
+        // unhandled rejection. The post-resolve `destroyed` guard below only
+        // covers the resolve-then-destroy race, not this reject-on-destroy one.
+        return -1
+      }
       if (destroyed) {
         try { pick_readback.unmap() } catch { /* already torn down */ }
         return -1


### PR DESCRIPTION
## Problem

Toggling large-system (WebGPU) performance mode **off while an atom pick is in flight** throws an unhandled rejection:

```
AbortError: Failed to execute 'mapAsync' on 'GPUBuffer': Buffer was destroyed before mapping was resolved.
```

Reproduced from production (`app.catgo-ucsd.org`) on the WebGPU→normal mode switch.

## Root cause

In `large-system-renderer.ts` `pick()`:

1. A pick runs `await pick_readback.mapAsync(GPUMapMode.READ, …)` — a pending async map.
2. Switching mode off runs `destroy()` → `pick_readback.destroy()` synchronously.
3. WebGPU **rejects** the pending `mapAsync` promise with `AbortError`.
4. Nothing catches it → unhandled rejection.

The existing `if (destroyed)` guard sits **after** the `await`, so it only covers the *resolve-then-destroy* race — it never runs when the `await` itself rejects on destroy.

## Fix

Wrap the `mapAsync` await in try/catch and abort the pick (`return -1`) when the buffer was destroyed mid-map. AbortError on destroy is spec-documented WebGPU behavior; the renderer owns the buffer + map, so it handles its own teardown race rather than leaking to callers.

## Verification

- ✅ `svelte-check`: 0 new errors (3 pre-existing `@webgpu/types` devDep errors unrelated)
- ✅ `vitest tests/vitest/structure/gpu/`: 52 passed, no regression
- ⚠️ In-browser GPU-path repro not run on the lab box (no WebGPU adapter); needs verification on a WebGPU-capable machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)