### PR TITLE
fix(viewer): stop structures bleeding across tabs and panes

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -52,6 +52,9 @@
     is_chgcar_file, NON_STRUCTURE_EXTS, update_export_format, format_from_ext,
     serialize_structure_content,
   } from './pane-utils'
+  // Deep-clone structures on assignment into a pane so panes/tabs never alias
+  // the same object (module-level samples, library entries, reused DB imports).
+  import { clone_structure } from '$lib/structure/clone'
   // Extracted tab manager (factory — must be called in component context)
   import { create_tab_manager } from './lib/tab-manager.svelte'
   // Extracted close-all helpers (pure functions)
@@ -216,7 +219,7 @@
     if (!pane) return
     // If pane has no structure, load water so Structure mounts
     if (!pane.structure && !pane.trajectory && !pane.cube_file) {
-      ts.panes[idx].structure = water as unknown as AnyStructure
+      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
       ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
       ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
     }
@@ -368,7 +371,7 @@
         if (parsed?.sites?.length) {
           const target_ts = tab_states[target_tab_id]
           if (target_ts) {
-            target_ts.panes[target_pane_idx].structure = parsed
+            target_ts.panes[target_pane_idx].structure = clone_structure(parsed)
             target_ts.panes[target_pane_idx].initial_structure_ref = parsed
             target_ts.panes[target_pane_idx].initial_site_count = parsed.sites.length
             target_ts.panes[target_pane_idx].modified = false
@@ -454,7 +457,7 @@
       console.warn(`[App] Tab limit reached, cannot open structure in new tab`)
       return
     }
-    ts.panes[0].structure = struct
+    ts.panes[0].structure = clone_structure(struct)
     ts.panes[0].initial_structure_ref = struct
     ts.panes[0].initial_site_count = struct.sites?.length ?? 0
     ts.panes[0].modified = false
@@ -679,7 +682,7 @@
     const target = modal.import_target_pane
     // Mutate the pane in-place so Svelte 5's deep $state proxy tracks the change
     const pane = ts.panes[target]
-    pane.structure = imported as AnyStructure
+    pane.structure = clone_structure(imported as AnyStructure)
     pane.initial_site_count = imported.sites.length
     pane.initial_structure_ref = imported as AnyStructure
     pane.modified = false
@@ -893,7 +896,7 @@
   ) {
     const p = ts.panes[target]
     if (e.cube_file) {
-      p.structure = e.structure
+      p.structure = clone_structure(e.structure)
       p.initial_site_count = e.structure?.sites?.length ?? 0
       p.initial_structure_ref = e.structure ?? null
       p.cube_file = e.cube_file
@@ -911,7 +914,7 @@
     } else {
       p.is_trajectory_mode = false
       p.trajectory = null
-      p.structure = e.structure
+      p.structure = clone_structure(e.structure)
       p.initial_site_count = e.structure?.sites?.length ?? 0
       p.initial_structure_ref = e.structure ?? null
       p.cube_file = null
@@ -1058,7 +1061,7 @@
         // Re-bind to new tab
         const new_panes = new_ts.panes
         if (data.structure) {
-          new_panes[0].structure = data.structure
+          new_panes[0].structure = clone_structure(data.structure)
           new_panes[0].is_trajectory_mode = false
           new_panes[0].trajectory = null
           new_panes[0].initial_site_count = data.structure.sites?.length ?? 0
@@ -1070,7 +1073,7 @@
         return
       }
       if (data.structure) {
-        ts.panes[target].structure = data.structure
+        ts.panes[target].structure = clone_structure(data.structure)
         ts.panes[target].is_trajectory_mode = false
         ts.panes[target].trajectory = null
         ts.panes[target].initial_site_count = data.structure.sites?.length ?? 0
@@ -1082,7 +1085,7 @@
         if (traj.metadata?.source_format === `single_structure` && traj.frames?.length === 1) {
           const frame = traj.frames[0] as { structure?: AnyStructure }
           if (frame?.structure) {
-            ts.panes[target].structure = frame.structure
+            ts.panes[target].structure = clone_structure(frame.structure)
             ts.panes[target].is_trajectory_mode = false
             ts.panes[target].trajectory = null
             ts.panes[target].initial_site_count = frame.structure.sites?.length ?? 0
@@ -1246,7 +1249,7 @@
       if (!struct) return false
       const ts = tab_states[`default`]
       if (!ts || !ts.panes?.[0]) return false
-      ts.panes[0].structure = struct
+      ts.panes[0].structure = clone_structure(struct)
       update_tab_label(`default`)
       return true
     }
@@ -1371,7 +1374,7 @@
     if (struct?.sites?.length) {
       const ts = tab_states[`default`]
       if (ts?.panes?.[0]) {
-        ts.panes[0].structure = struct
+        ts.panes[0].structure = clone_structure(struct)
         update_tab_label(`default`)
       }
       return
@@ -1383,7 +1386,7 @@
         if (!cached?.sites?.length) return
         const ts = tab_states[`default`]
         if (ts?.panes?.[0]) {
-          ts.panes[0].structure = cached
+          ts.panes[0].structure = clone_structure(cached)
           update_tab_label(`default`)
         }
       })
@@ -1639,7 +1642,7 @@
               {:else if pane.structure}
                 <Structure
                   tab_id={tab.id}
-                  is_active={ts.active_pane === idx}
+                  is_active={ts.active_pane === idx && tab.id === tm.active_tab_id}
                   bind:structure={ts.panes[idx].structure}
                   bind:saveable_structure={ts.panes[idx].saveable_structure}
                   bind:selected_sites={ts.panes[idx].selected_sites}
@@ -1678,7 +1681,7 @@
                         <button
                           class="sample-card"
                           onclick={() => {
-                            ts.panes[idx].structure = sample.data
+                            ts.panes[idx].structure = clone_structure(sample.data)
                             ts.panes[idx].initial_site_count = sample.data.sites?.length ?? 0
                             ts.panes[idx].initial_structure_ref = sample.data
                             ts.panes[idx].modified = false
@@ -1805,7 +1808,7 @@
                          in-browser (no backend) and can fetch/build structures from empty state. -->
                     <button class="import-card chat-card" onclick={() => {
                       console.log(`[CatGo:UI] Welcome card clicked: AI Chat → loading structure + opening Chat panel`)
-                      ts.panes[idx].structure = water as unknown as AnyStructure
+                      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
                       ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
                       ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
                       ts.panes[idx].initial_panel = `chat`
@@ -1824,7 +1827,7 @@
                     {#if !STATIC_ONLY}
                     <button class="import-card hpc-card" onclick={() => {
                       console.log(`[CatGo:UI] Welcome card clicked: HPC → loading structure + opening HPC panel`)
-                      ts.panes[idx].structure = water as unknown as AnyStructure
+                      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
                       ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
                       ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
                       ts.panes[idx].initial_panel = `hpc`
@@ -1842,7 +1845,7 @@
 
                     <button class="import-card terminal-card" onclick={() => {
                       console.log(`[CatGo:UI] Welcome card clicked: Terminal → loading structure + opening Terminal panel`)
-                      ts.panes[idx].structure = water as unknown as AnyStructure
+                      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
                       ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
                       ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
                       ts.panes[idx].initial_panel = `terminal`

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2164,21 +2164,35 @@
   // Reverse sync: store → viewer. The CatBot client-direct tool loop (STATIC_ONLY,
   // no backend) mutates structures via set_current_structure() in structure-tools.ts;
   // unlike the SDK/MCP path there's no SSE bridge to push the result back into the
-  // viewer. Pull it here. Guard against the mirror effect above: only adopt a store
-  // value that is a DIFFERENT object than what we last wrote (so the viewer's own
-  // structure→store mirror can't ping-pong). New ref from a tool → adopt it.
+  // viewer. Pull it here.
+  //
+  // CRITICAL multi-tab/pane guard: `current_structure_state()` is ONE global
+  // singleton holding the session's last-loaded structure across ALL tabs and
+  // panes. Naively adopting its value bleeds structures between viewers — e.g.
+  // load NaCl in tab2, switch back to tab1, and tab1 (`is_active` flips true on
+  // activation) would adopt NaCl. So we only adopt a store change that lands
+  // WHILE this pane is the visible active viewer (`is_active` already requires
+  // `tab === active_tab` from App.svelte). On (re)activation we BASELINE the
+  // current store value instead of adopting it — only genuinely NEW writes
+  // (real CatBot edits aimed at this viewer) are pulled in afterwards.
   const _cur_store = current_structure_state()
+  let _seen_store_val: typeof structure | null = _cur_store.value as typeof structure
+  let _was_active = false
   $effect(() => {
     if (tab_id === undefined) return
-    // Only the active pane adopts store mutations. In a split view every pane
-    // shares this one global store; without this guard, loading/editing one
-    // pane (which writes the store) makes every sibling pane's effect re-run
-    // and overwrite itself with that structure — all panes collapse to the
-    // same structure. The active pane is the one CatBot/loads target.
-    if (!is_active) return
-    const v = _cur_store.value
+    const v = _cur_store.value as typeof structure // subscribe unconditionally
+    if (!is_active) { _was_active = false; return } // inactive/hidden: never adopt
+    if (!_was_active) {
+      // Just activated: baseline the current global value, do NOT adopt it
+      // (it may be another tab's structure). Adopt only later changes.
+      _was_active = true
+      _seen_store_val = v
+      return
+    }
+    if (v === _seen_store_val) return // nothing new since activation
+    _seen_store_val = v
     if (v && v !== structure && v !== _last_mirrored_to_store) {
-      structure = v as typeof structure
+      structure = v
     }
   })
 

--- a/src/lib/structure/clone.ts
+++ b/src/lib/structure/clone.ts
@@ -1,0 +1,31 @@
+/**
+ * Deep-clone helper for structure objects assigned into viewer panes.
+ *
+ * Why this exists: a `PaneState.structure` may be sourced from an object that is
+ * ALSO referenced elsewhere — a module-level sample singleton, a tab's library
+ * entry (`LibraryEntry.structure`), or a reused database-import payload. The 3D
+ * viewer + WASM scene fast-ops (`try_move` / `try_add` / `try_replace`) mutate
+ * `structure.sites[i]` IN PLACE for performance, and `move_atom` keeps shared
+ * site-object references for unmoved atoms. So if two panes (or two tabs) alias
+ * the same source object, an edit in one pane bleeds into the other — observed
+ * as "structures cross between tabs / between panes".
+ *
+ * Fix: every pane must own an independent deep copy. Assign through this helper.
+ */
+
+import type { AnyStructure } from '$lib'
+
+/**
+ * Return a deep-independent copy of a structure. `null` / `undefined` pass
+ * through unchanged so call sites can wrap assignments unconditionally.
+ */
+export function clone_structure<T extends AnyStructure | null | undefined>(s: T): T {
+  if (s == null) return s
+  try {
+    return structuredClone(s)
+  } catch {
+    // Svelte $state proxies or exotic values can trip structuredClone; the
+    // JSON round-trip is a safe fallback for the plain-data structure shape.
+    return JSON.parse(JSON.stringify(s)) as T
+  }
+}

--- a/tests/vitest/structure/pane-structure-isolation.test.ts
+++ b/tests/vitest/structure/pane-structure-isolation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { clone_structure } from '$lib/structure/clone'
+import type { AnyStructure } from '$lib'
+
+/**
+ * Regression: structures crossing between panes / tabs.
+ *
+ * Panes used to receive structure objects BY REFERENCE (module-level sample
+ * singletons, shared library entries, reused DB imports). The viewer mutates
+ * `sites[i]` in place, so an edit in one pane bled into every other pane/tab
+ * aliasing the same source object. `clone_structure` gives each pane an
+ * independent deep copy.
+ */
+
+function make_structure(): AnyStructure {
+  return {
+    sites: [
+      { species: [{ element: 'O', occu: 1 }], xyz: [0, 0, 0], abc: [0, 0, 0], label: 'O' },
+      { species: [{ element: 'Ni', occu: 1 }], xyz: [1, 1, 1], abc: [0.5, 0.5, 0.5], label: 'Ni' },
+    ],
+    lattice: { matrix: [[2, 0, 0], [0, 2, 0], [0, 0, 2]] },
+  } as unknown as AnyStructure
+}
+
+describe('pane structure isolation', () => {
+  it('clone_structure returns a deep-independent copy', () => {
+    const src = make_structure()
+    const copy = clone_structure(src)
+    expect(copy).not.toBe(src)
+    expect(copy!.sites[0]).not.toBe(src.sites[0])
+    expect(copy!.sites[0].xyz).not.toBe(src.sites[0].xyz)
+    // mutate the copy in place (as the WASM fast-ops do)
+    ;(copy!.sites[0].xyz as number[])[0] = 99
+    expect((src.sites[0].xyz as number[])[0]).toBe(0)
+  })
+
+  it('passes null / undefined through unchanged', () => {
+    expect(clone_structure(undefined)).toBeUndefined()
+    expect(clone_structure(null)).toBeNull()
+  })
+
+  it('two panes loading the same shared source do not share site objects', () => {
+    const shared = make_structure() // module-singleton-style source
+    const pane1_structure = clone_structure(shared)
+    const pane2_structure = clone_structure(shared)
+    // in-place edit in pane 1 (e.g. atom move via scene fast-op)
+    ;(pane1_structure!.sites[0].xyz as number[])[0] = 5
+    expect((pane2_structure!.sites[0].xyz as number[])[0]).toBe(0)
+    expect((shared.sites[0].xyz as number[])[0]).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

Loading a structure in one tab/pane could overwrite what another tab/pane displayed — the data/label stayed correct but the 3D canvas rendered the wrong structure. Reproduced: water in tab1, NaCl in tab2, switch back to tab1 → tab1's canvas shows NaCl.

## Root cause

`src/lib/structure/current-structure.svelte.ts` is **one module-level `$state` singleton** holding the session's last-loaded structure (for the CatBot client-direct loop + workflow "capture from viewer"). All viewers stay mounted simultaneously (hidden tabs use `visibility:hidden` + `inert`), and `Structure.svelte`'s reverse-sync `$effect` adopted that global into its own `structure` whenever `is_active`. But `is_active` was only `ts.active_pane === idx` (per-tab) — switching **into** a background tab flips it true and pulls in whatever another tab loaded last.

## Fix (two parts, both required)

1. **`desktop/App.svelte`** — `is_active={ts.active_pane === idx && tab.id === tm.active_tab_id}` so only the *visible* active pane can adopt. (`is_active` is consumed solely by that reverse-sync guard, so tightening it is safe.)
2. **`src/lib/structure/Structure.svelte`** — the reverse-sync effect now **baselines** the store value on (re)activation instead of adopting it; only store changes that land *while actively viewing* (genuine CatBot edits) are pulled in. Inactive/hidden panes never adopt.

Also adds a defensive `clone_structure()` (`src/lib/structure/clone.ts`) applied to every `pane.structure` assignment in `App.svelte`, so panes never alias the same object (module-level samples, shared library entries, reused DB imports). Independent latent fix with regression test.

## Verification

- Full vitest suite green (3823 passed; one RDF test is a known load-dependent timeout, passes in isolation).
- `svelte-check`: only pre-existing `@webgpu/types` errors.
- Live (playwright): tab1 water / tab2 NaCl independent across switches; split panes NaCl + TiO2 independent; round-trip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)