### PR TITLE
ci: bound e2e/unit job time so a hung dev-server can't run to the 6h cap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,6 +65,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     continue-on-error: true
+    # Hard backstop: e2e is non-gating (continue-on-error) and has historically
+    # hung on the dev-server webServer, running to GitHub's 6h job cap. Bound it.
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,22 @@
 import type { PlaywrightTestConfig } from '@playwright/test'
 
+const CI = !!process.env.CI
+
 export default {
   webServer: {
     command: `vite dev --port 3005`,
     port: 3005,
-    reuseExistingServer: true,
+    // In CI always start a fresh server (never silently attach to a stale one);
+    // locally reuse an already-running dev server for fast iteration.
+    reuseExistingServer: !CI,
+    // Bound startup so a server that never becomes ready fails fast instead of
+    // stalling (paired with the job-level timeout-minutes in CI).
+    timeout: 120_000,
   },
-  workers: 8,
+  workers: CI ? 4 : 8,
   timeout: 15_000, // Global timeout per test
+  // Cap whole-run wall time so a hung navigation can't run to the job ceiling.
+  globalTimeout: CI ? 15 * 60_000 : undefined,
   testDir: `tests/playwright`,
   maxFailures: 1,
 } satisfies PlaywrightTestConfig


### PR DESCRIPTION
## Problem

Every **Tests** workflow run hits GitHub's **6h job ceiling** and gets cancelled — for days, every push shows `6h0m → cancelled`.

`unit` finishes in ~4m. The hang is **`e2e`**:
- The job has **no `timeout-minutes`** → GitHub default is 360 min.
- Its Playwright webServer is a bare `vite dev --port 3005`. The repo has **no plain `vite.config.ts`** (only `vite.desktop.config.ts`), so this command opens the port but never serves the SvelteKit site usefully. Playwright sees the port open → treats the server as "ready" → navigations stall → the job runs to the 6h cap.

Reproduced locally: `npx playwright test` ran 4+ min with **zero** test output, spawned ~70 processes, and left `vite dev` holding port 3005 even after SIGTERM.

e2e is already `continue-on-error: true`, so this never gated merges — it just burned hours of wall time and a runner slot per push.

## Fix (bound the time; this PR does not try to repair e2e itself)

- **`.github/workflows/test.yml`**: `timeout-minutes` — `unit` 15, `e2e` 20.
- **`playwright.config.ts`**:
  - `reuseExistingServer: !CI` — never silently attach to a stale server in CI.
  - `webServer.timeout: 120_000` — a server that never comes up fails fast.
  - `globalTimeout: 15m` in CI — a hung navigation can't reach the job ceiling.
  - `workers: 4` in CI (8 locally).

## Verification

- `npx playwright test --list` parses the config cleanly (565 tests / 31 files).
- `test.yml` YAML validates; `unit timeout-minutes=15`, `e2e timeout-minutes=20`.

## Follow-up (separate)

e2e's webServer command almost certainly needs the correct vite config (or a `vite build` + `vite preview`) to actually serve the site. Until then e2e is effectively non-functional — but now **bounded** instead of consuming 6h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)