### PR TITLE
docs(vscode-ext): fix license in readme — AGPL-3.0, not MIT

### DIFF
--- a/extensions/vscode/readme.md
+++ b/extensions/vscode/readme.md
@@ -163,7 +163,7 @@ If you encounter any issues with CatGo, you can use the built-in bug reporting c
 
 ## 📄 License
 
-This extension is [MIT-Licensed](./license).
+This extension is licensed under the [GNU AGPL-3.0](./license), matching the [catgo-LRG repository](https://github.com/Hello-QM/catgo-LRG).
 
 ## 🔗 Related Projects
 


### PR DESCRIPTION
## Why
The extension **Overview** page on the VS Code Marketplace / Open VSX (rendered from `extensions/vscode/readme.md`) says *"This extension is MIT-Licensed"*. That's wrong:
- `extensions/vscode/license` is the **GNU AGPL-3.0** full text
- `extensions/vscode/package.json` and root `package.json` both declare `AGPL-3.0-or-later`
- The GitHub repo is identified as **AGPL-3.0**

## Change
Readme license line: `MIT-Licensed` → `GNU AGPL-3.0`, linking the repo for consistency.

## Note
The published Overview is a snapshot taken at publish time, so the live Marketplace/Open VSX pages will only update on the **next version publish** (a re-publish of the same version is a no-op). Rolls in with the next release.