### PR TITLE
fix(desktop): grant fs stat/read-text-file perms so drag-drop can read dropped files

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,10 +14,13 @@
     "core:webview:allow-create-webview-window",
     "fs:default",
     "fs:allow-read-file",
+    "fs:allow-read-text-file",
     "fs:allow-read-dir",
     "fs:allow-write-file",
     "fs:allow-write-text-file",
     "fs:allow-exists",
+    "fs:allow-stat",
+    "fs:allow-lstat",
     {
       "identifier": "fs:scope",
       "allow": [


### PR DESCRIPTION
## Problem

Dragging a structure file into the **desktop** app shows
**"Could not read any file from the drop"**, while the **web** build works fine.

Root cause: on desktop, `dragDropEnabled: true` makes Tauri intercept the OS
drop and deliver file **paths** via `tauri://drag-drop` (not `File` objects).
`read_dropped_paths()` (`src/lib/io/tauri.ts`) then calls `stat(p)` to tell a
dropped file from a directory, and `read_paths()` uses `readTextFile()` for text
formats. But the capability set only granted `read-file` / `read-dir` /
`write-*` / `exists` — **not `stat` or `read-text-file`**. So `stat()` threw
"not allowed", the path was caught-and-skipped, the collected list came up empty,
and the user got "Could not read any file from the drop". The web path is
unaffected because it reads `File` objects via `FileReader`, never touching the
fs plugin.

This is why **web works but desktop doesn't** — only the desktop path goes
through `@tauri-apps/plugin-fs`.

## Fix

Add the missing permissions to `src-tauri/capabilities/default.json`:
- `fs:allow-stat` — for `stat()` in `read_dropped_paths()` (file-vs-dir check)
- `fs:allow-lstat` — companion, in case symlinked drops are stat'd
- `fs:allow-read-text-file` — for `readTextFile()` in `read_paths()` (CIF etc. are text)

`fs:scope` already allows `**`, so no scope change is needed — only the per-command
allow-permissions were missing. Capabilities are compiled into the app, so this
takes effect on the next build.

## Verification
- Root cause traced directly from the code: `read_dropped_paths()` → `stat()` and
  `read_paths()` → `readTextFile()`, neither permitted by the prior capability set.
- Builds cleanly on CI (the permission identifiers are valid Tauri v2 fs perms).
- Runtime drag-drop confirmation on the rebuilt Windows installer is in progress.

## Scope
- `src-tauri/capabilities/default.json` — add 3 fs permissions (+3 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)