### PR TITLE
feat(catbot): conversational heterostructure + passivation tools (client-direct) + markdown crash fix

### DIFF
--- a/docs/superpowers/specs/2026-05-27-catbot-heterostructure-tools-design.md
+++ b/docs/superpowers/specs/2026-05-27-catbot-heterostructure-tools-design.md
@@ -1,0 +1,100 @@
+# CatBot Conversational Heterostructure Tools — Design
+
+**Date:** 2026-05-27
+**Depends on:** PR #144 (client-side builders, merged) + PR #145 (client-direct CatBot, open) — this work stacks **after** #145.
+**Status:** Approved design, pending implementation plan
+
+## Goal
+
+Let the in-browser CatBot agent (client-direct, STATIC_ONLY, no Python backend) **build heterostructures conversationally** — gather two structures, search lattice-matched interfaces, pick one, build, and load into the viewer — wrapping PR #144's `api/heterostructure.ts` WASM path.
+
+Heterostructure is a multi-step workflow (two structures, per-side Miller + thickness, area/strain match tolerances yielding a *list of candidate matches*, interface gap, vacuum, twist, optional xy-shift scan). The user chose **full conversational build** (not GUI hand-off), with the second structure supplied via a **stash** mechanism.
+
+## Decisions (locked in brainstorming)
+- **Conversational build** — CatBot runs search → pick → build → load via tools; the LLM fills params from natural language.
+- **Film via stash** — a `set_film` tool stores the current viewer structure as the film; the substrate is the current structure at build time.
+- **Match selection** — `heterostructure_search` stashes the candidate matches and returns a readable summary; `build_heterostructure` takes a `match_index` (default 0 = lowest strain) — transform matrices are never threaded through the LLM.
+- **Manual slab cutting** is NOT a heterostructure feature — it's the existing `generate_slab` tool: cut → `set_film` → cut substrate → build. `build_heterostructure` documents that an already-cut slab can be used as-is.
+- **grid_scan is Phase 2** — ship search/build first.
+
+## Architecture
+
+Two module-level stashes in a new `src/lib/chat/hetero-stash.svelte.ts` (mirrors `current-structure.svelte.ts`):
+- `film` — the stashed PymatgenStructure (set by `set_film`).
+- `last_matches` — the `HeterostructureMatch[]` from the most recent `heterostructure_search` (so `build` can resolve `match_index` → transforms without the LLM passing matrices).
+
+Tools registered in `structure-tools.ts` (same registry as the other client-direct tools). All call `api/heterostructure.ts` functions, which already route to WASM under STATIC_ONLY.
+
+```
+set_film (current viewer structure → stash.film)
+   │
+heterostructure_search(substrate=current, film=stash.film, miller/tol params)
+   │  → searchHeterostructureMatches() → stash.last_matches; return summary list
+   │
+build_heterostructure(match_index, gap, vacuum, twist, swap)
+   │  → look up stash.last_matches[match_index] transforms
+   │  → buildHeterostructureManual(substrate, film, sub_transform, film_transform, gap, vacuum, twist, xy_shift)
+   │  → set_current_structure(result.structure)   (viewer reverse-syncs — PR #145)
+```
+
+## Tools
+
+### 1. `set_film` (utility, kind `read`)
+- Input: none.
+- Stores `get_current_structure()` into `stash.film`. Errors if no current structure.
+- Returns `{ film_formula, film_num_sites }`.
+- Description tells the model: "Mark the currently-loaded structure as the FILM for a heterostructure. Then load/fetch the substrate and call heterostructure_search."
+
+### 2. `heterostructure_search` (kind `read`)
+- Inputs (all optional with defaults): `substrate_miller` ([h,k,l], default [0,0,1]), `film_miller` ([h,k,l], default [0,0,1]), `max_area` (default 400), `max_strain_pct` (→ `max_area_ratio_tol`/tolerances; default ~5), `max_results` (default 10).
+- Requires `stash.film` set (else error: "call set_film first") and a current structure (substrate).
+- Calls `searchHeterostructureMatches(substrate, film, params)`; stores `result.matches` in `stash.last_matches`; returns a compact list: `[{ index, strain, match_area, n_atoms_substrate, n_atoms_film, film_miller, substrate_miller }]` (index = position in matches, default-sorted by strain).
+- Returns `{ n_matches, matches: [...summary] }`.
+
+### 3. `build_heterostructure` (kind `mutate`)
+- Inputs: `match_index` (integer, default 0), `gap` (Å, default 2.0), `vacuum` (Å, default 20.0), `twist_angle` (deg, default 0), `swap` (bool, default false — swap which structure is substrate vs film), `xy_shift` ([a_frac, b_frac], default [0,0]).
+- Requires `stash.last_matches` non-empty (else error: "run heterostructure_search first"). Looks up `m = stash.last_matches[match_index]`.
+- substrate = current structure, film = `stash.film` (swapped if `swap`).
+- Calls `buildHeterostructureManual(substrate, film, m.substrate_transformation, m.film_transformation, gap, vacuum, twist_angle, xy_shift)`.
+- `set_current_structure(result.structure)` → viewer loads it (PR #145 reverse-sync).
+- Returns `{ num_sites, strain, match_area, formula }`.
+- **Thickness note (resolve in plan):** `buildHeterostructureManual` takes transforms + gap/vacuum/twist/xy_shift but NOT explicit thickness, whereas `HeterostructureBuildParams` (used by the auto `buildHeterostructure`) has `substrate_thickness`/`film_thickness`. The plan must read both `buildHeterostructureManual` and `buildHeterostructure` (heterostructure.ts:118 and :201) and decide: either (a) use `buildHeterostructureManual` (manual transforms, thickness implicit/default — matches the stash-match flow), or (b) add thickness by routing through `buildHeterostructure` with the chosen match. Prefer (a) for the match-index flow; expose `substrate_thickness`/`film_thickness` only if (a) supports them. Do NOT invent a thickness arg that the chosen build fn ignores.
+
+### 4. `grid_scan_heterostructure` (kind `read`) — **Phase 2, deferred**
+Wrap `gridScanHeterostructure` (heterostructure.ts:588) — scan an N×N xy-shift grid (or symmetry-irreducible wedge), return per-shift metrics so the user picks a shift, then `build_heterostructure` with that `xy_shift`. Out of scope for the first PR.
+
+## Requirement → param mapping (the user's enumerated options)
+| User requirement | Mechanism |
+|---|---|
+| which on top / bottom | `swap` on build (default film-on-top) |
+| cut each how thick | `substrate_thickness`/`film_thickness` IF the chosen build fn supports it (see thickness note); else slabs use default cut |
+| cut yourself / push to viewer | use existing `generate_slab` tool first, then `set_film`/build — not a hetero param |
+| layer distance | `gap` |
+| vacuum | `vacuum` |
+| twist | `twist_angle` |
+| translate to scan combinations | `grid_scan_heterostructure` (Phase 2) → feeds `xy_shift` |
+| how to translate | grid params (Phase 2) / explicit `xy_shift` on build |
+| which candidate match | `heterostructure_search` list + `match_index` on build |
+
+## Error handling
+- `set_film` with no current structure → error.
+- `heterostructure_search` with no `stash.film` → error pointing to `set_film`.
+- `build_heterostructure` with empty `stash.last_matches` or out-of-range `match_index` → error pointing to `heterostructure_search`.
+- Underlying API throw (no commensurate match, WASM failure) → propagates as `{error}` via `execute_tool`.
+- `twist_angle` may be unsupported on the WASM path (heterostructure.ts notes it) — if so, document that twist requires the backend; default 0 works client-side.
+
+## Testing
+- `hetero-stash` unit: set/get film + matches round-trip.
+- Tool kind assertions: `set_film`/`heterostructure_search` = read, `build_heterostructure` = mutate.
+- `heterostructure_search` executor (vitest): mock `searchHeterostructureMatches` → assert matches stashed + summary shape.
+- `build_heterostructure` executor: stash a fake match, mock `buildHeterostructureManual` → assert it's called with the stashed transforms + `set_current_structure` receives the result. (Full WASM not run in node — mock the api fn, matching how other builder tools are kind-only/mocked.)
+- Run via `rtk proxy pnpm exec vitest`.
+
+## Scope / delivery
+- Files: `src/lib/chat/hetero-stash.svelte.ts` (new), `src/lib/chat/structure-tools.ts` (+3 tools), `src/lib/chat/__tests__/structure-tools.test.ts` (+tests), maybe a `hetero-stash.test.ts`.
+- **Own branch + PR**, stacked after #145 (per PR-separation preference). Do not bundle into #145.
+- Phase 2 (`grid_scan_heterostructure`) is a follow-up.
+
+## Engineering constraints
+- Branch off #145's head (so the builder API + client-direct loop are present); never work on main.
+- Worktree dev-server caveat: stale-serve after edits → kill all worktree vite + `rm -rf node_modules/.vite` + relaunch `VITE_STATIC_ONLY=true PORT=3210 pnpm desktop:dev --force` + browser hard-refresh before verifying.

--- a/src/lib/chat/__tests__/hetero-stash.test.ts
+++ b/src/lib/chat/__tests__/hetero-stash.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  get_film_stash,
+  get_hetero_matches,
+  set_film_stash,
+  set_hetero_matches,
+} from '../hetero-stash.svelte'
+import type { HeterostructureMatch } from '$lib/api/heterostructure'
+
+const CUBIC = {
+  '@module': `pymatgen.core.structure`,
+  '@class': `Structure`,
+  lattice: { matrix: [[3.5, 0, 0], [0, 3.5, 0], [0, 0, 3.5]] },
+  sites: [{ species: [{ element: `Cu`, occu: 1 }], abc: [0, 0, 0], xyz: [0, 0, 0], label: `Cu` }],
+}
+
+const MATCH: HeterostructureMatch = {
+  match_id: 0,
+  match_area: 50,
+  film_miller: [0, 0, 1],
+  substrate_miller: [0, 0, 1],
+  film_transformation: [[1, 0], [0, 1]],
+  substrate_transformation: [[1, 0], [0, 1]],
+  film_sl_vectors: [],
+  substrate_sl_vectors: [],
+  strain: 0.5,
+  n_atoms_substrate: 4,
+  n_atoms_film: 4,
+}
+
+describe(`hetero-stash`, () => {
+  it(`film set/get round-trips`, () => {
+    set_film_stash(CUBIC as never)
+    expect(get_film_stash()).toStrictEqual(CUBIC as never)
+  })
+
+  it(`matches set/get round-trips`, () => {
+    set_hetero_matches([MATCH])
+    const out = get_hetero_matches()
+    expect(out).toHaveLength(1)
+    expect(out[0].match_id).toBe(0)
+    expect(out[0].substrate_transformation).toEqual([[1, 0], [0, 1]])
+  })
+})

