### PR TITLE
fix(slab): correct (110) stoichiometry + uncapped slab-cutter controls

### DIFF
--- a/extensions/rust/src/slab.rs
+++ b/extensions/rust/src/slab.rs
@@ -1062,6 +1062,56 @@ mod tests {
         );
     }
 
+    fn create_rocksalt_nio() -> Structure {
+        // Rocksalt NiO conventional cubic cell, a = 4.13792322 Å (4 Ni + 4 O)
+        let lattice = Lattice::cubic(4.13792322);
+        let frac_coords = vec![
+            Vector3::new(0.0, 0.0, 0.0), // Ni
+            Vector3::new(0.5, 0.5, 0.0), // Ni
+            Vector3::new(0.5, 0.0, 0.5), // Ni
+            Vector3::new(0.0, 0.5, 0.5), // Ni
+            Vector3::new(0.0, 0.0, 0.5), // O
+            Vector3::new(0.5, 0.0, 0.0), // O
+            Vector3::new(0.0, 0.5, 0.0), // O
+            Vector3::new(0.5, 0.5, 0.5), // O
+        ];
+        let ni = Species::from_string("Ni").unwrap();
+        let o = Species::from_string("O").unwrap();
+        let occ = vec![
+            SiteOccupancy::ordered(ni), SiteOccupancy::ordered(ni),
+            SiteOccupancy::ordered(ni), SiteOccupancy::ordered(ni),
+            SiteOccupancy::ordered(o), SiteOccupancy::ordered(o),
+            SiteOccupancy::ordered(o), SiteOccupancy::ordered(o),
+        ];
+        Structure::try_new_from_occupancies(lattice, occ, frac_coords).unwrap()
+    }
+
+    fn count_species(s: &Structure, sym: &str) -> usize {
+        s.site_occupancies
+            .iter()
+            .filter(|o| o.dominant_species().element.symbol() == sym)
+            .count()
+    }
+
+    /// Rocksalt (110) is a neutral, stoichiometric surface: every slab must keep
+    /// Ni:O = 1:1. Regression test for the species-blind primitive reduction that
+    /// accepted the c/2 cation→anion glide and deleted one whole species.
+    #[test]
+    fn nio_110_is_stoichiometric() {
+        let bulk = create_rocksalt_nio();
+        for n in [2usize, 3, 4] {
+            let slab = generate_slab_layers(&bulk, [1, 1, 0], n, 0, 15.0, [1, 1]).unwrap();
+            let ni = count_species(&slab, "Ni");
+            let o = count_species(&slab, "O");
+            eprintln!(
+                "NiO(110) layers={n}: Ni={ni} O={o} total={}",
+                slab.num_sites()
+            );
+            assert!(ni > 0 && o > 0, "layers={n}: a species was deleted (Ni={ni} O={o})");
+            assert_eq!(ni, o, "layers={n}: non-stoichiometric Ni={ni} O={o}");
+        }
+    }
+
     #[test]
     fn test_normalize_miller() {
         assert_eq!(normalize_miller([2, 4, 6]), [1, 2, 3]);

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -3203,20 +3203,60 @@ pub fn reduce_slab_in_plane_primitive(structure: Structure, symprec: f64) -> Res
         if !unique_vecs.iter().any(|u| (v - u).norm() < 1e-4) { unique_vecs.push(*v); }
     }
 
