### PR TITLE
fix(viewer): stop Site Indices/Labels freezing the tab (color-mix self-nesting)

### DIFF
--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -85,14 +85,35 @@
   })
 
   // Atom label color management
+  //
+  // `scene_props.site_label_bg_color` is the *composed* value the renderer
+  // consumes: `color-mix(in srgb, <picker color> <opacity%>, transparent)`.
+  // The two $state vars below hold the *raw* inputs (color picker + opacity
+  // slider) and the $effect recomposes them. Seeding the raw color directly
+  // from the composed value re-wrapped it in another color-mix() on every
+  // mount; the result persisted to localStorage, so the nesting depth grew by
+  // one each session. A deeply nested color-mix() is O(2^depth) for the CSS
+  // engine to resolve, so once site labels/indices became visible the main
+  // thread froze (no JS error — pure style computation). Parse the composed
+  // value back into its raw parts so the round-trip is idempotent.
+  function parse_label_bg(raw: unknown): { color: string; opacity: number } {
+    const fallback = { color: DEFAULTS.structure.site_label_bg_color, opacity: 0 }
+    if (typeof raw !== `string` || raw === ``) return fallback
+    const mix_count = (raw.match(/color-mix\(/g) ?? []).length
+    if (mix_count === 0) return { color: raw, opacity: 0 } // legacy plain color
+    if (mix_count > 1) return fallback // corrupted nested value → reset
+    const m = raw.match(/^color-mix\(in srgb,\s*(.+?)\s+([\d.]+)%\s*,\s*transparent\)$/)
+    if (!m) return fallback
+    return { color: m[1], opacity: Number(m[2]) / 100 }
+  }
+
   // untrack: intentional initial value capture from scene_props
   let site_label_hex_color = $state(
     untrack(() => scene_props.site_label_color) || DEFAULTS.structure.site_label_color,
   )
-  let site_label_bg_hex_color = $state(
-    untrack(() => scene_props.site_label_bg_color) || DEFAULTS.structure.site_label_bg_color,
-  )
-  let site_label_background_opacity = $state(0)
+  const __label_bg_seed = untrack(() => parse_label_bg(scene_props.site_label_bg_color))
+  let site_label_bg_hex_color = $state(__label_bg_seed.color)
+  let site_label_background_opacity = $state(__label_bg_seed.opacity)
 
   $effect(() => {
     scene_props.site_label_color = site_label_hex_color

--- a/src/lib/structure/controllers/settings.svelte.ts
+++ b/src/lib/structure/controllers/settings.svelte.ts
@@ -116,6 +116,20 @@ function load_persisted(): PersistedSettings {
         ;(parsed as Record<string, unknown>)._site_idx_default_false_migrated = true
         try { localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed)) } catch { /* ignore */ }
       }
+      // One-time cleanup: an earlier bug re-wrapped site_label_bg_color in an
+      // extra `color-mix(...)` on every mount, so the persisted value
+      // accumulated dozens of nesting levels. A deeply nested color-mix() is
+      // O(2^depth) for the CSS engine to resolve, freezing the main thread when
+      // site labels/indices rendered. Drop any value with >1 color-mix() so the
+      // default re-applies; the code fix (parse_label_bg) keeps it single-level.
+      if (is_plain_object(parsed.scene_props)) {
+        const sp = parsed.scene_props as Record<string, unknown>
+        const bg = sp.site_label_bg_color
+        if (typeof bg === `string` && (bg.match(/color-mix\(/g) ?? []).length > 1) {
+          delete sp.site_label_bg_color
+          try { localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed)) } catch { /* ignore */ }
+        }
+      }
       return parsed as PersistedSettings
     }
 


### PR DESCRIPTION
## Problem
Clicking **Site Indices** (or **Site Labels**) in the structure viewer froze the tab — **no console error** (reported as 卡死).

## Root cause
A self-nesting CSS `color-mix()` feedback loop.

`StructureControls.svelte` seeded `site_label_bg_hex_color` (a raw `<input type=color>` value) from the **composed** `scene_props.site_label_bg_color`, while a `$effect` recomposes that field as `color-mix(in srgb, <hex> <opacity%>, transparent)`. So every mount wrapped the prior value in **another** `color-mix()`, and the result persisted to the `catgo-viewer-settings` localStorage → nesting depth grew **+1 each session** (observed ~32 levels).

A deeply nested `color-mix()` is ~`O(2^depth)` for the CSS engine to resolve. The string only attaches to a DOM node via `style:background` when label `<span>`s render — i.e. exactly when Site Indices/Labels turn on → **main thread freezes on pure style computation** (no JS error). Measured: `getComputedStyle` on a 20+ level nested `color-mix()` times out.

## Fix
- **`StructureControls.svelte`** — `parse_label_bg()` seeds the raw color + opacity by parsing the composed value; resets to default when it contains `>1` `color-mix(` (corrupted). Round-trip is now idempotent (nesting stays at depth 1); persisted opacity also round-trips.
- **`controllers/settings.svelte.ts`** — one-time migration drops any persisted `site_label_bg_color` with `>1` `color-mix(`, so existing corrupted localStorage **self-heals** on next load.

## Verification
End-to-end in the running dev app with `show_site_indices=true` (the exact freeze trigger):
- labels render (6 spans, depth-1 `color-mix`, resolves instantly)
- page stays responsive
- parse↔compose round-trip holds nesting at **1** across repeated mounts (was +1 each)
- `svelte-check`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)