--- a/src/lib/chat/__tests__/hetero-stash.test.ts
+++ b/src/lib/chat/__tests__/hetero-stash.test.ts
@@ -3,11 +3,13 @@ import {
   get_bulk_stash,
   get_film_stash,
   get_hetero_matches,
+  get_lateral_matches,
   set_bulk_stash,
   set_film_stash,
   set_hetero_matches,
+  set_lateral_matches,
 } from '../hetero-stash.svelte'
-import type { HeterostructureMatch } from '$lib/api/heterostructure'
+import type { HeterostructureMatch, LateralMatch } from '$lib/api/heterostructure'
 
 const CUBIC = {
   '@module': `pymatgen.core.structure`,
@@ -48,5 +50,24 @@ describe(`hetero-stash`, () => {
     expect(get_bulk_stash()).toBeNull()
     set_bulk_stash(CUBIC as never)
     expect(get_bulk_stash()).toStrictEqual(CUBIC as never)
+  })
+
+  it(`lateral-matches set/get round-trips`, () => {
+    const lateral: LateralMatch = {
+      match_id: 3,
+      n1: 2,
+      n2: 3,
+      edge_length_A: 10.2,
+      edge_length_B: 10.1,
+      strain_percent: 0.9,
+      n_atoms_A: 6,
+      n_atoms_B: 8,
+    }
+    set_lateral_matches([lateral])
+    const out = get_lateral_matches()
+    expect(out).toHaveLength(1)
+    expect(out[0].match_id).toBe(3)
+    expect(out[0].strain_percent).toBe(0.9)
+    expect(out[0].edge_length_A).toBe(10.2)
   })
 })

--- a/src/lib/chat/__tests__/hetero-stash.test.ts
+++ b/src/lib/chat/__tests__/hetero-stash.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
+  get_bulk_stash,
   get_film_stash,
   get_hetero_matches,
+  set_bulk_stash,
   set_film_stash,
   set_hetero_matches,
 } from '../hetero-stash.svelte'
@@ -40,5 +42,11 @@ describe(`hetero-stash`, () => {
     expect(out).toHaveLength(1)
     expect(out[0].match_id).toBe(0)
     expect(out[0].substrate_transformation).toEqual([[1, 0], [0, 1]])
+  })
+
+  it(`bulk set/get round-trips`, () => {
+    expect(get_bulk_stash()).toBeNull()
+    set_bulk_stash(CUBIC as never)
+    expect(get_bulk_stash()).toStrictEqual(CUBIC as never)
   })
 })

