### PR TITLE
fix(viewer): split-pane structure clobber + database crystal import demotion

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1639,6 +1639,7 @@
               {:else if pane.structure}
                 <Structure
                   tab_id={tab.id}
+                  is_active={ts.active_pane === idx}
                   bind:structure={ts.panes[idx].structure}
                   bind:saveable_structure={ts.panes[idx].saveable_structure}
                   bind:selected_sites={ts.panes[idx].selected_sites}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -832,6 +832,7 @@
     vibration_data = null as { eigenvector: number[][]; base_positions: number[][]; amplitude: number; playing: boolean } | null,
     initial_bulk = null as PymatgenStructure | null,
     tab_id,
+    is_active = true,
     ...rest
   }:
     & {
@@ -978,6 +979,12 @@
       // correct tab instead of colliding on a single "default" panel.
       // Defaults to "default" for callers that don't supply one.
       tab_id?: string
+      // True when this pane is the active/focused one in its tab. Only the
+      // active pane adopts global current-structure store mutations (CatBot
+      // client-direct edits); background panes in a split view must NOT be
+      // clobbered by a load/edit that targeted a sibling pane. Defaults true
+      // so single-pane and preview usages behave as before.
+      is_active?: boolean
     }
     & Omit<ComponentProps<typeof StructureControls>, `children` | `onclose`>
     & Omit<HTMLAttributes<HTMLDivElement>, `children`> = $props()
@@ -2158,6 +2165,12 @@
   const _cur_store = current_structure_state()
   $effect(() => {
     if (tab_id === undefined) return
+    // Only the active pane adopts store mutations. In a split view every pane
+    // shares this one global store; without this guard, loading/editing one
+    // pane (which writes the store) makes every sibling pane's effect re-run
+    // and overwrite itself with that structure — all panes collapse to the
+    // same structure. The active pane is the one CatBot/loads target.
+    if (!is_active) return
     const v = _cur_store.value
     if (v && v !== structure && v !== _last_mirrored_to_store) {
       structure = v as typeof structure
@@ -2456,9 +2469,14 @@
     get_atom_fast_ops: () => scene_atom_fast_ops,
   })
 
-  // Handle OPTIMADE / PubChem structure import.
-  //   • empty pane  → load the imported structure (with a full camera reset)
-  //   • loaded pane → merge the import into the current structure
+  // Handle OPTIMADE / PubChem structure import — always REPLACES the pane.
+  // Previously a loaded pane MERGED the import into its current structure. That
+  // silently combined a freshly-imported crystal with whatever was left in the
+  // pane (e.g. a leftover water molecule) and — because merge_structures keeps
+  // only the base's lattice — dropped the crystal's own cell, demoting a
+  // periodic TiO2 to a lattice-less molecular cluster. Importing a database
+  // structure means "show me this structure", so replace (undo-able). Composite
+  // building (adsorbate-on-surface) has dedicated tools/paste for that.
   // Because `structure` is bound to the active pane, the write-back targets the
   // correct pane in multi-pane layouts — no parent routing required.
   function handle_optimade_import(imported_structure: PymatgenStructure) {
@@ -2466,22 +2484,13 @@
       return
     }
 
-    if (structure?.sites?.length) {
-      // Save current state for undo, then merge the import outside the existing
-      // structure (offset with padding).
-      push_to_undo()
-      const import_position = get_import_position_outside(structure, imported_structure)
-      const merged = merge_structures(structure, imported_structure, import_position)
-      // Mark _aligned so align_on_load doesn't re-rotate the merged structure,
-      // which would shift the original atoms and cause overlap.
-      structure = { ...merged, _aligned: true } as any as typeof structure
-    } else {
-      // Empty pane: load the import directly with a full camera reset.
-      scene_props.camera_position = [0, 0, 0] // triggers auto-positioning at correct distance
-      center_camera_trigger++ // re-center orbit target on structure
-      camera_has_moved = false
-      structure = imported_structure
-    }
+    // Keep the prior content undo-able when replacing a non-empty pane.
+    if (structure?.sites?.length) push_to_undo()
+
+    scene_props.camera_position = [0, 0, 0] // triggers auto-positioning at correct distance
+    center_camera_trigger++ // re-center orbit target on structure
+    camera_has_moved = false
+    structure = imported_structure
 
     selected_sites = []
     optimade_import_position = null

--- a/src/lib/structure/atom-manipulation.ts
+++ b/src/lib/structure/atom-manipulation.ts
@@ -176,14 +176,24 @@ export function merge_structures(
     position[2] - incoming_center[2],
   ]
 
-  // Check if base has a lattice
+  // Pick the lattice for the merged result. Prefer the base's lattice; but if
+  // the base is lattice-less (a molecule) while the incoming structure is a
+  // periodic crystal, ADOPT the incoming lattice — otherwise merging a crystal
+  // onto a molecule silently drops the crystal's cell and demotes it to a
+  // molecule (the TiO2-becomes-molecular bug).
   const base_lattice = (base as PymatgenStructure).lattice
-  const has_lattice = base_lattice?.matrix
+  const incoming_lattice = (incoming as PymatgenStructure).lattice
+  const merged_lattice = base_lattice?.matrix
+    ? base_lattice
+    : (incoming_lattice?.matrix ? incoming_lattice : null)
+  // True when we took the incoming lattice because base had none — base sites'
+  // abc are then cartesian placeholders and must be recomputed below.
+  const adopted_incoming_lattice = !base_lattice?.matrix && !!merged_lattice?.matrix
 
   // Calculate inverse lattice matrix for converting xyz to abc
   let inv_matrix: Matrix3x3 | null = null
-  if (has_lattice) {
-    inv_matrix = matrix_inverse_3x3(transpose_3x3_matrix(base_lattice.matrix))
+  if (merged_lattice?.matrix) {
+    inv_matrix = matrix_inverse_3x3(transpose_3x3_matrix(merged_lattice.matrix))
   }
 
   // Add incoming sites with offset applied
@@ -209,19 +219,26 @@ export function merge_structures(
     }
   })
 
