### PR TITLE
feat(trajectory): stream large trajectories frame-by-frame instead of freezing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.4] - 2026-05-30
+
+### Added
+- **Cluster config validation**: a "Test configuration" button in the Run dialog (and a CatBot tool, `validate_hpc_config` / `catgo_validate_config`) that probes the live HPC cluster over SSH — POTCAR root/functional directories, per-element pseudopotentials, and VASP binary resolution under the real module-load + conda environment — so a broken cluster config is caught before submitting instead of crashing silently on the cluster.
+- **In-app AI gains tools**: non-SDK providers (DeepSeek/Qwen/Kimi/Gemini/…) now run the in-browser tool-calling loop, so CatBot can validate clusters, load skill guides on demand (`get_skill`), and **run and monitor workflows** (`run_workflow`, `get_workflow_run_status`) using a per-workflow run config persisted at submit time.
+- **File tree "Open in editor"**: right-click context-menu action to open a file in the Monaco editor.
+
+### Fixed
+- **Skill system restored**: corrected `_SKILLS_DIR` (it pointed at a non-existent doubled `catgo/` path), so `GET /api/skills` and the `catgo_skills` MCP tool serve all skill guides again — the in-app AI was silently getting no skill guidance.
+- **POTCAR generation**: the configured POTCAR directory was written to `hpc.job_defaults` but read from the hpc root, so POTCAR generation was silently skipped and VASP ran without one; the directory is now read correctly, and generation failures are surfaced as errored tasks (naming the missing element) instead of crashing silently on the cluster.
+- **Local files in browser/web mode**: clicking the download button or previewing an image/PDF/binary in the local file browser no longer throws `Cannot read properties of undefined (reading 'invoke')` outside the desktop app — these now stream through a dev file route; markdown images load in parallel (was one slow request per image).
+- **Terminal rendering**: default to the DOM renderer (WebGL opt-in) plus a Nerd Font / emoji / CJK glyph fallback chain, so terminal output no longer renders as tofu boxes in browser mode.
+
 ## [1.1.3] - 2026-05-30
 
 ### Added

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -7,7 +7,7 @@
   import type { AnyStructure } from '$lib'
   import { parse_cube_header, cube_atoms_to_molecule } from '$lib/cube'
   import { API_BASE, STATIC_ONLY } from '$lib/api/config'
-  import { check_tauri, init_tauri, open_files as tauri_open_files, open_folder as tauri_open_folder, read_dropped_paths as tauri_read_dropped_paths } from '$lib/io/tauri'
+  import { check_tauri, init_tauri, read_dropped_paths as tauri_read_dropped_paths, pick_structure_paths as tauri_pick_structure_paths, pick_folder_paths as tauri_pick_folder_paths } from '$lib/io/tauri'
   import { decompress_file } from '$lib/io/decompress'
   import { is_trajectory_file, parse_trajectory_data } from '$lib/trajectory/parse'
   import type { TrajectoryType } from '$lib/trajectory'
@@ -175,6 +175,8 @@
     get_active_tab_id: () => tm.active_tab_id,
     process_file_content,
     import_many,
+    stream_trajectory: (path, filename) => stream_path_if_large(path, filename),
+    stream_trajectory_file: (file) => stream_file_if_large(file),
     get_drag_target_pane: () => drag_target_pane,
     set_drag_target_pane: (v) => { drag_target_pane = v },
     set_is_loading: (v) => { is_loading = v },
@@ -193,6 +195,72 @@
   function handle_sidebar_preview(mode: string, filename: string, file_path: string, session_id: string, content?: string, binary_data?: string, mime_type?: string) { _handle_sidebar_preview(sidebar_deps, mode, filename, file_path, session_id, content, binary_data, mime_type) }
   function handle_sidebar_open_editor(content: string, filename: string, file_path: string, session_id: string) { _handle_sidebar_open_editor(sidebar_deps, content, filename, file_path, session_id) }
   function handle_sidebar_load_trajectory(content: string, filename: string, _meta?: { session_id: string; dir_path: string }) { _handle_sidebar_load_trajectory(sidebar_deps, content, filename, _meta) }
+  // Backend-streamed trajectory: never reads the full file into the webview.
+  // Builds a minimal indexed TrajectoryType (frames 0..9 + frame_loader) from
+  // the backend index and drops it straight into a pane — no parse-all, no
+  // base64. See src/lib/trajectory/remote-frame-loader.ts.
+  async function handle_load_trajectory_stream(path: string, filename: string) {
+    let tab_id = tm.active_tab_id
+    let ts = tab_states[tab_id]
+    if (!ts) return
+    let target = find_import_target_pane(ts, ts.active_pane)
+    if (target === -1) {
+      open_tab(`structure`)
+      tab_id = tm.active_tab_id
+      ts = tab_states[tab_id]
+      if (!ts) return
+      target = 0
+    }
+    try {
+      const { load_remote_trajectory } = await import(`$lib/trajectory/remote-frame-loader`)
+      const trajectory = await load_remote_trajectory(path, filename)
+      apply_entry_to_pane(tab_id, ts, target, {
+        id: `stream-${filename}-${Date.now()}`,
+        filename,
+        source_path: path,
+        format: `xyz`,
+        structure: undefined,
+        trajectory,
+        is_trajectory: true,
+        cube_file: null,
+        raw_traj_b64: ``,
+        raw_traj_format: `xyz`,
+      }, null, path)
+    } catch (e) {
+      console.error(`Streamed trajectory load failed for ${filename}:`, e)
+    }
+  }
+  // Probe a local path; if it's a large multi-frame trajectory, load it via the
+  // backend streamer and return true (caller then skips the in-memory read that
+  // would otherwise freeze the webview). Shared by every path-based entry point.
+  async function stream_path_if_large(path: string, filename: string): Promise<boolean> {
+    try {
+      const { probe_streamable_trajectory } = await import(`$lib/trajectory/remote-frame-loader`)
+      const probe = await probe_streamable_trajectory(path, filename)
+      if (probe?.stream) {
+        await handle_load_trajectory_stream(path, filename)
+        return true
+      }
+    } catch (e) {
+      console.error(`stream probe failed for ${filename}:`, e)
+    }
+    return false
+  }
+  // Web-mode counterpart: a large browser File has no path, so upload it once
+  // to the backend cache, then stream. Returns true if streamed.
+  async function stream_file_if_large(file: File): Promise<boolean> {
+    try {
+      const { materialize_file_if_large } = await import(`$lib/trajectory/remote-frame-loader`)
+      const local = await materialize_file_if_large(file)
+      if (local) {
+        await handle_load_trajectory_stream(local, file.name)
+        return true
+      }
+    } catch (e) {
+      console.error(`file stream failed for ${file.name}:`, e)
+    }
+    return false
+  }
   function handle_terminal_open_file(file_path: string, filename: string, session_id: string) { return _handle_terminal_open_file(sidebar_deps, file_path, filename, session_id) }
   function handle_unload(tab_id: string, pane_idx: number) { _handle_unload(pane_deps, tab_id, pane_idx) }
   function close_panel(tab_id: string, pane_idx: number) { _close_panel(pane_deps, tab_id, pane_idx) }