+    // A candidate in-plane vector is only a real surface lattice translation if
+    // shifting every atom by it lands on an atom of the SAME species. Geometry
+    // alone is not enough: e.g. rocksalt (110) has a c/2 glide that maps the
+    // cation sublattice onto the anion sublattice. That operation preserves
+    // positions but swaps species; accepting it would halve the cell and the
+    // remap below would then delete one entire species (all-cation/all-anion
+    // slab with the wrong stoichiometry).
+    let det_ab = a.x * b.y - a.y * b.x;
+    let frac_tol = 2e-3_f64;
+    let is_lattice_translation = |t: &Vector3<f64>| -> bool {
+        if det_ab.abs() < 1e-12 { return false; }
+        for (i, fc) in structure.frac_coords.iter().enumerate() {
+            let sx = a.x * fc.x + b.x * fc.y + t.x;
+            let sy = a.y * fc.x + b.y * fc.y + t.y;
+            let mut fa = (sx * b.y - sy * b.x) / det_ab;
+            let mut fb = (-sx * a.y + sy * a.x) / det_ab;
+            fa -= fa.floor();
+            fb -= fb.floor();
+            let sp = structure.site_occupancies[i].dominant_species();
+            let z = fc.z;
+            let matched = structure.frac_coords.iter().enumerate().any(|(j, o)| {
+                if structure.site_occupancies[j].dominant_species() != sp { return false; }
+                if (o.z - z).abs() > 0.01 { return false; }
+                let oa = o.x - o.x.floor();
+                let ob = o.y - o.y.floor();
+                let da = (fa - oa).abs();
+                let db = (fb - ob).abs();
+                da.min(1.0 - da) < frac_tol && db.min(1.0 - db) < frac_tol
+            });
+            if !matched { return false; }
+        }
+        true
+    };
+
     // Find shortest pair with minimal area that forms a valid sub-lattice.
     // Verification: all layer atoms must be expressible as integer combinations
-    // of the candidate pair (solved via Cramer's rule on the Gram matrix).
+    // of the candidate pair (solved via Cramer's rule on the Gram matrix), AND
+    // each basis vector must be a species-preserving lattice translation.
+    let limit = unique_vecs.len().min(80);
+    let trans_ok: Vec<bool> = (0..limit).map(|i| is_lattice_translation(&unique_vecs[i])).collect();
+    drop(is_lattice_translation); // release immutable borrow of `structure`
     let mut best_a = a;
     let mut best_b = b;
     let mut best_area = orig_area;
     let mut found_smaller = false;
 
