### PR TITLE
fix(trajectory): keyboard shortcuts (incl. Ctrl+A→first) work without clicking the viewer

### DIFF
--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1516,6 +1516,18 @@
   }}
 />
 
+<!-- The wrapper's element-level onkeydown only fires when focus is INSIDE it.
+     When nothing is focused (focus on <body>), forward the trajectory shortcuts
+     so keys like Ctrl+A→first frame / A·D / Space work without first clicking
+     the viewer. If focus is on a specific element (an input, another pane), we
+     bail and let that element's own handler decide — so this never hijacks keys
+     from another focused pane. -->
+<svelte:window onkeydown={(event) => {
+  const ae = document.activeElement
+  if (ae && ae !== document.body) return
+  onkeydown(event)
+}} />
+
 <div
   class:dragover
   class:active={is_playing || structure_info_open || structure_controls_open ||


### PR DESCRIPTION
## Problem

Trajectory shortcuts (`A`/`D`, `Space`, `Ctrl+A`/`Ctrl+D` first/last, `Home`/`End`) only worked when the trajectory wrapper (or a descendant) had focus, because they were on the wrapper's element-level `onkeydown`. With focus on `<body>` (common — the user hasn't clicked the view), nothing happened. `Ctrl+A`→first frame looked especially "broken" because the structure interaction controller's **document-level** handler `preventDefault`s `Ctrl+A` (to block browser select-all), so even the browser default did nothing.

## Fix

Add a `<svelte:window onkeydown>` that forwards to the existing trajectory key handler **only when nothing specific is focused** (`document.activeElement` is null/`<body>`). If focus is on an input or another pane, it bails — so it never hijacks keys from a focused element. It exists only while a `Trajectory` is mounted (no effect in normal structure mode), and the element-level handler still covers the focused case (the window guard returns early when focus is inside, so no double-handling).

Event order makes `Ctrl+A` correct: the document-level interaction handler fires first (`preventDefault` blocks select-all), then the window handler runs `go_to_step(0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)