### PR TITLE
chore(release): v1.1.1 — Linux .rpm bundle + version bump

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -32,10 +32,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             backend_target: x86_64-unknown-linux-gnu
             name: Linux
-            # Ship .deb only. AppImage (linuxdeploy) and .rpm (rpmbuild) both
-            # hang for 20+ min on GitHub runners; .deb builds in seconds and
-            # covers Debian/Ubuntu — the primary Linux desktop target.
-            bundles: deb
+            # Ship .deb + .rpm. AppImage (linuxdeploy) still excluded: it needs
+            # FUSE and hangs 20+ min on GitHub runners. Tauri v2's RPM bundler is
+            # pure-Rust (no rpmbuild), so .rpm builds fine and covers Fedora/RHEL.
+            bundles: deb rpm
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.name }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2026-05-28
+
+### Added
+- **Client-side builders**: Nanotube, Moiré, Passivate, Heterostructure (ZSL lattice matching), and Nanoscroll now run fully in-browser via `ferrox-wasm` — no backend required (works in STATIC_ONLY web builds).
+- **MOF/COF builder**: Reticular framework construction via PORMAKE, plus MOFX-DB search.
+- **CatBot client-side tool-calling**: CatBot operates in STATIC_ONLY web builds, including conversational heterostructure (vertical + lateral) and passivation tools.
+- **Client-side input generation**: VASP (INCAR/KPOINTS), Quantum ESPRESSO, LAMMPS, and CP2K inputs generate offline on any backend failure.
+- **Large-system performance mode**: WebGPU overlay for million-atom rendering.
+- **MCP builders**: Heterostructure (vertical + lateral in-plane), nanotube, and moiré builders exposed to CatBot via MCP.
+- **Linux RPM packages**: Releases now ship `.rpm` alongside `.deb` (Fedora/RHEL).
+
+### Fixed
+- Materials Project API key now works in STATIC_ONLY web builds.
+- Resolved split-pane structure clobber and DB crystal import demotion.
+- Water-layer packing is client-side with clash-free PBC boundaries.
+- Stopped Site Indices/Labels from freezing the tab (color-mix self-nesting).
+- VASP `KSPACING` uses true VASP semantics, not kppvol density.
+- Swallow WebGPU `AbortError` when the pick buffer is destroyed mid-map.
+- Prevented an infinite loop in the chat markdown table parser.
+- Preserve camera view when switching projection (orthographic ↔ perspective).
+- Stopped whole-app freeze on gesture enable → disable → re-enable.
+- Allow atom delete/edit in non-1×1×1 supercells.
+
+### Changed
+- Added Dockerfile and GHCR container publish workflow.
+
 ## [1.0.0] - 2026-05-12
 
 ### Added

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures and MD trajectories — POSCAR/CIF/XYZ/extXYZ/ASE .traj/HDF5/DCD/XTC/TRR. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, charge-density cube isosurfaces, trajectory scrubbing with energy/force overlays, themes that follow VS Code.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.22.1",
  "catgo-graph",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.1.0"
+version = "1.1.1"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
## Summary
- Bump version 1.1.0 → 1.1.1 (package.json, tauri.conf.json, Cargo.toml/lock)
- Add `.rpm` to the Linux desktop bundle (Tauri v2 pure-Rust RPM bundler; no rpmbuild)
- AppImage stays excluded (needs FUSE on runners)
- CHANGELOG [1.1.1] entry

Tag `v1.1.1` already pushed at the branch tip (`889ba1f7`) to kick off the all-platform release build (Windows / macOS / Linux deb+rpm). This PR lands the same version-bump commit on `main`.

## Test plan
- [ ] All three platforms build green on the `v1.1.1` tag run
- [ ] Linux artifacts include both `.deb` and `.rpm`