### PR TITLE
fix(mp): Materials Project API key + energies in STATIC_ONLY web build

### DIFF
--- a/src/lib/api/__tests__/optimade.test.ts
+++ b/src/lib/api/__tests__/optimade.test.ts
@@ -8,6 +8,12 @@ describe(`optimade static MP routing`, () => {
     expect(needs_relay(`https://optimade.materialsproject.org/v1/structures`)).toBe(true)
     expect(needs_relay(`https://alexandria.icams.rub.de/pbe/v1/structures`)).toBe(false)
   })
+
+  it(`MP REST API host (energies/band gaps) needs relay`, () => {
+    // api.materialsproject.org also sends no ACAO; the API-key validation +
+    // summary enrichment must traverse the relay in the static web build.
+    expect(needs_relay(`https://api.materialsproject.org/materials/summary/?_limit=1`)).toBe(true)
+  })
 })
 
 // Stronger integration: in static mode the OPTIMADE search must go out through

--- a/src/lib/api/materials-project.ts
+++ b/src/lib/api/materials-project.ts
@@ -1,7 +1,11 @@
-// Materials Project API utilities (via backend proxy to avoid CORS)
+// Materials Project API utilities.
 // Requires user's API key from https://materialsproject.org/
+// Three transports: VSCode extension host proxy, FastAPI backend proxy, and
+// (STATIC_ONLY web build) browser-direct via the CORS relay — api.materialsproject.org
+// sends no Access-Control-Allow-Origin, so direct browser fetches are blocked.
 
-import { API_BASE as _DEFAULT_API } from './config'
+import { API_BASE as _DEFAULT_API, STATIC_ONLY } from './config'
+import { relay_fetch } from '$lib/chat/provider-routing'
 
 // API base URL - same as other API modules
 let API_BASE = _DEFAULT_API
@@ -109,7 +113,10 @@ async function fetch_json_smart(url: string, api_key: string): Promise<unknown> 
     }
   }
 
-  const response = await fetch(url, {
+  // Web context: relay-aware fetch. api.materialsproject.org is CORS-blocked, so
+  // relay_fetch transparently routes it through the edge relay (which forwards the
+  // X-API-KEY header). Open hosts/backend-proxy URLs go direct.
+  const response = await relay_fetch(url, {
     headers: {
       'Content-Type': `application/json`,
       'X-API-KEY': api_key,
@@ -155,8 +162,8 @@ export async function search_mp_structures(
   let url: string
   let data: { data?: MPSummaryData[] }
 
-  if (vscode_api) {
-    // Direct Materials Project API call
+  if (vscode_api || STATIC_ONLY) {
+    // Direct Materials Project API call (relay-routed in the web build)
     const params = new URLSearchParams({
       _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal`,
       _limit: String(limit),
@@ -216,8 +223,8 @@ export async function get_mp_structure_summary(material_id: string): Promise<MPS
     let url: string
     let data: { data?: MPSummaryData }
 
-    if (vscode_api) {
-      // Direct API call
+    if (vscode_api || STATIC_ONLY) {
+      // Direct API call (relay-routed in the web build)
       const params = new URLSearchParams({
         _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal`,
       })
@@ -261,6 +268,13 @@ export async function validate_mp_api_key(key: string): Promise<boolean> {
       url = `https://api.materialsproject.org/materials/summary/?_limit=1`
       await fetch_json_smart(url, key)
       return true // If we got here without error, key is valid
+    } else if (STATIC_ONLY) {
+      // Web build: validate via the new MP API summary endpoint through the relay
+      // (the www.materialsproject.org api_check host is not relay-allowlisted).
+      // fetch_json_smart throws on a non-2xx (e.g. 401 invalid key) → caught below.
+      url = `https://api.materialsproject.org/materials/summary/?_limit=1`
+      await fetch_json_smart(url, key)
+      return true
     } else {
       // Backend proxy
       const response = await fetch(`${API_BASE}/mp/validate-key`, {

--- a/src/lib/chat/provider-routing.ts
+++ b/src/lib/chat/provider-routing.ts
@@ -8,8 +8,13 @@ export const RELAY_URL: string =
   (typeof import.meta.env.VITE_CORS_RELAY_URL === `string` && import.meta.env.VITE_CORS_RELAY_URL) ||
   `https://catgo-cors-relay.guangshengliu2021.workers.dev`
 
-/** Hosts known to block browser CORS — fetches to these must go through the relay. */
-const RELAY_HOSTS = new Set<string>([`optimade.materialsproject.org`])
+/** Hosts known to block browser CORS — fetches to these must go through the relay.
+ *  Both Materials Project surfaces (OPTIMADE + the REST API that serves energies/
+ *  band gaps) send no Access-Control-Allow-Origin, so they must be relayed. */
+const RELAY_HOSTS = new Set<string>([
+  `optimade.materialsproject.org`,
+  `api.materialsproject.org`,
+])
 
 export function needs_relay(url: string): boolean {
   try {

--- a/workers/cors-relay/wrangler.relay.toml
+++ b/workers/cors-relay/wrangler.relay.toml
@@ -3,4 +3,4 @@ main = "src/index.ts"
 compatibility_date = "2026-05-26"
 
 [vars]
-ALLOWED_HOSTS = "optimade.materialsproject.org"
+ALLOWED_HOSTS = "optimade.materialsproject.org,api.materialsproject.org"


### PR DESCRIPTION
## Problem

In the web build (`STATIC_ONLY`, no Python backend), entering a **valid** Materials Project API key shows "API 密钥无效 / Invalid API key", and no energies are shown.

Root cause: `materials-project.ts` (`validate_mp_api_key`, `search_mp_structures`, `get_mp_structure_summary`) only had two transports — VSCode extension proxy or FastAPI backend proxy (`${API_BASE}/mp/*`). In a static deploy there is no backend, so every call hit a dead URL and `validate_mp_api_key` returned `false`. There was **no browser-direct path** (unlike `optimade.ts`, which was already relay-aware).

`api.materialsproject.org` sends **no `Access-Control-Allow-Origin`** (confirmed), so a direct browser fetch is CORS-blocked. The MP REST API is what serves energies / band gaps, so it can't be skipped.

## Fix

Route the MP REST API through the existing edge CORS relay (which already forwards `X-API-KEY`):

- `materials-project.ts`: add a `STATIC_ONLY` branch to validate/search/summary; `fetch_json_smart` is now relay-aware (`relay_fetch`).
- `provider-routing.ts`: add `api.materialsproject.org` to `RELAY_HOSTS`.
- `workers/cors-relay/wrangler.relay.toml`: add `api.materialsproject.org` to `ALLOWED_HOSTS`.
- test: assert the MP REST host needs the relay.

## ⚠️ Required manual step

The deployed relay Worker must be **redeployed** for the new allowlisted host to take effect — until then it `403`s `api.materialsproject.org`:

```
cd workers/cors-relay && wrangler deploy -c wrangler.relay.toml
```

(Needs your Cloudflare account.)

## Verify
- `pnpm exec vitest run src/lib/api/__tests__/optimade.test.ts` → 4 passed
- `svelte-check` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)