### PR TITLE
fix(server): correct cube-processor path (Charge) + surface real DOS dir error

### DIFF
--- a/server/catgo/routers/chgcar.py
+++ b/server/catgo/routers/chgcar.py
@@ -16,9 +16,12 @@ from fastapi.responses import Response
 
 router = APIRouter(prefix="/chgcar", tags=["chgcar"])
 
-# Path to the Rust binary (same as cube.py)
+# Path to the Rust binary (same as cube.py). __file__ is
+# server/catgo/routers/chgcar.py, so four .parent hops reach the repo root
+# where tools/cube-processor lives (three only reached server/, which has no
+# tools/ → binary never found even when built).
 CUBE_PROCESSOR = (
-    Path(__file__).parent.parent.parent
+    Path(__file__).parent.parent.parent.parent
     / "tools"
     / "cube-processor"
     / "target"

--- a/server/catgo/routers/cube.py
+++ b/server/catgo/routers/cube.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/cube", tags=["cube"])
 
 # Path to the Rust binary (relative to server directory)
 CUBE_PROCESSOR = (
-    Path(__file__).parent.parent.parent / "tools" / "cube-processor" / "target" / "release" / "cube-processor"
+    Path(__file__).parent.parent.parent.parent / "tools" / "cube-processor" / "target" / "release" / "cube-processor"
 )
 
 # Cache directory for uploaded cube files and results

--- a/server/catgo/routers/dos.py
+++ b/server/catgo/routers/dos.py
@@ -356,7 +356,14 @@ async def dos_from_directory(session_id: str, remote_path: str):
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to load from directory: {e}")
+        # Log the full traceback and surface the exception TYPE in the detail —
+        # some failures (e.g. asyncio.TimeoutError) have an empty str(), which
+        # produced the useless "Failed to load from directory: " message.
+        logger.exception("dos_from_directory failed for remote_path=%s", remote_path)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to load from directory: {type(e).__name__}: {e}".rstrip(": "),
+        )
 
 
 ## ---------- Compute Endpoints (unified VaspData path) ---------- ##

--- a/server/catgo/routers/dos.py
+++ b/server/catgo/routers/dos.py
@@ -281,9 +281,14 @@ async def dos_from_directory(session_id: str, remote_path: str):
             raise HTTPException(status_code=503, detail=f"HPC session {session_id} not connected")
 
         async def _read_remote_text(path: str) -> str:
-            """Read a remote text file via SSH."""
+            """Read a remote text file via SSH.
+
+            PROCAR/OUTCAR can be tens of MB and stream back over a slow remote
+            link (e.g. through a ProxyJump), so allow well beyond the default
+            60s `conn.run` timeout — otherwise the read aborts with TimeoutError.
+            """
             result = await hpc.conn.run(
-                f"cat {shlex.quote(path)} 2>/dev/null", check=False
+                f"cat {shlex.quote(path)} 2>/dev/null", check=False, timeout=900
             )
             if result.exit_status != 0 or not result.stdout:
                 return ""

--- a/server/catgo/utils/local_connection.py
+++ b/server/catgo/utils/local_connection.py
@@ -36,7 +36,7 @@ class SubprocessSSHRunner:
     def __init__(self, ssh_alias: str) -> None:
         self.ssh_alias = ssh_alias
 
-    async def run(self, cmd: str, check: bool = False) -> SubprocessCompletedProcess:
+    async def run(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
         # Wrap in login shell so module-managed tools (sbatch, squeue, etc.) are in PATH
         login_cmd = f"bash -l -c {shlex.quote(cmd)}"
         proc = await asyncio.create_subprocess_exec(
@@ -49,9 +49,19 @@ class SubprocessSSHRunner:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=60
-        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            raise TimeoutError(
+                f"ssh '{self.ssh_alias}' command timed out after {timeout:g}s "
+                f"(transferring a large file? cmd: {cmd[:80]})"
+            )
         result = SubprocessCompletedProcess(
             exit_status=proc.returncode or 0,
             stdout=stdout_bytes.decode("utf-8", errors="replace"),
@@ -76,14 +86,14 @@ class LocalCommandRunner:
     (conn.run("cat ..."), conn.run("head -c ..."), etc.) work transparently.
     """
 
-    async def run(self, cmd: str, check: bool = False) -> SubprocessCompletedProcess:
+    async def run(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
         proc = await asyncio.create_subprocess_shell(
             cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=60
+            proc.communicate(), timeout=timeout
         )
         result = SubprocessCompletedProcess(
             exit_status=proc.returncode or 0,


### PR DESCRIPTION
## Charge — cube-processor path bug

`chgcar.py` / `cube.py` resolved the Rust binary as `Path(__file__).parent.parent.parent / "tools" / ...`. From `server/catgo/routers/*.py` that lands at **`server/tools/cube-processor`** (nonexistent) instead of repo-root **`tools/cube-processor`** where it's built. So every Charge / cube conversion 503'd "cube-processor binary not found" even after building it. Use **4** parent hops to reach the repo root.

(The binary also wasn't built locally — built it with `cd tools/cube-processor && cargo build --release`; with the path fixed both routers now resolve to it and it runs.)

## DOS — blank error message

`dos_from_directory`'s catch-all returned `"Failed to load from directory: {e}"`. Exceptions whose `str()` is empty (e.g. `asyncio.TimeoutError`) produced the undiagnosable **`{"detail":"Failed to load from directory: "}`** the user hit. Now logs the full traceback and includes `type(e).__name__` in the detail, so the real cause is visible on the next attempt.

(Confirmed offline that the files exist, `cat` is fast, and `read_procar` parses the real 20 MB PROCAR fine — so the remaining failure is in the session/connection layer, which this change will surface.)

## Verification

- `py_compile` passes on all three files.
- Charge: both routers' `CUBE_PROCESSOR.exists()` → True; `cube-processor --help` runs.
- Backend restarts with `0 errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)