-    for i in 0..unique_vecs.len().min(80) {
+    for i in 0..limit {
         let va = unique_vecs[i];
         if va.dot(&surf_normal).abs() / va.norm() > 0.1 { continue; }
-        for j in (i + 1)..unique_vecs.len().min(80) {
+        if !trans_ok[i] { continue; }
+        for j in (i + 1)..limit {
             let vb = unique_vecs[j];
             if vb.dot(&surf_normal).abs() / vb.norm() > 0.1 { continue; }
+            if !trans_ok[j] { continue; }
             let area = va.cross(&vb).norm();
             if area < 1e-10 || area >= best_area - 1e-10 { continue; }
             let ratio = orig_area / area;
@@ -3263,7 +3303,9 @@ pub fn reduce_slab_in_plane_primitive(structure: Structure, symprec: f64) -> Res
         nf.y = nf.y.rem_euclid(1.0);
         if nf.x >= 1.0 - 1e-6 { nf.x = 0.0; }
         if nf.y >= 1.0 - 1e-6 { nf.y = 0.0; }
-        let is_dup = new_frac_coords.iter().any(|e| {
+        let cur_sp = occ.dominant_species();
+        let is_dup = new_frac_coords.iter().zip(new_occupancies.iter()).any(|(e, eo)| {
+            if eo.dominant_species() != cur_sp { return false; }
             let da = (nf.x - e.x).abs().min(1.0 - (nf.x - e.x).abs());
             let db = (nf.y - e.y).abs().min(1.0 - (nf.y - e.y).abs());
             let dc = (nf.z - e.z).abs();

--- a/src/lib/structure/MillerSlabCutterPane.svelte
+++ b/src/lib/structure/MillerSlabCutterPane.svelte
@@ -305,17 +305,14 @@
     }
   })
 
-  // Compute bounds for sliders when miller index changes (but not during commit)
+  // Structure extent along the surface normal — used to center the offset when
+  // the Miller index changes.
   let bounds = $derived.by<[number, number]>(() => {
     if (!calc_structure?.lattice || !is_valid || is_committing) return [0, 10]
     const lattice = calc_structure.lattice.matrix as Matrix3x3
     const normal = miller_to_normal(miller_index, lattice)
     return get_bounds_along_normal(calc_structure, normal)
   })
-
-  let min_offset = $derived(bounds[0] - 2)
-  let max_offset = $derived(bounds[1] + 2)
-  let offset_range = $derived(max_offset - min_offset)
 
   // Reset offset to center when miller index changes (but not during commit)
   $effect(() => {
@@ -633,13 +630,6 @@
     }, 150)
   }
 
-  function on_offset_input(e: Event) {
-    const raw_val = parseFloat((e.target as HTMLInputElement).value)
-    pending_offset = raw_val
-    schedule_raf_update()
-    schedule_precision_update()
-  }
-
   function on_thickness_input(e: Event) {
     const val = parseFloat((e.target as HTMLInputElement).value)
     pending_thickness = val
@@ -662,6 +652,43 @@
     on_push_undo?.()
     supercell_a = a
     supercell_b = b
+  }
+
+  // User-selectable +/- increment for the offset stepper.
+  let offset_step = $state(0.5)
+
+  // Plane offset +/- stepper. `dir` is ±1; step size is user-chosen.
+  function on_offset_step(dir: number) {
+    local_offset = +(local_offset + dir * offset_step).toFixed(2)
+    plane_offset = local_offset
+    start_fade_animation()
+  }
+
+  // Plane offset free numeric entry (exact value, no layer snapping).
+  function on_offset_number(e: Event) {
+    const v = parseFloat((e.target as HTMLInputElement).value)
+    if (!isNaN(v)) {
+      local_offset = v
+      plane_offset = v
+      start_fade_animation()
+    }
+  }
+
+  // User-selectable +/- increment for the thickness stepper.
+  let thickness_step = $state(1)
+
+  // Thickness +/- stepper (Angstrom mode). `dir` is ±1; step size is user-chosen.
+  function on_thickness_step(dir: number) {
+    const v = Math.max(0, +(local_thickness + dir * thickness_step).toFixed(2))
+    local_thickness = v
+    plane_thickness = v
+    thickness_mode = 'angstrom'
+    start_fade_animation()
+  }
+
+  // Vacuum +/- stepper. No upper cap.
+  function on_vacuum_step(delta: number) {
+    vacuum = Math.max(0, +(vacuum + delta).toFixed(2))
   }
 
   // Cleanup
@@ -784,23 +811,45 @@
           <h5>Position & Thickness</h5>
         </div>
 
-        <!-- Offset Slider -->
-        <div class="slider-group">
-          <div class="slider-label">
-            <span>Plane Offset</span>
-            <span class="value">{fmt(local_offset)} A</span>
+        <!-- Plane Offset — stepper + free numeric entry, user-chosen step -->
+        <div class="number-row">
+          <span>Plane Offset</span>
+          <div class="stepper">
+            <button class="layer-btn" onclick={() => on_offset_step(-1)}>-</button>
+            <div class="number-field">
+              <input
+                type="number"
+                step={offset_step}
+                value={local_offset}
+                oninput={on_offset_number}
+              />
+              <span class="unit">A</span>
+            </div>
+            <button class="layer-btn" onclick={() => on_offset_step(1)}>+</button>
           </div>
-          <input
-            type="range"
-            min={min_offset}
-            max={max_offset}
-            step={offset_range / 200}
-            value={local_offset}
-            oninput={on_offset_input}
-          />
-          <div class="slider-bounds">
-            <span>{fmt(min_offset)}</span>
-            <span>{fmt(max_offset)}</span>
+        </div>
+        <!-- Step-size selector for the offset +/- buttons: presets + custom -->
+        <div class="step-size">
+          <span class="step-size-label">Step</span>
+          {#each [0.1, 0.5, 1, 2] as s}
+            <button
+              class="step-size-btn"
+              class:active={offset_step === s}
+              onclick={() => offset_step = s}
+            >
+              {s}
+            </button>
+          {/each}
+          <div class="number-field step-custom">
+            <input
+              type="number"
+              min="0.01"
+              step="0.1"
+              value={offset_step}
+              oninput={(e) => { const v = parseFloat(e.currentTarget.value); if (!isNaN(v) && v > 0) offset_step = v }}
+              title="Custom step size"
+            />
+            <span class="unit">A</span>
           </div>
         </div>
 
@@ -828,20 +877,44 @@
           </div>
 
           {#if thickness_mode === 'angstrom'}
-            <!-- Thickness Slider (Angstroms) -->
-            <div class="slider-group">
-              <div class="slider-label">
-                <span></span>
-                <span class="value">{fmt(local_thickness)} A</span>
+            <!-- Thickness (Angstroms) — stepper + free numeric entry, no upper cap -->
+            <div class="stepper">
+              <button class="layer-btn" onclick={() => on_thickness_step(-1)} disabled={local_thickness <= 0}>-</button>
+              <div class="number-field">
+                <input
+                  type="number"
+                  min="0"
+                  step={thickness_step}
+                  value={local_thickness}
+                  oninput={on_thickness_input}
+                />
+                <span class="unit">A</span>
               </div>
-              <input
-                type="range"
-                min={0}
-                max={Math.max(20, offset_range)}
-                step={0.1}
-                value={local_thickness}
-                oninput={on_thickness_input}
-              />
+              <button class="layer-btn" onclick={() => on_thickness_step(1)}>+</button>
+            </div>
+            <!-- Step-size selector for the +/- buttons: presets + custom entry -->
+            <div class="step-size">
+              <span class="step-size-label">Step</span>
+              {#each [0.1, 0.5, 1, 2] as s}
+                <button
+                  class="step-size-btn"
+                  class:active={thickness_step === s}
+                  onclick={() => thickness_step = s}
+                >
+                  {s}
+                </button>
+              {/each}
+              <div class="number-field step-custom">
+                <input
+                  type="number"
+                  min="0.01"
+                  step="0.1"
+                  value={thickness_step}
+                  oninput={(e) => { const v = parseFloat(e.currentTarget.value); if (!isNaN(v) && v > 0) thickness_step = v }}
+                  title="Custom step size"
+                />
+                <span class="unit">A</span>
+              </div>
             </div>
           {:else}
             <!-- Layer Count Control -->
@@ -923,20 +996,6 @@
           </div>
         </div>
 
-        <!-- Vacuum Layer -->
-        <div class="slider-group">
-          <div class="slider-label">
-            <span>Vacuum Layer</span>
-            <span class="value">{fmt(vacuum)} A</span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={30}
-            step={1}
-            bind:value={vacuum}
-          />
-        </div>
       </section>
 
       <!-- Step C: Supercell -->
@@ -979,6 +1038,19 @@
           <span>Show bonds</span>
         </label>
       </section>
+
+      <!-- Vacuum Layer — stepper + free numeric entry, no upper cap -->
+      <div class="number-row vacuum-row">
+        <span>Vacuum Layer</span>
+        <div class="stepper">
+          <button class="layer-btn" onclick={() => on_vacuum_step(-1)} disabled={vacuum <= 0}>-</button>
+          <div class="number-field">
+            <input type="number" min="0" step="1" bind:value={vacuum} />
+            <span class="unit">A</span>
+          </div>
+          <button class="layer-btn" onclick={() => on_vacuum_step(1)}>+</button>
+        </div>
+      </div>
 
       <!-- Preview Statistics -->
       {#if preview}
@@ -1234,56 +1306,106 @@
     border-color: var(--accent-color, #007acc);
   }
 
-  .slider-group {
-    margin-bottom: 0.6em;
-  }
-
-  .slider-label {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 3px;
-    opacity: 0.8;
-  }
-
-  .slider-label .value {
-    font-weight: bold;
-    color: var(--accent-color, #007acc);
-    opacity: 1;
-  }
-
-  .slider-group input[type="range"] {
-    width: 100%;
-    height: 5px;
-    border-radius: 3px;
-    background: var(--border-color, rgba(255, 255, 255, 0.15));
-    appearance: none;
-    cursor: pointer;
-  }
-
-  .slider-group input[type="range"]::-webkit-slider-thumb {
-    appearance: none;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: var(--accent-color, #007acc);
-    cursor: grab;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  }
-
-  .slider-group input[type="range"]::-webkit-slider-thumb:active {
-    cursor: grabbing;
-  }
-
-  .slider-bounds {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.8em;
-    opacity: 0.5;
-    margin-top: 2px;
-  }
-
   .thickness-control {
     margin-bottom: 0.6em;
+  }
+
+  .number-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 0.6em;
+  }
+
+  .vacuum-row {
+    padding: 0 4px;
+    margin: 0.2em 0 1em;
+  }
+
+  .step-size {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 6px;
+  }
+
+  .step-size-label {
+    font-size: 0.8em;
+    opacity: 0.6;
+    margin-right: 2px;
+  }
+
+  .step-custom input[type="number"] {
+    width: 52px;
+    padding: 3px 6px;
+    font-size: 0.85em;
+    font-weight: normal;
+  }
+
+  .step-custom .unit {
+    font-size: 0.8em;
+  }
+
+  .step-size-btn {
+    flex: 1;
+    padding: 3px 6px;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+    background: var(--btn-bg, rgba(255, 255, 255, 0.1));
+    color: inherit;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    transition: all 0.15s;
+  }
+
+  .step-size-btn:hover {
+    background: var(--btn-bg-hover, rgba(255, 255, 255, 0.15));
+  }
+
+  .step-size-btn.active {
+    background: var(--accent-color, #007acc);
+    border-color: var(--accent-color, #007acc);
+    color: white;
+  }
+
+  .stepper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 6px;
+    background: var(--btn-bg, rgba(0, 0, 0, 0.2));
+    border-radius: 4px;
+  }
+
+  .number-field {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .number-field input[type="number"] {
+    width: 72px;
+    padding: 6px 8px;
+    text-align: right;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+    background: var(--btn-bg, rgba(0, 0, 0, 0.2));
+    color: inherit;
+    border-radius: 4px;
+    font-size: 1em;
+    font-weight: bold;
+  }
+
+  .number-field input[type="number"]:focus {
+    outline: none;
+    border-color: var(--accent-color, #007acc);
+  }
+
+  .number-field .unit {
+    opacity: 0.6;
+    font-size: 0.9em;
   }
 
   .thickness-header {

--- a/src/lib/structure/__tests__/miller-slab-stoichiometry.test.ts
+++ b/src/lib/structure/__tests__/miller-slab-stoichiometry.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { generate_slab_pipeline } from '../miller-slab'
+import type { Matrix3x3 } from '$lib/math'
+
+// Rocksalt NiO conventional cubic cell, a = 4.13792322 Å (4 Ni + 4 O).
+const A = 4.13792322
+const lattice = [
+  [A, 0, 0],
+  [0, A, 0],
+  [0, 0, A],
+] as Matrix3x3
+
+const frac: { el: string; f: [number, number, number] }[] = [
+  { el: 'Ni', f: [0, 0, 0] },
+  { el: 'Ni', f: [0.5, 0.5, 0] },
+  { el: 'Ni', f: [0.5, 0, 0.5] },
+  { el: 'Ni', f: [0, 0.5, 0.5] },
+  { el: 'O', f: [0, 0, 0.5] },
+  { el: 'O', f: [0.5, 0, 0] },
+  { el: 'O', f: [0, 0.5, 0] },
+  { el: 'O', f: [0.5, 0.5, 0.5] },
+]
+
+const structure: any = {
+  lattice: { matrix: lattice, a: A, b: A, c: A, alpha: 90, beta: 90, gamma: 90, volume: A ** 3, pbc: [true, true, true] },
+  sites: frac.map((s, i) => ({
+    species: [{ element: s.el, occu: 1 }],
+    abc: s.f,
+    xyz: [s.f[0] * A, s.f[1] * A, s.f[2] * A],
+    label: `${s.el}${i}`,
+    properties: {},
+  })),
+}
+
+function composition(sites: any[]): Record<string, number> {
+  const c: Record<string, number> = {}
+  for (const s of sites) {
+    const el = s.species[0].element
+    c[el] = (c[el] ?? 0) + 1
+  }
+  return c
+}
+
+function min_pair_distance(sites: any[]): number {
+  let m = Infinity
+  for (let i = 0; i < sites.length; i++) {
+    for (let j = i + 1; j < sites.length; j++) {
+      const d = Math.hypot(
+        sites[i].xyz[0] - sites[j].xyz[0],
+        sites[i].xyz[1] - sites[j].xyz[1],
+        sites[i].xyz[2] - sites[j].xyz[2],
+      )
+      if (d < m) m = d
+    }
+  }
+  return m
+}
+
+// Regression: the species-blind primitive reduction used to accept the c/2
+// cation→anion glide in rocksalt (110) and then delete one whole species,
+// producing an all-Ni / zero-O slab. (110) is a neutral, stoichiometric
+// surface — every slab must keep Ni:O = 1:1 with no overlapping atoms.
+describe('NiO (110) slab is stoichiometric', () => {
+  const D = 2.926 // d-spacing(110) ≈ a/√2
+  const mid = D / 2
+
+  for (const growth of ['centered', 'anchor_minus_z'] as const) {
+    for (const mult of [1, 2, 3]) {
+      it(`growth=${growth} thickness=${mult}d keeps Ni:O = 1:1`, () => {
+        const res = generate_slab_pipeline(structure, {
+          miller_index: [1, 1, 0],
+          offset: growth === 'centered' ? mid : D,
+          thickness: mult * D,
+          vacuum: 15,
+          growth_mode: growth,
+          supercell: [1, 1],
+        })
+        expect(res).not.toBeNull()
+        const comp = composition(res!.sites)
+        expect(comp.Ni).toBeGreaterThan(0)
+        expect(comp.O).toBeGreaterThan(0)
+        expect(comp.Ni).toBe(comp.O)
+        expect(min_pair_distance(res!.sites)).toBeGreaterThan(0.5)
+      })
+    }
+  }
+})

--- a/src/lib/structure/miller-slab.ts
+++ b/src/lib/structure/miller-slab.ts
@@ -605,7 +605,9 @@ function cartesian_to_fractional_2d(xyz: Vec3, a: Vec3, b: Vec3): [number, numbe
  * 4. Verify all layer atoms are integer combinations of the new basis (Cramer's rule)
  * 5. Remap all atoms into the new cell
  */
-function reduce_in_plane_primitive<T extends { abc: Vec3; xyz: Vec3 }>(
+function reduce_in_plane_primitive<
+  T extends { abc: Vec3; xyz: Vec3; species?: Array<{ element?: string }> },
+>(
   sites: T[], a: Vec3, b: Vec3,
 ): { new_a: Vec3; new_b: Vec3; sites: T[] } | null {
   const cross_z = a[0] * b[1] - a[1] * b[0]
@@ -675,17 +677,57 @@ function reduce_in_plane_primitive<T extends { abc: Vec3; xyz: Vec3 }>(
     if (!unique.some(u => Math.hypot(v[0]-u[0], v[1]-u[1]) < 1e-4)) unique.push(v)
   }
 
+  // A candidate in-plane vector is only a real surface lattice translation if
+  // shifting every atom by it lands on an atom of the SAME species. Geometry
+  // alone is not enough: in e.g. rocksalt (110) a glide of c/2 maps the cation
+  // sublattice onto the anion sublattice, which is a position-preserving but
+  // species-swapping operation. Accepting it would halve the cell and then the
+  // remap dedup would delete one whole species (all-cation/all-anion slab).
+  const det_ab = a[0]*b[1] - a[1]*b[0]
+  const el_of = (s: T) => s.species?.[0]?.element ?? ''
+  const FRAC_TOL = 2e-3
+  const is_lattice_translation = (t: Vec3): boolean => {
+    if (Math.abs(det_ab) < 1e-12) return false
+    for (const s of sites) {
+      const sx = a[0]*s.abc[0] + b[0]*s.abc[1] + t[0]
+      const sy = a[1]*s.abc[0] + b[1]*s.abc[1] + t[1]
+      let fa = (sx*b[1] - sy*b[0]) / det_ab
+      let fb = (-sx*a[1] + sy*a[0]) / det_ab
+      fa -= Math.floor(fa); fb -= Math.floor(fb)
+      const el = el_of(s), z = s.abc[2]
+      const matched = sites.some((o) => {
+        if (el_of(o) !== el) return false
+        if (Math.abs(o.abc[2] - z) > 0.01) return false
+        const oa = o.abc[0] - Math.floor(o.abc[0])
+        const ob = o.abc[1] - Math.floor(o.abc[1])
+        const da = Math.abs(fa - oa), db = Math.abs(fb - ob)
+        return Math.min(da, 1 - da) < FRAC_TOL && Math.min(db, 1 - db) < FRAC_TOL
+      })
+      if (!matched) return false
+    }
+    return true
+  }
+  const trans_memo = new Map<string, boolean>()
+  const is_translation = (v: Vec3): boolean => {
+    const key = `${v[0].toFixed(4)},${v[1].toFixed(4)}`
+    let r = trans_memo.get(key)
+    if (r === undefined) { r = is_lattice_translation(v); trans_memo.set(key, r) }
+    return r
+  }
+
   // Find shortest pair with minimal area
   let best_a = a, best_b = b, best_area = orig_area, found = false
   const limit = Math.min(unique.length, 80)
   for (let i = 0; i < limit; i++) {
     const va = unique[i]
+    if (!is_translation(va)) continue
     for (let j = i + 1; j < limit; j++) {
       const vb = unique[j]
       const area = Math.abs(va[0]*vb[1] - va[1]*vb[0])
       if (area < 1e-10 || area >= best_area - 1e-10) continue
       const ratio = orig_area / area
       if (Math.abs(ratio - Math.round(ratio)) > 0.1) continue
+      if (!is_translation(vb)) continue
       // Verify all layer atoms are integer combos of (va, vb)
       const va2 = va[0]*va[0]+va[1]*va[1], vab = va[0]*vb[0]+va[1]*vb[1], vb2 = vb[0]*vb[0]+vb[1]*vb[1]
       const det = va2*vb2 - vab*vab
@@ -745,9 +787,10 @@ function reduce_in_plane_primitive<T extends { abc: Vec3; xyz: Vec3 }>(
     nfa = nfa - Math.floor(nfa); nfb = nfb - Math.floor(nfb)
     if (nfa >= 1 - 1e-6) nfa = 0; if (nfb >= 1 - 1e-6) nfb = 0
     const nfc = site.abc[2]
-    // Deduplicate
+    // Deduplicate (same position AND same species — never merge across species)
     const tol = 1e-3
     const dup = new_sites.some(e => {
+      if (el_of(e) !== el_of(site)) return false
       const da = Math.abs(nfa - e.abc[0]), db = Math.abs(nfb - e.abc[1]), dc = Math.abs(nfc - e.abc[2])
       return Math.min(da, 1-da) < tol && Math.min(db, 1-db) < tol && dc < tol
     })


### PR DESCRIPTION
## Summary

Two related changes in the Miller Slab Cutter.

### 1. Fix: species-blind in-plane primitive reduction (`f319713`)
Cutting a rocksalt (110) slab (e.g. NiO) produced an **all-cation, zero-anion** slab with the wrong atom count. The slab primitive-cell reducer — in **both** the TS preview pipeline (`miller-slab.ts`) and the Rust/WASM apply path (`structure.rs`) — validated candidate surface lattice vectors using geometry only. Rocksalt (110) has a `c/2` glide that maps the cation sublattice onto the anion sublattice (positions coincide, species differ); the reducer accepted it as a primitive vector, halved the cell, and the species-blind remap dedup then collapsed each cation+anion pair, deleting one whole species.

Fix: a candidate vector is now accepted as a lattice translation only if shifting every atom by it lands on a **same-species** atom; the remap dedup also checks species. Single-element slabs are unaffected.

### 2. Feat: uncapped slab-cutter controls (`ca13aaf`)
Plane Offset / Slab Thickness / Vacuum Layer were hard-capped range sliders (vacuum ≤ 30 Å, thickness ≤ 20 Å, no exact entry). Replaced with −/+ steppers + editable number boxes (no upper cap). Offset and Thickness get a step-size selector (presets + custom value); Vacuum moved below the In-Plane Supercell section. Dead slider markup/CSS/derivations removed.

## Test plan
- [x] New TS regression test `miller-slab-stoichiometry.test.ts` — NiO(110) Ni:O = 1:1, no overlaps (6 cases)
- [x] New Rust test `nio_110_is_stoichiometric`; full Rust suite green (984/984)
- [x] Verified end-to-end in the live app: (110) preview 12 Ni / 12 O, WASM apply 6 Ni / 6 O
- [x] Swept (100)/(110)/(111)/(211)/(321) through the full apply pipeline — no overlaps, (111) polar non-stoichiometry is physical (expected)
- [x] UI controls verified via HMR + manual inspection in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)