--- a/src/lib/chat/__tests__/markdown.test.ts
+++ b/src/lib/chat/__tests__/markdown.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { markdown_to_html } from '../markdown'
+
+/**
+ * Regression tests for the markdown_to_html no-progress guard.
+ *
+ * Background: a CatBot reply crashed the app with
+ *   `RangeError: Invalid array length at Array.push (markdown_to_html)`
+ * caused by the main `while (idx < lines.length)` loop failing to advance
+ * `idx` for some line pattern → the same line reprocessed forever → `out`
+ * grew past ~2³² entries. The fix adds a belt-and-suspenders `_stuck_at`
+ * guard that force-advances after detecting a non-progressing iteration.
+ *
+ * These tests assert termination (the function RETURNS rather than hanging /
+ * throwing) and that output still contains the offending line's text, while a
+ * normal-markdown sample proves there is no rendering regression.
+ */
+
+describe(`markdown_to_html — infinite-loop guard`, () => {
+  it(`returns (does not hang/throw) on a lone pipe row that is not a valid table`, () => {
+    const input = `Candidate matches incoming:\n|\nmore prose follows`
+    const html = markdown_to_html(input)
+    expect(typeof html).toBe(`string`)
+    expect(html).toContain(`Candidate matches incoming`)
+    expect(html).toContain(`more prose follows`)
+  })
+
+  it(`returns on a malformed / single-row table that never completes`, () => {
+    const input = `| only one bar but no closing structure`
+    const html = markdown_to_html(input)
+    expect(typeof html).toBe(`string`)
+    // The text content must survive in the output (escaped / wrapped).
+    expect(html).toContain(`only one bar`)
+  })
+
+  it(`returns on decorative / DAG-trigger lines that an inner loop may not consume`, () => {
+    // Box-drawing / tree characters that exercise the DAG + decorative branches.
+    const input = `structure_input (RuO2) |\n├── slab (110)\n│\n└── done`
+    const html = markdown_to_html(input)
+    expect(typeof html).toBe(`string`)
+    expect(html).toContain(`done`)
+  })
+
+  it(`returns on a pathological mix designed to stress every branch`, () => {
+    const lines = [
+      `intro text`,
+      ``,
+      `|`,
+      `│`,
+      `──`,
+      `★`,
+      `> `,
+      `| a |`,
+      `not a row`,
+      `| b |`,
+      `\\[`,
+      `x^2`,
+      // intentionally no closing \]
+    ]
+    // Repeat the block many times so any non-advancing branch would explode
+    // `out` long before a sane timeout; the guard must keep it bounded.
+    const input = Array.from({ length: 200 }, () => lines.join(`\n`)).join(`\n`)
+    const html = markdown_to_html(input)
+    expect(typeof html).toBe(`string`)
+    expect(html.length).toBeLessThan(5_000_000)
+    expect(html).toContain(`intro text`)
+  })
+
+  it(`force-emits escaped text for a genuinely stuck line without losing content`, () => {
+    // A bare `|` line: the table branch consumes it, finds < 2 rows, and the
+    // fallback emits it; the guard is the final safety net.
+    const html = markdown_to_html(`|`)
+    expect(typeof html).toBe(`string`)
+    expect(html).toContain(`|`)
+  })
+})
+
+describe(`markdown_to_html — no regression on normal markdown`, () => {
+  it(`renders headings, lists, code fences and real tables correctly`, () => {
+    const input = [
+      `# Heading One`,
+      ``,
+      `Some **bold** and *italic* prose.`,
+      ``,
+      `- item one`,
+      `- item two`,
+      ``,
+      `1. first`,
+      `2. second`,
+      ``,
+      `| Material | Mismatch |`,
+      `|---|---|`,
+      `| MoS2 | 0.21 |`,
+      `| WS2 | 1.8 |`,
+      ``,
+      `\`\`\`python`,
+      `def f(x):`,
+      `    return x + 1`,
+      `\`\`\``,
+    ].join(`\n`)
+
+    const html = markdown_to_html(input)
+
+    // Heading (level 1 markdown → h3 in this renderer's offset scheme)
+    expect(html).toContain(`<h3>Heading One</h3>`)
+    // Inline formatting
+    expect(html).toContain(`<strong>bold</strong>`)
+    expect(html).toContain(`<em>italic</em>`)
+    // Lists
+    expect(html).toContain(`<ul>`)
+    expect(html).toContain(`<li>item one</li>`)
+    expect(html).toContain(`<ol>`)
+    expect(html).toContain(`<li>first</li>`)
+    // Real table renders as a <table>
+    expect(html).toContain(`<table>`)
+    expect(html).toContain(`<th>Material</th>`)
+    expect(html).toContain(`<td>MoS2</td>`)
+    // Code fence renders as the code-block wrapper
+    expect(html).toContain(`code-block-wrapper`)
+    expect(html).toContain(`data-lang="python"`)
+  })
+
+  it(`renders a long code block with the collapse wrapper`, () => {
+    const body = Array.from({ length: 30 }, (_, i) => `line_${i} = ${i}`).join(`\n`)
+    const input = `\`\`\`python\n${body}\n\`\`\``
+    const html = markdown_to_html(input)
+    expect(html).toContain(`code-block-wrapper`)
+    expect(html).toContain(`data-collapsed="true"`)
+    expect(html).toContain(`Show all 30 lines`)
+  })
+})

--- a/src/lib/chat/__tests__/structure-tools.test.ts
+++ b/src/lib/chat/__tests__/structure-tools.test.ts
@@ -3,6 +3,9 @@ import { CLIENT_TOOLS, execute_tool, tool_kind } from '../structure-tools'
 import { set_current_structure, get_current_structure } from '$lib/structure/current-structure.svelte'
 import * as routing from '../provider-routing'
 import * as ferrox from '$lib/structure/ferrox-wasm'
