### PR TITLE
fix(ui): active dialog tab invisible (accent text on accent fill)

### DIFF
--- a/src/lib/dialog-shared.css
+++ b/src/lib/dialog-shared.css
@@ -90,6 +90,12 @@
 .dialog-modal .tab-bar button.active,
 .dialog-modal .tab-bar .tab.active,
 .dialog-modal .tab-bar .tab-btn.active {
+  /* `background: none` is load-bearing: when a dialog is rendered inside a
+     .draggable-pane, pane-shared.css's `.draggable-pane .tab-bar button.active`
+     fills the active tab with the accent color. This underline-style rule only
+     set `color: accent`, so the result was accent text on an accent fill —
+     invisible. Reset the background so the dialog's underline style wins. */
+  background: none;
   color: var(--accent-color, light-dark(#4f46e5, cornflowerblue));
   border-bottom-color: var(--accent-color, light-dark(#4f46e5, cornflowerblue));
 }


### PR DESCRIPTION
## Problem

In the DOS "Load Data" dialog (and any `.dialog-modal` rendered inside a `.draggable-pane`), the **active tab shows as a solid accent block with no visible label** — the text is the same color as the fill.

## Cause

Two rules collide on the active tab button:
- `pane-shared.css`: `.draggable-pane .tab-bar button.active` → `background: accent; color: white` (specificity 0,3,1)
- `dialog-shared.css`: `.dialog-modal .tab-bar .tab.active` → `color: accent` only (specificity 0,4,0)

The dialog rule out-specifies the pane rule on `color`, so the text became **accent** — but pane-shared's `background: accent` still applied (nothing overrode it). Accent text on an accent fill = invisible.

## Fix

Add `background: none` to the dialog active-tab rule. At (0,4,0) it beats pane-shared's (0,3,1) background too, so the dialog's intended underline style wins: no fill, accent text + accent bottom-border, readable. One-line shared-CSS change; fixes every dialog nested in a pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)