-  // Combine sites
-  const combined_sites = [...base.sites, ...incoming_sites]
+  // When we adopted the incoming lattice, the base sites' abc were cartesian
+  // placeholders (base had no cell) — recompute them against the merged lattice.
+  const base_sites: Site[] = (adopted_incoming_lattice && inv_matrix)
+    ? base.sites.map(site => ({ ...site, abc: mat3x3_vec3_multiply(inv_matrix!, site.xyz) }))
+    : base.sites
 
-  // Return with base's lattice preserved
-  if (has_lattice) {
+  // Combine sites
+  const combined_sites = [...base_sites, ...incoming_sites]
+
+  // Return with the merged lattice (base's, or incoming's if base had none).
+  if (merged_lattice?.matrix) {
     return {
       ...(base as PymatgenStructure),
+      lattice: merged_lattice,
       sites: combined_sites,
       charge: (base.charge || 0) + (incoming.charge || 0),
     }
   }
 
-  // No lattice - return as molecule
+  // Neither structure has a lattice - return as molecule
   return {
     sites: combined_sites,
     charge: (base.charge || 0) + (incoming.charge || 0),


### PR DESCRIPTION
Two viewer bugs (both regressions/issues from the client-side CatBot work in #145), root-caused via multi-agent review and confirmed by manual test.

## Bug 1 — split view: all panes collapse to the same structure

**Symptom:** in 左右分屏 (splitH), load Cu then load Fe → BOTH panes show Fe (both headers read "Fe").

**Root cause:** the module-global `current-structure` store has a reverse-sync `$effect` in `Structure.svelte` (added in #145 so CatBot client-direct edits reflect in the viewer). Every pane's `<Structure>` shares that one global store. Loading Fe into pane 1 writes the store; pane 0's effect re-runs, sees a new value, and overwrites its own structure with Fe. The `_last_mirrored_to_store` guard only protects the pane that wrote — siblings get clobbered. Affects any multi-pane layout.

**Fix:** gate the reverse-sync `$effect` to the **active pane only** (new `is_active` prop, default `true`; `App.svelte` passes `active_pane === idx`). Store stays global for CatBot / workflow "Capture from Viewer".

## Bug 2 — database import: crystal becomes a lattice-less molecule + leftover water

**Symptom:** importing a TiO2 crystal from the database shows a molecular cluster (no unit cell) plus a floating H2O.

**Root cause:** `handle_optimade_import` MERGED the import into the pane's existing content instead of replacing. With a leftover water molecule in the pane, TiO2 got merged with it; and `merge_structures` keeps only the **base** lattice, so a crystal merged onto a lattice-less molecule lost its own cell → demoted to a molecule (and the water stayed).

**Fix:**
- `handle_optimade_import` now **replaces** (undo-able) rather than silently merging. Composite building (adsorbate-on-surface) stays on the dedicated tools/paste path.
- `merge_structures` now **adopts the incoming lattice when the base has none** (recomputing base-site fractional coords), so a periodic crystal is never demoted by a merge.

## Verify
- `svelte-check`: 0 errors
- Manually tested both fixes on a local STATIC_ONLY build (split-pane Cu/Fe stays separate; DB TiO2 import loads a clean periodic crystal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)