### PR TITLE
perf(hpc): gzip remote file reads over the slow SSH link (~6x faster)

### DIFF
--- a/server/catgo/routers/dos.py
+++ b/server/catgo/routers/dos.py
@@ -281,18 +281,33 @@ async def dos_from_directory(session_id: str, remote_path: str):
             raise HTTPException(status_code=503, detail=f"HPC session {session_id} not connected")
 
         async def _read_remote_text(path: str) -> str:
-            """Read a remote text file via SSH.
+            """Read a remote text file via SSH, gzip-compressed in transit.
 
-            PROCAR/OUTCAR can be tens of MB and stream back over a slow remote
-            link (e.g. through a ProxyJump), so allow well beyond the default
-            60s `conn.run` timeout — otherwise the read aborts with TimeoutError.
+            PROCAR/OUTCAR are large text files and the remote link can be slow
+            (~0.2 MB/s through a ProxyJump to shaheen). gzip+base64 cuts the
+            transfer ~6x (text compresses well; a 20 MB PROCAR drops to ~2.3 MB
+            and ~15 s vs ~100 s). The large timeout still guards the slow path.
+            Falls back to plain `cat` if the compressed read isn't decodable.
             """
-            result = await hpc.conn.run(
+            import base64 as _b64
+            import gzip as _gzip
+            r = await hpc.conn.run(
+                f"gzip -c {shlex.quote(path)} 2>/dev/null | base64",
+                check=False, timeout=900,
+            )
+            if r.exit_status == 0 and r.stdout.strip():
+                try:
+                    return _gzip.decompress(_b64.b64decode(r.stdout)).decode(
+                        "utf-8", errors="replace"
+                    )
+                except Exception:
+                    logger.warning("gzip read failed for %s; falling back to cat", path)
+            r = await hpc.conn.run(
                 f"cat {shlex.quote(path)} 2>/dev/null", check=False, timeout=900
             )
-            if result.exit_status != 0 or not result.stdout:
+            if r.exit_status != 0 or not r.stdout:
                 return ""
-            return result.stdout
+            return r.stdout
 
         # List directory to find files
         resolved, files = await hpc.list_remote_dir(remote_path)

--- a/server/catgo/utils/ssh_file_ops.py
+++ b/server/catgo/utils/ssh_file_ops.py
@@ -180,16 +180,28 @@ class SSHFileOpsMixin:
                 yield chunk
 
     async def _download_subprocess(self, remote_path: str):
+        # gzip on the remote side and inflate the stream locally. Large text
+        # volumetric files (CHGCAR/AECCAR/LOCPOT) compress heavily, cutting the
+        # slow-link transfer several-fold; already-compressed files (.h5) still
+        # transfer correctly, just without a size win. Requires `gzip` on the
+        # remote (universal on HPC); a missing gzip surfaces via returncode != 0.
+        import zlib
         proc = await asyncio.create_subprocess_exec(
-            "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"cat {shlex.quote(remote_path)}",
+            "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"gzip -c {shlex.quote(remote_path)}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        decomp = zlib.decompressobj(16 + zlib.MAX_WBITS)  # 16 => expect gzip header
         while True:
             chunk = await proc.stdout.read(65536)
             if not chunk:
                 break
-            yield chunk
+            out = decomp.decompress(chunk)
+            if out:
+                yield out
+        tail = decomp.flush()
+        if tail:
+            yield tail
         await proc.wait()
         if proc.returncode != 0:
             stderr = await proc.stderr.read()

--- a/server/catgo/utils/ssh_file_ops.py
+++ b/server/catgo/utils/ssh_file_ops.py
@@ -235,17 +235,28 @@ class SSHFileOpsMixin:
     async def download_to_local(self, remote_path: str, local_path: str) -> None:
         """Download a remote file to a local path. Works for both SSH and subprocess modes."""
         if self.is_subprocess_mode:
+            # gzip on the remote and inflate locally: large text files
+            # (COHPCAR.lobster for COHP, CHGCAR, etc.) compress heavily, cutting
+            # the slow-link transfer several-fold; already-compressed files
+            # (vaspout.h5) still arrive correctly, just without a size win.
+            import zlib
             proc = await asyncio.create_subprocess_exec(
-                "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"cat {shlex.quote(remote_path)}",
+                "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"gzip -c {shlex.quote(remote_path)}",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
+            decomp = zlib.decompressobj(16 + zlib.MAX_WBITS)  # 16 => expect gzip header
             with open(local_path, "wb") as f:
                 while True:
                     chunk = await proc.stdout.read(65536)
                     if not chunk:
                         break
-                    f.write(chunk)
+                    out = decomp.decompress(chunk)
+                    if out:
+                        f.write(out)
+                tail = decomp.flush()
+                if tail:
+                    f.write(tail)
             await proc.wait()
             if proc.returncode != 0:
                 stderr = await proc.stderr.read()


### PR DESCRIPTION
## Why

The link to shaheen (ProxyJump, transatlantic) measures **~0.2 MB/s**, so a 20 MB PROCAR took **~100s** to `cat` back — past the old 60s `conn.run` timeout, and slow even at 900s. VASP volumetric/text files compress heavily, so gzip them remotely and inflate locally.

## Changes

- **`dos.py` `_read_remote_text`** — `gzip -c <file> | base64` → local `b64decode` + `gunzip`. PROCAR 20 MB → ~2.3 MB transferred, **~15s vs ~100s**. Falls back to plain `cat` if the compressed read isn't decodable.
- **`ssh_file_ops.py` `_download_subprocess`** — stream `gzip -c <file>` through a `zlib` gzip `decompressobj`. Speeds the generic binary download path used for remote **CHGCAR/AECCAR (Charge)** and other large files; `.h5` (already compressed) still transfers correctly.

## Verification

- Real transfer measured: `gzip -c PROCAR | base64` to local = **15.6s** vs **100s** for raw `cat` (6.4x); decoded byte-identical to the original.
- Streaming inflate of the gzip stream: byte-identical roundtrip on the real 20 MB PROCAR (→ 1.46 MB gz).
- `py_compile` passes; backend restarts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)