### PR TITLE
fix(viewer): atom delete no longer drops unrelated surviving bonds

### DIFF
--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -112,6 +112,8 @@
     build_constraints_section,
     build_charge_label_section,
     validate_bond_edits,
+    reindex_bond_edits,
+    reindex_site_indices,
   } from './controllers/viewer-controller'
   // tool-controller.svelte.ts exists but is not yet wired (template bind: compatibility)
   import StructureToolbar from './StructureToolbar.svelte'
@@ -439,6 +441,9 @@
           const deleted_set = new Set(sorted_indices)
           const next_sites: Site[] = structure.sites.filter((_, i) => !deleted_set.has(i))
           scene_atom_fast_ops?.try_delete(sorted_indices, next_sites)
+          // Reindex index-keyed edit state (manual bonds / deleted-bond keys /
+          // hidden sites) with the OLD-index deleted list before renumbering.
+          reindex_edits_on_delete(sorted_indices)
           structure = delete_atoms(structure, sorted_indices)
           selected_sites = []
         }
@@ -2391,6 +2396,7 @@
     set_context_menu_visible: (v) => { context_menu_visible = v },
     get_on_atoms_manipulated: () => on_atoms_manipulated,
     get_on_atoms_deleted: () => on_atoms_deleted,
+    reindex_edits_after_delete: (deleted) => reindex_edits_on_delete(deleted),
     get_original_atoms_only,
     set_cached_rotation_target: (v) => { cached_rotation_target = v },
     set_saved_selection: (v) => { saved_selection = v },
@@ -2421,6 +2427,20 @@
   })
 
   // (铅笔/键编辑 handler 函数已移到 pencil controller)
+
+  // Reindex index-keyed edit state after an atom delete. Deleting atoms
+  // RENUMBERS the survivors, so any state keyed by atom index (manual bonds,
+  // deleted-bond keys, hidden sites) must be shifted to follow that renumber —
+  // not merely pruned. Without this, a survivor's renumbered bond can collide
+  // with a STALE deleted-bond key and vanish from the render ("delete one atom,
+  // an unrelated bond disappears"). Must be called with the OLD-index deleted
+  // list (the same `sorted_indices` the delete paths already compute).
+  function reindex_edits_on_delete(deleted: number[]) {
+    const r = reindex_bond_edits(pencil.manual_bonds, pencil.deleted_bond_keys, deleted)
+    pencil.manual_bonds = r.manual_bonds
+    pencil.deleted_bond_keys = r.deleted_bond_keys
+    hidden_sites = reindex_site_indices(hidden_sites, deleted)
+  }
 
   // --- 右键菜单动作分发 (controllers/context-menu-actions.ts) ---
   // 右键菜单的所有动作（添加/删除/替换原子、选择、约束、颜色、电荷标签等）由独立模块管理
@@ -2456,6 +2476,7 @@
     push_selection_to_undo,
     is_image_atom,
     get_original_atoms_only,
+    reindex_edits_after_delete: (deleted) => reindex_edits_on_delete(deleted),
     get_on_atom_added: () => on_atom_added,
     get_on_atoms_deleted: () => on_atoms_deleted,
     get_on_atom_replaced: () => on_atom_replaced,

