### PR TITLE
ci: build VS Code extension sidecar binaries on per-platform runners

### DIFF
--- a/.github/workflows/build-vscode-sidecars.yml
+++ b/.github/workflows/build-vscode-sidecars.yml
@@ -1,0 +1,112 @@
+name: Build VSCode Sidecar Binaries
+
+# The VS Code / Open VSX extension ships WITHOUT the ~463 MB catgo-server
+# binary (Marketplace has a ~100 MB cap). On first activate, src/sidecar.ts
+# downloads the platform-appropriate binary from this release:
+#   https://github.com/Hello-QM/catgo-LRG/releases/download/v<version>/catgo-server-<platform>
+# This workflow builds those binaries on real per-platform runners (a single
+# Linux runner cannot cross-compile a PyInstaller bundle for macOS/Windows)
+# and attaches them to the matching release.
+#
+# Triggers:
+#   - push of a v* tag  → builds + attaches to that tag's release (normal release flow)
+#   - workflow_dispatch → builds + attaches to `tag` input (backfill an existing release,
+#                          e.g. v1.1.1 which shipped without these binaries)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach binaries to (e.g. v1.1.1). Defaults to the pushed tag.'
+        type: string
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-22.04
+            asset_name: catgo-server-linux-x64
+            dist_bin: catgo-server
+          - platform: macos-latest
+            asset_name: catgo-server-darwin-arm64
+            dist_bin: catgo-server
+          - platform: windows-latest
+            asset_name: catgo-server-win-x64.exe
+            dist_bin: catgo-server.exe
+
+    runs-on: ${{ matrix.platform }}
+    name: sidecar (${{ matrix.asset_name }})
+
+    # login shell so the conda env activated by setup-miniconda is on PATH
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # --- Python backend toolchain (mirrors tauri-build.yml backend build) ---
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: '3.11'
+          channels: conda-forge
+          auto-activate-base: false
+          activate-environment: catgo
+
+      - name: Install Python dependencies
+        run: |
+          conda install -y -c conda-forge openbabel pip
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          # openbabel comes from conda-forge, not pip
+          grep -iv '^openbabel' server/requirements.txt > reqs_no_ob.txt
+          pip install -r reqs_no_ob.txt
+          rm reqs_no_ob.txt
+
+      # catgo_server.spec bundles the Rust cube-processor binary; build it first
+      # or PyInstaller fails with "Unable to find ...cube-processor".
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build cube-processor
+        run: cargo build --release --manifest-path tools/cube-processor/Cargo.toml
+
+      - name: Build catgo-server (PyInstaller)
+        run: |
+          cd server
+          python -m PyInstaller catgo_server.spec --noconfirm
+
+      - name: Stage sidecar binary
+        run: |
+          cp "server/dist/${{ matrix.dist_bin }}" "${{ matrix.asset_name }}"
+          if [ "${{ runner.os }}" != "Windows" ]; then
+            chmod +x "${{ matrix.asset_name }}"
+          fi
+          ls -la "${{ matrix.asset_name }}"
+
+      - name: Attach sidecar to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.inputs.tag }}"
+          if [ -z "$tag" ]; then tag="${GITHUB_REF_NAME}"; fi
+          echo "Attaching ${{ matrix.asset_name }} to release $tag"
+          # The desktop build (tauri-build.yml) creates the release on tag push;
+          # retry briefly in case this job wins the race, then upload.
+          for i in 1 2 3 4 5; do
+            if gh release view "$tag" >/dev/null 2>&1; then break; fi
+            gh release create "$tag" --title "$tag" --notes "Release $tag" && break || sleep 15
+          done
+          gh release upload "$tag" "${{ matrix.asset_name }}" --clobber

--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -126,7 +126,7 @@ jobs:
           path: extensions/vscode/catgo-*.vsix
           retention-days: 90
 
-      - name: Attach VSIX and sidecar binaries to GitHub Release
+      - name: Attach VSIX to GitHub Release
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,13 +137,8 @@ jobs:
           gh release view "$tag" >/dev/null 2>&1 \
             || gh release create "$tag" --title "$tag" --notes "Release $tag"
           gh release upload "$tag" "$vsix" --clobber
-          # Sidecar binaries (linux-x64, darwin-arm64, win-x64) live alongside
-          # the .vsix on the release so `extensions/vscode/src/sidecar.ts` can
-          # fetch the right one for the user's platform on first activate.
-          # The .vsix itself ships without bin/ to stay under the Marketplace
-          # ~100 MB size limit.
-          for f in extensions/vscode/bin/catgo-server-linux-x64 \
-                   extensions/vscode/bin/catgo-server-darwin-arm64 \
-                   extensions/vscode/bin/catgo-server-win-x64.exe; do
-            [ -f "$f" ] && gh release upload "$tag" "$f" --clobber || true
-          done
+          # The platform sidecar binaries (catgo-server-{linux-x64,darwin-arm64,
+          # win-x64.exe}) that src/sidecar.ts downloads on first activate are
+          # built and attached by the separate build-vscode-sidecars.yml
+          # workflow — they can't be produced on this single Linux runner, and
+          # the old `[ -f ] && upload` loop here silently uploaded nothing.


### PR DESCRIPTION
## Why
The VS Code / Open VSX extension ships **without** the ~463 MB `catgo-server` binary (Marketplace ~100 MB cap). On first activate, `extensions/vscode/src/sidecar.ts` downloads the platform binary from:
```
https://github.com/Hello-QM/catgo-LRG/releases/download/v<version>/catgo-server-<platform>
```
But **those binaries were never built**. `vsix-publish.yml` runs on a single Linux runner and its release-attach step used `[ -f "$f" ] && gh release upload || true` over `extensions/vscode/bin/catgo-server-*` — files that no step ever produced, so it silently uploaded nothing. Result: **every release (v1.1.0, v1.1.1) 404s** for end users:
> `CatGo server sidecar unavailable: HTTP 404 fetching .../v1.1.1/catgo-server-linux-x64`

## Changes
- **New `build-vscode-sidecars.yml`** — 3-platform matrix (`ubuntu-22.04`→linux-x64, `macos-latest`→darwin-arm64, `windows-latest`→win-x64.exe). Each runner mirrors the **already-proven** backend build from `tauri-build.yml` (conda `openbabel` + `requirements.txt`, `cargo build` cube-processor, `PyInstaller catgo_server.spec`), then attaches the renamed binary to the release with `gh release upload --clobber`.
  - Triggers on `v*` tag push (normal release flow) **and** `workflow_dispatch` with a `tag` input to backfill an existing release.
- **`vsix-publish.yml`** — removed the dead sidecar-upload loop (could never find the binaries); comment now points at the new workflow. VSIX attach unchanged.

## Test plan
- [ ] Merge, then `workflow_dispatch` this workflow with `tag: v1.1.1` → confirm `catgo-server-linux-x64` / `-darwin-arm64` / `-win-x64.exe` appear on the v1.1.1 release
- [ ] Install the extension on Linux → first activate downloads the sidecar, no 404
- [ ] Next tagged release auto-attaches all three binaries

## Notes
- macOS is Apple-Silicon only (`catgo-server-darwin-arm64`), matching `sidecar.ts` (no darwin-x64 path).
- Each PyInstaller bundle is large (~hundreds of MB); the matrix build adds ~15–20 min per platform, parallelized.