+import * as hetero_api from '$lib/api/heterostructure'
+import { set_film_stash, set_hetero_matches } from '../hetero-stash.svelte'
+import type { HeterostructureMatch } from '$lib/api/heterostructure'
 
 const CUBIC_NACL = {
   '@module': `pymatgen.core.structure`,
@@ -166,5 +169,107 @@ describe(`client-direct builder tools (#144 wasm)`, () => {
   it(`build_moire is a mutate tool`, () => {
     expect(CLIENT_TOOLS.find((t) => t.name === `build_moire`)).toBeTruthy()
     expect(tool_kind(`build_moire`)).toBe(`mutate`)
+  })
+})
+
+describe(`heterostructure tools`, () => {
+  const FAKE_MATCH: HeterostructureMatch = {
+    match_id: 0,
+    strain: 0.5,
+    match_area: 50,
+    n_atoms_substrate: 4,
+    n_atoms_film: 4,
+    substrate_transformation: [[1, 0], [0, 1]],
+    film_transformation: [[1, 0], [0, 1]],
+    film_miller: [0, 0, 1],
+    substrate_miller: [0, 0, 1],
+    film_sl_vectors: [],
+    substrate_sl_vectors: [],
+  }
+
+  beforeEach(() => set_current_structure(CUBIC_NACL as never))
+
+  it(`set_film is a read tool`, () => {
+    expect(CLIENT_TOOLS.find((t) => t.name === `set_film`)).toBeTruthy()
+    expect(tool_kind(`set_film`)).toBe(`read`)
+  })
+
+  it(`heterostructure_search is a read tool`, () => {
+    expect(tool_kind(`heterostructure_search`)).toBe(`read`)
+  })
+
+  it(`build_heterostructure is a mutate tool`, () => {
+    expect(tool_kind(`build_heterostructure`)).toBe(`mutate`)
+  })
+
+  it(`set_film stashes the current structure and returns formula + site count`, async () => {
+    const out = JSON.parse(await execute_tool(`set_film`, {}))
+    expect(out.film_num_sites).toBe(2)
+    expect(out.film_formula).toContain(`Na`)
+    expect(out.film_formula).toContain(`Cl`)
+  })
+
+  it(`heterostructure_search stashes matches and returns a compact summary`, async () => {
+    // Stash a film, then mock the api so no WASM/backend is hit.
+    set_film_stash(CUBIC_NACL as never)
+    const spy = vi.spyOn(hetero_api, `searchHeterostructureMatches`).mockResolvedValue({
+      matches: [FAKE_MATCH],
+      terminations: [],
+      n_matches: 1,
+      n_terminations: 0,
+      message: `ok`,
+    })
+    const out = JSON.parse(await execute_tool(`heterostructure_search`, {}))
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(out.n_matches).toBe(1)
+    expect(out.matches[0].index).toBe(0)
+    expect(out.matches[0].strain).toBe(0.5)
+    expect(out.matches[0].n_atoms_substrate).toBe(4)
+    spy.mockRestore()
+  })
+
+  it(`heterostructure_search errors when no film is stashed`, async () => {
+    set_film_stash(null as never)
+    const out = JSON.parse(await execute_tool(`heterostructure_search`, {}))
+    expect(out.error).toMatch(/set_film/i)
+  })
+
+  it(`build_heterostructure uses stashed transforms and writes the result back`, async () => {
+    set_film_stash(CUBIC_NACL as never)
+    set_hetero_matches([FAKE_MATCH])
+    const built = {
+      ...CUBIC_NACL,
+      sites: Array.from({ length: 8 }, (_, i) => ({
+        species: [{ element: i < 4 ? `Na` : `Cl`, occu: 1 }],
+        abc: [0, 0, 0],
+        xyz: [0, 0, 0],
+        label: i < 4 ? `Na` : `Cl`,
+      })),
+    }
+    const spy = vi.spyOn(hetero_api, `buildHeterostructureManual`).mockResolvedValue({
+      structure: built as never,
+      n_atoms: 8,
+      n_atoms_substrate: 4,
+      n_atoms_film: 4,
+      match_area: 50,
+      strain: 0.5,
+      message: `ok`,
+    })
+    const out = JSON.parse(await execute_tool(`build_heterostructure`, { match_index: 0 }))
+    expect(spy).toHaveBeenCalledTimes(1)
+    // called with the stashed substrate/film transforms (args 3 and 4)
+    expect(spy.mock.calls[0][2]).toEqual(FAKE_MATCH.substrate_transformation)
+    expect(spy.mock.calls[0][3]).toEqual(FAKE_MATCH.film_transformation)
+    expect(out.num_sites).toBe(8)
+    expect(out.strain).toBe(0.5)
+    // set_current_structure received the built (8-site) structure
+    expect((get_current_structure() as never as { sites: unknown[] }).sites).toHaveLength(8)
+    spy.mockRestore()
+  })
+
+  it(`build_heterostructure errors when no matches are stashed`, async () => {
+    set_hetero_matches([])
+    const out = JSON.parse(await execute_tool(`build_heterostructure`, {}))
+    expect(out.error).toMatch(/heterostructure_search/i)
   })
 })

--- a/src/lib/chat/__tests__/structure-tools.test.ts
+++ b/src/lib/chat/__tests__/structure-tools.test.ts
@@ -4,7 +4,8 @@ import { set_current_structure, get_current_structure } from '$lib/structure/cur
 import * as routing from '../provider-routing'
 import * as ferrox from '$lib/structure/ferrox-wasm'
 import * as hetero_api from '$lib/api/heterostructure'
-import { set_film_stash, set_hetero_matches } from '../hetero-stash.svelte'
+import * as pseudo_h from '$lib/api/pseudo-hydrogen'
+import { set_bulk_stash, set_film_stash, set_hetero_matches } from '../hetero-stash.svelte'
 import type { HeterostructureMatch } from '$lib/api/heterostructure'
 
 const CUBIC_NACL = {
@@ -271,5 +272,104 @@ describe(`heterostructure tools`, () => {
     set_hetero_matches([])
     const out = JSON.parse(await execute_tool(`build_heterostructure`, {}))
     expect(out.error).toMatch(/heterostructure_search/i)
+  })
+})
+
+describe(`pseudo-hydrogen passivation tools`, () => {
+  // A distinct cubic "bulk" reference, separate from the slab (CUBIC_NACL).
+  const CUBIC_BULK = {
+    '@module': `pymatgen.core.structure`,
+    '@class': `Structure`,
+    lattice: { matrix: [[3.5, 0, 0], [0, 3.5, 0], [0, 0, 3.5]] },
+    sites: [{ species: [{ element: `Cu`, occu: 1 }], abc: [0, 0, 0], xyz: [0, 0, 0], label: `Cu` }],
+  }
+
+  beforeEach(() => {
+    set_current_structure(CUBIC_NACL as never)
+    set_bulk_stash(null as never)
+  })
+
+  it(`set_bulk_reference is a read tool`, () => {
+    expect(CLIENT_TOOLS.find((t) => t.name === `set_bulk_reference`)).toBeTruthy()
+    expect(tool_kind(`set_bulk_reference`)).toBe(`read`)
+  })
+
+  it(`passivate_surface is a mutate tool`, () => {
+    expect(CLIENT_TOOLS.find((t) => t.name === `passivate_surface`)).toBeTruthy()
+    expect(tool_kind(`passivate_surface`)).toBe(`mutate`)
+  })
+
+  it(`set_bulk_reference stashes the current structure and returns formula + site count`, async () => {
+    set_current_structure(CUBIC_BULK as never)
+    const out = JSON.parse(await execute_tool(`set_bulk_reference`, {}))
+    expect(out.bulk_num_sites).toBe(1)
+    expect(out.bulk_formula).toContain(`Cu`)
+  })
+
+  it(`passivate_surface errors when no bulk stashed and no bulk_coordination given`, async () => {
+    set_bulk_stash(null as never)
+    const out = JSON.parse(await execute_tool(`passivate_surface`, {}))
+    expect(out.error).toMatch(/bulk reference|bulk_coordination/i)
+  })
+
+  it(`passivate_surface passes (slab, bulk, params) and writes the result back`, async () => {
+    // Stash a distinct bulk; current = the slab.
+    set_bulk_stash(CUBIC_BULK as never)
+    set_current_structure(CUBIC_NACL as never)
+    const passivated = {
+      ...CUBIC_NACL,
+      sites: Array.from({ length: 6 }, (_, i) => ({
+        species: [{ element: i < 2 ? (i === 0 ? `Na` : `Cl`) : `H`, occu: 1 }],
+        abc: [0, 0, 0],
+        xyz: [0, 0, 0],
+        label: `X`,
+      })),
+    }
+    const spy = vi.spyOn(pseudo_h, `passivateSlab`).mockResolvedValue({
+      structure: passivated as never,
+      n_pseudo_h: 4,
+      bulk_coordination: { Na: 6, Cl: 6 },
+      valence_used: {},
+      pseudo_h_list: [],
+      unique_potcars: [],
+      bond_warnings: [],
+      message: `ok`,
+    })
+    const out = JSON.parse(await execute_tool(`passivate_surface`, {}))
+    expect(spy).toHaveBeenCalledTimes(1)
+    // arg 0 = slab (current), arg 1 = stashed bulk
+    expect((spy.mock.calls[0][0] as { sites: unknown[] }).sites).toHaveLength(2)
+    expect((spy.mock.calls[0][1] as { sites: unknown[] }).sites).toHaveLength(1)
+    expect(out.num_sites).toBe(6)
+    expect(out.n_hydrogens_added).toBe(4)
+    // set_current_structure received the passivated structure
+    expect((get_current_structure() as never as { sites: unknown[] }).sites).toHaveLength(6)
+    spy.mockRestore()
+  })
+
+  it(`passivate_surface accepts explicit bulk_coordination without a stashed bulk`, async () => {
+    set_bulk_stash(null as never)
+    set_current_structure(CUBIC_NACL as never)
+    const spy = vi.spyOn(pseudo_h, `passivateSlab`).mockResolvedValue({
+      structure: CUBIC_NACL as never,
+      n_pseudo_h: 0,
+      bulk_coordination: { Na: 6, Cl: 6 },
+      valence_used: {},
+      pseudo_h_list: [],
+      unique_potcars: [],
+      bond_warnings: [],
+      message: `ok`,
+    })
+    const out = JSON.parse(
+      await execute_tool(`passivate_surface`, { bulk_coordination: { Na: 6, Cl: 6 } }),
+    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    // explicit coordination passed through params (arg 2)
+    expect((spy.mock.calls[0][2] as { bulk_coordination?: unknown }).bulk_coordination).toEqual({
+      Na: 6,
+      Cl: 6,
+    })
+    expect(out.num_sites).toBe(2)
+    spy.mockRestore()
   })
 })

--- a/src/lib/chat/__tests__/structure-tools.test.ts
+++ b/src/lib/chat/__tests__/structure-tools.test.ts
@@ -5,8 +5,8 @@ import * as routing from '../provider-routing'
 import * as ferrox from '$lib/structure/ferrox-wasm'
 import * as hetero_api from '$lib/api/heterostructure'
 import * as pseudo_h from '$lib/api/pseudo-hydrogen'
-import { set_bulk_stash, set_film_stash, set_hetero_matches } from '../hetero-stash.svelte'
-import type { HeterostructureMatch } from '$lib/api/heterostructure'
+import { set_bulk_stash, set_film_stash, set_hetero_matches, set_lateral_matches } from '../hetero-stash.svelte'
+import type { HeterostructureMatch, LateralMatch } from '$lib/api/heterostructure'
 
 const CUBIC_NACL = {
   '@module': `pymatgen.core.structure`,
@@ -272,6 +272,96 @@ describe(`heterostructure tools`, () => {
     set_hetero_matches([])
     const out = JSON.parse(await execute_tool(`build_heterostructure`, {}))
     expect(out.error).toMatch(/heterostructure_search/i)
+  })
+})
+
+describe(`lateral heterostructure tools`, () => {
+  const FAKE_LATERAL: LateralMatch = {
+    match_id: 0,
+    n1: 2,
+    n2: 3,
+    edge_length_A: 10.0,
+    edge_length_B: 9.8,
+    strain_percent: 1.2,
+    n_atoms_A: 6,
+    n_atoms_B: 8,
+  }
+
+  beforeEach(() => {
+    set_current_structure(CUBIC_NACL as never)
+    set_film_stash(null as never)
+    set_lateral_matches([])
+  })
+
+  it(`lateral_heterostructure_search is a read tool`, () => {
+    expect(CLIENT_TOOLS.find((t) => t.name === `lateral_heterostructure_search`)).toBeTruthy()
+    expect(tool_kind(`lateral_heterostructure_search`)).toBe(`read`)
+  })
+
+  it(`build_lateral_heterostructure is a mutate tool`, () => {
+    expect(CLIENT_TOOLS.find((t) => t.name === `build_lateral_heterostructure`)).toBeTruthy()
+    expect(tool_kind(`build_lateral_heterostructure`)).toBe(`mutate`)
+  })
+
+  it(`lateral_heterostructure_search stashes matches and returns a compact summary`, async () => {
+    set_film_stash(CUBIC_NACL as never)
+    const spy = vi.spyOn(hetero_api, `searchLateralMatches`).mockResolvedValue({
+      matches: [FAKE_LATERAL],
+      n_matches: 1,
+      message: `ok`,
+    })
+    const out = JSON.parse(await execute_tool(`lateral_heterostructure_search`, {}))
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(out.n_matches).toBe(1)
+    expect(out.matches[0].index).toBe(0)
+    expect(out.matches[0].strain).toBe(1.2)
+    expect(out.matches[0].edge_length_A).toBe(10.0)
+    expect(out.matches[0].n_atoms_A).toBe(6)
+    spy.mockRestore()
+  })
+
+  it(`lateral_heterostructure_search errors when no film is stashed`, async () => {
+    set_film_stash(null as never)
+    const out = JSON.parse(await execute_tool(`lateral_heterostructure_search`, {}))
+    expect(out.error).toMatch(/set_film/i)
+  })
+
+  it(`build_lateral_heterostructure uses the stashed match and writes the result back`, async () => {
+    set_film_stash(CUBIC_NACL as never)
+    set_lateral_matches([FAKE_LATERAL])
+    const built = {
+      ...CUBIC_NACL,
+      sites: Array.from({ length: 14 }, () => ({
+        species: [{ element: `Na`, occu: 1 }],
+        abc: [0, 0, 0],
+        xyz: [0, 0, 0],
+        label: `Na`,
+      })),
+    }
+    const spy = vi.spyOn(hetero_api, `buildLateralInterface`).mockResolvedValue({
+      structure: built as never,
+      n_atoms: 14,
+      n_atoms_A: 6,
+      n_atoms_B: 8,
+      interface_length: 10.0,
+      strain: 1.2,
+      message: `ok`,
+    })
+    const out = JSON.parse(await execute_tool(`build_lateral_heterostructure`, { match_index: 0 }))
+    expect(spy).toHaveBeenCalledTimes(1)
+    // called with the stashed match object as the 3rd arg
+    expect(spy.mock.calls[0][2]).toEqual(FAKE_LATERAL)
+    expect(out.num_sites).toBe(14)
+    expect(out.strain).toBe(1.2)
+    expect(out.n_atoms_A).toBe(6)
+    expect((get_current_structure() as never as { sites: unknown[] }).sites).toHaveLength(14)
+    spy.mockRestore()
+  })
+
+  it(`build_lateral_heterostructure errors when no matches are stashed`, async () => {
+    set_lateral_matches([])
+    const out = JSON.parse(await execute_tool(`build_lateral_heterostructure`, {}))
+    expect(out.error).toMatch(/lateral_heterostructure_search/i)
   })
 })
 

