### PR TITLE
feat(desktop): web 模式查看本地文件 + MD 图片并行加载

### DIFF
--- a/desktop/sidebar/fs-browser.svelte.ts
+++ b/desktop/sidebar/fs-browser.svelte.ts
@@ -8,6 +8,7 @@
 import { browse_files, read_file, export_structure } from '$lib/api/project'
 import type { FileBrowseItem } from '$lib/api/project'
 import { is_structure_file, is_db_file } from '../sidebar-utils'
+import { check_tauri } from '$lib/io/tauri'
 
 export interface FsBrowserCallbacks {
   on_load_file: (content: string | ArrayBuffer, filename: string, file_path?: string, session_id?: string) => void
@@ -85,21 +86,35 @@ export function create_fs_browser_state(callbacks: FsBrowserCallbacks) {
     }
 
     const lower_name = item.name.toLowerCase()
+    const is_tauri = check_tauri()
+
+    // Read raw bytes of a local file in BOTH modes: the Tauri fs plugin in the
+    // desktop app, or the Vite dev /__files/raw route in browser/web mode.
+    // Without the web branch, the plugin-fs import throws "Cannot read
+    // properties of undefined (reading 'invoke')" and previews fail in web mode.
+    async function read_local_bytes(path: string): Promise<Uint8Array> {
+      if (is_tauri) {
+        const { readFile } = await import(`@tauri-apps/plugin-fs`)
+        return await readFile(path)
+      }
+      const resp = await fetch(`/__files/raw?path=${encodeURIComponent(path)}`)
+      if (!resp.ok) throw new Error(`Cannot read file (HTTP ${resp.status})`)
+      return new Uint8Array(await resp.arrayBuffer())
+    }
+    function bytes_to_base64(bytes: Uint8Array): string {
+      let bin = ``
+      const chunk_size = 8192
+      for (let i = 0; i < bytes.length; i += chunk_size) bin += String.fromCharCode(...bytes.subarray(i, i + chunk_size))
+      return btoa(bin)
+    }
 
     // In-app preview for images
     if (callbacks.on_preview_file && /\.(png|jpg|jpeg|gif|bmp|webp|svg|ico|tiff?)$/i.test(lower_name)) {
       try {
-        const { readFile } = await import(`@tauri-apps/plugin-fs`)
-        const bytes = await readFile(item.path)
+        const bytes = await read_local_bytes(item.path)
         const ext = lower_name.split(`.`).pop() || ``
         const mime = ext === `svg` ? `image/svg+xml` : ext === `gif` ? `image/gif` : ext === `webp` ? `image/webp` : ext === `bmp` ? `image/bmp` : ext.startsWith(`tif`) ? `image/tiff` : `image/${ext === `jpg` ? `jpeg` : ext}`
-        let bin = ``
-        const chunk_size = 8192
-        for (let i = 0; i < bytes.length; i += chunk_size) {
-          bin += String.fromCharCode(...bytes.subarray(i, i + chunk_size))
-        }
-        const base64 = btoa(bin)
-        callbacks.on_preview_file(`image`, item.name, item.path, ``, undefined, base64, mime)
+        callbacks.on_preview_file(`image`, item.name, item.path, ``, undefined, bytes_to_base64(bytes), mime)
       } catch (e) {
         fs_error = e instanceof Error ? e.message : `Cannot read image`
       }
@@ -109,26 +124,24 @@ export function create_fs_browser_state(callbacks: FsBrowserCallbacks) {
     // In-app preview for PDFs
     if (callbacks.on_preview_file && /\.pdf$/i.test(lower_name)) {
       try {
-        const { readFile } = await import(`@tauri-apps/plugin-fs`)
-        const bytes = await readFile(item.path)
-        let bin = ``
-        const chunk_size = 8192
-        for (let i = 0; i < bytes.length; i += chunk_size) {
-          bin += String.fromCharCode(...bytes.subarray(i, i + chunk_size))
-        }
-        const base64 = btoa(bin)
-        callbacks.on_preview_file(`pdf`, item.name, item.path, ``, undefined, base64, `application/pdf`)
+        const bytes = await read_local_bytes(item.path)
+        callbacks.on_preview_file(`pdf`, item.name, item.path, ``, undefined, bytes_to_base64(bytes), `application/pdf`)
       } catch (e) {
         fs_error = e instanceof Error ? e.message : `Cannot read PDF`
       }
       return
     }
 
-    // Non-previewable binary files: open with system default app
+    // Non-previewable binary files: open with the system default app (desktop),
+    // or open the raw file in a new browser tab in web mode.
     if (/\.(xlsx?|xlsm|xlsb|ods|mp[34]|wav|ogg|avi|mov|mkv|zip|gz|tar|rar|7z|exe|dll|so|dylib|woff2?|ttf|eot|doc|docx|ppt|pptx)$/i.test(lower_name)) {
       try {
-        const { open } = await import(`@tauri-apps/plugin-shell`)
-        await open(item.path)
+        if (is_tauri) {
+          const { open } = await import(`@tauri-apps/plugin-shell`)
+          await open(item.path)
+        } else {
+          window.open(`/__files/raw?path=${encodeURIComponent(item.path)}`, `_blank`)
+        }
       } catch (e) {
         fs_error = e instanceof Error ? e.message : `Cannot open file`
       }

--- a/desktop/sidebar/hpc-browser.svelte.ts
+++ b/desktop/sidebar/hpc-browser.svelte.ts
@@ -197,12 +197,28 @@ export function create_hpc_browser_state(callbacks: HpcBrowserCallbacks) {
   async function hpc_download(file: RemoteFile) {
     const source = callbacks.get_source()
     if (source === LOCAL_SESSION_ID) {
-      // Local file: open with system default app
-      try {
-        const { open } = await import(`@tauri-apps/plugin-shell`)
-        await open(file.path)
-      } catch {
-        // Fallback: copy path to clipboard
+      const { check_tauri } = await import(`$lib/io/tauri`)
+      if (check_tauri()) {
+        // Desktop app: open the local file with the system default app.
+        try {
+          const { open } = await import(`@tauri-apps/plugin-shell`)
+          await open(file.path)
+        } catch {
+          navigator.clipboard.writeText(file.path).catch(() => {})
+        }
+      } else if (!file.is_dir) {
+        // Web/dev mode: Tauri shell is unavailable (the button was a silent
+        // no-op), so stream the file via /__files/raw and trigger a browser
+        // download.
+        const link = document.createElement(`a`)
+        link.href = `/__files/raw?path=${encodeURIComponent(file.path)}`
+        link.download = file.name
+        link.rel = `noopener`
+        link.style.display = `none`
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
+      } else {
         navigator.clipboard.writeText(file.path).catch(() => {})
       }
       return

--- a/src/lib/structure/FilePreviewPanel.svelte
+++ b/src/lib/structure/FilePreviewPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { markdown_to_html } from '$lib/chat/markdown'
+  import { check_tauri } from '$lib/io/tauri'
   import { download as unified_download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
@@ -67,46 +68,83 @@
     if (mode !== `markdown`) { rendered_markdown = ``; return }
     const html = markdown_to_html(content)
     rendered_markdown = html
+    if (!file_path) return
 
-    // Resolve remote images when viewing HPC markdown files
-    if (session_id && file_path) {
-      resolve_remote_images(html, session_id, file_path).then((resolved) => {
-        if (resolved !== html) rendered_markdown = resolved
-      })
-    }
+    // Resolve markdown <img> relative paths. Remote (HPC) reads over SSH;
+    // local reads via the Tauri fs plugin. Both run in PARALLEL (was serial,
+    // one slow roundtrip per image) and only apply if this render is still
+    // current, so images appear together instead of slowly or not at all.
+    const base = html
+    const resolver = session_id
+      ? resolve_remote_images(base, session_id, file_path)
+      : resolve_local_images(base, file_path)
+    resolver.then((resolved) => {
+      if (resolved !== base && rendered_markdown === base) rendered_markdown = resolved
+    })
   })
 
-  /** Scan rendered HTML for <img> with relative src, fetch from HPC, replace with data URI. */
-  async function resolve_remote_images(html: string, sid: string, md_path: string): Promise<string> {
-    const { readRemoteBinaryFile } = await import(`$lib/api/hpc`)
+  /** Scan rendered HTML for <img> with relative src, resolve each (in parallel,
+   *  de-duplicated) via `load`, and swap in the result. */
+  async function resolve_images(
+    html: string,
+    md_path: string,
+    load: (abs_path: string, src: string) => Promise<string | null>,
+  ): Promise<string> {
     const dir = md_path.substring(0, md_path.lastIndexOf(`/`))
-    // Match both src="..." and src=&quot;...&quot; (HTML-escaped from esc())
     const img_regex = /<img\s[^>]*?src="([^"]+)"/g
-    const matches = [...html.matchAll(img_regex)]
-    if (matches.length === 0) return html
+    const srcs = [...new Set([...html.matchAll(img_regex)].map((m) => m[1]))].filter(
+      (src) => !src.startsWith(`data:`) && !src.startsWith(`http://`) && !src.startsWith(`https://`),
+    )
+    if (srcs.length === 0) return html
+
+    const resolved = await Promise.all(
+      srcs.map(async (src) => {
+        const abs_path = src.startsWith(`/`) ? src : `${dir}/${src}`
+        try {
+          return [src, await load(abs_path, src)] as const
+        } catch (err) {
+          console.warn(`[FilePreview] image load failed: ${abs_path}`, err)
+          return [src, null] as const
+        }
+      }),
+    )
 
     let result = html
-    for (const match of matches) {
-      const src = match[1]
-      if (src.startsWith(`data:`) || src.startsWith(`http://`) || src.startsWith(`https://`)) continue
-      const abs_path = src.startsWith(`/`) ? src : `${dir}/${src}`
-      try {
-        const resp = await readRemoteBinaryFile(sid, abs_path)
-        if (resp.success && resp.data) {
-          // Guess MIME from extension if not provided
-          const mime = resp.mime_type || guess_image_mime(src)
-          result = result.replace(
-            `src="${src}"`,
-            `src="data:${mime};base64,${resp.data}"`,
-          )
-        } else {
-          console.warn(`[FilePreview] Failed to load remote image: ${abs_path}`, resp.message)
-        }
-      } catch (err) {
-        console.warn(`[FilePreview] Error fetching remote image: ${abs_path}`, err)
-      }
+    for (const [src, uri] of resolved) {
+      if (uri) result = result.replaceAll(`src="${src}"`, `src="${uri}"`)
     }
     return result
+  }
+
+  /** HPC markdown: fetch each image over SSH and inline as a data URI. */
+  async function resolve_remote_images(html: string, sid: string, md_path: string): Promise<string> {
+    const { readRemoteBinaryFile } = await import(`$lib/api/hpc`)
+    return resolve_images(html, md_path, async (abs_path, src) => {
+      const resp = await readRemoteBinaryFile(sid, abs_path)
+      if (resp.success && resp.data) return `data:${resp.mime_type || guess_image_mime(src)};base64,${resp.data}`
+      console.warn(`[FilePreview] Failed to load remote image: ${abs_path}`, resp.message)
+      return null
+    })
+  }
+
+  /** Local markdown: read each image via the Tauri fs plugin and inline it.
+   *  In a plain browser (no Tauri) local files can't be read, so leave the
+   *  markdown as-is rather than throwing. */
+  async function resolve_local_images(html: string, md_path: string): Promise<string> {
+    if (check_tauri()) {
+      // Desktop app: read each image via the Tauri fs plugin and inline it.
+      const { readFile } = await import(`@tauri-apps/plugin-fs`)
+      return resolve_images(html, md_path, async (abs_path, src) => {
+        const bytes = await readFile(abs_path)
+        let bin = ``
+        const chunk = 8192
+        for (let i = 0; i < bytes.length; i += chunk) bin += String.fromCharCode(...bytes.subarray(i, i + chunk))
+        return `data:${guess_image_mime(src)};base64,${btoa(bin)}`
+      })
+    }
+    // Web/dev: point each relative image at the raw-file route so the browser
+    // loads it natively — parallel and cached, no base64 bloat (like VSCode).
+    return resolve_images(html, md_path, async (abs_path) => `/__files/raw?path=${encodeURIComponent(abs_path)}`)
   }
 
   function guess_image_mime(path: string): string {

--- a/src/lib/structure/FileTree.svelte
+++ b/src/lib/structure/FileTree.svelte
@@ -737,6 +737,9 @@
       {#if ctx_menu.node.file.is_dir && on_mkdir}
         <button class="ft-ctx-item" onclick={() => { new_folder_parent = ctx_menu?.node.file.path ?? current_root; new_folder_name = t('sidebar.new_folder'); close_ctx_menu() }}>{t('sidebar.new_folder')}</button>
       {/if}
+      {#if on_open_editor && !ctx_menu.node.file.is_dir}
+        <button class="ft-ctx-item" onclick={() => { if (ctx_menu) on_open_editor?.(ctx_menu.node.file); close_ctx_menu() }}>{t('app.open_in_editor')}</button>
+      {/if}
       {#if on_rename}
         <button class="ft-ctx-item" onclick={() => { renaming_node = ctx_menu?.node ?? null; rename_value = ctx_menu?.node.file.name ?? ``; close_ctx_menu() }}>{t('common.rename')}</button>
       {/if}

--- a/src/lib/structure/ServerPane.svelte
+++ b/src/lib/structure/ServerPane.svelte
@@ -845,10 +845,29 @@
     const filename = file.is_dir ? `${file.name}.tar.gz` : file.name
 
     if (session_id === LOCAL_SESSION_ID) {
-      try {
-        const { open } = await import(`@tauri-apps/plugin-shell`)
-        await open(file.path)
-      } catch {
+      const { check_tauri } = await import(`$lib/io/tauri`)
+      if (check_tauri()) {
+        // Desktop app: open the local file with the system default app.
+        try {
+          const { open } = await import(`@tauri-apps/plugin-shell`)
+          await open(file.path)
+        } catch {
+          navigator.clipboard.writeText(file.path).catch(() => {})
+        }
+      } else if (!file.is_dir) {
+        // Web/dev mode: stream the local file via /__files/raw and trigger a
+        // browser download (Tauri shell open is unavailable, so the button was
+        // a silent no-op before).
+        const link = document.createElement(`a`)
+        link.href = `/__files/raw?path=${encodeURIComponent(file.path)}`
+        link.download = file.name
+        link.rel = `noopener`
+        link.style.display = `none`
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
+      } else {
+        // Local directory in web mode: no raw stream for dirs — copy the path.
         navigator.clipboard.writeText(file.path).catch(() => {})
       }
       return

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -314,6 +314,34 @@ export default defineConfig({
             return
           }
 
+          // [2026-05] Serve raw file bytes (images, pdf, binaries) so the
+          // browser/web build can load local files natively via <img src> /
+          // <embed> instead of Tauri-only fs reads. Parallel + browser-cached,
+          // so markdown images load instantly like a native preview.
+          if (url.pathname === `/__files/raw`) {
+            const p = resolve_path(url.searchParams.get(`path`) || ``)
+            if (!existsSync(p) || statSync(p).isDirectory()) {
+              res.statusCode = 404
+              res.end(`not found`)
+              return
+            }
+            try {
+              const ext = (p.split(`.`).pop() || ``).toLowerCase()
+              const mime: Record<string, string> = {
+                png: `image/png`, jpg: `image/jpeg`, jpeg: `image/jpeg`, gif: `image/gif`,
+                webp: `image/webp`, bmp: `image/bmp`, svg: `image/svg+xml`, ico: `image/x-icon`,
+                tif: `image/tiff`, tiff: `image/tiff`, pdf: `application/pdf`,
+              }
+              res.setHeader(`Content-Type`, mime[ext] || `application/octet-stream`)
+              res.setHeader(`Cache-Control`, `no-cache`)
+              res.end(readFileSync(p))
+            } catch {
+              res.statusCode = 400
+              res.end(`cannot read file`)
+            }
+            return
+          }
+
           // [2026-03] Write text content to a file
           if (url.pathname === `/__files/write` && req.method === `POST`) {
             let body = ``


### PR DESCRIPTION
## 问题
web/浏览器模式(`desktop:serve`)下：点本地图片/PDF/二进制报 `Cannot read properties of undefined (reading 'invoke')`，本地 markdown 里的图加载很慢或不显示。根因：代码用 Tauri `plugin-fs` 读字节，非 Tauri 环境没有 `invoke`。

## 修复
- Vite dev 加 `/__files/raw` 路由，流本地文件字节 + 正确 Content-Type。
- **fs-browser**：桌面用 `plugin-fs`，web 用 `/__files/raw`(图/PDF 预览，二进制新标签打开)。
- **FilePreviewPanel**：markdown `<img>` 相对路径**并行**解析(原来逐张串行 SSH 往返)；本地图 web 模式走 `/__files/raw` 原生加载(无 base64、像 VSCode)，桌面走 `plugin-fs`。

## 验证
`/__files/raw` 实测服务 PNG(200 image/png)、PDF(200 application/pdf 7.2MB)；FE 编译 200。

🤖 Generated with [Claude Code](https://claude.com/claude-code)