--- a/src/lib/structure/bonding/bond-manager.svelte.ts
+++ b/src/lib/structure/bonding/bond-manager.svelte.ts
@@ -588,6 +588,7 @@ export class BondManager {
 		const old_count = this.#count;
 		const pairs = this.#pairs;
 		const kinds = this.#kinds;
+		const jimages = this.#jimages;
 		const colors_start = this.#colors_start;
 		const colors_end = this.#colors_end;
 		const opacity = this.#opacity_buffer;
@@ -629,6 +630,9 @@ export class BondManager {
 					if (opacity !== null) {
 						opacity[write] = opacity[read];
 					}
+					jimages[write * 3] = jimages[read * 3];
+					jimages[write * 3 + 1] = jimages[read * 3 + 1];
+					jimages[write * 3 + 2] = jimages[read * 3 + 2];
 				}
 				if (first_change === -1) first_change = write;
 				last_change = read;

--- a/src/lib/structure/controllers/context-menu-actions.ts
+++ b/src/lib/structure/controllers/context-menu-actions.ts
@@ -94,6 +94,13 @@ export interface ContextMenuDeps {
   is_image_atom: (idx: number) => boolean
   get_original_atoms_only: (indices: number[]) => number[]
 
+  /**
+   * Reindex index-keyed edit state (manual bonds / deleted-bond keys / hidden
+   * sites) after an atom delete. Called with the OLD-index deleted list so
+   * survivor edit state follows the renumber instead of going stale.
+   */
+  reindex_edits_after_delete: (deleted: number[]) => void
+
   // ── Phase X6 fast-path hook (null until StructureScene's $effect
   //    populates it; also null when USE_NEW_ATOM_SYSTEM is off). Optional
   //    so tests / legacy callers can skip wiring it. ──
@@ -235,6 +242,8 @@ export function create_context_menu_actions(deps: ContextMenuDeps) {
         const deleted_set = new Set(sorted_indices)
         const next_structure = delete_atoms(structure, sorted_indices)
         deps.get_atom_fast_ops?.()?.try_delete(sorted_indices, next_structure.sites)
+        // Reindex index-keyed edit state with the OLD-index deleted set.
+        deps.reindex_edits_after_delete([...deleted_set])
         deps.set_structure(next_structure)
         deps.get_on_atoms_deleted?.()?.({ site_indices: sorted_indices })
         deps.set_selected_sites(deps.get_selected_sites().filter((idx) => !deleted_set.has(idx)))

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -156,6 +156,14 @@ export interface InteractionDeps {
   get_on_atoms_manipulated: () => ((event: AtomManipulationEvent) => void) | undefined
   get_on_atoms_deleted: () => ((event: { site_indices: number[] }) => void) | undefined
 
+  /**
+   * Reindex index-keyed edit state (manual bonds / deleted-bond keys / hidden
+   * sites) after an atom delete. Must be called with the OLD-index deleted list
+   * (the `sorted_indices` this path already computes), so the controller has no
+   * direct access to pencil/hidden_sites — it delegates to Structure.svelte.
+   */
+  reindex_edits_after_delete: (deleted: number[]) => void
+
   // ── 原子操作工具 ──
   get_original_atoms_only: (indices: number[]) => number[]
 
@@ -1050,6 +1058,8 @@ export function create_interaction_controller(deps: InteractionDeps) {
             for (const idx of sorted_indices) new_atom_overrides.delete(idx)
             deps.set_atom_opacity_overrides(new_atom_overrides)
           }
+          // Reindex index-keyed edit state with the OLD-index deleted list.
+          deps.reindex_edits_after_delete(sorted_indices)
           deps.set_structure(delete_atoms(structure, sorted_indices))
           deps.get_on_atoms_deleted()?.({ site_indices: sorted_indices })
           deps.set_selected_sites([])

--- a/src/lib/structure/controllers/viewer-controller.ts
+++ b/src/lib/structure/controllers/viewer-controller.ts
@@ -159,3 +159,88 @@ export function validate_bond_edits(
     deleted_bond_keys: deleted_changed ? valid_deleted : null,
   }
 }
+
+/** Count of deleted indices strictly below `idx` (binary search on a sorted
+ *  ascending array). This is the amount a surviving atom at `idx` shifts down
+ *  when the deleted atoms are removed. */
+function count_deleted_below(sorted_deleted: readonly number[], idx: number): number {
+  let lo = 0
+  let hi = sorted_deleted.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (sorted_deleted[mid] < idx) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+function to_sorted_deleted(deleted_indices: readonly number[] | ReadonlySet<number>): number[] {
+  const arr = deleted_indices instanceof Set ? [...deleted_indices] : [...(deleted_indices as readonly number[])]
+  return arr.sort((a, b) => a - b)
+}
+
+/**
+ * Reindex manual bonds + deleted-bond keys after atom INDICES are deleted.
+ *
+ * Deleting atoms RENUMBERS survivors: a surviving atom at old index `i` moves
+ * to `i - (count of deleted indices below i)`. Bond-edit state keyed by atom
+ * index must follow that shift, NOT merely be pruned (which is all
+ * `validate_bond_edits` does). Without the shift, a survivor bond's renumbered
+ * pair can collide with a STALE deleted-bond key and get filtered out of the
+ * render — the "delete one atom, an unrelated bond vanishes" bug.
+ *
+ * Entries referencing a deleted atom are dropped. Pure: no WASM, no recompute.
+ */
+export function reindex_bond_edits(
+  manual_bonds: ManualBond[],
+  deleted_bond_keys: Set<string>,
+  deleted_indices: readonly number[] | ReadonlySet<number>,
+): { manual_bonds: ManualBond[]; deleted_bond_keys: Set<string> } {
+  const deleted = deleted_indices instanceof Set ? deleted_indices : new Set(deleted_indices)
+  const sorted = to_sorted_deleted(deleted)
+  const shift = (idx: number): number => count_deleted_below(sorted, idx)
+
+  const next_manual: ManualBond[] = []
+  for (const b of manual_bonds) {
+    if (deleted.has(b.site_idx_1) || deleted.has(b.site_idx_2)) continue
+    next_manual.push({ ...b, site_idx_1: b.site_idx_1 - shift(b.site_idx_1), site_idx_2: b.site_idx_2 - shift(b.site_idx_2) })
+  }
+
+  const next_keys = new Set<string>()
+  for (const key of deleted_bond_keys) {
+    // `lo-hi` (home cell) or `lo-hi-dx,dy,dz` (cross-cell jimage; dx may be negative).
+    const m = key.match(/^(\d+)-(\d+)(?:-(.*))?$/)
+    if (!m) { next_keys.add(key); continue } // unrecognized format — leave verbatim
+    const a = Number(m[1])
+    const b = Number(m[2])
+    const suffix = m[3]
+    if (deleted.has(a) || deleted.has(b)) continue
+    const na = a - shift(a)
+    const nb = b - shift(b)
+    const lo = Math.min(na, nb)
+    const hi = Math.max(na, nb)
+    next_keys.add(suffix === undefined ? `${lo}-${hi}` : `${lo}-${hi}-${suffix}`)
+  }
+
+  return { manual_bonds: next_manual, deleted_bond_keys: next_keys }
+}
+
+/**
+ * Reindex a Set of site indices (e.g. `hidden_sites`, selection) after atom
+ * deletion: shift survivors down by the count of deleted indices below them;
+ * drop any index that was itself deleted. Keeps per-site UI state attached to
+ * the same physical atom after renumbering.
+ */
+export function reindex_site_indices(
+  indices: ReadonlySet<number>,
+  deleted_indices: readonly number[] | ReadonlySet<number>,
+): Set<number> {
+  const deleted = deleted_indices instanceof Set ? deleted_indices : new Set(deleted_indices)
+  const sorted = to_sorted_deleted(deleted)
+  const next = new Set<number>()
+  for (const idx of indices) {
+    if (deleted.has(idx)) continue
+    next.add(idx - count_deleted_below(sorted, idx))
+  }
+  return next
+}

--- a/tests/vitest/structure/bond-manager.test.ts
+++ b/tests/vitest/structure/bond-manager.test.ts
@@ -166,6 +166,31 @@ describe(`BondManager remove preserves jimage column`, () => {
 		expect(mgr.get_b(0)).toBe(3)
 		expect(mgr.get_jimage(0)).toEqual([2, 2, 2])
 	})
+
+	test(`apply_atom_delete keeps each survivor's own jimage after compaction`, () => {
+		const mgr = new BondManager()
+		// Distinct jimages so a clobber is detectable per-slot.
+		mgr.add_bond(0, 1, BOND_KIND.AUTO, [0, 0, 0]) // slot 0 — survives, no shift
+		mgr.add_bond(2, 3, BOND_KIND.AUTO, [1, 0, 0]) // slot 1 — DROPPED (atom 2 deleted)
+		mgr.add_bond(4, 5, BOND_KIND.AUTO, [0, 0, 0]) // slot 2 — survives, compacts to slot 1
+		mgr.add_bond(6, 7, BOND_KIND.AUTO, [0, 1, 0]) // slot 3 — survives, compacts to slot 2
+		// Delete atom 2: drops the (2,3) bond and forces slots 2,3 to compact
+		// down into slots 1,2 (and reindexes endpoints above index 2).
+		mgr.apply_atom_delete([2])
+		expect(mgr.count).toBe(3)
+		// Slot 0 unchanged.
+		expect(mgr.get_jimage(0)).toEqual([0, 0, 0])
+		// Survivor originally at slot 2 (atoms 4,5 -> 3,4) now in slot 1 — must
+		// keep ITS jimage [0,0,0], not inherit the dropped bond's stale [1,0,0].
+		expect(mgr.get_a(1)).toBe(3)
+		expect(mgr.get_b(1)).toBe(4)
+		expect(mgr.get_jimage(1)).toEqual([0, 0, 0])
+		// Survivor originally at slot 3 (atoms 6,7 -> 5,6) now in slot 2 — must
+		// keep its own jimage [0,1,0], not the prior slot-2 occupant's [0,0,0].
+		expect(mgr.get_a(2)).toBe(5)
+		expect(mgr.get_b(2)).toBe(6)
+		expect(mgr.get_jimage(2)).toEqual([0, 1, 0])
+	})
 })
 
 describe(`BondManager capacity grow preserves jimages`, () => {

--- a/tests/vitest/structure/controllers.test.ts
+++ b/tests/vitest/structure/controllers.test.ts
@@ -21,6 +21,8 @@ import {
   build_constraints_section,
   build_charge_label_section,
   validate_bond_edits,
+  reindex_bond_edits,
+  reindex_site_indices,
 } from '$lib/structure/controllers/viewer-controller'
 
 import type { AnyStructure } from '$lib/structure'
@@ -620,5 +622,68 @@ describe('validate_bond_edits', () => {
     expect(result.manual_bonds!).toHaveLength(0)
     expect(result.deleted_bond_keys).not.toBeNull()
     expect(result.deleted_bond_keys!.size).toBe(0)
+  })
+})
+
+describe('reindex_bond_edits (atom-delete renumbering)', () => {
+  // Deleting atoms renumbers survivors: each survivor index drops by the count
+  // of deleted indices below it. Bond-edit state keyed by atom index must be
+  // SHIFTED to follow survivors (not merely pruned), or a survivor bond's new
+  // index pair collides with a STALE deleted-bond key and gets filtered out of
+  // the render — the reported "delete one atom, an unrelated bond vanishes" bug.
+
+  test('shifts a surviving deleted-bond key down so it no longer collides with a renumbered survivor pair', () => {
+    // User had deleted the bond between old atoms 76 and 84 -> key "76-84".
+    // Now delete scattered atoms {3,5,7,10}. Old (76,84) -> new (72,80).
+    // The survivor bond old (80,88) -> new (76,84): it must NOT inherit the
+    // stale "76-84" deleted key.
+    const { deleted_bond_keys } = reindex_bond_edits([], new Set(['76-84']), [3, 5, 7, 10])
+    expect(deleted_bond_keys.has('72-80')).toBe(true)
+    expect(deleted_bond_keys.has('76-84')).toBe(false)
+  })
+
+  test('drops a deleted-bond key whose endpoint was itself deleted', () => {
+    const { deleted_bond_keys } = reindex_bond_edits([], new Set(['5-12']), [5])
+    expect(deleted_bond_keys.size).toBe(0)
+  })
+
+  test('shifts manual bond endpoints and drops manual bonds touching a deleted atom', () => {
+    const manual: ManualBond[] = [
+      { site_idx_1: 80, site_idx_2: 88, id: 'keep' },
+      { site_idx_1: 7, site_idx_2: 20, id: 'drop' },
+    ]
+    const { manual_bonds } = reindex_bond_edits(manual, new Set(), [3, 5, 7, 10])
+    expect(manual_bonds).toHaveLength(1)
+    expect(manual_bonds[0].id).toBe('keep')
+    expect(manual_bonds[0].site_idx_1).toBe(76) // 80 - 4 below
+    expect(manual_bonds[0].site_idx_2).toBe(84) // 88 - 4 below
+  })
+
+  test('preserves a jimage-tagged cross-cell deleted key suffix while shifting indices', () => {
+    const { deleted_bond_keys } = reindex_bond_edits([], new Set(['80-88-1,0,0']), [3, 5, 7, 10])
+    expect(deleted_bond_keys.has('76-84-1,0,0')).toBe(true)
+  })
+
+  test('no-op when nothing is deleted (returns shifted-by-zero copies)', () => {
+    const { deleted_bond_keys, manual_bonds } = reindex_bond_edits(
+      [{ site_idx_1: 2, site_idx_2: 9, id: 'b' }], new Set(['2-9']), [],
+    )
+    expect(deleted_bond_keys.has('2-9')).toBe(true)
+    expect(manual_bonds[0].site_idx_1).toBe(2)
+  })
+})
+
+describe('reindex_site_indices (atom-delete renumbering)', () => {
+  test('shifts surviving site indices down and drops deleted ones', () => {
+    const result = reindex_site_indices(new Set([1, 8, 88]), [3, 5, 7, 10])
+    expect(result.has(1)).toBe(true)   // below all deletions, unchanged
+    expect(result.has(5)).toBe(true)   // 8 - 3 below (3,5,7)
+    expect(result.has(84)).toBe(true)  // 88 - 4 below (3,5,7,10)
+    expect(result.size).toBe(3)
+  })
+
+  test('drops a hidden index that was itself deleted', () => {
+    const result = reindex_site_indices(new Set([5]), [5])
+    expect(result.size).toBe(0)
   })
 })


### PR DESCRIPTION
## Problem

Deleting an atom made a **different, surviving** atom's bond disappear from the 3D render (intra-cell, default settings). User-reported and reproduced.

## Root cause

Not a recompute issue — bonding is pairwise (solid_angle), so deleting atom X can't change whether survivors Y–Z are bonded. The real cause is a **class of bugs**: deleting atoms **renumbers** survivors (old index `i` → `i − count_of_deleted_below(i)`, non-uniform for scattered deletes), but several pieces of **index-keyed edit state were pruned of out-of-range entries, never shifted**:

- **A.** `deleted_bond_keys` + `manual_bonds` (`validate_bond_edits` is prune-only) → a survivor bond's renumbered `lo-hi` key collides with a **stale** deleted-bond key → filtered out of `filtered_bond_pairs` → shadow-sync drops its GPU slot.
- **B.** `hidden_sites` → a stale index lands on a survivor → `is_site_visible` rejects it → its bonds drop.
- **C.** `BondManager.apply_atom_delete` compacted survivors but never copied the `#jimages` column → an intra-cell survivor momentarily renders as a misplaced cross-cell stub.

## Fix (no WASM recompute)

- Pure `reindex_bond_edits` + `reindex_site_indices` helpers (shift survivors, drop deleted-endpoint entries, jimage-suffix aware) in `viewer-controller.ts`.
- Wired into all three atom-delete paths (`delete_selected`, keyboard Delete, context menu) via one DRY `reindex_edits_on_delete` closure exposed through each controller's deps.
- Copy `#jimages` on compaction in `BondManager.apply_atom_delete`, matching `remove_atom`/`remove_where`.

## Tests / verification

- `controllers.test.ts` +7 reindex unit tests (incl. scattered-delete collision case); `bond-manager.test.ts` +1 jimage-preservation test.
- Full suite **3814 pass / 0 fail**, `svelte-check` **0 errors**.
- **User-verified live** on the running dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)