### PR TITLE
chore(release): v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.3] - 2026-05-30
+
+### Added
+- **Redo**: `Ctrl+Shift+Z` / `Ctrl+Y` to redo structure changes (undo was already `Ctrl+Z`).
+- **CatBot `set_lattice`**: the web (STATIC_ONLY) assistant can give a molecule a periodic box client-side.
+- **Landing page**: a "Star on GitHub" link on the welcome screen.
+
+### Fixed
+- **Cross-tab / cross-pane bleed**: loading a structure in one tab or pane no longer overwrites another.
+- **Atom delete**: deleting an atom no longer drops unrelated surviving bonds.
+- **(110) slab stoichiometry**: species-aware in-plane primitive reduction (TS + Rust); slab-cutter controls are no longer hard-capped.
+- **Desktop file association**: "Open with CatGo" now loads the file on Windows & Linux, and drag-drop can read dropped files.
+- **DOS / COHP analysis**: extension packages are importable again (was "Failed to fetch"), and large remote reads (PROCAR / COHPCAR / CHGCAR) are gzip-compressed in transit (~6× faster on slow links); the Charge `cube-processor` path was corrected.
+- **CatBot**: "Allow for session" now persists in the client-direct path.
+- **UI**: the active dialog tab no longer renders invisible (accent text on an accent fill); Structure-Info usage tips were corrected to match the real key/mouse bindings.
+- **Large-system mode**: the toggle is disabled with an explanatory tooltip when WebGPU isn't actually available (no GPU adapter).
+- **Trajectory**: keyboard shortcuts (A/D, Space, Ctrl+A/D, Home/End) work without first clicking into the viewer.
+- **VASP**: a successful offline (client-side) input generation shows as info, not a red error.
+- Fixed a startup crash ("Cannot access '_view_dir' before initialization").
+
+### Changed
+- **HPC**: ControlMaster-mode SSH commands use `BatchMode=yes` so a missing master fails cleanly instead of hanging on `ssh-askpass`.
+- **CI**: bounded the e2e/unit job time so a hung dev-server can't run to the 6h cap; hardened cargo network flakes.
+
 ## [1.1.2] - 2026-05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "base64 0.22.1",
  "catgo-graph",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.1.2"
+version = "1.1.3"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump 1.1.2 → 1.1.3 (package.json, src-tauri Cargo.toml/Cargo.lock/tauri.conf.json) + CHANGELOG.

Highlights since v1.1.2:
- **Added**: redo (Ctrl+Shift+Z / Ctrl+Y); client-side `set_lattice` for web CatBot; landing "Star on GitHub".
- **Fixed**: cross-tab/pane structure bleed; atom-delete bond loss; (110) slab stoichiometry; desktop file-association (Win/Linux) + drag-drop; DOS/COHP import + gzip remote reads (~6×) + Charge path; CatBot "allow for session"; invisible dialog tab; usage-tips accuracy; large-system toggle disabled when no WebGPU; trajectory keys without focus; VASP offline = info; `_view_dir` TDZ crash.
- **Changed**: SSH BatchMode; CI time bounds + cargo flake hardening.

Merging this, then tagging `v1.1.3` triggers the all-platform desktop build + draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)