### PR TITLE
fix: normalize Windows file browser breadcrumb paths

### DIFF
--- a/desktop/sidebar-utils.ts
+++ b/desktop/sidebar-utils.ts
@@ -55,9 +55,21 @@ export function get_file_icon(name: string): string {
 
 export function fs_get_breadcrumbs(dir: string): Array<{ label: string; path: string }> {
   if (!dir) return []
-  const sep = dir.includes(`\\`) ? `\\` : `/`
-  const parts = dir.split(sep).filter(Boolean)
+  const normalized_dir = dir.replace(/^\\\\\?\\([A-Za-z]:[\\/])/, `$1`)
+  const is_windows_drive = /^[A-Za-z]:[\\/]/.test(normalized_dir)
+  const sep = normalized_dir.includes(`\\`) ? `\\` : `/`
+  const parts = is_windows_drive
+    ? normalized_dir.split(/[\\/]+/).filter(Boolean)
+    : normalized_dir.split(sep).filter(Boolean)
   const crumbs: Array<{ label: string; path: string }> = []
+  if (is_windows_drive) {
+    let acc = ``
+    for (const p of parts) {
+      acc = acc ? `${acc}${sep}${p}` : p
+      crumbs.push({ label: p, path: acc + sep })
+    }
+    return crumbs
+  }
   // On Unix, start with /
   if (sep === `/`) {
     crumbs.push({ label: `/`, path: `/` })

--- a/src-tauri/src/db/files.rs
+++ b/src-tauri/src/db/files.rs
@@ -1,7 +1,7 @@
 //! Filesystem commands: browse, read, write, mkdir, delete, rename, copy, move.
 
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::util::expand_tilde;
 
@@ -58,6 +58,38 @@ pub struct FileOpResult {
     pub message: String,
 }
 
+fn path_to_ui_string(path: &Path) -> String {
+    strip_windows_verbatim_prefix(&path.to_string_lossy())
+}
+
+fn strip_windows_verbatim_prefix(path: &str) -> String {
+    if cfg!(windows) {
+        if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+            return format!(r"\\{rest}");
+        }
+        if let Some(rest) = path.strip_prefix(r"\\?\") {
+            return rest.to_string();
+        }
+    }
+    path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_windows_verbatim_prefix;
+
+    #[test]
+    fn strips_windows_verbatim_drive_prefix_for_ui() {
+        let input = r"\\?\E:\Projects\example\data";
+        let expected = if cfg!(windows) {
+            r"E:\Projects\example\data"
+        } else {
+            input
+        };
+        assert_eq!(strip_windows_verbatim_prefix(input), expected);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tauri commands: DB browse directory
 // ---------------------------------------------------------------------------
@@ -108,7 +140,7 @@ pub fn db_browse_directory(dir: Option<String>) -> Result<BrowseResult, String> 
             items.push(BrowseItem {
                 name,
                 item_type: "dir".to_string(),
-                path: path.to_string_lossy().to_string(),
+                path: path_to_ui_string(&path),
             });
         } else if let Some(ext) = path.extension() {
             let ext_lower = ext.to_string_lossy().to_lowercase();
@@ -116,20 +148,16 @@ pub fn db_browse_directory(dir: Option<String>) -> Result<BrowseResult, String> 
                 items.push(BrowseItem {
                     name,
                     item_type: "file".to_string(),
-                    path: path.to_string_lossy().to_string(),
+                    path: path_to_ui_string(&path),
                 });
             }
         }
     }
 
-    let parent = target
-        .parent()
-        .unwrap_or(&target)
-        .to_string_lossy()
-        .to_string();
+    let parent = path_to_ui_string(target.parent().unwrap_or(&target));
 
     Ok(BrowseResult {
-        dir: target.to_string_lossy().to_string(),
+        dir: path_to_ui_string(&target),
         parent,
         items,
     })
@@ -147,7 +175,7 @@ pub fn db_browse_files(dir: Option<String>) -> Result<FileBrowseResult, String> 
 
     let parent = canonical
         .parent()
-        .map(|p| p.to_string_lossy().to_string())
+        .map(path_to_ui_string)
         .unwrap_or_default();
 
     let mut items = Vec::new();
@@ -169,7 +197,7 @@ pub fn db_browse_files(dir: Option<String>) -> Result<FileBrowseResult, String> 
             } else {
                 "file".to_string()
             },
-            path: entry.path().to_string_lossy().to_string(),
+            path: path_to_ui_string(&entry.path()),
         });
     }
     // Sort: directories first, then files, alphabetically
