### PR TITLE
fix(server): put extension packages on sys.path so DOS/COHP routers import

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -24,6 +24,17 @@ warnings.filterwarnings("ignore", message=".*weights_only.*torch\\.load.*")
 # Add server directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
+# Make local extension packages importable by the routers. catgo_dos /
+# catgo_cohp live under extensions/<name>/ with their own pyproject and are NOT
+# pip-installed; the DOS/COHP routers bare-import them, so put the extension
+# dirs on sys.path at startup. (The CLI does this lazily via
+# catgo.cli._extpath.ensure_extension; the long-running server does it once.)
+_repo_root = Path(__file__).resolve().parent.parent
+for _ext_dir_name in ("dos-analysis", "cohp-analysis"):
+    _ext_dir = _repo_root / "extensions" / _ext_dir_name
+    if _ext_dir.is_dir() and str(_ext_dir) not in sys.path:
+        sys.path.insert(0, str(_ext_dir))
+
 
 def _worktree_offset() -> int:
     """Compute deterministic port offset from worktree directory name.


### PR DESCRIPTION
## Problem

Loading remote DOS data ("Download & Load") failed with **"Failed to fetch"** in the UI. The backend was actually 500-ing:

```
File "server/catgo/routers/dos.py", line 275, in dos_from_directory
    from catgo_dos.io import read_procar, extract_efermi_outcar, read_vaspout_h5
ModuleNotFoundError: No module named 'catgo_dos'
```

`catgo_dos` / `catgo_cohp` live under `extensions/<name>/` with their own pyproject and are **not** pip-installed. The DOS/COHP/plugins routers bare-import them (13 sites), but the server only added `server/` to `sys.path` at startup — so every remote DOS/COHP load crashed.

The CLI avoids this by lazily calling `catgo.cli._extpath.ensure_extension()` before each import; the routers don't.

## Fix

Add the two extension dirs (`extensions/dos-analysis`, `extensions/cohp-analysis`) to `sys.path` once at server startup in `server/main.py`. One place, fixes all 13 router imports.

## Verification

- With the dirs on path: `from catgo_dos.io import ...` and `from catgo_cohp.io import ...` import cleanly (deps present in the env).
- Backend restarts with `0 errors` at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)