### PR TITLE
fix(vasp): show offline generation success as info, not a red error

### DIFF
--- a/src/lib/structure/ExportPane.svelte
+++ b/src/lib/structure/ExportPane.svelte
@@ -177,6 +177,10 @@
   let prefix = $state('calc')
   let generated_output = $state<Record<string, string>>({})
   let generation_error = $state<string | null>(null)
+  // Non-error feedback for the offline / partial fallback paths (web + desktop
+  // when the Python backend is unreachable). Kept separate from generation_error
+  // so a successful client-side generation isn't rendered as a red failure.
+  let generation_notice = $state<{ text: string; severity: 'info' | 'warning' } | null>(null)
   let active_file = $state('')
 
   // ====== Shared constraint state ======
@@ -392,6 +396,7 @@
     active_section
     generated_output = {}
     generation_error = null
+    generation_notice = null
     active_file = ''
   })
 
@@ -602,6 +607,7 @@
       {unique_elements}
       bind:generated_output
       bind:generation_error
+      bind:generation_notice
       bind:active_file
       {on_request_vacuum_box}
     />
@@ -721,6 +727,9 @@
   {#if generation_error}
     <p class="error">{generation_error}</p>
   {/if}
+  {#if generation_notice}
+    <p class="gen-notice {generation_notice.severity}">{generation_notice.text}</p>
+  {/if}
 {/snippet}
 
 {#if embedded}
@@ -801,6 +810,17 @@
   }
   .quick-export-btn:hover { background: light-dark(rgba(0,0,0,0.12), rgba(255,255,255,0.15)); }
   .quick-export-hint { font-size: 0.75em; opacity: 0.5; margin-top: 3px; }
+  .gen-notice { margin-top: 0.5em; padding: 6px 10px; border-radius: 4px; font-size: 0.85em; line-height: 1.4; }
+  .gen-notice.info {
+    background: rgba(59, 130, 246, 0.12);
+    border: 1px solid var(--accent-color, #3b82f6);
+    color: var(--accent-color, #3b82f6);
+  }
+  .gen-notice.warning {
+    background: rgba(255, 152, 0, 0.12);
+    border: 1px solid var(--warning-color, #f59e0b);
+    color: var(--warning-color, #f59e0b);
+  }
   .supercell-export-notice {
     display: flex; align-items: center; gap: 6px; font-size: 0.78em;
     padding: 5px 8px; margin-bottom: 0.6em; border-radius: 4px;

--- a/src/lib/structure/export/VaspExport.svelte
+++ b/src/lib/structure/export/VaspExport.svelte
@@ -22,6 +22,7 @@
     unique_elements = [],
     generated_output = $bindable<Record<string, string>>({}),
     generation_error = $bindable<string | null>(null),
+    generation_notice = $bindable<{ text: string; severity: 'info' | 'warning' } | null>(null),
     active_file = $bindable(''),
     on_request_vacuum_box = undefined,
   }: {
@@ -30,6 +31,7 @@
     unique_elements?: string[]
     generated_output?: Record<string, string>
     generation_error?: string | null
+    generation_notice?: { text: string; severity: 'info' | 'warning' } | null
     active_file?: string
     on_request_vacuum_box?: () => void
   } = $props()
@@ -145,6 +147,7 @@
     if (!structure) { generation_error = 'No structure'; return }
     vasp_generating = true
     generation_error = null
+    generation_notice = null
     vasp_files = null
     try {
       let kpoints: number[][] | undefined = undefined
@@ -274,7 +277,10 @@
       if (files.incar_nelect) generated_output['INCAR_NELECT'] = files.incar_nelect
       active_file = vasp_constant_potential !== 'none' ? 'INCAR_NELECT' : 'INCAR'
     } catch (e) {
-      // Backend unavailable — generate client-side with $lib/io/vasp-input.
+      // Backend unavailable (web/static build, or desktop sidecar down/unreachable)
+      // OR backend returned an error — surface the real reason for diagnosis,
+      // then generate client-side with $lib/io/vasp-input as a fallback.
+      console.warn('[VASP] backend generation failed; falling back to client-side (offline) generation:', e)
       try {
         const poscar = structure_to_poscar(structure as unknown as StructureData)
         const { generate_incar_str, generate_kpoints_str, face_centered_from_symmetry, SUPPORTED_CALC_TYPES } =
@@ -317,13 +323,22 @@
           )
           generated_output = { 'INCAR': incar, 'POSCAR': poscar, 'KPOINTS': kpoints_str }
           active_file = 'INCAR'
-          generation_error = 'Generated client-side (offline). Advanced options (MD / constant-potential / element-specific POTCAR & MAGMOM tuning) require the Python backend.'
+          // Successful offline generation — this is not an error.
+          generation_notice = {
+            text: 'Generated client-side (offline). Advanced options (MD / constant-potential / element-specific POTCAR & MAGMOM tuning) require the Python backend.',
+            severity: 'info',
+          }
         } else {
           generated_output = { 'POSCAR': poscar }
           active_file = 'POSCAR'
-          generation_error = `Backend unavailable — '${vasp_calculation}' needs the Python backend; only POSCAR exported offline.`
+          // Partial result — the requested calc type can't be produced offline.
+          generation_notice = {
+            text: `Backend unavailable — '${vasp_calculation}' needs the Python backend; only POSCAR exported offline.`,
+            severity: 'warning',
+          }
         }
       } catch (offlineErr) {
+        console.error('[VASP] client-side fallback also failed:', offlineErr)
         generation_error = e instanceof Error ? e.message : 'Failed to generate VASP inputs'
       }
     } finally {


### PR DESCRIPTION
## Problem

PR #122 added client-side VASP **offline** generation, but routed both the
success and the partial-result messages through `generation_error` —
which `ExportPane` renders in **red**. So a *successful* offline
generation (full INCAR/POSCAR/KPOINTS) looked like a failure to the user.
This is purely a presentation bug introduced alongside #122; the offline
generation itself works.

Reproduces in both the **web/static** build (backend intentionally
unreachable → offline path is normal) and the **desktop** app whenever
the Python sidecar is down/unreachable.

## Fix

Split feedback into a dedicated `generation_notice` channel, kept
separate from the red `generation_error`:

| Outcome | Before | After |
|---|---|---|
| Offline success (INCAR+POSCAR+KPOINTS) | 🔴 red error | 🔵 info (blue) |
| Partial (only POSCAR; MD / constant-potential not offline-capable) | 🔴 red error | 🟠 warning (orange) |
| Real failure (offline also threw) | 🔴 red error | 🔴 red error (unchanged) |

Also surfaces the previously-swallowed backend error via
`console.warn` / `console.error`, so desktop sidecar/connectivity
failures are diagnosable instead of silently falling back.

## Scope
- `src/lib/structure/export/VaspExport.svelte` — new `generation_notice` bindable; route the three outcomes; log swallowed errors.
- `src/lib/structure/ExportPane.svelte` — `generation_notice` state, reset on section change, bind to VaspExport, render + `.gen-notice` info/warning styles (consistent with the existing `.supercell-export-notice`).

**No change to the generated files** — presentation only.

## Verification
- `svelte-check`: 0 errors in the touched files (the only repo errors are a pre-existing `@webgpu/types` missing-dep, unrelated).
- The offline generator logic itself is already covered by `tests/vitest/io/vasp-input.test.ts` (byte-exact vs pymatgen) — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)