@@ -179,7 +207,7 @@ pub fn db_browse_files(dir: Option<String>) -> Result<FileBrowseResult, String> 
     });
 
     Ok(FileBrowseResult {
-        dir: canonical.to_string_lossy().to_string(),
+        dir: path_to_ui_string(&canonical),
         parent,
         items,
     })

--- a/src-tauri/src/db/util.rs
+++ b/src-tauri/src/db/util.rs
@@ -190,7 +190,23 @@ pub fn expand_tilde(dir: &str) -> PathBuf {
             return home.join(dir.strip_prefix("~/").unwrap_or(""));
         }
     }
-    PathBuf::from(dir)
+    let normalized = normalize_windows_drive_path(dir);
+    PathBuf::from(normalized)
+}
+
+fn normalize_windows_drive_path(path: &str) -> &str {
+    if cfg!(windows) {
+        let bytes = path.as_bytes();
+        if bytes.len() >= 4
+            && (bytes[0] == b'/' || bytes[0] == b'\\')
+            && bytes[2] == b':'
+            && (bytes[3] == b'/' || bytes[3] == b'\\')
+            && bytes[1].is_ascii_alphabetic()
+        {
+            return &path[1..];
+        }
+    }
+    path
 }
 
 /// Get a text_key_value for a system row.

--- a/tests/vitest/desktop/sidebar-utils.test.ts
+++ b/tests/vitest/desktop/sidebar-utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest'
+import { fs_get_breadcrumbs } from '../../../desktop/sidebar-utils'
+
+describe(`fs_get_breadcrumbs`, () => {
+  test(`keeps Windows drive paths valid when they use forward slashes`, () => {
+    expect(fs_get_breadcrumbs(`E:/Projects/example/data`)).toEqual([
+      { label: `E:`, path: `E:/` },
+      { label: `Projects`, path: `E:/Projects/` },
+      { label: `example`, path: `E:/Projects/example/` },
+      { label: `data`, path: `E:/Projects/example/data/` },
+    ])
+  })
+
+  test(`keeps Windows drive paths valid when they use backslashes`, () => {
+    expect(fs_get_breadcrumbs(`E:\\Projects\\example\\data`)).toEqual([
+      { label: `E:`, path: `E:\\` },
+      { label: `Projects`, path: `E:\\Projects\\` },
+      { label: `example`, path: `E:\\Projects\\example\\` },
+      { label: `data`, path: `E:\\Projects\\example\\data\\` },
+    ])
+  })
+
+  test(`normalizes Windows verbatim drive prefixes`, () => {
+    expect(fs_get_breadcrumbs(`\\\\?\\E:\\Projects\\example\\data`)).toEqual([
+      { label: `E:`, path: `E:\\` },
+      { label: `Projects`, path: `E:\\Projects\\` },
+      { label: `example`, path: `E:\\Projects\\example\\` },
+      { label: `data`, path: `E:\\Projects\\example\\data\\` },
+    ])
+  })
+
+  test(`keeps Unix paths rooted at slash`, () => {
+    expect(fs_get_breadcrumbs(`/var/tmp/data`)).toEqual([
+      { label: `/`, path: `/` },
+      { label: `var`, path: `/var` },
+      { label: `tmp`, path: `/var/tmp` },
+      { label: `data`, path: `/var/tmp/data` },
+    ])
+  })
+})


### PR DESCRIPTION
## Problem

On Windows, the Local Files breadcrumb can fail to navigate parent folders and show:

`resolve path: 文件名、目录名或卷标语法不正确。 (os error 123)`

This can happen for paths such as `D:/...` or Windows verbatim paths like `\\?\D:\...`.

## Cause

`fs_get_breadcrumbs()` treated Windows drive paths with forward slashes as Unix paths, generating invalid breadcrumb targets such as `/D:/...`.

In addition, Rust `canonicalize()` may return Windows verbatim paths with the `\\?\` prefix. Those paths were returned directly to the UI, where the breadcrumb splitter did not handle them correctly.

## Solution

- Normalize Windows verbatim drive prefixes in the desktop breadcrumb helper.
- Detect Windows drive paths regardless of slash style.
- Strip `\\?\` / `\\?\UNC\` prefixes from filesystem paths returned to the UI.
- Add a Rust-side fallback to accept accidental leading-slash drive paths such as `/D:/...`.
- Add regression tests for Windows slash styles and verbatim paths.

## Validation

- `pnpm exec vitest run tests/vitest/desktop/sidebar-utils.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml strips_windows_verbatim_drive_prefix_for_ui --target x86_64-pc-windows-msvc`