### PR TITLE
fix(hpc): add BatchMode=yes to ControlMaster-mode ssh subprocess calls

### DIFF
--- a/server/catgo/routers/hpc.py
+++ b/server/catgo/routers/hpc.py
@@ -954,7 +954,9 @@ def stream_install(
                 ssh_alias = getattr(conn, "ssh_alias", None)
                 if ssh_alias:
                     proc = await asyncio.create_subprocess_exec(
-                        "ssh", ssh_alias, login_cmd,
+                        # BatchMode=yes: ControlMaster mode — master socket must
+                        # already exist; never fall back to interactive askpass.
+                        "ssh", "-o", "BatchMode=yes", ssh_alias, login_cmd,
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.STDOUT,
                     )

--- a/server/catgo/utils/local_connection.py
+++ b/server/catgo/utils/local_connection.py
@@ -40,7 +40,12 @@ class SubprocessSSHRunner:
         # Wrap in login shell so module-managed tools (sbatch, squeue, etc.) are in PATH
         login_cmd = f"bash -l -c {shlex.quote(cmd)}"
         proc = await asyncio.create_subprocess_exec(
-            "ssh", self.ssh_alias, login_cmd,
+            # BatchMode=yes: ControlMaster mode assumes a master socket already
+            # exists, so no prompt is ever needed. Without it, a missing master
+            # makes ssh fall back to interactive auth → no TTY → it execs
+            # /usr/bin/ssh-askpass and dies with "Connection closed ... port 65535"
+            # instead of a clean "Permission denied / master not active" error.
+            "ssh", "-o", "BatchMode=yes", self.ssh_alias, login_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/server/catgo/utils/ssh_file_ops.py
+++ b/server/catgo/utils/ssh_file_ops.py
@@ -120,7 +120,7 @@ class SSHFileOpsMixin:
             home = result.stdout.strip()
             remote_path = remote_path.replace("~", home, 1)
         proc = await asyncio.create_subprocess_exec(
-            "ssh", self.ssh_alias, f"cat > {shlex.quote(remote_path)}",
+            "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"cat > {shlex.quote(remote_path)}",
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -181,7 +181,7 @@ class SSHFileOpsMixin:
 
     async def _download_subprocess(self, remote_path: str):
         proc = await asyncio.create_subprocess_exec(
-            "ssh", self.ssh_alias, f"cat {shlex.quote(remote_path)}",
+            "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"cat {shlex.quote(remote_path)}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -224,7 +224,7 @@ class SSHFileOpsMixin:
         """Download a remote file to a local path. Works for both SSH and subprocess modes."""
         if self.is_subprocess_mode:
             proc = await asyncio.create_subprocess_exec(
-                "ssh", self.ssh_alias, f"cat {shlex.quote(remote_path)}",
+                "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"cat {shlex.quote(remote_path)}",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )


### PR DESCRIPTION
## Problem

Connecting to an HPC alias (e.g. `shaheen-node`) in ControlMaster mode failed with:

```
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Connection closed by UNKNOWN port 65535
```

ControlMaster mode shells out to `ssh <alias> …` and assumes the master socket is already up (no prompt needed). But the subprocess calls omitted `-o BatchMode=yes`, so when the master was **not** active, ssh fell back to interactive auth — and with no TTY it exec'd `/usr/bin/ssh-askpass`, which (when not installed) dies with the cryptic error above, masking the real cause (ControlMaster not active).

## Fix

Add `-o BatchMode=yes` to every ControlMaster-mode ssh subprocess call, matching what `hpc_link.py` already does. A missing master now fails fast with a clean "Permission denied", which the connection layer surfaces as *"Is ControlMaster active for '<alias>'?"* instead of the askpass red herring.

Sites:
- `server/catgo/utils/local_connection.py` — `SubprocessSSHRunner.run`
- `server/catgo/utils/ssh_file_ops.py` — cat read/write (3 calls)
- `server/catgo/routers/hpc.py` — ControlMaster exec path

## Verification

- `grep` confirms every `"ssh",` subprocess call now carries `BatchMode=yes`.
- `python -m py_compile` passes on all three files.
- Behavior unchanged when the master IS active (BatchMode never prompts in that case); only the no-master failure mode becomes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)