### PR TITLE
fix(workflow): POTCAR 可靠生成 + 失败显式报错

### DIFF
--- a/server/catgo/workflow/engine/scanner.py
+++ b/server/catgo/workflow/engine/scanner.py
@@ -384,6 +384,14 @@ class WorkflowEngine:
                             "cp2k_data_dir", "cp2k_command"):
                     if cc.get(key):
                         hpc.setdefault("job_defaults", {})[key] = cc[key]
+                # POTCAR root/functional are read at hpc ROOT level by the VASP
+                # submitter (submitter._submit_one / batch_submitter), not from
+                # job_defaults. Without this, a configured POTCAR dir lands only
+                # in job_defaults, the submitter reads "" from root, and POTCAR
+                # generation is silently skipped.
+                for key in ("potcar_root", "potcar_functional"):
+                    if cc.get(key):
+                        hpc[key] = cc[key]
 
             # Direct hpc-level keys (backward compat for legacy configs)
             for key in ("run_commands",):

--- a/server/catgo/workflow/engine/submitter.py
+++ b/server/catgo/workflow/engine/submitter.py
@@ -7,6 +7,7 @@ same type are READY (fan-out from a map task).
 from __future__ import annotations
 import json
 import logging
+import shlex
 from collections import defaultdict
 from typing import Any
 
@@ -442,27 +443,57 @@ _POTCAR_VARIANTS = {
 async def _generate_potcar(
     hpc, work_dir: str, potcar_root: str, potcar_functional: str,
 ) -> None:
-    """Concatenate POTCAR files on remote from POSCAR element order."""
+    """Concatenate POTCAR files on remote from POSCAR element order.
+
+    Raises RuntimeError on any failure (unreadable POSCAR, a missing source
+    POTCAR, a failed concat, or an empty result). The caller (_submit_one /
+    submit_batch_tasks) turns the exception into a REMOTE_ERROR task so the
+    failure is surfaced in the UI instead of silently submitting a VASP job
+    with no POTCAR that later crashes on the cluster with no visible error.
+    """
+    wd = shlex.quote(work_dir)
     # Read POSCAR to get element order
-    result = await hpc.run_on_owner(lambda: hpc.conn.run(f"cat {work_dir}/POSCAR", check=False))
+    result = await hpc.run_on_owner(lambda: hpc.conn.run(f"cat {wd}/POSCAR", check=False))
     if result.exit_status != 0 or not result.stdout.strip():
-        logger.warning("Cannot read POSCAR for POTCAR generation")
-        return
+        raise RuntimeError(f"Cannot read POSCAR for POTCAR generation in {work_dir}")
 
     lines = result.stdout.strip().split("\n")
     if len(lines) < 6:
-        return
+        raise RuntimeError("POSCAR has fewer than 6 lines; cannot determine element order for POTCAR")
     # Element symbols are on line 6 (0-indexed: line 5)
     elements = lines[5].split()
+    if not elements:
+        raise RuntimeError("POSCAR line 6 lists no element symbols; cannot build POTCAR")
 
     parts = []
     for el in elements:
         variant = _POTCAR_VARIANTS.get(el, el)
         parts.append(f"{potcar_root}/{potcar_functional}/{variant}/POTCAR")
 
-    cat_cmd = f"cat {' '.join(parts)} > {work_dir}/POTCAR"
+    # Verify every source POTCAR exists first, so the error names the culprit
+    # element/path instead of leaving a partial or empty POTCAR behind.
+    check_cmd = " ; ".join(f"test -f {shlex.quote(p)} || echo MISSING {p}" for p in parts)
+    chk = await hpc.run_on_owner(lambda: hpc.conn.run(check_cmd, check=False))
+    missing = [ln[len("MISSING "):] for ln in (chk.stdout or "").splitlines() if ln.startswith("MISSING ")]
+    if missing:
+        raise RuntimeError(
+            "POTCAR source files not found (check POTCAR root/functional and "
+            f"element→pseudopotential mapping): {', '.join(missing)}"
+        )
+
+    cat_cmd = f"cat {' '.join(shlex.quote(p) for p in parts)} > {wd}/POTCAR"
     result = await hpc.run_on_owner(lambda: hpc.conn.run(cat_cmd, check=False))
     if result.exit_status != 0:
-        logger.error("POTCAR generation failed: %s", result.stderr if hasattr(result, 'stderr') else "")
-    else:
-        logger.info("POTCAR generated from %d elements: %s", len(elements), elements)
+        stderr = (getattr(result, "stderr", "") or "").strip()
+        raise RuntimeError(f"POTCAR concatenation failed: {stderr or 'unknown error'}")
+
+    # Sanity: a real POTCAR is never empty.
+    size = await hpc.run_on_owner(lambda: hpc.conn.run(f"wc -c < {wd}/POTCAR", check=False))
+    try:
+        nbytes = int((size.stdout or "0").strip())
+    except ValueError:
+        nbytes = 0
+    if nbytes <= 0:
+        raise RuntimeError("Generated POTCAR is empty after concatenation")
+
+    logger.info("POTCAR generated from %d elements: %s", len(elements), elements)


### PR DESCRIPTION
## 问题
HPC 跑 VASP，POTCAR 没生成，作业却照样提交、崩了 UI 还不报错。两个 bug：

1. **配置 key 路径不匹配**：`scanner._merged_config` 把 `potcar_root` 写进 `hpc.job_defaults`，submitter 从 `hpc` 根层读 → `""` → POTCAR 生成被静默跳过（配了也没用）。修：根层也写。
2. **失败静默**：`_generate_potcar` 失败只记日志就返回 → 任务照样提交 → VASP 崩、UI 不报错。修：逐元素预检 + 失败 raise → submitter 转 `REMOTE_ERROR` 标红，点名缺哪个元素。

## 验证
py_compile 通过；预检端点真打 shaheen 证实用户 POTCAR 目录有效（O/H/Ru 都在）→ 坐实根因是 key 路径 bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code)