### PR TITLE
fix(workflow): INCAR/输入编辑器无法粘贴 (Ctrl+V/C/A/Z 被画布快捷键吞掉)

### DIFF
--- a/src/lib/structure/AdsorptionSiteMarkers.svelte
+++ b/src/lib/structure/AdsorptionSiteMarkers.svelte
@@ -46,11 +46,14 @@
 
   // Handle Delete/Backspace key for adsorption sites
   function handle_adsorption_site_delete(event: KeyboardEvent) {
-    // Ignore if user is typing in an input field
+    // Ignore if user is typing in an input field or an embedded editor.
+    // Monaco (EditContext) focuses a <div>, not a <textarea>, so a tagName-only
+    // check would let Delete/Backspace in the editor delete an adsorption site.
     const target = event.target as HTMLElement
     if (
       target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' ||
-      target.tagName === 'SELECT'
+      target.tagName === 'SELECT' ||
+      target?.closest?.('.monaco-editor, .native-edit-context, [contenteditable=""], [contenteditable="true"]')
     ) return
 
     // Check for Delete or Backspace key

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -840,6 +840,11 @@ export function create_interaction_controller(deps: InteractionDeps) {
   function onkeydown(event: KeyboardEvent) {
     if (!event.key) return
     const target = event.target as HTMLElement
+    // Don't hijack edit/clipboard keys when typing inside an embedded editor.
+    // Monaco (file/INCAR editor in Structure.svelte) uses the EditContext API,
+    // so its focused element is a <div>, not a <textarea>; a tagName-only check
+    // misses it and would swallow native Ctrl+Z/A/C/V/Delete in the editor.
+    if (target?.closest?.(`.monaco-editor, .native-edit-context, [contenteditable=""], [contenteditable="true"]`)) return
     const is_input_focused = target.tagName === `INPUT` || target.tagName === `TEXTAREA`
 
     // Ctrl/Cmd+Z 撤销

--- a/src/lib/structure/interaction-handlers.ts
+++ b/src/lib/structure/interaction-handlers.ts
@@ -100,11 +100,14 @@ export function handle_keyboard_rotation(
 ): void {
   if (!camera || !orbit_controls) return
 
-  // Ignore if user is typing in an input field
+  // Ignore if user is typing in an input field. Monaco (EditContext) focuses a
+  // <div>, not a <textarea>, so also bail on embedded editors / contenteditable
+  // — otherwise plain s/w/arrow keys typed in the editor get swallowed.
   const target = event.target as HTMLElement
   if (
     target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' ||
-    target.tagName === 'SELECT'
+    target.tagName === 'SELECT' ||
+    target?.closest?.('.monaco-editor, .native-edit-context, [contenteditable=""], [contenteditable="true"]')
   ) return
 
   // Don't handle if modifier keys are pressed (for browser shortcuts)

--- a/src/lib/workflow/WorkflowEditor.svelte
+++ b/src/lib/workflow/WorkflowEditor.svelte
@@ -2040,8 +2040,14 @@
   // ─── Keyboard ───
   $effect(() => {
     function handler(e: KeyboardEvent) {
-      const tag = (e.target as HTMLElement)?.tagName
+      const target = e.target as HTMLElement | null
+      const tag = target?.tagName
       if (tag === `INPUT` || tag === `TEXTAREA` || tag === `SELECT`) return
+      // Don't hijack Ctrl+C/V/A/Z when typing inside an embedded editor.
+      // Monaco (INCAR/KPOINTS, ORCA/CP2K/LAMMPS input editors) uses the
+      // EditContext API, so its focused element is a <div>, not a <textarea> —
+      // without this the canvas shortcuts swallow native paste/undo/select.
+      if (target?.closest(`.monaco-editor, .native-edit-context, [contenteditable=""], [contenteditable="true"]`)) return
       if ((e.metaKey || e.ctrlKey) && e.key === `z` && !e.shiftKey) { e.preventDefault(); undo() }
       if ((e.metaKey || e.ctrlKey) && e.key === `z` && e.shiftKey) { e.preventDefault(); redo() }
       if ((e.metaKey || e.ctrlKey) && e.key === `y`) { e.preventDefault(); redo() }


### PR DESCRIPTION
## 问题

用户反馈（Windows）：工作流里 VASP **INCAR** 编辑框只能手敲，**复制粘贴(Ctrl+V)用不了**。

## 根因

INCAR/KPOINTS（及 ORCA/CP2K/LAMMPS）输入编辑器是渲染在工作流画布之上的 **Monaco** 实例。`WorkflowEditor.svelte` 的 window 级 keydown 处理器管画布快捷键（Ctrl+V 粘贴节点、Ctrl+C/A/Z），放行判断只在 `INPUT`/`TEXTAREA`/`SELECT` 时早退。

但 **Monaco 0.55 默认用 EditContext API**，焦点元素是 `<div class="native-edit-context">`，**不是 textarea** → 判断没命中 → 处理器照跑 `preventDefault()` + 画布 `paste()` → 编辑框内原生粘贴被吞。Ctrl+Z/C/A 同理被劫持。手敲普通键不受影响，所以"只能敲不能粘"。

非用户操作问题，是 bug。

## 修法

放行判断追加：事件源在 `.monaco-editor` / `.native-edit-context` / `[contenteditable]` 内则早退，让原生编辑键到达编辑器。一处修复同时覆盖 VASP 与 ORCA/CP2K/LAMMPS 输入编辑器。

## 验证建议

桌面版打开 INCAR 编辑器 → Ctrl+A / Ctrl+C / Ctrl+V / Ctrl+Z 应正常作用于编辑器内文本，而非画布节点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)