### PR TITLE
chore(release): v1.1.2 — sidecar fix, license correction, i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2026-05-29
+
+### Added
+- **i18n**: Localized many additional UI surfaces (workflow, file browser, trajectory, phase diagram, plugins, gesture, MD analysis panels).
+
+### Fixed
+- **VS Code extension sidecar 404**: The `catgo-server` binary the extension downloads on first activate is now built on real per-platform runners and attached to each release (`catgo-server-linux-x64` / `-darwin-arm64` / `-win-x64.exe`). Previously these were never produced, so first activate failed with HTTP 404.
+- **Extension license**: Overview/readme now correctly states GNU AGPL-3.0 (was mislabeled MIT), matching the repository.
+
+### Changed
+- **Release CI**: The VS Code extension version is auto-synced from the root `package.json` at publish time, and publish steps now fail loudly on real errors instead of silently swallowing them.
+
 ## [1.1.1] - 2026-05-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "catgo-graph",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.1.1"
+version = "1.1.2"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Bumps 1.1.1 → 1.1.2 to ship the fixes that only reach users via a new version:
- **Extension sidecar 404** fixed — `catgo-server-*` binaries now built on per-platform runners and attached to the release (#155)
- **Extension license** corrected to AGPL-3.0 in overview/readme (#154)
- **i18n** coverage for more UI surfaces (#151)
- Release CI hardening: extension version auto-sync + fail-loud publish (#153)

Tag `v1.1.2` (d5bbdbe1) pushed to trigger the all-platform desktop build, the extension publish (auto-synced to 1.1.2), and the new sidecar build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)