@@ -602,9 +670,21 @@
     ts.active_pane = pane_idx
     if (is_tauri) {
       try {
-        const results = await tauri_open_files()
-        if (results && results.length > 0) {
-          await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+        // Pick paths first; divert large trajectories to the backend streamer
+        // before any 100s-of-MB read hits the webview.
+        const paths = await tauri_pick_structure_paths()
+        const read_paths: string[] = []
+        for (const pth of paths) {
+          const nm = pth.split(/[/\\]/).pop() || `unknown`
+          if (await stream_path_if_large(pth, nm)) continue
+          read_paths.push(pth)
+        }
+        if (read_paths.length > 0) {
+          const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
+          const results = await tauri_read_dropped_paths(read_paths, accept)
+          if (results.length > 0) {
+            await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+          }
         }
       } catch (err) {
         console.error(err)
@@ -624,9 +704,20 @@
     const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
     if (is_tauri) {
       try {
-        const results = await tauri_open_folder(accept)
-        if (results && results.length > 0) {
-          await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+        // Path-first so a folder containing a huge trajectory streams instead
+        // of reading the whole file into the webview.
+        const paths = await tauri_pick_folder_paths(accept)
+        const read_paths: string[] = []
+        for (const pth of paths) {
+          const nm = pth.split(/[/\\]/).pop() || `unknown`
+          if (await stream_path_if_large(pth, nm)) continue
+          read_paths.push(pth)
+        }
+        if (read_paths.length > 0) {
+          const results = await tauri_read_dropped_paths(read_paths, accept)
+          if (results.length > 0) {
+            await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+          }
         }
       } catch (err) {
         console.error(err)
@@ -643,11 +734,18 @@
     const files = Array.from(input.files ?? [])
     if (files.length === 0) return
     try {
-      await import_many(
-        file_input_target_tab,
-        files.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
-        file_input_target_pane,
-      )
+      const to_import: File[] = []
+      for (const f of files) {
+        if (await stream_file_if_large(f)) continue
+        to_import.push(f)
+      }
+      if (to_import.length > 0) {
+        await import_many(
+          file_input_target_tab,
+          to_import.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
+          file_input_target_pane,
+        )
+      }
     } catch (err) {
       console.error(err)
     } finally {
@@ -662,11 +760,18 @@
     const files = all.filter(f => is_structure_file(f.name) || is_trajectory_file(f.name) || is_chgcar_file(f.name))
     if (files.length === 0) { input.value = ``; return }
     try {
-      await import_many(
-        file_input_target_tab,
-        files.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
-        file_input_target_pane,
-      )
+      const to_import: File[] = []
+      for (const f of files) {
+        if (await stream_file_if_large(f)) continue
+        to_import.push(f)
+      }
+      if (to_import.length > 0) {
+        await import_many(
+          file_input_target_tab,
+          to_import.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
+          file_input_target_pane,
+        )
+      }
     } catch (err) {
       console.error(err)
     } finally {
@@ -1166,12 +1271,23 @@
 
             if (other_paths.length === 0) return
 
+            // Large on-disk trajectories: stream frame-by-frame from the
+            // backend instead of reading the whole 100s-of-MB file into the
+            // webview (which freezes it).
+            const read_paths: string[] = []
+            for (const pth of other_paths) {
+              const nm = pth.split(/[/\\]/).pop() || `trajectory.xyz`
+              if (await stream_path_if_large(pth, nm)) continue
+              read_paths.push(pth)
+            }
+            if (read_paths.length === 0) return
+
             const ts = get_active_ts()
             if (!ts) return
             is_loading = true
             try {
               const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
-              const files = await tauri_read_dropped_paths(other_paths, accept)
+              const files = await tauri_read_dropped_paths(read_paths, accept)
               const target_pane = ts.panes.findIndex(p => !pane_has_content(p))
               const pane_idx = target_pane >= 0 ? target_pane : ts.active_pane
               if (files.length > 0) {
@@ -1474,6 +1590,7 @@
     on_open_editor={handle_sidebar_open_editor}
     on_preview_file={handle_sidebar_preview}
     on_load_trajectory={handle_sidebar_load_trajectory}
+    on_load_trajectory_stream={handle_load_trajectory_stream}
     on_open_workflow={handle_sidebar_open_workflow}
     on_save_structure={get_current_structure}
     on_save_workflow={() => {

--- a/desktop/Sidebar.svelte
+++ b/desktop/Sidebar.svelte
@@ -60,6 +60,7 @@
     on_load_file,
     on_open_editor,
     on_load_trajectory,
+    on_load_trajectory_stream,
     on_open_workflow, // [2025-02] open workflow editor from sidebar
     on_save_structure,
     on_save_workflow, // [2025-02] returns workflow_id if active pane is workflow editor
@@ -77,6 +78,7 @@
     on_load_file: (content: string | ArrayBuffer, filename: string, file_path?: string, session_id?: string) => void
     on_open_editor?: (content: string, filename: string, file_path: string, session_id: string) => void
     on_load_trajectory?: (content: string, filename: string, meta?: { session_id: string; dir_path: string }) => void
+    on_load_trajectory_stream?: (path: string, filename: string) => void | Promise<void>
     on_open_workflow?: (workflow_id: string) => void
     on_save_structure?: () => Record<string, unknown> | null
     on_save_workflow?: () => string | null
@@ -230,6 +232,10 @@
     on_load_file,
     on_open_editor,
     on_load_trajectory,
+    // Wrap in a closure so the (reactive) prop is read at call time, not
+    // captured as its initial value when create_fs_browser_state runs.
+    on_load_trajectory_stream: (path: string, filename: string) =>
+      on_load_trajectory_stream?.(path, filename),
     on_save_structure,
     on_preview_file,
     on_before_db_switch,
@@ -784,6 +790,9 @@
     on_load_file,
     on_open_editor,
     on_load_trajectory,
+    // Closure so the reactive prop is read at call time, not captured at init.
+    on_load_trajectory_stream: (path: string, filename: string) =>
+      on_load_trajectory_stream?.(path, filename),
     on_preview_file,
   })
   // Sync bindable props with internal path state

--- a/desktop/lib/drag-drop-handlers.ts
+++ b/desktop/lib/drag-drop-handlers.ts
@@ -20,6 +20,10 @@ export interface DragDropDeps {
   get_active_tab_id: () => string
   process_file_content: (tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number) => Promise<void>
   import_many: (tab_id: string, items: ImportItem[], pane_idx: number) => Promise<void>
+  /** If `path` is a large on-disk trajectory, stream it and return true. */
+  stream_trajectory: (path: string, filename: string) => Promise<boolean>
+  /** If `file` is a large trajectory (web mode, no path), upload+stream it; return true. */
+  stream_trajectory_file: (file: File) => Promise<boolean>
   get_drag_target_pane: () => number | null
   set_drag_target_pane: (v: number | null) => void
   set_is_loading: (v: boolean) => void
@@ -115,6 +119,12 @@ export async function handle_drop(deps: DragDropDeps, event: DragEvent) {
   if (fs_path) {
     deps.set_is_loading(true)
     try {
+      // Large on-disk trajectory → stream frame-by-frame, never read it whole.
+      const fs_name = fs_path.split(/[/\\]/).pop() || `file`
+      if (await deps.stream_trajectory(fs_path, fs_name)) {
+        ts.active_pane = pane_idx
+        return
+      }
       const { read_file } = await import(`$lib/api/project`)
       const result = await read_file(fs_path)
       await deps.process_file_content(deps.get_active_tab_id(), result.content, result.name, pane_idx)
@@ -153,9 +163,17 @@ export async function handle_drop(deps: DragDropDeps, event: DragEvent) {
       for (const f of flat_files) collected.push({ file: f, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })
     }
     if (collected.length === 0) return
+    // Large trajectories (no fs path in web mode) → upload+stream, don't parse
+    // the whole file into the webview (which freezes it).
+    const to_import: Array<{ file: File; path: string | null }> = []
+    for (const c of collected) {
+      if (await deps.stream_trajectory_file(c.file)) continue
+      to_import.push(c)
+    }
+    if (to_import.length === 0) { ts.active_pane = pane_idx; return }
     await deps.import_many(
       deps.get_active_tab_id(),
-      collected.map(c => ({ file: c.file, filename: c.file.name, path: c.path })),
+      to_import.map(c => ({ file: c.file, filename: c.file.name, path: c.path })),
       pane_idx,
     )
     ts.active_pane = pane_idx

--- a/desktop/sidebar/fs-browser.svelte.ts
+++ b/desktop/sidebar/fs-browser.svelte.ts
@@ -14,6 +14,8 @@ export interface FsBrowserCallbacks {
   on_load_file: (content: string | ArrayBuffer, filename: string, file_path?: string, session_id?: string) => void
   on_open_editor?: (content: string, filename: string, file_path: string, session_id: string) => void
   on_load_trajectory?: (content: string, filename: string, meta?: { session_id: string; dir_path: string }) => void
+  /** Stream a large on-disk trajectory frame-by-frame via the backend (no full read). */
+  on_load_trajectory_stream?: (path: string, filename: string) => void | Promise<void>
   on_save_structure?: () => Record<string, unknown> | null
   on_preview_file?: (mode: string, filename: string, file_path: string, session_id: string, content?: string, binary_data?: string, mime_type?: string) => void
   on_before_db_switch?: () => Promise<boolean>
@@ -146,6 +148,17 @@ export function create_fs_browser_state(callbacks: FsBrowserCallbacks) {
         fs_error = e instanceof Error ? e.message : `Cannot open file`
       }
       return
+    }
+
+    // Large on-disk trajectory: stream frame-by-frame from the backend instead
+    // of slurping 100s of MB into the webview (which freezes it).
+    if (callbacks.on_load_trajectory_stream) {
+      const { probe_streamable_trajectory } = await import('$lib/trajectory/remote-frame-loader')
+      const probe = await probe_streamable_trajectory(item.path, item.name)
+      if (probe?.stream) {
+        await callbacks.on_load_trajectory_stream(item.path, item.name)
+        return
+      }
     }
 
     // Text-based files: read content

--- a/desktop/sidebar/hpc-browser.svelte.ts
+++ b/desktop/sidebar/hpc-browser.svelte.ts
@@ -15,6 +15,8 @@ export interface HpcBrowserCallbacks {
   on_load_file: (content: string | ArrayBuffer, filename: string, file_path?: string, session_id?: string) => void
   on_open_editor?: (content: string, filename: string, file_path: string, session_id: string) => void
   on_load_trajectory?: (content: string, filename: string, meta?: { session_id: string; dir_path: string }) => void
+  /** Stream a large trajectory from a backend-local path (after remote materialize). */
+  on_load_trajectory_stream?: (path: string, filename: string) => void | Promise<void>
   on_preview_file?: (mode: string, filename: string, file_path: string, session_id: string, content?: string, binary_data?: string, mime_type?: string) => void
 }
 
@@ -90,6 +92,18 @@ export function create_hpc_browser_state(callbacks: HpcBrowserCallbacks) {
     const source = callbacks.get_source()
     hpc_loading_file = { name: file.name, size: file.size_bytes }
     try {
+      // Large remote trajectory → materialize to a backend-local cache file
+      // (gzip on the wire) and stream frames, instead of pulling the whole
+      // file into the webview (which freezes it).
+      if (callbacks.on_load_trajectory_stream) {
+        const { materialize_remote_if_large } = await import('$lib/trajectory/remote-frame-loader')
+        const local = await materialize_remote_if_large(source, file.path, file.name, file.size_bytes)
+        if (local) {
+          const nm = file.path.split(/[/\\]/).pop() || file.name
+          await callbacks.on_load_trajectory_stream(local, nm)
+          return
+        }
+      }
       const content = await read_file_content(file)
       if (!content) return
       const filename = file.path.split(/[/\\]/).pop() || file.name

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/server/catgo/routers/__init__.py
+++ b/server/catgo/routers/__init__.py
@@ -50,6 +50,7 @@ _ROUTERS: dict[str, str] = {
     "pseudo_hydrogen_router": "pseudo_hydrogen",
     "build_router": "build",
     "trajectory_edit_router": "trajectory_edit",
+    "trajectory_stream_router": "trajectory_stream",
     "pty_router": "pty",
     "orca_router": "orca",
     "chat_router": "chat",

--- a/server/catgo/routers/hpc.py
+++ b/server/catgo/routers/hpc.py
@@ -950,6 +950,69 @@ async def download_file(
         raise HTTPException(status_code=500, detail=str(exc))
 
 
+@router.get("/materialize_trajectory")
+async def materialize_trajectory(
+    session_id: str = Query(...),
+    remote_path: str = Query(...),
+) -> dict:
+    """Pull a large remote trajectory to a local cache file, then index it.
+
+    A 100s-of-MB remote XYZ can't be slurped into the webview (it freezes) and
+    per-frame SFTP is too chatty over WAN. Instead we transfer the file ONCE,
+    gzip-compressed on the wire (``download_remote_file`` already inflates text
+    via ``gzip -c`` remotely), write the inflated bytes to a backend-local cache
+    file, and index it. The frontend then streams frames from that local file
+    through the existing ``/trajectory/{frames,metadata}`` endpoints — the
+    webview only ever holds the current frames. Cached by (session, path, size)
+    so re-opening is instant.
+    """
+    import hashlib
+    from pathlib import Path
+
+    hpc = _get_hpc(session_id)
+    await _ensure_within_work_root(hpc, remote_path)
+    size = await hpc.run_on_owner(lambda: hpc.get_remote_file_size(remote_path))
+
+    key = hashlib.sha1(f"{session_id}\0{remote_path}\0{size}".encode()).hexdigest()[:16]
+    ext = os.path.splitext(remote_path)[1] or ".xyz"
+    cache_dir = Path.home() / ".catgoat" / "cache" / "traj"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    local = cache_dir / f"{key}{ext}"
+
+    if not (local.is_file() and local.stat().st_size > 0):
+        tmp = local.with_name(local.name + ".part")
+        written = 0
+        try:
+            with tmp.open("wb") as fh:
+                async for chunk in hpc.stream_on_owner(
+                    lambda: hpc.download_remote_file(remote_path)
+                ):
+                    fh.write(chunk)
+                    written += len(chunk)
+            tmp.replace(local)
+        except Exception as exc:
+            tmp.unlink(missing_ok=True)
+            raise HTTPException(status_code=500, detail=f"materialize failed: {exc}") from exc
+        logger.info(
+            "Materialized remote trajectory %s -> %s (%d bytes)", remote_path, local, written
+        )
+
+    from .trajectory_stream import _get_index
+
+    try:
+        _, idx = _get_index(str(local))
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"index failed: {exc}") from exc
+
+    return {
+        "ok": True,
+        "local_path": str(local),
+        "total_frames": idx.total_frames,
+        "n_atoms": idx.n_atoms,
+        "file_size": idx.file_size,
+    }
+
+
 # ====== Connections Listing + Overview ======
 
 

--- a/server/catgo/routers/trajectory_stream.py
+++ b/server/catgo/routers/trajectory_stream.py
@@ -1,0 +1,469 @@
+"""Streaming loader for large multi-frame XYZ trajectories.
+
+A 300+ MB / 10k-frame AIMD ``*-pos-1.xyz`` must never be slurped whole into
+the webview — JSON-encoding the file, ``JSON.parse`` on the main thread, an
+eager all-frames parse, and a base64 copy together exhaust the WebKitGTK heap
+and freeze the page.
+
+This router keeps the file on disk and serves it frame-by-frame:
+
+1. ``/trajectory/index``  — scan the file once, cache a byte-offset table
+   (one ``int`` per frame), return ``total_frames`` + ``n_atoms``.
+2. ``/trajectory/frames`` — ``seek`` to a frame's offset and read ONLY that
+   frame's bytes; return a small batch (initial load + scrub prefetch).
+3. ``/trajectory/metadata`` — sampled per-frame comment-line properties
+   (energy / temperature / ...) for the plot panel.
+
+The index is cached in-process keyed by ``(abspath, mtime_ns, size)`` so a
+re-open is instant and edits invalidate automatically. Memory held per file is
+just the offset list (~8 bytes/frame), never the file content.
+"""
+
+from __future__ import annotations
+
+import logging
+import hashlib
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/trajectory", tags=["trajectory-stream"])
+
+
+# -----------------------------------------------------------------------------
+# Index cache
+# -----------------------------------------------------------------------------
+
+
+class _TrajIndex:
+    """Per-frame index for a trajectory file, plus basic shape.
+
+    ``fmt`` selects the reader. For text formats (``xyz``/``lammpstrj``)
+    ``offsets`` holds the byte offset of each frame start and ``total_frames``
+    is ``len(offsets)``. For ``traj`` (ASE binary) ``offsets`` is empty and the
+    frame count is stored in ``_total`` (ASE handles random access itself).
+    """
+
+    __slots__ = ("fmt", "offsets", "file_size", "n_atoms", "_total")
+
+    def __init__(
+        self,
+        fmt: str,
+        offsets: list[int],
+        file_size: int,
+        n_atoms: int,
+        total: int | None = None,
+    ) -> None:
+        self.fmt = fmt
+        self.offsets = offsets
+        self.file_size = file_size
+        self.n_atoms = n_atoms
+        self._total = total if total is not None else len(offsets)
+
+    @property
+    def total_frames(self) -> int:
+        return self._total
+
+    def frame_span(self, n: int) -> tuple[int, int]:
+        """Return ``(start, end)`` byte range of frame ``n`` (text formats)."""
+        start = self.offsets[n]
+        end = self.offsets[n + 1] if n + 1 < len(self.offsets) else self.file_size
+        return start, end
+
+
+# Keyed by (abspath, mtime_ns, size) so any on-disk change rebuilds the index.
+_INDEX_CACHE: dict[tuple[str, int, int], _TrajIndex] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _detect_format(p: Path) -> str:
+    """Map a file extension to a reader format."""
+    suffix = p.suffix.lower()
+    if suffix == ".lammpstrj":
+        return "lammpstrj"
+    if suffix == ".traj":
+        return "traj"
+    return "xyz"  # .xyz / .extxyz / default
+
+# Property patterns for the plot panel. Word boundaries + a MANDATORY `=`/`:`
+# keep single-letter keys (E/V/P/T) from matching the trailing letter of an
+# unrelated word — e.g. the `e` in "tim<e> = 5500" must NOT read as energy.
+# CP2K AIMD comments look like: ` i = 0, time = 0.000, E = -3572.1`.
+_NUM = r"([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)"
+_META_PATTERNS: dict[str, re.Pattern[str]] = {
+    "energy": re.compile(rf"\b(?:energy|etot|E)\b\s*[=:]\s*{_NUM}", re.I),
+    "volume": re.compile(rf"\b(?:volume|vol|V)\b\s*[=:]\s*{_NUM}", re.I),
+    "pressure": re.compile(rf"\b(?:pressure|press|P)\b\s*[=:]\s*{_NUM}", re.I),
+    "temperature": re.compile(rf"\b(?:temperature|temp|T)\b\s*[=:]\s*{_NUM}", re.I),
+    "force_max": re.compile(rf"\b(?:max_force|fmax)\b\s*[=:]\s*{_NUM}", re.I),
+}
+_STEP_PATTERN = re.compile(r"\b(?:step|frame|i)\b\s*[=:]\s*(\d+)", re.I)
+
+
+def _resolve_path(path: str) -> Path:
+    """Resolve a user-supplied local path; reject anything not a real file."""
+    if not path:
+        raise HTTPException(status_code=400, detail="path is required")
+    p = Path(path).expanduser()
+    try:
+        p = p.resolve()
+    except OSError as exc:
+        raise HTTPException(status_code=400, detail=f"bad path: {exc}") from exc
+    if not p.is_file():
+        raise HTTPException(status_code=404, detail=f"not a file: {path}")
+    return p
+
+
+def _build_xyz_index(p: Path) -> _XYZIndex:
+    """Single binary pass building per-frame byte offsets (no content kept)."""
+    offsets: list[int] = []
+    n_atoms = 0
+    with p.open("rb") as fh:
+        while True:
+            frame_start = fh.tell()
+            header = fh.readline()
+            if not header:
+                break
+            stripped = header.strip()
+            if not stripped:
+                continue
+            try:
+                num = int(stripped)
+            except ValueError:
+                continue
+            if num <= 0:
+                continue
+
+            # Valid frame header — record its start, then skip comment + atoms.
+            if not n_atoms:
+                n_atoms = num
+            complete = fh.readline() != b""  # comment line
+            for _ in range(num):
+                if not fh.readline():
+                    complete = False
+                    break
+            if not complete:
+                break  # truncated final frame — drop it
+            offsets.append(frame_start)
+
+    file_size = p.stat().st_size
+    return _TrajIndex("xyz", offsets, file_size, n_atoms)
+
+
+# Frame-boundary marker for a LAMMPS dump (`*.lammpstrj`). Each frame begins
+# with an "ITEM: TIMESTEP" line, followed by the count, box, and atom blocks.
+_LAMMPS_FRAME_MARKER = b"ITEM: TIMESTEP"
+
+
+def _build_lammps_index(p: Path) -> _TrajIndex:
+    """Byte-offset index of a LAMMPS dump: one offset per ``ITEM: TIMESTEP``."""
+    offsets: list[int] = []
+    n_atoms = 0
+    with p.open("rb") as fh:
+        while True:
+            pos = fh.tell()
+            line = fh.readline()
+            if not line:
+                break
+            if line.startswith(_LAMMPS_FRAME_MARKER):
+                offsets.append(pos)
+            elif not n_atoms and line.startswith(b"ITEM: NUMBER OF ATOMS"):
+                try:
+                    n_atoms = int(fh.readline().strip())
+                except ValueError:
+                    n_atoms = 0
+    file_size = p.stat().st_size
+    return _TrajIndex("lammpstrj", offsets, file_size, n_atoms)
+
+
+def _build_traj_index(p: Path) -> _TrajIndex:
+    """Index an ASE ``.traj`` — ASE owns random access, so just count frames."""
+    from ase.io.trajectory import Trajectory
+
+    traj = Trajectory(str(p), mode="r")
+    try:
+        total = len(traj)
+        n_atoms = len(traj[0]) if total else 0
+    finally:
+        traj.close()
+    return _TrajIndex("traj", [], p.stat().st_size, n_atoms, total=total)
+
+
+def _get_index(path: str) -> tuple[Path, _TrajIndex]:
+    """Return the cached index for ``path``, building it on first access."""
+    p = _resolve_path(path)
+    st = p.stat()
+    key = (str(p), st.st_mtime_ns, st.st_size)
+    with _CACHE_LOCK:
+        idx = _INDEX_CACHE.get(key)
+    if idx is None:
+        fmt = _detect_format(p)
+        logger.info("Indexing %s trajectory: %s (%.0f MB)", fmt, p, st.st_size / 1e6)
+        if fmt == "lammpstrj":
+            idx = _build_lammps_index(p)
+        elif fmt == "traj":
+            idx = _build_traj_index(p)
+        else:
+            idx = _build_xyz_index(p)
+        with _CACHE_LOCK:
+            _INDEX_CACHE[key] = idx
+        logger.info("Indexed %d frames (%d atoms) in %s", idx.total_frames, idx.n_atoms, p.name)
+    return p, idx
+
+
+def _read_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
+    """Read and parse frame ``n``, dispatching on the indexed format."""
+    if idx.fmt == "lammpstrj":
+        return _read_lammps_frame(p, idx, n)
+    if idx.fmt == "traj":
+        return _read_traj_frame(p, idx, n)
+    return _read_xyz_frame(p, idx, n)
+
+
+def _atoms_to_frame(n: int, atoms: Any) -> dict[str, Any]:
+    """Convert an ASE ``Atoms`` to the wire frame shape (+ energy if present)."""
+    props: dict[str, float] = {}
+    try:
+        props["energy"] = float(atoms.get_potential_energy())
+    except Exception:
+        pass
+    return {
+        "frame_number": n,
+        "elements": list(atoms.get_chemical_symbols()),
+        "positions": atoms.get_positions().tolist(),
+        "comment": "",
+        "properties": props,
+    }
+
+
+def _read_lammps_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
+    """Slice frame ``n``'s bytes and parse the single dump frame via ASE."""
+    from io import StringIO
+
+    from ase.io import read as ase_read
+
+    start, end = idx.frame_span(n)
+    with p.open("rb") as fh:
+        fh.seek(start)
+        raw = fh.read(end - start)
+    try:
+        atoms = ase_read(StringIO(raw.decode("utf-8", "replace")), format="lammps-dump-text")
+    except Exception as exc:
+        logger.warning("lammps frame %d parse failed: %s", n, exc)
+        return {"frame_number": n, "elements": [], "positions": [], "comment": ""}
+    return _atoms_to_frame(n, atoms)
+
+
+def _read_traj_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
+    """Random-access frame ``n`` from an ASE ``.traj``."""
+    from ase.io.trajectory import Trajectory
+
+    traj = Trajectory(str(p), mode="r")
+    try:
+        atoms = traj[n]
+    finally:
+        traj.close()
+    return _atoms_to_frame(n, atoms)
+
+
+def _read_xyz_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
+    """Read and parse a single XYZ frame ``n`` via its byte span."""
+    start, end = idx.frame_span(n)
+    with p.open("rb") as fh:
+        fh.seek(start)
+        raw = fh.read(end - start)
+    lines = raw.decode("utf-8", "replace").splitlines()
+
+    head = 0
+    while head < len(lines) and not lines[head].strip():
+        head += 1
+    if head >= len(lines):
+        return {"frame_number": n, "elements": [], "positions": [], "comment": ""}
+
+    try:
+        num = int(lines[head].strip())
+    except ValueError:
+        return {"frame_number": n, "elements": [], "positions": [], "comment": ""}
+
+    comment = lines[head + 1] if head + 1 < len(lines) else ""
+    elements: list[str] = []
+    positions: list[list[float]] = []
+    for i in range(num):
+        li = head + 2 + i
+        if li >= len(lines):
+            break
+        parts = lines[li].split()
+        if len(parts) >= 4:
+            elements.append(parts[0])
+            try:
+                positions.append([float(parts[1]), float(parts[2]), float(parts[3])])
+            except ValueError:
+                positions.append([0.0, 0.0, 0.0])
+
+    return {
+        "frame_number": n,
+        "elements": elements,
+        "positions": positions,
+        "comment": comment,
+        "properties": _parse_comment(comment),
+    }
+
+
+def _parse_comment(comment: str) -> dict[str, float]:
+    """Extract numeric plot properties from a frame comment line."""
+    props: dict[str, float] = {}
+    for key, pat in _META_PATTERNS.items():
+        m = pat.search(comment)
+        if m:
+            try:
+                props[key] = float(m.group(1))
+            except ValueError:
+                pass
+    return props
+
+
+# -----------------------------------------------------------------------------
+# Response models
+# -----------------------------------------------------------------------------
+
+
+class IndexResponse(BaseModel):
+    ok: bool = True
+    total_frames: int
+    n_atoms: int
+    format: str = "xyz"
+    file_size: int
+
+
+class FramesResponse(BaseModel):
+    ok: bool = True
+    frames: list[dict[str, Any]]
+
+
+class MetadataResponse(BaseModel):
+    ok: bool = True
+    stride: int
+    metadata: list[dict[str, Any]]
+
+
+# -----------------------------------------------------------------------------
+# Endpoints
+# -----------------------------------------------------------------------------
+
+
+@router.get("/index", response_model=IndexResponse)
+def trajectory_index(path: str = Query(...)) -> IndexResponse:
+    """Build (and cache) the frame index for a trajectory; return its shape."""
+    p, idx = _get_index(path)
+    if idx.total_frames == 0:
+        raise HTTPException(status_code=422, detail=f"no frames found in {p.name}")
+    return IndexResponse(
+        total_frames=idx.total_frames,
+        n_atoms=idx.n_atoms,
+        format=idx.fmt,
+        file_size=idx.file_size,
+    )
+
+
+@router.get("/frames", response_model=FramesResponse)
+def trajectory_frames(
+    path: str = Query(...),
+    start: int = Query(0, ge=0),
+    count: int = Query(1, ge=1, le=64),
+) -> FramesResponse:
+    """Return a contiguous batch of parsed frames ``[start, start+count)``."""
+    p, idx = _get_index(path)
+    total = idx.total_frames
+    if start >= total:
+        raise HTTPException(status_code=416, detail=f"start {start} >= total_frames {total}")
+    end = min(start + count, total)
+    frames = [_read_frame(p, idx, n) for n in range(start, end)]
+    logger.info("Streamed frames [%d, %d) of %s", start, end, p.name)
+    return FramesResponse(frames=frames)
+
+
+@router.get("/metadata", response_model=MetadataResponse)
+def trajectory_metadata(
+    path: str = Query(...),
+    stride: int = Query(1, ge=1),
+) -> MetadataResponse:
+    """Sampled per-frame comment properties for the trajectory plot panel.
+
+    Only the comment line of every ``stride``-th frame is read (two short
+    reads per sampled frame), so this stays cheap even for 10k+ frames.
+    """
+    p, idx = _get_index(path)
+    out: list[dict[str, Any]] = []
+    if idx.fmt == "xyz":
+        # Cheap: only the comment line of every strided frame is read.
+        with p.open("rb") as fh:
+            for n in range(0, idx.total_frames, stride):
+                start, _ = idx.frame_span(n)
+                fh.seek(start)
+                fh.readline()  # count line
+                comment = fh.readline().decode("utf-8", "replace")
+                step_m = _STEP_PATTERN.search(comment)
+                step = int(step_m.group(1)) if step_m else n
+                out.append({"frame_number": n, "step": step, "properties": _parse_comment(comment)})
+    else:
+        # lammps/traj: derive plot props (energy) from the parsed frame.
+        for n in range(0, idx.total_frames, stride):
+            frame = _read_frame(p, idx, n)
+            out.append({"frame_number": n, "step": n, "properties": frame.get("properties", {})})
+    return MetadataResponse(stride=stride, metadata=out)
+
+
+@router.post("/upload")
+async def trajectory_upload(file: UploadFile = File(...)) -> dict:
+    """Cache an uploaded trajectory to disk and index it, then stream frames.
+
+    The web (non-Tauri) drop / file-picker yields a browser ``File`` with no
+    filesystem path, so the streamer can't read it in place. We stream the
+    upload to a backend-local cache file (content-hashed → dedup), index it, and
+    return the local path the frame endpoints read — the webview never holds the
+    whole file. The upload itself is a one-time localhost transfer.
+    """
+    cache_dir = Path.home() / ".catgoat" / "cache" / "traj"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    ext = os.path.splitext(file.filename or "upload.xyz")[1] or ".xyz"
+
+    tmp = cache_dir / f".upload-{os.getpid()}-{id(file)}{ext}.part"
+    sha = hashlib.sha1()
+    size = 0
+    try:
+        with tmp.open("wb") as fh:
+            while True:
+                chunk = await file.read(1 << 20)
+                if not chunk:
+                    break
+                fh.write(chunk)
+                sha.update(chunk)
+                size += len(chunk)
+        local = cache_dir / f"{sha.hexdigest()[:16]}{ext}"
+        if local.is_file() and local.stat().st_size == size:
+            tmp.unlink(missing_ok=True)  # identical content already cached
+        else:
+            tmp.replace(local)
+    except Exception as exc:
+        tmp.unlink(missing_ok=True)
+        raise HTTPException(status_code=500, detail=f"upload failed: {exc}") from exc
+
+    try:
+        _, idx = _get_index(str(local))
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"index failed: {exc}") from exc
+    logger.info("Uploaded trajectory %s -> %s (%d frames)", file.filename, local.name, idx.total_frames)
+    return {
+        "ok": True,
+        "local_path": str(local),
+        "total_frames": idx.total_frames,
+        "n_atoms": idx.n_atoms,
+        "file_size": idx.file_size,
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -90,6 +90,7 @@ from catgo.routers import (
     workflow_router,
     build_router,
     trajectory_edit_router,
+    trajectory_stream_router,
     pty_router,
     chat_router,
     structure_ops_router,
@@ -406,6 +407,7 @@ app.include_router(mofdb_router, prefix="/api")
 app.include_router(dos_router, prefix="/api")
 app.include_router(cohp_router, prefix="/api")
 app.include_router(bands_router, prefix="/api")
+app.include_router(trajectory_stream_router, prefix="/api")
 app.include_router(workflow_router, prefix="/api")
 app.include_router(pseudo_hydrogen_router, prefix="/api")
 app.include_router(build_router, prefix="/api")

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "base64 0.22.1",
  "catgo-graph",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.1.3"
+version = "1.1.4"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",

--- a/src/lib/api/hpc.ts
+++ b/src/lib/api/hpc.ts
@@ -629,6 +629,31 @@ export async function fetchOverview(session_id: string): Promise<HPCOverview> {
   return handleResponse(response)
 }
 
+export interface MaterializeTrajectoryResponse {
+  ok: boolean
+  local_path: string
+  total_frames: number
+  n_atoms: number
+  file_size: number
+}
+
+/**
+ * Pull a large remote trajectory to a backend-local cache file (gzip-compressed
+ * on the wire) and index it. Returns the local path the frame-streaming
+ * endpoints can then read. Lets a huge remote XYZ open without slurping it into
+ * the webview.
+ */
+export async function materializeRemoteTrajectory(
+  session_id: string,
+  remote_path: string,
+): Promise<MaterializeTrajectoryResponse> {
+  const url = `${API_BASE}/hpc/materialize_trajectory` +
+    `?session_id=${encodeURIComponent(session_id)}` +
+    `&remote_path=${encodeURIComponent(remote_path)}`
+  const response = await fetch(url)
+  return handleResponse<MaterializeTrajectoryResponse>(response)
+}
+
 export async function readRemoteFile(
   session_id: string,
   file_path: string,

--- a/src/lib/io/tauri.ts
+++ b/src/lib/io/tauri.ts
@@ -228,6 +228,47 @@ export async function open_folder(
 }
 
 /**
+ * Open the multi-file dialog and return the picked paths WITHOUT reading them.
+ * Lets callers probe each path (e.g. divert a huge trajectory to the backend
+ * streamer) before deciding to read its content into memory.
+ */
+export async function pick_structure_paths(): Promise<string[]> {
+  if (!check_tauri()) return []
+  try {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const picked = await open({ multiple: true, filters: STRUCTURE_DIALOG_FILTERS })
+    if (!picked) return []
+    return Array.isArray(picked) ? picked : [picked]
+  } catch (error) {
+    console.error('Tauri pick-paths error:', error)
+    return []
+  }
+}
+
+/**
+ * Open the directory dialog and return every accepted file path inside WITHOUT
+ * reading them — the path-only sibling of {@link open_folder}.
+ */
+export async function pick_folder_paths(
+  accept: (filename: string) => boolean,
+  max_depth = 3,
+  max_files = 500,
+): Promise<string[]> {
+  if (!check_tauri()) return []
+  try {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const dir = await open({ directory: true, multiple: false })
+    if (!dir || Array.isArray(dir)) return []
+    const collected: string[] = []
+    await walk_dir(dir, accept, collected, 0, max_depth, max_files)
+    return collected
+  } catch (error) {
+    console.error('Tauri folder pick-paths error:', error)
+    return []
+  }
+}
+
+/**
  * Expand a list of dropped paths (files and/or directories) into readable
  * files, filtering by `accept`. Directories are walked like open_folder.
  */

--- a/src/lib/structure/ServerPane.svelte
+++ b/src/lib/structure/ServerPane.svelte
@@ -72,6 +72,7 @@
     on_open_editor,
     on_preview_file,
     on_load_trajectory,
+    on_load_trajectory_stream,
     on_analyze_report,
     external_navigate_path = $bindable<string | undefined>(undefined),
   }: {
@@ -84,6 +85,7 @@
     on_open_editor?: (content: string, filename: string, file_path: string, session_id: string) => void
     on_preview_file?: (mode: string, filename: string, file_path: string, session_id: string, content?: string, binary_data?: string, mime_type?: string) => void
     on_load_trajectory?: (content: string, filename: string, remote_origin?: { session_id: string; dir_path: string }) => void
+    on_load_trajectory_stream?: (local_path: string, filename: string) => void | Promise<void>
     on_analyze_report?: (content: string, filename: string) => void
     external_navigate_path?: string | undefined
   } = $props()
@@ -918,6 +920,18 @@
     loading_file = { name: file.name, size: file.size_bytes }
     loading_error = null
     try {
+      // Large remote trajectory → materialize to a backend-local cache file
+      // (gzip on the wire) and stream frames, instead of pulling the whole file
+      // into the webview (which freezes it).
+      if (on_load_trajectory_stream) {
+        const { materialize_remote_if_large } = await import('$lib/trajectory/remote-frame-loader')
+        const local = await materialize_remote_if_large(active_session.session_id, file.path, file.name, file.size_bytes)
+        if (local) {
+          await on_load_trajectory_stream(local, file.name)
+          loading_file = null
+          return
+        }
+      }
       // Detect trajectory files early — default 2MB limit truncates large XDATCAR etc.
       const { is_trajectory_file } = await import('$lib/trajectory/parse')
       const likely_traj = on_load_trajectory && is_trajectory_file(file.name)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3678,6 +3678,17 @@
               // Dispatch event to SlowGrowthPane with the text content
               window.dispatchEvent(new CustomEvent(`catgo-sg-upload-text`, { detail: { content } }))
             }}
+            on_load_trajectory_stream={async (local_path, filename) => {
+              // Large remote trajectory already materialized to a backend-local
+              // file — build a streamed trajectory and open it in the viewer.
+              try {
+                const { load_remote_trajectory } = await import('$lib/trajectory/remote-frame-loader')
+                const trajectory = await load_remote_trajectory(local_path, filename)
+                if (trajectory && on_file_load) on_file_load({ trajectory, filename } as any)
+              } catch (e) {
+                console.error(`streamed remote trajectory open failed:`, e)
+              }
+            }}
             on_load_trajectory={async (content, filename, remote_origin) => {
               // Route through on_file_load so App.svelte can open in Trajectory viewer
               try {

--- a/src/lib/trajectory/parsers/frame-loader.ts
+++ b/src/lib/trajectory/parsers/frame-loader.ts
@@ -113,6 +113,18 @@ export class TrajFrameReader implements FrameLoader {
     const total_frames = await this.get_total_frames(data)
     const frame_index: FrameIndex[] = []
 
+    // Progress reporter that never lets a throwing callback break indexing.
+    const report = (current: number, stage: string): void => {
+      if (!on_progress) return
+      try {
+        on_progress({ current, total: 100, stage })
+      } catch {
+        /* a misbehaving progress callback must not abort the index build */
+      }
+    }
+    // ~10 updates across the run so callers always see progress climb past 0.
+    const step = Math.max(1, Math.floor(total_frames / 10))
+
     if (this.format === `xyz`) {
       // Offsets are character indices into the source string (built once,
       // cached). `byte_offset`/`estimated_size` here carry char offset/length
@@ -127,13 +139,8 @@ export class TrajFrameReader implements FrameLoader {
             estimated_size: offsets[current_frame + 1] - offsets[current_frame],
           })
         }
-
-        if (on_progress && current_frame % 1000 === 0) {
-          on_progress({
-            current: (current_frame / total_frames) * 100,
-            total: 100,
-            stage: `Indexing: ${current_frame}`,
-          })
+        if (current_frame % step === 0) {
+          report((current_frame / total_frames) * 100, `Indexing: ${current_frame}`)
         }
       }
     } else {
@@ -148,17 +155,13 @@ export class TrajFrameReader implements FrameLoader {
           byte_offset: frame_offset,
           estimated_size: 0,
         })
-
-        if (on_progress && i % 10000 === 0) {
-          on_progress({
-            current: (i / total_frames) * 100,
-            total: 100,
-            stage: `Indexing ASE: ${i}`,
-          })
+        if (i % step === 0) {
+          report((i / total_frames) * 100, `Indexing ASE: ${i}`)
         }
       }
     }
 
+    report(100, `Indexed ${total_frames} frames`)
     return frame_index
   }
 

--- a/src/lib/trajectory/parsers/frame-loader.ts
+++ b/src/lib/trajectory/parsers/frame-loader.ts
@@ -11,7 +11,6 @@ import type {
 } from '../index'
 import {
   convert_atomic_numbers,
-  count_xyz_frames,
   create_trajectory_frame,
   MAX_METADATA_SIZE,
   MAX_SAFE_STRING_LENGTH,
@@ -21,9 +20,72 @@ import {
 export class TrajFrameReader implements FrameLoader {
   private format: `xyz` | `ase`
   private global_numbers?: number[] // For ASE trajectories
+  // Cached per-frame character offsets into the XYZ source string.
+  // Length = n_frames + 1; frame i spans [offsets[i], offsets[i + 1]).
+  // Built once via a single newline-walking pass (NO whole-file split),
+  // then reused for counting / indexing / random frame access so large
+  // trajectories never re-split the 100s-of-MB string on the main thread.
+  private xyz_offsets?: number[]
+  private xyz_offsets_src?: string
 
   constructor(filename: string) {
     this.format = filename.toLowerCase().endsWith(`.traj`) ? `ase` : `xyz`
+  }
+
+  /**
+   * Build (and cache) frame start offsets for an XYZ string in a single pass.
+   *
+   * Walks line boundaries with `indexOf('\n')` instead of
+   * `data.split(/\r?\n/)`, so it never allocates a multi-million-element line
+   * array or copies the whole file via `.trim()`. Only the per-frame count
+   * line is sliced+parsed; the comment + atom lines are skipped by offset.
+   */
+  private ensure_xyz_offsets(data: string): number[] {
+    if (this.xyz_offsets && this.xyz_offsets_src === data) return this.xyz_offsets
+
+    const n = data.length
+    const offsets: number[] = []
+    let pos = 0
+
+    while (pos < n) {
+      let nl = data.indexOf(`\n`, pos)
+      if (nl === -1) nl = n
+      const header = data.slice(pos, nl).trim()
+      if (!header) { // blank line between frames
+        pos = nl + 1
+        continue
+      }
+
+      const num_atoms = parseInt(header, 10)
+      if (isNaN(num_atoms) || num_atoms <= 0) { // not a frame header — skip line
+        pos = nl + 1
+        continue
+      }
+
+      const frame_start = pos
+      // Advance over: count line + comment line + num_atoms atom lines.
+      const lines_to_skip = 2 + num_atoms
+      let p = pos
+      let complete = true
+      for (let k = 0; k < lines_to_skip; k++) {
+        let e = data.indexOf(`\n`, p)
+        if (e === -1) { // EOF
+          if (k < lines_to_skip - 1) complete = false // truncated final frame
+          p = n
+          break
+        }
+        p = e + 1
+      }
+      if (!complete) break
+
+      offsets.push(frame_start)
+      pos = p
+    }
+
+    offsets.push(n) // end sentinel
+    this.xyz_offsets = offsets
+    this.xyz_offsets_src = data
+    return offsets
   }
 
   // async needed to satisfy FrameLoader interface
@@ -33,7 +95,7 @@ export class TrajFrameReader implements FrameLoader {
   ): Promise<number> {
     if (this.format === `xyz`) {
       if (data instanceof ArrayBuffer) throw new Error(`XYZ loader requires text data`)
-      return count_xyz_frames(data)
+      return this.ensure_xyz_offsets(data).length - 1
     } else {
       if (!(data instanceof ArrayBuffer)) {
         throw new Error(`ASE loader requires binary data`)
@@ -52,56 +114,19 @@ export class TrajFrameReader implements FrameLoader {
     const frame_index: FrameIndex[] = []
 
     if (this.format === `xyz`) {
-      const data_str = data as string
-      const lines = data_str.trim().split(/\r?\n/)
-      const encoder = new TextEncoder() // Reuse single encoder instance
+      // Offsets are character indices into the source string (built once,
+      // cached). `byte_offset`/`estimated_size` here carry char offset/length
+      // — used only for slicing the same string and for display.
+      const offsets = this.ensure_xyz_offsets(data as string)
 
-      // Detect the actual newline sequence used in the file
-      const newline_sequence = data_str.includes(`\r\n`) ? `\r\n` : `\n`
-      const newline_byte_len = encoder.encode(newline_sequence).length
-
-      let [current_frame, line_idx, byte_offset] = [0, 0, 0]
-
-      while (line_idx < lines.length && current_frame < total_frames) {
-        if (!lines[line_idx]?.trim()) {
-          byte_offset += encoder.encode(lines[line_idx]).length +
-            newline_byte_len
-          line_idx++
-          continue
-        }
-
-        const num_atoms = parseInt(lines[line_idx].trim(), 10)
-        if (
-          isNaN(num_atoms) || num_atoms <= 0 || line_idx + num_atoms + 1 >= lines.length
-        ) {
-          byte_offset += encoder.encode(lines[line_idx]).length +
-            newline_byte_len
-          line_idx++
-          continue
-        }
-
+      for (let current_frame = 0; current_frame < total_frames; current_frame++) {
         if (current_frame % sample_rate === 0) {
           frame_index.push({
             frame_number: current_frame,
-            byte_offset,
-            estimated_size: 0,
+            byte_offset: offsets[current_frame],
+            estimated_size: offsets[current_frame + 1] - offsets[current_frame],
           })
         }
-
-        // Calculate frame size and advance using actual byte lengths
-        const frame_start = line_idx
-        line_idx += 2 + num_atoms
-        let frame_size = 0
-        for (let i = frame_start; i < line_idx; i++) {
-          frame_size += encoder.encode(lines[i]).length + newline_byte_len
-        }
-
-        if (current_frame % sample_rate === 0) {
-          frame_index[frame_index.length - 1].estimated_size = frame_size
-        }
-
-        byte_offset += frame_size
-        current_frame++
 
         if (on_progress && current_frame % 1000 === 0) {
           on_progress({
@@ -157,25 +182,23 @@ export class TrajFrameReader implements FrameLoader {
     const total_frames = await this.get_total_frames(data)
 
     if (this.format === `xyz`) {
-      const lines = (data as string).trim().split(/\r?\n/)
-      let [current_frame, line_idx] = [0, 0]
+      const data_str = data as string
+      const offsets = this.ensure_xyz_offsets(data_str)
 
-      while (line_idx < lines.length && current_frame < total_frames) {
-        if (!lines[line_idx]?.trim()) {
-          line_idx++
-          continue
-        }
-
-        const num_atoms = parseInt(lines[line_idx].trim(), 10)
-        if (
-          isNaN(num_atoms) || num_atoms <= 0 || line_idx + num_atoms + 1 >= lines.length
-        ) {
-          line_idx++
-          continue
-        }
-
+      for (let current_frame = 0; current_frame < total_frames; current_frame++) {
         if (current_frame % sample_rate === 0) {
-          const comment = lines[line_idx + 1] || ``
+          // Comment is the 2nd line of the frame; slice just that line
+          // instead of materialising the whole atom block.
+          const start = offsets[current_frame]
+          const first_nl = data_str.indexOf(`\n`, start)
+          const second_nl = first_nl === -1
+            ? -1
+            : data_str.indexOf(`\n`, first_nl + 1)
+          const comment = first_nl === -1
+            ? ``
+            : data_str.slice(first_nl + 1, second_nl === -1 ? undefined : second_nl)
+              .trim()
+
           const frame_metadata = this.parse_xyz_metadata(comment, current_frame)
 
           if (properties) {
@@ -189,9 +212,6 @@ export class TrajFrameReader implements FrameLoader {
 
           metadata_list.push(frame_metadata)
         }
-
-        line_idx += 2 + num_atoms
-        current_frame++
 
         if (on_progress && current_frame % 5000 === 0) {
           on_progress({
@@ -257,35 +277,27 @@ export class TrajFrameReader implements FrameLoader {
     data: string,
     frame_number: number,
   ): TrajectoryFrame | null {
-    const lines = data.trim().split(/\r?\n/)
-    let [current_frame, line_idx] = [0, 0]
+    // O(1) random access: slice only this frame's bytes via the cached
+    // offset index, then split the small chunk (not the whole file).
+    const offsets = this.ensure_xyz_offsets(data)
+    if (frame_number < 0 || frame_number + 1 >= offsets.length) return null
 
-    // Skip to target frame
-    while (line_idx < lines.length && current_frame < frame_number) {
-      if (!lines[line_idx]?.trim()) {
-        line_idx++
-        continue
-      }
-      const num_atoms = parseInt(lines[line_idx].trim(), 10)
-      if (isNaN(num_atoms) || num_atoms <= 0) {
-        line_idx++
-        continue
-      }
-      line_idx += 2 + num_atoms
-      current_frame++
-    }
+    const chunk = data.slice(offsets[frame_number], offsets[frame_number + 1])
+    const lines = chunk.split(/\r?\n/)
 
-    // Parse target frame
-    if (line_idx >= lines.length) return null
-    const num_atoms = parseInt(lines[line_idx].trim(), 10)
-    if (isNaN(num_atoms) || line_idx + num_atoms + 1 >= lines.length) return null
+    // First non-empty line is the atom count (offset points at it, but stay
+    // defensive about stray leading blanks).
+    let head = 0
+    while (head < lines.length && !lines[head]?.trim()) head++
+    const num_atoms = parseInt(lines[head]?.trim(), 10)
+    if (isNaN(num_atoms) || head + num_atoms + 1 >= lines.length) return null
 
-    const comment = lines[line_idx + 1] || ``
+    const comment = lines[head + 1] || ``
     const positions: number[][] = []
     const elements: ElementSymbol[] = []
 
     for (let i = 0; i < num_atoms; i++) {
-      const parts = lines[line_idx + 2 + i]?.trim().split(/\s+/)
+      const parts = lines[head + 2 + i]?.trim().split(/\s+/)
       if (parts?.length >= 4) {
         elements.push(parts[0] as ElementSymbol)
         positions.push([parseFloat(parts[1]), parseFloat(parts[2]), parseFloat(parts[3])])

--- a/src/lib/trajectory/remote-frame-loader.ts
+++ b/src/lib/trajectory/remote-frame-loader.ts
@@ -1,0 +1,293 @@
+// Remote (backend-streamed) frame loader for very large trajectories.
+//
+// Huge AIMD XYZ files (100s of MB, 10k+ frames) must not be slurped into the
+// webview — see `server/catgo/routers/trajectory_stream.py`. Instead the
+// backend indexes the file on disk and serves frame N on demand; this loader
+// fetches frames over HTTP, so the webview only ever holds the current +
+// prefetched frames. It implements the same `FrameLoader` contract as the
+// in-memory `TrajFrameReader`, but ignores the `data` argument (there is no
+// in-memory content) and addresses frames by the file path instead.
+
+import type { ElementSymbol } from '$lib'
+import { API_BASE } from '$lib/api/config'
+import { create_trajectory_frame } from './parsers/common'
+import type {
+  FrameIndex,
+  FrameLoader,
+  TrajectoryFrame,
+  TrajectoryMetadata,
+  TrajectoryType,
+} from './index'
+
+interface BackendFrame {
+  frame_number: number
+  elements: string[]
+  positions: number[][]
+  comment?: string
+  properties?: Record<string, number>
+}
+
+/** Cap plot sampling so the metadata fetch stays small for 10k+ frames. */
+const MAX_PLOT_POINTS = 2000
+
+/** Frames fetched per HTTP request (backend caps `count` at 64). */
+const BATCH = 16
+/** Max frames kept in the per-loader LRU cache (~hundreds of MB headroom). */
+const CACHE_CAP = 400
+
+function backend_frame_to_trajectory_frame(bf: BackendFrame): TrajectoryFrame {
+  return create_trajectory_frame(
+    bf.positions,
+    bf.elements as ElementSymbol[],
+    undefined, // lattice — CP2K pos files carry no cell
+    undefined, // pbc
+    bf.frame_number,
+    { comment: bf.comment ?? ``, ...(bf.properties ?? {}) },
+  )
+}
+
+function frames_url(path: string, start: number, count: number): string {
+  return `${API_BASE}/trajectory/frames?path=${encodeURIComponent(path)}` +
+    `&start=${start}&count=${count}`
+}
+
+/** Extensions the backend trajectory streamer can index. */
+const STREAMABLE_RE = /\.(xyz|extxyz|lammpstrj|traj)$/i
+
+export interface StreamProbe {
+  stream: boolean
+  total_frames: number
+  file_size: number
+}
+
+/**
+ * Decide whether an on-disk file should be streamed frame-by-frame.
+ *
+ * Returns `null` for unsupported extensions / unreachable backend (caller then
+ * falls back to the in-memory read path). Returns `{ stream: true, ... }` only
+ * for genuinely large multi-frame files so small trajectories keep the snappier
+ * in-memory path. Shared by every path-based entry point (file tree, drag-drop,
+ * open-file, open-folder) so the threshold lives in one place.
+ */
+export async function probe_streamable_trajectory(
+  path: string,
+  filename: string,
+  min_bytes = 20 * 1024 * 1024,
+): Promise<StreamProbe | null> {
+  if (!STREAMABLE_RE.test(filename)) return null
+  try {
+    const resp = await fetch(
+      `${API_BASE}/trajectory/index?path=${encodeURIComponent(path)}`,
+    )
+    if (!resp.ok) return null
+    const idx = await resp.json()
+    const total_frames = idx?.total_frames ?? 0
+    const file_size = idx?.file_size ?? 0
+    return { stream: total_frames >= 2 && file_size > min_bytes, total_frames, file_size }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * For a large remote trajectory, pull it to a backend-local cache file (once,
+ * gzip-compressed on the wire) and return that local path — which the normal
+ * {@link load_remote_trajectory} streamer can then read. Returns `null` for
+ * unsupported extensions / small files / failures (caller falls back to the
+ * in-memory remote read).
+ */
+export async function materialize_remote_if_large(
+  session_id: string,
+  remote_path: string,
+  filename: string,
+  size_bytes: number,
+  min_bytes = 20 * 1024 * 1024,
+): Promise<string | null> {
+  if (!STREAMABLE_RE.test(filename) || (size_bytes ?? 0) <= min_bytes) return null
+  try {
+    const { materializeRemoteTrajectory } = await import('$lib/api/hpc')
+    const mat = await materializeRemoteTrajectory(session_id, remote_path)
+    if (mat?.ok && mat.total_frames >= 2) return mat.local_path
+  } catch (error) {
+    console.error(`remote trajectory materialize failed for ${filename}:`, error)
+  }
+  return null
+}
+
+/**
+ * For a large browser ``File`` with no filesystem path (web-mode drop / file
+ * picker), upload it once to a backend-local cache and return that local path
+ * for {@link load_remote_trajectory}. Returns `null` for unsupported / small
+ * files / failures (caller falls back to the in-memory parse).
+ */
+export async function materialize_file_if_large(
+  file: File,
+  min_bytes = 20 * 1024 * 1024,
+): Promise<string | null> {
+  if (!STREAMABLE_RE.test(file.name) || file.size <= min_bytes) return null
+  try {
+    const fd = new FormData()
+    fd.append('file', file, file.name)
+    const resp = await fetch(`${API_BASE}/trajectory/upload`, { method: 'POST', body: fd })
+    if (!resp.ok) return null
+    const mat = await resp.json()
+    if (mat?.ok && mat.total_frames >= 2) return mat.local_path
+  } catch (error) {
+    console.error(`trajectory upload failed for ${file.name}:`, error)
+  }
+  return null
+}
+
+export class RemoteFrameLoader implements FrameLoader {
+  // Insertion-ordered LRU of parsed frames + in-flight chunk dedupe, so
+  // sequential playback costs ~1 HTTP request per BATCH frames and re-visited
+  // frames are instant.
+  private readonly cache = new Map<number, TrajectoryFrame>()
+  private readonly inflight = new Map<number, Promise<void>>()
+
+  constructor(
+    private readonly path: string,
+    private readonly total: number,
+  ) {}
+
+  // deno-lint-ignore require-await
+  async get_total_frames(): Promise<number> {
+    return this.total
+  }
+
+  private chunk_start(n: number): number {
+    return Math.floor(n / BATCH) * BATCH
+  }
+
+  /** Fetch (once) the BATCH-aligned chunk containing `start`; cache all frames. */
+  private fetch_chunk(start: number): Promise<void> {
+    const existing = this.inflight.get(start)
+    if (existing) return existing
+    const count = Math.min(BATCH, this.total - start)
+    const p = (async () => {
+      try {
+        const resp = await fetch(frames_url(this.path, start, count))
+        if (!resp.ok) return
+        const data = await resp.json()
+        for (const bf of (data?.frames ?? []) as BackendFrame[]) {
+          this.cache.set(bf.frame_number, backend_frame_to_trajectory_frame(bf))
+        }
+        this.evict()
+      } catch (error) {
+        console.error(`RemoteFrameLoader.fetch_chunk(${start}) failed:`, error)
+      }
+    })().finally(() => this.inflight.delete(start))
+    this.inflight.set(start, p)
+    return p
+  }
+
+  private evict(): void {
+    let over = this.cache.size - CACHE_CAP
+    if (over <= 0) return
+    for (const key of this.cache.keys()) {
+      if (over-- <= 0) break
+      this.cache.delete(key)
+    }
+  }
+
+  // deno-lint-ignore require-await
+  async build_frame_index(
+    _data: string | ArrayBuffer,
+    sample_rate: number,
+  ): Promise<FrameIndex[]> {
+    // The scrubber ranges over `total_frames`; a full offset table is held on
+    // the backend, so we only synthesize lightweight markers here.
+    const step = Math.max(1, sample_rate)
+    const out: FrameIndex[] = []
+    for (let i = 0; i < this.total; i += step) {
+      out.push({ frame_number: i, byte_offset: 0, estimated_size: 0 })
+    }
+    return out
+  }
+
+  async load_frame(
+    _data: string | ArrayBuffer,
+    frame_number: number,
+  ): Promise<TrajectoryFrame | null> {
+    if (frame_number < 0 || frame_number >= this.total) return null
+    if (!this.cache.has(frame_number)) {
+      await this.fetch_chunk(this.chunk_start(frame_number))
+    }
+    // Prefetch the next chunk so forward playback never blocks on a fetch.
+    const next = this.chunk_start(frame_number) + BATCH
+    if (next < this.total && !this.cache.has(next) && !this.inflight.has(next)) {
+      void this.fetch_chunk(next)
+    }
+    return this.cache.get(frame_number) ?? null
+  }
+
+  async extract_plot_metadata(
+    _data: string | ArrayBuffer,
+    options?: { sample_rate?: number },
+  ): Promise<TrajectoryMetadata[]> {
+    const stride = Math.max(1, options?.sample_rate ?? 1)
+    try {
+      const resp = await fetch(
+        `${API_BASE}/trajectory/metadata?path=${encodeURIComponent(this.path)}&stride=${stride}`,
+      )
+      if (!resp.ok) return []
+      const data = await resp.json()
+      return (data?.metadata ?? []) as TrajectoryMetadata[]
+    } catch (error) {
+      console.error(`RemoteFrameLoader.extract_plot_metadata failed:`, error)
+      return []
+    }
+  }
+}
+
+/**
+ * Build a streamed `TrajectoryType` for a large on-disk trajectory.
+ *
+ * Fetches the frame index, the first `initial` frames, and sampled plot
+ * metadata, then attaches a {@link RemoteFrameLoader}. The returned object is
+ * the minimum `<Trajectory>` needs: `frames[0..initial)`, `total_frames`,
+ * `is_indexed`, `plot_metadata`, and the monkey-patched `frame_loader`
+ * (mirroring `Trajectory.svelte`'s `load_with_indexing`).
+ */
+export async function load_remote_trajectory(
+  path: string,
+  filename: string,
+  initial = 10,
+): Promise<TrajectoryType> {
+  const idx_resp = await fetch(
+    `${API_BASE}/trajectory/index?path=${encodeURIComponent(path)}`,
+  )
+  if (!idx_resp.ok) {
+    throw new Error(`trajectory index failed (HTTP ${idx_resp.status}) for ${filename}`)
+  }
+  const idx = await idx_resp.json()
+  const total: number = idx.total_frames ?? 0
+  if (total <= 0) throw new Error(`no frames indexed in ${filename}`)
+
+  const loader = new RemoteFrameLoader(path, total)
+
+  const n0 = Math.min(initial, total)
+  const fr_resp = await fetch(frames_url(path, 0, n0))
+  const fr_data = fr_resp.ok ? await fr_resp.json() : { frames: [] }
+  const frames: TrajectoryFrame[] = (fr_data.frames ?? [])
+    .map(backend_frame_to_trajectory_frame)
+
+  const stride = Math.max(1, Math.ceil(total / MAX_PLOT_POINTS))
+  const plot_metadata = await loader.extract_plot_metadata(``, { sample_rate: stride })
+
+  const trajectory: TrajectoryType = {
+    frames,
+    total_frames: total,
+    is_indexed: true,
+    plot_metadata,
+    metadata: {
+      filename,
+      source: `remote-stream`,
+      n_atoms: idx.n_atoms,
+      file_size: idx.file_size,
+    },
+  }
+  // `frame_loader` is consumed by Trajectory.svelte but not on TrajectoryType.
+  ;(trajectory as TrajectoryType & { frame_loader: FrameLoader }).frame_loader = loader
+  return trajectory
+}

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -335,17 +335,18 @@ describe(`Trajectory Streaming`, () => {
 
       const loader = new TrajFrameReader(`test.xyz`)
 
-      // Should skip corrupted frame and continue
+      // The byte-offset index skips the corrupted frame entirely, so the count
+      // drops to 9 and every remaining index resolves to a valid frame.
       const total_frames = await loader.get_total_frames(data)
       expect(total_frames).toBe(9) // One less due to corruption
 
       const frame_4 = await loader.load_frame(data, 4)
-      const frame_5 = await loader.load_frame(data, 5) // Try to load the corrupted frame
-      const frame_6 = await loader.load_frame(data, 6) // Skip the corrupted frame
+      const frame_8 = await loader.load_frame(data, 8) // last valid frame
+      const frame_oob = await loader.load_frame(data, 9) // out of bounds → null
 
       expect(frame_4).toBeTruthy()
-      expect(frame_5).toBeNull() // Corrupted frame should return null
-      expect(frame_6).toBeTruthy()
+      expect(frame_8).toBeTruthy()
+      expect(frame_oob).toBeNull()
     })
 
     it(`should handle empty or invalid trajectory data`, async () => {


### PR DESCRIPTION
## Problem

Opening a large multi-frame trajectory (e.g. a **333 MB / 11 001-frame** CP2K AIMD `*-pos-1.xyz`) **froze the app** ("Page Unresponsive"). The whole file was loaded as one JSON string, `JSON.parse`d on the main thread, eagerly parsed into millions of atom objects, and base64-copied — exhausting the WebKitGTK heap.

## Approach

Index the file on disk once; stream frames on demand. The webview only ever holds the **current + prefetched** frames.

### Backend — `server/catgo/routers/trajectory_stream.py`
- `/trajectory/index` — single byte-offset scan, cached by (path, mtime, size). 333 MB indexes in **~0.4 s**.
- `/trajectory/frames?start=&count=` — `seek` + read only that frame range (~0.3 ms/frame).
- `/trajectory/metadata?stride=` — sampled plot props. Fixed the CP2K `E=` energy regex (`tim<e> = 5500` no longer misread as energy).
- `/trajectory/upload` — cache a browser `File` (web mode, no path) and index it.
- **Multi-format**: `xyz`/`extxyz` (byte-offset), `lammpstrj` (`ITEM: TIMESTEP` offsets + ASE per-frame parse), `.traj` (ASE random access).
- `hpc.py:/materialize_trajectory` — pull a remote trajectory **once, gzip-compressed on the wire** (reuses the existing gzip `download_remote_file`) to a backend-local cache, then stream locally.

### Frontend — `src/lib/trajectory/remote-frame-loader.ts`
- `RemoteFrameLoader` (FrameLoader impl) fetches frames over HTTP with a **16-frame batched LRU cache + next-chunk prefetch**.
- `load_remote_trajectory` builds a minimal indexed `TrajectoryType`; shared probes (`probe_streamable_trajectory` / `materialize_remote_if_large` / `materialize_file_if_large`) gate every entry point on one threshold (>20 MB, ≥2 frames).
- `frame-loader.ts`: rewrote the in-memory indexed reader to a cached char-offset index (no repeated whole-file `.split`).

### Entry points wired to stream large trajectories
file-tree click · Tauri drag-drop / open-file / open-folder · web DOM drag-drop + file/folder pickers (upload) · sidebar HPC browser + in-Structure ServerPane (remote materialize). Small trajectories keep the snappier in-memory path.

## Verification
- ✅ 333 MB local xyz: opens instantly, scrubs all 11 001 frames, no freeze (confirmed in-app; backend logs `Streamed frames [..]` per scrub).
- ✅ `/trajectory/upload` end-to-end (cache + index + frames + energy).
- ✅ `lammpstrj` + `.traj` indexers (synthetic files).
- ✅ `materialize_trajectory` endpoint registered.
- 🟡 Remote HPC paths need a live cluster session to exercise end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)