--- a/src/lib/chat/hetero-stash.svelte.ts
+++ b/src/lib/chat/hetero-stash.svelte.ts
@@ -18,7 +18,8 @@ import type { HeterostructureMatch } from '$lib/api/heterostructure'
 const _state = $state<{
   film: AnyStructure | null
   matches: HeterostructureMatch[]
-}>({ film: null, matches: [] })
+  bulk: AnyStructure | null
+}>({ film: null, matches: [], bulk: null })
 
 /** Stash the FILM structure for the next heterostructure search/build. */
 export function set_film_stash(s: AnyStructure): void {
@@ -38,4 +39,15 @@ export function set_hetero_matches(m: HeterostructureMatch[]): void {
 /** The candidate matches from the most recent search (empty if none yet). */
 export function get_hetero_matches(): HeterostructureMatch[] {
   return _state.matches
+}
+
+/** Stash the BULK reference crystal for surface passivation (pseudo-hydrogen).
+ *  Used to compute reference coordination numbers when capping a slab. */
+export function set_bulk_stash(s: AnyStructure | null): void {
+  _state.bulk = s
+}
+
+/** The stashed BULK reference, or null if `set_bulk_reference` was never called. */
+export function get_bulk_stash(): AnyStructure | null {
+  return _state.bulk
 }

--- a/src/lib/chat/hetero-stash.svelte.ts
+++ b/src/lib/chat/hetero-stash.svelte.ts
@@ -13,13 +13,14 @@
 // pane is visible.
 
 import type { AnyStructure } from '$lib'
-import type { HeterostructureMatch } from '$lib/api/heterostructure'
+import type { HeterostructureMatch, LateralMatch } from '$lib/api/heterostructure'
 
 const _state = $state<{
   film: AnyStructure | null
   matches: HeterostructureMatch[]
+  lateral_matches: LateralMatch[]
   bulk: AnyStructure | null
-}>({ film: null, matches: [], bulk: null })
+}>({ film: null, matches: [], lateral_matches: [], bulk: null })
 
 /** Stash the FILM structure for the next heterostructure search/build. */
 export function set_film_stash(s: AnyStructure): void {
@@ -39,6 +40,16 @@ export function set_hetero_matches(m: HeterostructureMatch[]): void {
 /** The candidate matches from the most recent search (empty if none yet). */
 export function get_hetero_matches(): HeterostructureMatch[] {
   return _state.matches
+}
+
+/** Stash the candidate matches from the most recent LATERAL (in-plane) search. */
+export function set_lateral_matches(m: LateralMatch[]): void {
+  _state.lateral_matches = m
+}
+
+/** The candidate LATERAL matches from the most recent search (empty if none yet). */
+export function get_lateral_matches(): LateralMatch[] {
+  return _state.lateral_matches
 }
 
 /** Stash the BULK reference crystal for surface passivation (pseudo-hydrogen).

--- a/src/lib/chat/hetero-stash.svelte.ts
+++ b/src/lib/chat/hetero-stash.svelte.ts
@@ -1,0 +1,41 @@
+// Durable, module-level stashes for CatBot's conversational heterostructure flow.
+//
+// Building a heterostructure is a multi-step workflow that spans several tool
+// calls: `set_film` marks the current viewer structure as the FILM, then
+// `heterostructure_search` finds candidate lattice-matched interfaces, then
+// `build_heterostructure` picks one and builds it. The intermediate state
+// (the film structure, and the list of candidate matches) must survive between
+// those tool calls — but it should NOT be threaded through the LLM (transform
+// matrices are large and error-prone for a model to copy).
+//
+// These stashes mirror `current-structure.svelte.ts`: module-level Svelte 5
+// `$state` so the values persist for the whole session, independent of which
+// pane is visible.
+
+import type { AnyStructure } from '$lib'
+import type { HeterostructureMatch } from '$lib/api/heterostructure'
+
+const _state = $state<{
+  film: AnyStructure | null
+  matches: HeterostructureMatch[]
+}>({ film: null, matches: [] })
+
+/** Stash the FILM structure for the next heterostructure search/build. */
+export function set_film_stash(s: AnyStructure): void {
+  _state.film = s
+}
+
+/** The stashed FILM structure, or null if `set_film` was never called. */
+export function get_film_stash(): AnyStructure | null {
+  return _state.film
+}
+
+/** Stash the candidate matches from the most recent heterostructure search. */
+export function set_hetero_matches(m: HeterostructureMatch[]): void {
+  _state.matches = m
+}
+
+/** The candidate matches from the most recent search (empty if none yet). */
+export function get_hetero_matches(): HeterostructureMatch[] {
+  return _state.matches
+}

--- a/src/lib/chat/markdown.ts
+++ b/src/lib/chat/markdown.ts
@@ -144,7 +144,26 @@ export function markdown_to_html(md: string): string {
   const out: string[] = []
   let idx = 0
 
+  // No-progress guard (belt-and-suspenders): every branch below is expected to
+  // advance `idx` by ≥1. If any branch ever leaves `idx` unchanged (e.g. an
+  // inner consume-loop captured zero lines while its `continue` skips the
+  // normal fall-through), the same line would be reprocessed forever and `out`
+  // would grow until `Array.push` throws "RangeError: Invalid array length",
+  // crashing the whole app. This guard detects a repeated `idx` and force-emits
+  // the offending line as escaped text, guaranteeing termination for ANY input.
+  let _stuck_at = -1
+
   while (idx < lines.length) {
+    if (idx === _stuck_at) {
+      // Same line as the previous iteration → a branch failed to advance idx.
+      // Emit the raw (escaped) line and force progress.
+      out.push(esc(lines[idx]))
+      idx++
+      _stuck_at = -1
+      continue
+    }
+    _stuck_at = idx
+
     const line = lines[idx]
 
     // Skip empty lines that were left after stripping (but keep intentional blank lines)

--- a/src/lib/chat/structure-tools.ts
+++ b/src/lib/chat/structure-tools.ts
@@ -15,17 +15,28 @@ import { cartesian_to_fractional } from '$lib/structure/lattice-ops'
 import { buildNanotube } from '$lib/api/nanotube'
 import { buildNanoscroll } from '$lib/api/nanoscroll'
 import { searchMoireAngles, buildMoireBilayer } from '$lib/api/moire'
-import { buildHeterostructureManual, searchHeterostructureMatches } from '$lib/api/heterostructure'
-import type { HeterostructureSearchParams } from '$lib/api/heterostructure'
+import {
+  buildHeterostructureManual,
+  buildLateralInterface,
+  searchHeterostructureMatches,
+  searchLateralMatches,
+} from '$lib/api/heterostructure'
+import type {
+  HeterostructureSearchParams,
+  LateralBuildParams,
+  LateralSearchParams,
+} from '$lib/api/heterostructure'
 import { passivateSlab } from '$lib/api/pseudo-hydrogen'
 import type { PseudoHydrogenParams } from '$lib/api/pseudo-hydrogen'
 import {
   get_bulk_stash,
   get_film_stash,
   get_hetero_matches,
+  get_lateral_matches,
   set_bulk_stash,
   set_film_stash,
   set_hetero_matches,
+  set_lateral_matches,
 } from './hetero-stash.svelte'
 
 /** Minimal pymatgen-site shape the mutate executors read/write. */
@@ -663,6 +674,107 @@ register(
     )
     set_current_structure(result.structure as never)
     return { num_sites: result.n_atoms, strain: result.strain, match_area: result.match_area }
+  },
+)
+
+// ── lateral_heterostructure_search (read) ──
+register(
+  {
+    name: `lateral_heterostructure_search`,
+    description: `Search for LATERAL (in-plane) heterojunction edge-matches between the FILM (set earlier via set_film) and the SUBSTRATE (the currently-loaded structure). This is an IN-PLANE junction where the two slabs are stitched side-by-side along a shared edge — distinct from build_heterostructure, which stacks them vertically (one on top of the other). Returns candidate matches sorted by strain; use the match's index with build_lateral_heterostructure. Requires set_film to have been called first.`,
+    kind: `read`,
+    input_schema: {
+      type: `object`,
+      properties: {
+        interface_axis: {
+          type: `integer`,
+          enum: [0, 1],
+          description: `In-plane lattice axis along which the two slabs share their edge: 0=a, 1=b (default 0).`,
+        },
+        max_strain_pct: { type: `number`, description: `Max allowed edge-length mismatch strain, in percent (default 5).` },
+        max_length: { type: `number`, description: `Max interface edge length to consider, in Å (default 100).` },
+        max_results: { type: `integer`, minimum: 1, description: `Max candidate matches to return (default 10).` },
+      },
+    },
+  },
+  async (input) => {
+    const film = get_film_stash()
+    if (!film) throw new Error(`No film set. Call set_film first to mark the current structure as the film.`)
+    const substrate = require_structure()
+
+    const max_strain_pct = input.max_strain_pct === undefined ? 5 : Number(input.max_strain_pct)
+    const params: LateralSearchParams = {
+      interface_axis: input.interface_axis === undefined ? 0 : Math.trunc(Number(input.interface_axis)),
+      // The lateral API's `max_strain` is already expressed in percent.
+      max_strain: max_strain_pct,
+      max_length: input.max_length === undefined ? 100 : Number(input.max_length),
+      max_results: input.max_results === undefined ? 10 : Math.trunc(Number(input.max_results)),
+    }
+
+    const result = await searchLateralMatches(substrate as never, film as never, params)
+    set_lateral_matches(result.matches)
+    return {
+      n_matches: result.matches.length,
+      matches: result.matches.map((m, i) => ({
+        index: i,
+        strain: m.strain_percent,
+        edge_length_A: m.edge_length_A,
+        edge_length_B: m.edge_length_B,
+        n_atoms_A: m.n_atoms_A,
+        n_atoms_B: m.n_atoms_B,
+      })),
+    }
+  },
+)
+
+// ── build_lateral_heterostructure (mutate) ──
+register(
+  {
+    name: `build_lateral_heterostructure`,
+    description: `Build a LATERAL (in-plane) heterojunction for a chosen candidate match (from lateral_heterostructure_search) and load it into the viewer. The SUBSTRATE (current structure) and FILM (set via set_film) are stitched side-by-side along a shared in-plane edge — distinct from build_heterostructure, which stacks them vertically. Requires lateral_heterostructure_search to have been run first.`,
+    kind: `mutate`,
+    input_schema: {
+      type: `object`,
+      properties: {
+        match_index: { type: `integer`, minimum: 0, description: `Index of the match from lateral_heterostructure_search (default 0 = lowest strain).` },
+        width_A: { type: `integer`, minimum: 1, description: `Number of substrate (A) repeat units along the interface (default 1).` },
+        width_B: { type: `integer`, minimum: 1, description: `Number of film (B) repeat units along the interface (default 1).` },
+        buffer: { type: `number`, description: `Buffer gap between the two slabs at the junction, in Å (default 0).` },
+        vacuum: { type: `number`, description: `Vacuum padding in Å (default 20.0).` },
+      },
+    },
+  },
+  async (input) => {
+    const matches = get_lateral_matches()
+    if (matches.length === 0) {
+      throw new Error(`No lateral heterostructure matches available. Run lateral_heterostructure_search first.`)
+    }
+    const match_index = input.match_index === undefined ? 0 : Math.trunc(Number(input.match_index))
+    const m = matches[match_index]
+    if (!m) {
+      throw new Error(`match_index ${match_index} is out of range (0–${matches.length - 1}). Run lateral_heterostructure_search again or pick a valid index.`)
+    }
+
+    const substrate = require_structure()
+    const film = get_film_stash()
+    if (!film) throw new Error(`No film set. Call set_film first.`)
+
+    const params: LateralBuildParams = {
+      width_A: input.width_A === undefined ? 1 : Math.trunc(Number(input.width_A)),
+      width_B: input.width_B === undefined ? 1 : Math.trunc(Number(input.width_B)),
+      buffer: input.buffer === undefined ? 0 : Number(input.buffer),
+      vacuum: input.vacuum === undefined ? 20.0 : Number(input.vacuum),
+    }
+
+    const result = await buildLateralInterface(substrate as never, film as never, m, params)
+    set_current_structure(result.structure as never)
+    return {
+      num_sites: result.n_atoms,
+      strain: result.strain,
+      n_atoms_A: result.n_atoms_A,
+      n_atoms_B: result.n_atoms_B,
+      interface_length: result.interface_length,
+    }
   },
 )
 

--- a/src/lib/chat/structure-tools.ts
+++ b/src/lib/chat/structure-tools.ts
@@ -15,6 +15,14 @@ import { cartesian_to_fractional } from '$lib/structure/lattice-ops'
 import { buildNanotube } from '$lib/api/nanotube'
 import { buildNanoscroll } from '$lib/api/nanoscroll'
 import { searchMoireAngles, buildMoireBilayer } from '$lib/api/moire'
+import { buildHeterostructureManual, searchHeterostructureMatches } from '$lib/api/heterostructure'
+import type { HeterostructureSearchParams } from '$lib/api/heterostructure'
+import {
+  get_film_stash,
+  get_hetero_matches,
+  set_film_stash,
+  set_hetero_matches,
+} from './hetero-stash.svelte'
 
 /** Minimal pymatgen-site shape the mutate executors read/write. */
 interface MutSite {
@@ -64,6 +72,21 @@ function require_structure(): AnyStructure {
   const s = get_current_structure()
   if (!s) throw new Error(`No structure is currently loaded in the viewer.`)
   return s
+}
+
+/** Plain-text (no markup) reduced-count formula derived directly from sites.
+ *  Synchronous + node-safe (no WASM), suitable for compact tool results. */
+function plain_formula(structure: AnyStructure): string {
+  const sites = (structure as { sites?: { species?: { element?: string }[] }[] }).sites ?? []
+  const counts = new Map<string, number>()
+  for (const site of sites) {
+    const el = site.species?.[0]?.element
+    if (el) counts.set(el, (counts.get(el) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([el, n]) => (n === 1 ? el : `${el}${n}`))
+    .join(``)
 }
 
 // ── get_structure_info (read) ──
@@ -483,6 +506,159 @@ register(
     const result = await buildMoireBilayer(layer, candidate, null, {})
     set_current_structure(result.structure as never)
     return { num_sites: (result.structure as unknown as MutStructure).sites.length }
+  },
+)
+
+// ── set_film (read) ──
+register(
+  {
+    name: `set_film`,
+    description: `Mark the currently-loaded structure as the FILM for a heterostructure; then load/fetch the substrate and call heterostructure_search. Slab thickness uses the builder's default — for explicit thickness control, cut a slab with generate_slab first, then call set_film.`,
+    kind: `read`,
+    input_schema: { type: `object`, properties: {} },
+  },
+  () => {
+    const film = require_structure()
+    set_film_stash(film)
+    const sites = (film as { sites?: unknown[] }).sites ?? []
+    return { film_formula: plain_formula(film), film_num_sites: sites.length }
+  },
+)
+
+// ── heterostructure_search (read) ──
+register(
+  {
+    name: `heterostructure_search`,
+    description: `Search for lattice-matched heterostructure interfaces between the FILM (set earlier via set_film) and the SUBSTRATE (the currently-loaded structure). Returns a list of candidate matches sorted by strain — use the match's index with build_heterostructure. Requires set_film to have been called first.`,
+    kind: `read`,
+    input_schema: {
+      type: `object`,
+      properties: {
+        substrate_miller: {
+          type: `array`,
+          items: { type: `integer` },
+          minItems: 3,
+          maxItems: 3,
+          description: `Substrate Miller plane [h,k,l] (default [0,0,1]).`,
+        },
+        film_miller: {
+          type: `array`,
+          items: { type: `integer` },
+          minItems: 3,
+          maxItems: 3,
+          description: `Film Miller plane [h,k,l] (default [0,0,1]).`,
+        },
+        max_area: { type: `number`, description: `Max interface supercell area in Å² (default 400).` },
+        max_strain_pct: { type: `number`, description: `Max allowed strain, in percent (default 5).` },
+        max_results: { type: `integer`, minimum: 1, description: `Max candidate matches to return (default 10).` },
+      },
+    },
+  },
+  async (input) => {
+    const film = get_film_stash()
+    if (!film) throw new Error(`No film set. Call set_film first to mark the current structure as the film.`)
+    const substrate = require_structure()
+
+    const substrate_miller = (input.substrate_miller as number[] | undefined)?.map((n) => Math.trunc(Number(n))) as
+      | [number, number, number]
+      | undefined
+    const film_miller = (input.film_miller as number[] | undefined)?.map((n) => Math.trunc(Number(n))) as
+      | [number, number, number]
+      | undefined
+    const max_strain_pct = input.max_strain_pct === undefined ? 5 : Number(input.max_strain_pct)
+    // Map the user-facing percent strain onto the underlying tolerance fields.
+    // ratio_tol is a fractional (0–1) area-ratio tolerance ≈ strain/100; length
+    // and angle tolerances scale with the same allowance.
+    const ratio_tol = max_strain_pct / 100
+
+    const params: HeterostructureSearchParams = {
+      mode: `slab`,
+      substrate_miller: substrate_miller ?? [0, 0, 1],
+      film_miller: film_miller ?? [0, 0, 1],
+      max_area: input.max_area === undefined ? 400 : Number(input.max_area),
+      max_area_ratio_tol: ratio_tol,
+      max_length_tol: ratio_tol,
+      max_angle_tol: max_strain_pct,
+      max_results: input.max_results === undefined ? 10 : Math.trunc(Number(input.max_results)),
+    }
+
+    const result = await searchHeterostructureMatches(substrate as never, film as never, params)
+    set_hetero_matches(result.matches)
+    return {
+      n_matches: result.matches.length,
+      matches: result.matches.map((m, i) => ({
+        index: i,
+        strain: m.strain,
+        match_area: m.match_area,
+        n_atoms_substrate: m.n_atoms_substrate,
+        n_atoms_film: m.n_atoms_film,
+        film_miller: m.film_miller,
+        substrate_miller: m.substrate_miller,
+      })),
+    }
+  },
+)
+
+// ── build_heterostructure (mutate) ──
+register(
+  {
+    name: `build_heterostructure`,
+    description: `Build the heterostructure for a chosen candidate match (from heterostructure_search) and load it into the viewer. The film (set via set_film) is placed on the substrate (the current structure); use swap=true to invert which is on top. Slab thickness uses the builder's default — for explicit thickness, cut slabs with generate_slab before set_film. Requires heterostructure_search to have been run first. NOTE: twist_angle is not yet supported on the client-side (WASM) path and is ignored there; twist≠0 requires the Python backend, default 0 works offline.`,
+    kind: `mutate`,
+    input_schema: {
+      type: `object`,
+      properties: {
+        match_index: { type: `integer`, minimum: 0, description: `Index of the match from heterostructure_search (default 0 = lowest strain).` },
+        gap: { type: `number`, description: `Interface gap between film and substrate in Å (default 2.0).` },
+        vacuum: { type: `number`, description: `Vacuum padding in Å (default 20.0).` },
+        twist_angle: { type: `number`, description: `Twist between layers in degrees (default 0; backend-only, ignored client-side).` },
+        swap: { type: `boolean`, description: `Swap which structure is substrate vs film (default false).` },
+        xy_shift: {
+          type: `array`,
+          items: { type: `number` },
+          minItems: 2,
+          maxItems: 2,
+          description: `Fractional in-plane shift [a, b] of the film (default [0, 0]).`,
+        },
+      },
+    },
+  },
+  async (input) => {
+    const matches = get_hetero_matches()
+    if (matches.length === 0) {
+      throw new Error(`No heterostructure matches available. Run heterostructure_search first.`)
+    }
+    const match_index = input.match_index === undefined ? 0 : Math.trunc(Number(input.match_index))
+    const m = matches[match_index]
+    if (!m) {
+      throw new Error(`match_index ${match_index} is out of range (0–${matches.length - 1}). Run heterostructure_search again or pick a valid index.`)
+    }
+
+    const swap = input.swap === true
+    const current = require_structure()
+    const film = get_film_stash()
+    if (!film) throw new Error(`No film set. Call set_film first.`)
+    // Default: substrate = current structure, film = stashed film.
+    const substrate = swap ? film : current
+    const film_struct = swap ? current : film
+
+    const gap = input.gap === undefined ? 2.0 : Number(input.gap)
+    const vacuum = input.vacuum === undefined ? 20.0 : Number(input.vacuum)
+    const twist_angle = input.twist_angle === undefined ? 0 : Number(input.twist_angle)
+    const xy_shift = (input.xy_shift as number[] | undefined)?.map(Number) as [number, number] | undefined
+
+    const result = await buildHeterostructureManual(
+      substrate as never,
+      film_struct as never,
+      m.substrate_transformation,
+      m.film_transformation,
+      gap,
+      vacuum,
+      twist_angle,
+      xy_shift ?? [0, 0],
+    )
+    set_current_structure(result.structure as never)
+    return { num_sites: result.n_atoms, strain: result.strain, match_area: result.match_area }
   },
 )
 

--- a/src/lib/chat/structure-tools.ts
+++ b/src/lib/chat/structure-tools.ts
@@ -17,9 +17,13 @@ import { buildNanoscroll } from '$lib/api/nanoscroll'
 import { searchMoireAngles, buildMoireBilayer } from '$lib/api/moire'
 import { buildHeterostructureManual, searchHeterostructureMatches } from '$lib/api/heterostructure'
 import type { HeterostructureSearchParams } from '$lib/api/heterostructure'
+import { passivateSlab } from '$lib/api/pseudo-hydrogen'
+import type { PseudoHydrogenParams } from '$lib/api/pseudo-hydrogen'
 import {
+  get_bulk_stash,
   get_film_stash,
   get_hetero_matches,
+  set_bulk_stash,
   set_film_stash,
   set_hetero_matches,
 } from './hetero-stash.svelte'
@@ -659,6 +663,69 @@ register(
     )
     set_current_structure(result.structure as never)
     return { num_sites: result.n_atoms, strain: result.strain, match_area: result.match_area }
+  },
+)
+
+// ── set_bulk_reference (read) ──
+register(
+  {
+    name: `set_bulk_reference`,
+    description: `Mark the currently-loaded structure as the BULK reference for surface passivation (used to compute correct coordination numbers). Then load/cut the slab and call passivate_surface. Typical flow: load bulk → set_bulk_reference → generate_slab → passivate_surface.`,
+    kind: `read`,
+    input_schema: { type: `object`, properties: {} },
+  },
+  () => {
+    const bulk = require_structure()
+    set_bulk_stash(bulk)
+    const sites = (bulk as { sites?: unknown[] }).sites ?? []
+    return { bulk_formula: plain_formula(bulk), bulk_num_sites: sites.length }
+  },
+)
+
+// ── passivate_surface (mutate) ──
+register(
+  {
+    name: `passivate_surface`,
+    description: `Passivate dangling bonds on the current slab with pseudo-hydrogen. Requires a bulk reference (set_bulk_reference) or an explicit bulk_coordination map.`,
+    kind: `mutate`,
+    input_schema: {
+      type: `object`,
+      properties: {
+        bulk_coordination: {
+          type: `object`,
+          additionalProperties: { type: `number` },
+          description: `Optional map of element → expected (bulk) coordination number, e.g. {"Si": 4}. Overrides the bulk-derived coordination; lets you passivate without a stashed bulk reference.`,
+        },
+      },
+    },
+  },
+  async (input) => {
+    const slab = require_structure()
+    const bulk = get_bulk_stash()
+    const bulk_coordination = input.bulk_coordination as Record<string, number> | undefined
+
+    if (!bulk && !bulk_coordination) {
+      throw new Error(
+        `Set a bulk reference first (set_bulk_reference on the parent crystal), or pass bulk_coordination.`,
+      )
+    }
+
+    const params: PseudoHydrogenParams = {}
+    if (bulk_coordination) params.bulk_coordination = bulk_coordination
+
+    // With a stashed bulk, reference coordination is derived from it (params may
+    // still carry an explicit override). Without a bulk, the explicit
+    // bulk_coordination map is authoritative — pass the slab itself as the bulk
+    // arg (it is ignored once bulk_coordination is set).
+    const bulk_arg = bulk ?? slab
+    const result = await passivateSlab(slab as never, bulk_arg as never, params)
+
+    set_current_structure(result.structure as never)
+    const n_added = (result as { n_pseudo_h?: number }).n_pseudo_h
+    const sites = (result.structure as { sites?: unknown[] }).sites ?? []
+    return n_added === undefined
+      ? { num_sites: sites.length }
+      : { num_sites: sites.length, n_hydrogens_added: n_added }
   },
 )
 


### PR DESCRIPTION
## Summary

Stacks on #145 (client-direct CatBot, merged) + #144 (ferrox-wasm builders, merged). Exposes the remaining client-side structure builders as **CatBot conversational tools** so the in-browser agent (STATIC_ONLY, no Python backend) can build **heterostructures** (vertical + lateral) and **passivate slabs**, plus a **markdown-render crash fix**.

(The nanotube/nanoscroll/moire builder tools landed with #145; this PR adds the 2-structure flows + the crash guard.)

## New tools (registered in `src/lib/chat/structure-tools.ts`)
Two-structure flows use a small stash (`src/lib/chat/hetero-stash.svelte.ts`) so transform matrices / the second structure are never threaded through the LLM:
- **Passivation:** `set_bulk_reference` + `passivate_surface` — pseudo-H caps dangling bonds on the current slab using a stashed bulk reference (or an explicit `bulk_coordination` map). Wraps `passivateSlab`.
- **Vertical heterostructure:** `set_film` → `heterostructure_search` (stashes candidate matches, returns a summary list) → `build_heterostructure` (`match_index` → stashed transforms → `buildHeterostructureManual` → load). Thickness omitted (the manual builder has none; use `generate_slab` first); `twist_angle` is backend-only on the WASM path (documented).
- **Lateral (in-plane) heterostructure:** `lateral_heterostructure_search` + `build_lateral_heterostructure` — `searchLateralMatches`/`buildLateralInterface`, in-plane junction.

## markdown crash fix (`src/lib/chat/markdown.ts`)
A CatBot reply (heterostructure match table) hit `RangeError: Invalid array length` → a non-advancing-`idx` branch in `markdown_to_html`'s main loop could infinite-loop and overflow the output array, crashing ChatPane→App. Added a no-progress guard (`_stuck_at`: force-emit the raw line + advance if any branch fails to consume it) so no input can ever infinite-loop.

## Verified live (agent-browser + real DeepSeek, STATIC_ONLY build)
- Passivation: SiO₂ slab → pseudo-H caps (`set_bulk_reference`→`generate_slab`→`passivate_surface`, 3 tools).
- Vertical hetero: Cu/graphene built + loaded; CatBot correctly flagged the lattice mismatch and suggested better substrates.
- Lateral hetero: graphene–graphene in-plane junction (0% strain), built + loaded.
- markdown fix: the exact reply that previously crashed now renders.

## Tests
`vitest run src/lib/chat`: **67 pass** (6 suites; incl. hetero-stash round-trips, tool kind/executor tests with mocked api, markdown termination + no-regression). eslint: 0 new errors. `svelte-check --threshold error`: 0 errors.

## Follow-ups (not in this PR)
- Wrap markdown render in ChatPane in a try/catch error boundary (defense-in-depth so any future markdown bug degrades to plain text).
- Heterostructure match quality: graphene/Cu at small `max_area` yields high-strain forced cells — consider larger default area or surfacing the strain warning more prominently.
- `grid_scan_heterostructure` (xy-shift scan) — deferred phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)