### PR TITLE
fix(catbot): "Allow for session" now persists in the client-direct path

### DIFF
--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -1405,7 +1405,12 @@ import { is_client_direct, relay_fetch } from './provider-routing'
                     input={pb.input}
                     suggestions={pb.suggestions}
                     decisionReason={pb.decisionReason}
-                    onResolve={pb.resolve}
+                    onResolve={(approved, session) => {
+                      // "Allow for session": flip the session-scoped bypass so
+                      // subsequent mutating tools auto-approve (no re-prompt).
+                      if (session) slice.skip_permission.value = true
+                      pb.resolve(approved)
+                    }}
                   />
                 {/each}
                 <ThinkingSummary tools={slice.active_tool_blocks.entries}>

--- a/src/lib/chat/PermissionCard.svelte
+++ b/src/lib/chat/PermissionCard.svelte
@@ -13,7 +13,9 @@
         // Client-direct path only: when set, the card settles the in-browser
         // tool-loop's pending permission promise instead of (and in addition
         // to skipping) the SDK backend round-trip. Undefined on the SDK path.
-        onResolve?: (approved: boolean) => void
+        // `session` is true for "Allow for session" so the caller can flip the
+        // session-scoped skip_permission flag (the SDK path handles that itself).
+        onResolve?: (approved: boolean, session?: boolean) => void
     }
 
     let { permissionId, toolName, input, suggestions, decisionReason, onResolve }: Props = $props()
@@ -44,7 +46,10 @@
             const approved = behavior !== `deny`
             if (onResolve) {
                 // Client-direct: resolve the in-browser tool-loop's promise.
-                onResolve(approved)
+                // Pass `session` so "Allow for session" sets the session-scoped
+                // skip_permission flag — otherwise it behaves like a one-time
+                // Allow and every later tool re-prompts.
+                onResolve(approved, behavior === `allow_session`)
             } else {
                 // SDK path: backend round-trip.
                 await resolve_permission(permissionId, behavior, suggestions)


### PR DESCRIPTION
## Problem

In the web / STATIC_ONLY CatBot, clicking **"Allow for session"** on a tool-permission card still re-prompted for every later tool (even the same tool, same turn).

## Cause

The client-direct gate (`chat-state.svelte.ts` `request_permission`) auto-approves only when `slice.skip_permission.value` is true. But `PermissionCard.handle('allow_session')` did `const approved = behavior !== 'deny'; onResolve(approved)` — i.e. it treated `allow_session` exactly like a one-time `allow`, resolving the current promise without ever setting `skip_permission`. (The SDK path forwards `behavior` to the backend, so it was fine there.)

## Fix

- `PermissionCard`: pass a `session` flag — `onResolve(approved, behavior === 'allow_session')`.
- `ChatPane`: in the `onResolve` closure, set `slice.skip_permission.value = true` when `session` is set, then resolve.

`skip_permission` is only reset on new/resume/clear session, so the bypass now correctly lasts the whole session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)