### PR TITLE
feat(viewer): disable large-system toggle when WebGPU isn't really available

### DIFF
--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -931,6 +931,7 @@ const structure: Record<string, string> = {
   server_hpc: `Server (HPC)`,
   plugin_hub: `Plugin Hub`,
   large_system_mode: `Large-system performance mode`,
+  large_system_mode_unavailable: `Large-system mode — WebGPU unavailable in this browser (enable Unsafe WebGPU / Vulkan flags)`,
   ai_assistant: `AI Assistant`,
   restore_terminal: `Restore terminal`,
   minimize_terminal: `Minimize terminal`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -931,6 +931,7 @@ const structure: Record<string, string> = {
   server_hpc: `服务器 (HPC)`,
   plugin_hub: `插件中心`,
   large_system_mode: `大体系性能模式`,
+  large_system_mode_unavailable: `大体系性能模式 —— 此浏览器不支持 WebGPU（需开启 Unsafe WebGPU / Vulkan 标志）`,
   ai_assistant: `AI 助手`,
   restore_terminal: `还原终端`,
   minimize_terminal: `最小化终端`,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2001,6 +2001,21 @@
   // Task 9: experimental WebGPU large-system render path. Default OFF — when
   // off the overlay renders nothing and the WebGL viewer is unchanged.
   let large_system_mode = $state(false)
+  // Whether WebGPU can actually run here (a real adapter is obtainable, not just
+  // navigator.gpu existing). Optimistic until the async probe resolves; gates the
+  // toolbar toggle so it can't be enabled when the overlay would fail to render.
+  let webgpu_available = $state(true)
+  $effect(() => {
+    let cancelled = false
+    import('./gpu/webgpu-context').then(({ probe_webgpu_available }) =>
+      probe_webgpu_available().then((ok) => {
+        if (cancelled) return
+        webgpu_available = ok
+        if (!ok) large_system_mode = false // can't run — force OFF
+      }),
+    )
+    return () => { cancelled = true }
+  })
   // While the WebGPU overlay is active, the WebGL/Threlte path must do ZERO
   // per-frame work (not just zero painting): the overlay computes its own GPU
   // bonds/atoms, so any per-frame CPU recompute on the WebGL side is wasted and
@@ -2951,6 +2966,7 @@
       bind:server_pane_open
       bind:plugin_hub_open
       bind:large_system_mode
+      {webgpu_available}
       bind:chat_pane_open
       on_popout_chat={popout_chat}
       bind:show_terminal
@@ -3739,6 +3755,7 @@
           {structure}
           bind:bond_distance_rules
           bind:large_system_mode
+          {webgpu_available}
           {supercell_loading}
           closed_icon="Sliders"
         />

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -64,6 +64,7 @@
     server_pane_open = $bindable(false),
     plugin_hub_open = $bindable(false),
     large_system_mode = $bindable(false),
+    webgpu_available = true,
     chat_pane_open = $bindable(false),
     show_terminal = $bindable(false),
     side_panel_minimized = $bindable(false),
@@ -119,6 +120,7 @@
     server_pane_open?: boolean
     plugin_hub_open?: boolean
     large_system_mode?: boolean
+    webgpu_available?: boolean
     chat_pane_open?: boolean
     show_terminal?: boolean
     side_panel_minimized?: boolean
@@ -359,14 +361,15 @@
     <span class="struct-toolbar-tooltip-wrap">
       <button
         type="button"
-        onclick={() => { large_system_mode = !large_system_mode }}
+        disabled={!webgpu_available}
+        onclick={() => { if (webgpu_available) large_system_mode = !large_system_mode }}
         class="build-tools-toggle"
         class:active={large_system_mode}
         aria-pressed={large_system_mode}
       >
         <Icon icon="Gauge" />
       </button>
-      <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.large_system_mode')}</span>
+      <span class="struct-toolbar-tooltip" role="tooltip">{webgpu_available ? t('structure.large_system_mode') : t('structure.large_system_mode_unavailable')}</span>
     </span>
 
     {#if !hide_extra_tools}
@@ -722,8 +725,12 @@
   section.control-buttons > :global(button:hover),
   section.control-buttons :global(.pane-toggle:hover),
   section.control-buttons .view-mode-button:hover,
-  section.control-buttons .build-tools-toggle:hover {
+  section.control-buttons .build-tools-toggle:hover:not(:disabled) {
     background-color: color-mix(in srgb, currentColor 10%, transparent);
+  }
+  section.control-buttons .build-tools-toggle:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
   }
   section.control-buttons .build-tools-toggle.active,
   section.control-buttons .view-mode-button.active,

--- a/src/lib/structure/gpu/webgpu-context.ts
+++ b/src/lib/structure/gpu/webgpu-context.ts
@@ -5,6 +5,28 @@ export function is_webgpu_supported(): boolean {
   return typeof navigator !== `undefined` && `gpu` in navigator && navigator.gpu != null
 }
 
+let _adapter_probe: Promise<boolean> | null = null
+
+/** Real availability check: `is_webgpu_supported()` only confirms the API
+ *  EXISTS (navigator.gpu); on many setups (e.g. AMD integrated + Linux without
+ *  the Vulkan/WebGPU flags) `requestAdapter()` still returns null — API present
+ *  but no device obtainable. This probes for an actual adapter once and caches
+ *  the result, used to disable the large-system toggle when WebGPU can't really
+ *  run instead of letting it fail at render time. */
+export function probe_webgpu_available(): Promise<boolean> {
+  if (_adapter_probe) return _adapter_probe
+  _adapter_probe = (async () => {
+    if (!is_webgpu_supported()) return false
+    try {
+      const adapter = await navigator.gpu.requestAdapter({ powerPreference: `high-performance` })
+      return adapter != null
+    } catch {
+      return false
+    }
+  })()
+  return _adapter_probe
+}
+
 let cached_device: GPUDevice | null = null
 
 /** Acquire a GPUDevice, or null if WebGPU is unavailable / acquisition fails.


### PR DESCRIPTION
## Why

The large-system performance mode "wouldn't open" on some machines. Root cause: `is_webgpu_supported()` only checks that `navigator.gpu` **exists**, but on many setups (AMD integrated + Linux without the Vulkan/WebGPU flags) `requestAdapter()` still returns **null** — the API is present, no device obtainable. The toggle stayed enabled, then the WebGPU overlay failed at render time.

## Fix

- **`webgpu-context.ts`**: `probe_webgpu_available()` — cached async adapter probe (real availability).
- **`Structure.svelte`**: probe on mount → `webgpu_available`; forces `large_system_mode` OFF and passes the flag to the toolbar when no adapter.
- **`StructureToolbar.svelte`**: toggle `disabled` + greyed + explanatory tooltip when unavailable.
- **i18n en/zh**: `large_system_mode_unavailable`.

## Verification

Live (playwright) on a machine where `requestAdapter()` returns null: toggle renders `disabled` with tooltip *"…WebGPU unavailable… enable Unsafe WebGPU / Vulkan flags"*. 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)