### PR TITLE
ci(vsix-publish): sync extension version from root + fail loudly on real publish errors

### DIFF
--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -58,6 +58,16 @@ jobs:
       - name: Build documentation chunks
         run: pnpm run build:doc-chunks
 
+      # Single source of truth for the version: the VS Code extension always
+      # inherits the root package.json version at publish time. Prevents
+      # shipping a stale .vsix when a release bump forgets to update
+      # extensions/vscode/package.json (this happened for v1.1.1).
+      - name: Sync extension version from root package.json
+        run: |
+          root_ver=$(node -p "require('./package.json').version")
+          npm --prefix extensions/vscode pkg set version="$root_ver"
+          echo "Extension version synced to $root_ver"
+
       - name: Build extension
         working-directory: extensions/vscode
         run: pnpm build
@@ -66,25 +76,48 @@ jobs:
         working-directory: extensions/vscode
         run: pnpm dlx @vscode/vsce package --no-dependencies
 
+      # Real publish failures (bad token, network, packaging) now fail the job
+      # loudly instead of being swallowed by continue-on-error. The ONLY
+      # tolerated error is "already published" — keeps re-tagging the same
+      # version idempotent without masking genuine breakage.
       - name: Publish to VS Code Marketplace
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
-        # Don't fail the whole job (and skip the release-attach below) when the
-        # version is already published — e.g. re-tagging the same version.
-        continue-on-error: true
         working-directory: extensions/vscode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: pnpm dlx @vscode/vsce publish --no-dependencies --packagePath catgo-*.vsix
+        run: |
+          set +e
+          out=$(pnpm dlx @vscode/vsce publish --no-dependencies --packagePath catgo-*.vsix 2>&1)
+          code=$?
+          echo "$out"
+          if [ "$code" -ne 0 ]; then
+            if echo "$out" | grep -qiE "already (exists|published)"; then
+              echo "::warning::Version already on the VS Code Marketplace — treating as a no-op (idempotent re-tag)."
+            else
+              echo "::error::vsce publish failed (exit $code)."
+              exit "$code"
+            fi
+          fi
 
       - name: Publish to Open VSX (Cursor / VSCodium / Theia)
         if: ${{ (github.event_name == 'push' || inputs.dry_run == false) && env.OVSX_PAT != '' }}
-        continue-on-error: true
         working-directory: extensions/vscode
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
+          set +e
           vsix=$(ls catgo-*.vsix | head -1)
-          pnpm dlx ovsx publish "$vsix" --no-dependencies
+          out=$(pnpm dlx ovsx publish "$vsix" --no-dependencies 2>&1)
+          code=$?
+          echo "$out"
+          if [ "$code" -ne 0 ]; then
+            if echo "$out" | grep -qiE "already (exists|published)"; then
+              echo "::warning::Version already on Open VSX — treating as a no-op (idempotent re-tag)."
+            else
+              echo "::error::ovsx publish failed (exit $code)."
+              exit "$code"
+            fi
+          fi
 
       - name: Upload VSIX as workflow artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why
The v1.1.1 release shipped the VS Code extension as **1.1.0**: the release bump updated root `package.json` / `tauri.conf.json` / `Cargo.toml` but missed `extensions/vscode/package.json`. The tag-triggered publish then packaged `catgo-1.1.0.vsix`, and both registries rejected it (`already published`) — but `continue-on-error: true` swallowed the errors, so the run reported green while nothing shipped. (Fixed manually by re-dispatching the workflow on `main`; this PR prevents recurrence.)

## Changes
**A. Sync extension version from root** — new step runs `npm pkg set version=<root version>` before build/package. The extension always inherits the root version, so a release bump can no longer forget it.

**B. Fail loudly on real errors** — drop the blanket `continue-on-error: true` on both the VS Marketplace and Open VSX publish steps. Real failures (bad token, network, packaging) now fail the job. The **only** tolerated error is `already published`, which keeps re-tagging the same version idempotent (and lets the release-attach step still run) without masking genuine breakage.

## Test plan
- [ ] `workflow_dispatch` dry run (`dry_run: true`) packages a `.vsix` whose version matches root `package.json`
- [ ] A genuine publish failure now turns the job red; an `already published` reduces to a `::warning::` and the job stays green