### PR TITLE
ci(e2e): cache Playwright browsers + bound install step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Run inside Playwright's official image, which ships the browsers
+    # preinstalled at /ms-playwright. The chromium download from
+    # cdn.playwright.dev systematically stalled ~18min on the runner and tripped
+    # the job backstop before the tests ran; the image removes that download
+    # entirely. Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.0-noble
     continue-on-error: true
     # Hard backstop: e2e is non-gating (continue-on-error) and has historically
     # hung on the dev-server webServer, running to GitHub's 6h job cap. Bound it.
@@ -101,22 +108,7 @@ jobs:
       - name: Build documentation chunks
         run: pnpm run build:doc-chunks
 
-      # Cache the downloaded browser binaries. A cold `playwright install`
-      # historically stalled ~18min on the chromium download and tripped the
-      # 20min job backstop (job cancelled before tests ran). A cache hit skips
-      # the download; the per-step timeout fails fast on a stall instead of
-      # dragging the whole job to the backstop.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright
-        timeout-minutes: 5
-        run: npx playwright install chromium
-
+      # Browsers are preinstalled in the container image, so no download step.
       - name: Run e2e tests
         continue-on-error: true
         run: npx playwright test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,20 @@ jobs:
       - name: Build documentation chunks
         run: pnpm run build:doc-chunks
 
+      # Cache the downloaded browser binaries. A cold `playwright install`
+      # historically stalled ~18min on the chromium download and tripped the
+      # 20min job backstop (job cancelled before tests ran). A cache hit skips
+      # the download; the per-step timeout fails fast on a stall instead of
+      # dragging the whole job to the backstop.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright
+        timeout-minutes: 5
         run: npx playwright install chromium
 
       - name: Run e2e tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,11 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      # The Playwright image is minimal and lacks a C toolchain. Native deps
+      # (node-pty) need node-gyp -> make/g++/python3 to build during install.
+      - name: Install build toolchain for native modules
+        run: apt-get update && apt-get install -y --no-install-recommends build-essential python3
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## 问题

main 上一堆 commit 的 e2e job 显示红/取消。排查发现**不是测试失败,是 job 被取消**：

```
Install Playwright   cancelled   09:58:39 → 10:16:43  ← 卡 ~18 分钟
Run e2e tests        skipped     ← 根本没跑到
```

`npx playwright install chromium` 冷下载 chromium 卡住约 18 分钟,撞上 job 的 `timeout-minutes: 20` 兜底 → 整个 job 取消,e2e 测试一行没跑。e2e 本身是非门禁(`continue-on-error`),不影响代码正确性,但白烧 CI 分钟且看着吓人。

## 修法

- **缓存浏览器**：`actions/cache` 缓存 `~/.cache/ms-playwright`,key 绑 `pnpm-lock.yaml`。命中后跳过下载。
- **安装步骤单独限时**：`timeout-minutes: 5`,卡住快速失败,不再拖满 20 分钟。

## 影响

只动 `.github/workflows/test.yml` 的 e2e job。unit/build/lint 门禁不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)