### PR TITLE
feat(tauri): native russh SSH layer — connect/exec + persistent TOFU pinning (mobile step 2)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +121,18 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
 
 [[package]]
 name = "arrayvec"
@@ -260,6 +307,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +348,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,9 +372,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -299,10 +392,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -327,6 +438,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -427,9 +548,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -440,7 +561,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -509,10 +630,13 @@ dependencies = [
  "catgo-graph",
  "chrono",
  "dirs",
+ "flate2",
  "log",
  "objc2",
  "portable-pty",
  "rusqlite",
+ "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
  "tauri",
@@ -550,12 +674,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -605,10 +740,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
+name = "chacha20"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -616,6 +762,25 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -636,6 +801,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -722,7 +893,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -735,7 +906,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -772,6 +943,18 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -821,6 +1004,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,10 +1075,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -891,7 +1152,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -927,7 +1190,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -1019,6 +1282,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1375,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1169,6 +1504,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,12 +1621,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1337,6 +1710,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1464,6 +1838,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1505,6 +1880,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,7 +1927,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1590,6 +1975,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1995,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1727,6 +2135,39 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -2019,6 +2460,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.11+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,11 +2584,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "js-sys"
-version = "0.3.85"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2142,7 +2633,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -2164,6 +2655,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libappindicator"
@@ -2206,12 +2700,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -2306,6 +2806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,7 +2880,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2410,9 +2916,21 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -2423,10 +2941,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2435,6 +3000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2484,7 +3050,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -2505,7 +3071,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2516,7 +3082,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2527,7 +3093,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -2538,7 +3104,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2561,7 +3127,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2573,7 +3139,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2601,7 +3167,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -2614,7 +3180,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2635,7 +3201,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2647,7 +3213,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2658,7 +3224,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2670,7 +3236,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2682,9 +3248,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -2722,6 +3294,61 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
+name = "pageant"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb28bd89a207e5cad59072ac4b364b08459d05f90ccfbcdaa920a95857d94430"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -2779,10 +3406,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2948,6 +3605,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3689,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,7 +3724,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -3043,6 +3761,15 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3355,7 +4082,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3474,6 +4201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,7 +4244,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3541,17 +4278,146 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "russh"
+version = "0.54.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3ee9363fcf66d434d8015d9ae7d879681206981534c21bfdff8a7e34f52cca"
+dependencies = [
+ "aes",
+ "aws-lc-rs",
+ "base64ct",
+ "bitflags 2.11.1",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac",
+ "home",
+ "inout",
+ "internal-russh-forked-ssh-key",
+ "log",
+ "md5",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "ssh-encoding",
+ "winapi",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "gloo-timers",
+ "log",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3591,7 +4457,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3630,7 +4496,7 @@ checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3644,6 +4510,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -3712,10 +4587,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "selectors"
@@ -3765,6 +4665,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3940,6 +4850,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4933,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4106,6 +5037,51 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468",
+ "sha2",
 ]
 
 [[package]]
@@ -4210,7 +5186,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4244,7 +5220,7 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -4272,7 +5248,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4349,7 +5325,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4576,7 +5552,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4602,7 +5578,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4822,6 +5798,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -4943,7 +5920,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5103,10 +6080,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -5255,9 +6248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5268,23 +6261,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5292,9 +6281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5305,9 +6294,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5327,9 +6316,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5406,9 +6395,9 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
 ]
 
@@ -5430,7 +6419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5482,6 +6471,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5504,11 +6503,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -5521,7 +6533,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -5537,6 +6549,17 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5610,6 +6633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5976,7 +7008,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,27 @@ catgo-graph = { path = "../crates/catgo-graph" }
 tokio = { version = "1", features = ["rt", "sync", "time", "net", "io-util", "macros", "rt-multi-thread"] }
 tokio-util = "0.7"
 
+# ── SSH foundation (mobile HPC transport) ────────────────────────────────────
+# russh is the future mobile SSH transport but is NOT cfg-gated: it compiles on
+# every target (including desktop) so the ssh module can be validated on desktop.
+#
+# Version pin rationale (from the russh API spike):
+#   * `cargo add russh` silently resolves to 0.54.5 under this crate's
+#     `rust-version = "1.77.2"` pin (russh 0.61.1 needs rustc 1.85). We pin
+#     `=0.54.5` explicitly to keep the build reproducible under 1.77.2 and to
+#     stay within the existing MSRV instead of bumping it.
+#   * russh 0.54.6 is BROKEN (yanked transitive dep `libcrux-ml-kem 0.0.3`) —
+#     the `=` pin guarantees we never float onto it.
+#   * `russh-keys` standalone is OBSOLETE (latest 0.49.2 is incompatible with
+#     russh 0.54+). Keys live at `russh::keys::*` (always compiled, no feature
+#     gate), so we add only `russh` — never `russh-keys`.
+#   * The Handler trait uses native `async fn` (RPITIT) — no `async-trait`.
+russh = "=0.54.5"
+# Independent crate (still separate from russh); used by the future SFTP layer.
+russh-sftp = "2.3.0"
+# gzip/deflate helper for the future compressed file-transfer path.
+flate2 = "1"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -275,6 +275,10 @@ pub fn run() {
             ssh::auth::ssh_connect,
             ssh::exec::ssh_exec,
             ssh::otp::ssh_submit_otp,
+            ssh::pty::ssh_pty_open,
+            ssh::pty::ssh_pty_write,
+            ssh::pty::ssh_pty_resize,
+            ssh::pty::ssh_pty_close,
         ]);
 
     // Mobile handler: identical to the desktop handler above minus the local-PTY
@@ -336,6 +340,10 @@ pub fn run() {
             ssh::auth::ssh_connect,
             ssh::exec::ssh_exec,
             ssh::otp::ssh_submit_otp,
+            ssh::pty::ssh_pty_open,
+            ssh::pty::ssh_pty_write,
+            ssh::pty::ssh_pty_resize,
+            ssh::pty::ssh_pty_close,
         ]);
 
     let app = builder

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,9 @@ mod db;
 // russh layer instead, so portable-pty (and this module) is not compiled there.
 #[cfg(desktop)]
 mod pty;
+// SSH foundation for the future mobile HPC transport. NOT cfg-gated: russh
+// compiles on every target, so this builds (and is validated) on desktop too.
+mod ssh;
 mod workflow_engine;
 
 // Global state to track the Python backend process.
@@ -195,7 +198,10 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .manage(Mutex::new(OpenedFiles { paths: Vec::new() }))
         .manage(db::DbState::default())
-        .manage(workflow_engine::WorkflowEngineState::default());
+        .manage(workflow_engine::WorkflowEngineState::default())
+        // SSH session registry — shared by ssh_connect/ssh_exec/ssh_submit_otp
+        // on both desktop and mobile (the SSH module is not cfg-gated).
+        .manage(ssh::SshState::default());
 
     // Desktop-only managed state: the Python/Node sidecars (BackendState,
     // AgentState) and the local-PTY terminal (PtyState) only exist on desktop.
@@ -265,6 +271,10 @@ pub fn run() {
             workflow_engine::db_run_workflow,
             workflow_engine::db_pause_workflow,
             workflow_engine::db_resume_workflow,
+            // SSH transport (mobile HPC; compiled & registered on desktop too)
+            ssh::auth::ssh_connect,
+            ssh::exec::ssh_exec,
+            ssh::otp::ssh_submit_otp,
         ]);
 
     // Mobile handler: identical to the desktop handler above minus the local-PTY
@@ -322,6 +332,10 @@ pub fn run() {
             workflow_engine::db_run_workflow,
             workflow_engine::db_pause_workflow,
             workflow_engine::db_resume_workflow,
+            // SSH transport (mobile HPC) — same commands as the desktop handler.
+            ssh::auth::ssh_connect,
+            ssh::exec::ssh_exec,
+            ssh::otp::ssh_submit_otp,
         ]);
 
     let app = builder

--- a/src-tauri/src/ssh/auth.rs
+++ b/src-tauri/src/ssh/auth.rs
@@ -1,0 +1,209 @@
+//! SSH connect + authentication command.
+//!
+//! Implements the `ssh_connect` Tauri command: open a TCP+SSH session via
+//! `russh::client::connect`, verify the server key through the TOFU
+//! [`MobileHandler`], then authenticate with PASSWORD or PUBLIC-KEY.
+//!
+//! KEYBOARD-INTERACTIVE / OTP (2FA) needs a frontend round-trip — the server
+//! emits one or more `InfoRequest` prompt rounds and the user has to type the
+//! codes — so it CANNOT complete inside a single `ssh_connect` call. We detect
+//! it and return `needs_otp = true`; the actual prompt/response loop is a
+//! clearly-marked TODO in [`super::otp`].
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+use russh::client::{self, AuthResult};
+use russh::keys::{load_secret_key, HashAlg, PrivateKeyWithHashAlg};
+
+use super::handler::MobileHandler;
+use super::state::{SshSession, SshState};
+
+/// Authentication method selector sent from the frontend.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase", tag = "method")]
+pub enum AuthConfig {
+    /// Username + password.
+    Password { password: String },
+    /// Public key loaded from a file path on disk. `passphrase` decrypts an
+    /// encrypted private key (`None`/empty => unencrypted).
+    Publickey {
+        key_path: String,
+        #[serde(default)]
+        passphrase: Option<String>,
+    },
+    /// Keyboard-interactive (OTP / 2FA). Needs the frontend round-trip — see
+    /// `super::otp`. We still accept it here so the frontend can signal intent.
+    KeyboardInteractive,
+}
+
+/// Connection request from the frontend.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConnectConfig {
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    pub username: String,
+    #[serde(flatten)]
+    pub auth: AuthConfig,
+}
+
+fn default_port() -> u16 {
+    22
+}
+
+/// Result of an `ssh_connect` attempt.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ConnectResult {
+    /// `true` when a session was established and authenticated.
+    pub connected: bool,
+    /// Opaque session id (UUID v4) when `connected` is true; empty otherwise.
+    pub session_id: String,
+    /// `true` when the server requires keyboard-interactive / OTP and the
+    /// frontend must drive `ssh_submit_otp` (NOT yet implemented — see otp.rs).
+    pub needs_otp: bool,
+    /// Human-readable error / status message (empty on success).
+    pub message: String,
+}
+
+/// Open + authenticate an SSH session.
+///
+/// NEVER throws across the Tauri boundary on a *connection* failure: returns a
+/// `ConnectResult { connected: false, message }` instead, mirroring the
+/// never-throw philosophy of the Python scheduler layer. (A `Result::Err` is
+/// reserved for truly unexpected internal faults.)
+#[tauri::command]
+pub async fn ssh_connect(
+    app: tauri::AppHandle,
+    config: ConnectConfig,
+    state: tauri::State<'_, SshState>,
+) -> Result<ConnectResult, String> {
+    let ConnectConfig {
+        host,
+        port,
+        username,
+        auth,
+    } = config;
+
+    // 1. Open TCP + SSH transport and run the persistent-TOFU server-key check.
+    //    The pinned-key store lives under the app data dir; a key MISMATCH there
+    //    refuses the connection (possible MITM).
+    let pin_store = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("could not resolve app data dir: {e}"))?
+        .join("ssh_known_hosts.json");
+    let key_mismatch = Arc::new(AtomicBool::new(false));
+
+    let ssh_config = Arc::new(client::Config::default());
+    let handler = MobileHandler::new(host.clone(), port, pin_store, key_mismatch.clone());
+    let addr = (host.as_str(), port);
+
+    let mut handle = match client::connect(ssh_config, addr, handler).await {
+        Ok(h) => h,
+        Err(e) => {
+            let message = if key_mismatch.load(Ordering::SeqCst) {
+                format!(
+                    "Host key for {host}:{port} CHANGED — refusing to connect (possible \
+                     man-in-the-middle). If the host key legitimately changed, remove its \
+                     entry from ssh_known_hosts.json and reconnect."
+                )
+            } else {
+                format!("SSH connect to {host}:{port} failed: {e}")
+            };
+            return Ok(ConnectResult { message, ..Default::default() });
+        }
+    };
+
+    // 2. Authenticate per the requested method.
+    match auth {
+        AuthConfig::Password { password } => {
+            match handle.authenticate_password(&username, password).await {
+                Ok(AuthResult::Success) => {}
+                Ok(AuthResult::Failure { .. }) => {
+                    return Ok(ConnectResult {
+                        message: "Password authentication rejected".into(),
+                        ..Default::default()
+                    });
+                }
+                Err(e) => {
+                    return Ok(ConnectResult {
+                        message: format!("Password auth error: {e}"),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+        AuthConfig::Publickey {
+            key_path,
+            passphrase,
+        } => {
+            // load_secret_key wants Option<&str> for the passphrase.
+            let pass_ref = passphrase.as_deref().filter(|s| !s.is_empty());
+            let key = match load_secret_key(&key_path, pass_ref) {
+                Ok(k) => k,
+                Err(e) => {
+                    return Ok(ConnectResult {
+                        message: format!("Could not load private key {key_path}: {e}"),
+                        ..Default::default()
+                    });
+                }
+            };
+            // hash_alg only matters for RSA (Sha512 here); ignored & forced to
+            // None for ed25519/ecdsa by PrivateKeyWithHashAlg::new.
+            let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key), Some(HashAlg::Sha512));
+            match handle.authenticate_publickey(&username, key_with_alg).await {
+                Ok(AuthResult::Success) => {}
+                Ok(AuthResult::Failure { .. }) => {
+                    return Ok(ConnectResult {
+                        message: "Public-key authentication rejected".into(),
+                        ..Default::default()
+                    });
+                }
+                Err(e) => {
+                    return Ok(ConnectResult {
+                        message: format!("Public-key auth error: {e}"),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+        AuthConfig::KeyboardInteractive => {
+            // Keyboard-interactive / OTP requires a frontend round-trip: the
+            // server sends prompt rounds (password, then OTP, ...) that the user
+            // must answer interactively. That handshake cannot finish inside this
+            // single command, so we surface `needs_otp` and leave the pending
+            // handle wiring to `ssh_submit_otp`.
+            //
+            // TODO(OTP-wiring): to support this we must KEEP the partially-
+            // authed `handle` alive between `ssh_connect` and `ssh_submit_otp`
+            // (the start/respond loop is `&mut self` on the SAME handle). That
+            // means stashing the in-flight handle in a separate "pending" map in
+            // SshState and resuming the loop in `ssh_submit_otp`. Doing that
+            // correctly (prompt surfacing, multi-round loops, echo masking,
+            // timeout/cancel) is deliberately deferred rather than guessed.
+            return Ok(ConnectResult {
+                needs_otp: true,
+                message: "Keyboard-interactive/OTP not yet wired (see ssh_submit_otp TODO)".into(),
+                ..Default::default()
+            });
+        }
+    }
+
+    // 3. Authenticated — register the live session.
+    let session = Arc::new(SshSession::new(handle, host.clone(), username.clone()));
+    let session_id = state.insert(session).await;
+    log::info!(
+        "[CatGo SSH] connected session {session_id} ({username}@{host}:{port})"
+    );
+
+    Ok(ConnectResult {
+        connected: true,
+        session_id,
+        message: String::new(),
+        needs_otp: false,
+    })
+}

--- a/src-tauri/src/ssh/auth.rs
+++ b/src-tauri/src/ssh/auth.rs
@@ -6,9 +6,10 @@
 //!
 //! KEYBOARD-INTERACTIVE / OTP (2FA) needs a frontend round-trip — the server
 //! emits one or more `InfoRequest` prompt rounds and the user has to type the
-//! codes — so it CANNOT complete inside a single `ssh_connect` call. We detect
-//! it and return `needs_otp = true`; the actual prompt/response loop is a
-//! clearly-marked TODO in [`super::otp`].
+//! codes — so it CANNOT complete inside a single `ssh_connect` call. We start
+//! the handshake here, stash the in-flight handle in [`SshState`]'s pending map,
+//! and return `needs_otp = true` + `pending_id` + `prompts`; the response
+//! rounds are driven by [`super::otp::ssh_submit_otp`].
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -16,11 +17,35 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
-use russh::client::{self, AuthResult};
+use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse, Prompt};
 use russh::keys::{load_secret_key, HashAlg, PrivateKeyWithHashAlg};
 
 use super::handler::MobileHandler;
-use super::state::{SshSession, SshState};
+use super::state::{PendingAuth, SshSession, SshState};
+
+/// One keyboard-interactive / OTP prompt surfaced to the frontend.
+///
+/// Mirrors russh's [`russh::client::Prompt`] but is `Serialize` so it can cross
+/// the Tauri boundary. `echo == false` => the answer is secret (OTP / password)
+/// and the UI MUST mask it; `echo == true` => plain, visible input.
+#[derive(Debug, Clone, Serialize)]
+pub struct OtpPrompt {
+    /// Prompt text to show the user (e.g. "One-time password: ").
+    pub prompt: String,
+    /// Whether the typed answer should be echoed (`false` => mask as a secret).
+    pub echo: bool,
+}
+
+impl From<&Prompt> for OtpPrompt {
+    fn from(p: &Prompt) -> Self {
+        Self { prompt: p.prompt.clone(), echo: p.echo }
+    }
+}
+
+/// Map a russh `Vec<Prompt>` to the serializable wire form.
+pub fn map_prompts(prompts: &[Prompt]) -> Vec<OtpPrompt> {
+    prompts.iter().map(OtpPrompt::from).collect()
+}
 
 /// Authentication method selector sent from the frontend.
 #[derive(Debug, Clone, Deserialize)]
@@ -63,10 +88,23 @@ pub struct ConnectResult {
     /// Opaque session id (UUID v4) when `connected` is true; empty otherwise.
     pub session_id: String,
     /// `true` when the server requires keyboard-interactive / OTP and the
-    /// frontend must drive `ssh_submit_otp` (NOT yet implemented — see otp.rs).
+    /// frontend must drive `ssh_submit_otp` with `pending_id` + `prompts`.
     pub needs_otp: bool,
     /// Human-readable error / status message (empty on success).
     pub message: String,
+    /// In-flight handshake id to pass back to `ssh_submit_otp` (only set when
+    /// `needs_otp` is true). Skipped from the wire when empty so the
+    /// password/public-key paths serialize unchanged.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub pending_id: String,
+    /// The prompts the user must answer this round (only set with `needs_otp`).
+    /// `echo == false` => mask the answer. Skipped when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prompts: Vec<OtpPrompt>,
+    /// Server-supplied instructions for this round (may be empty). Skipped when
+    /// empty so non-OTP paths stay clean.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub instructions: String,
 }
 
 /// Open + authenticate an SSH session.
@@ -172,24 +210,54 @@ pub async fn ssh_connect(
             }
         }
         AuthConfig::KeyboardInteractive => {
-            // Keyboard-interactive / OTP requires a frontend round-trip: the
-            // server sends prompt rounds (password, then OTP, ...) that the user
-            // must answer interactively. That handshake cannot finish inside this
-            // single command, so we surface `needs_otp` and leave the pending
-            // handle wiring to `ssh_submit_otp`.
-            //
-            // TODO(OTP-wiring): to support this we must KEEP the partially-
-            // authed `handle` alive between `ssh_connect` and `ssh_submit_otp`
-            // (the start/respond loop is `&mut self` on the SAME handle). That
-            // means stashing the in-flight handle in a separate "pending" map in
-            // SshState and resuming the loop in `ssh_submit_otp`. Doing that
-            // correctly (prompt surfacing, multi-round loops, echo masking,
-            // timeout/cancel) is deliberately deferred rather than guessed.
-            return Ok(ConnectResult {
-                needs_otp: true,
-                message: "Keyboard-interactive/OTP not yet wired (see ssh_submit_otp TODO)".into(),
-                ..Default::default()
-            });
+            // Start the keyboard-interactive handshake. The server may answer
+            // immediately (Success, e.g. no actual prompts), reject (Failure),
+            // or — the common 2FA case — return an `InfoRequest` round of
+            // prompts (password, then OTP, ...). Because the start/respond loop
+            // is `&mut self` on the SAME handle and can span MULTIPLE rounds,
+            // each `InfoRequest` is handed back to the frontend and the mid-auth
+            // handle is parked in the `pending` map for `ssh_submit_otp` to
+            // resume. `None` submethods => let the server choose.
+            match handle
+                .authenticate_keyboard_interactive_start(&username, None)
+                .await
+            {
+                // Authed in one shot — fall through to "register live session".
+                Ok(KeyboardInteractiveAuthResponse::Success) => {}
+                Ok(KeyboardInteractiveAuthResponse::InfoRequest {
+                    instructions,
+                    prompts,
+                    ..
+                }) => {
+                    let wire_prompts = map_prompts(&prompts);
+                    let pending = PendingAuth::new(handle, host.clone(), username.clone());
+                    let pending_id = state.insert_pending(pending).await;
+                    log::info!(
+                        "[CatGo SSH] keyboard-interactive challenge for {username}@{host}:{port} \
+                         — pending {pending_id} ({} prompt(s))",
+                        wire_prompts.len()
+                    );
+                    return Ok(ConnectResult {
+                        needs_otp: true,
+                        pending_id,
+                        prompts: wire_prompts,
+                        instructions,
+                        ..Default::default()
+                    });
+                }
+                Ok(KeyboardInteractiveAuthResponse::Failure { .. }) => {
+                    return Ok(ConnectResult {
+                        message: "Keyboard-interactive auth rejected".into(),
+                        ..Default::default()
+                    });
+                }
+                Err(e) => {
+                    return Ok(ConnectResult {
+                        message: format!("Keyboard-interactive auth error: {e}"),
+                        ..Default::default()
+                    });
+                }
+            }
         }
     }
 
@@ -203,7 +271,6 @@ pub async fn ssh_connect(
     Ok(ConnectResult {
         connected: true,
         session_id,
-        message: String::new(),
-        needs_otp: false,
+        ..Default::default()
     })
 }

--- a/src-tauri/src/ssh/exec.rs
+++ b/src-tauri/src/ssh/exec.rs
@@ -1,0 +1,182 @@
+//! Remote command execution over an established SSH session.
+//!
+//! Ports the semantics of `server/catgo/utils/scheduler_base.py::_run`:
+//!   * the command is wrapped in a LOGIN shell — `bash -l -c '<quoted cmd>'` —
+//!     so module-managed tools (sbatch/squeue/...) are on PATH;
+//!   * a default ~30s timeout applies;
+//!   * it NEVER throws on a remote/transport error — on any failure it returns
+//!     `code = -1` plus the error text in `stderr` (matching the Python layer's
+//!     `check=False` + caller-tolerant contract).
+//!
+//! Channel I/O follows the spike: open a session channel, `exec(true, cmd)`,
+//! then drain `ChannelMsg` until the channel closes, collecting `Data` (stdout),
+//! `ExtendedData { ext == 1 }` (stderr), and `ExitStatus` (the u32 exit code).
+
+use serde::Serialize;
+
+use russh::ChannelMsg;
+
+use super::state::SshState;
+
+/// Default command timeout, mirroring the Python scheduler's `timeout=30`.
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
+/// `SSH_EXTENDED_DATA_STDERR` — the `ext` discriminator for stderr bytes.
+const SSH_EXTENDED_DATA_STDERR: u32 = 1;
+
+/// Result of a remote command.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecResult {
+    pub stdout: String,
+    pub stderr: String,
+    /// Process exit code, or `-1` on any transport/timeout/internal error
+    /// (matching the Python never-throw contract).
+    pub code: i32,
+}
+
+impl ExecResult {
+    /// Build an error result (`code = -1`) with the given stderr message.
+    fn error(msg: impl Into<String>) -> Self {
+        Self {
+            stdout: String::new(),
+            stderr: msg.into(),
+            code: -1,
+        }
+    }
+}
+
+/// POSIX single-quote shell escaping, equivalent to Python's `shlex.quote`.
+///
+/// Wraps the string in single quotes and renders embedded single quotes as the
+/// classic `'\''` sequence. Empty string becomes `''`.
+fn shlex_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    // Fast path: if every char is a safe unquoted shell token char, return as-is
+    // (matches shlex.quote, which leaves such strings unquoted).
+    let safe = s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '@' | '%' | '_' | '-' | '+' | '=' | ':' | ',' | '.' | '/'));
+    if safe {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Execute `cmd` on an established session and collect its output.
+///
+/// `timeout_ms` overrides the default ~30s timeout. Never throws across the
+/// Tauri boundary: every failure path yields `ExecResult { code: -1, stderr }`.
+#[tauri::command]
+pub async fn ssh_exec(
+    session_id: String,
+    cmd: String,
+    timeout_ms: Option<u64>,
+    state: tauri::State<'_, SshState>,
+) -> Result<ExecResult, String> {
+    let session = match state.get(&session_id).await {
+        Some(s) => s,
+        None => {
+            return Ok(ExecResult::error(format!(
+                "No such SSH session: {session_id}"
+            )));
+        }
+    };
+    if !session.is_alive() {
+        return Ok(ExecResult::error(format!(
+            "SSH session {session_id} is no longer alive"
+        )));
+    }
+
+    // bash -l -c '<shlex-quoted cmd>'  (login shell, like the Python layer).
+    let login_cmd = format!("bash -l -c {}", shlex_quote(&cmd));
+    let timeout = std::time::Duration::from_millis(timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+
+    // Drive the whole exchange under a single timeout. Errors map to code = -1.
+    let fut = run_exec(&session, login_cmd);
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(msg)) => {
+            session.mark_dead();
+            Ok(ExecResult::error(msg))
+        }
+        Err(_elapsed) => Ok(ExecResult::error(format!(
+            "SSH command timed out ({}ms): {}",
+            timeout.as_millis(),
+            cmd.chars().take(80).collect::<String>()
+        ))),
+    }
+}
+
+/// Open a channel, exec the (already-wrapped) command, and drain output.
+///
+/// Returns `Err(message)` on any transport error; the caller turns that into a
+/// `code = -1` result.
+async fn run_exec(
+    session: &super::state::SshSession,
+    login_cmd: String,
+) -> Result<ExecResult, String> {
+    // `Channel::wait()` is `&mut self`, so we must hold the handle's async mutex
+    // for the duration of the exec stream.
+    let handle = session.handle.lock().await;
+
+    let channel = handle
+        .channel_open_session()
+        .await
+        .map_err(|e| format!("channel_open_session failed: {e}"))?;
+
+    channel
+        .exec(true, login_cmd.into_bytes())
+        .await
+        .map_err(|e| format!("exec failed: {e}"))?;
+
+    let mut stdout: Vec<u8> = Vec::new();
+    let mut stderr: Vec<u8> = Vec::new();
+    let mut code: Option<i32> = None;
+
+    // `wait()` needs `&mut`; the channel is owned locally so that's fine.
+    let mut channel = channel;
+    while let Some(msg) = channel.wait().await {
+        match msg {
+            ChannelMsg::Data { data } => stdout.extend_from_slice(&data),
+            ChannelMsg::ExtendedData { data, ext } if ext == SSH_EXTENDED_DATA_STDERR => {
+                stderr.extend_from_slice(&data)
+            }
+            ChannelMsg::ExitStatus { exit_status } => code = Some(exit_status as i32),
+            // Killed-by-signal: surface the signal name in stderr, mark nonzero.
+            ChannelMsg::ExitSignal {
+                signal_name,
+                error_message,
+                ..
+            } => {
+                stderr.extend_from_slice(
+                    format!("[signal {signal_name:?}] {error_message}\n").as_bytes(),
+                );
+                if code.is_none() {
+                    code = Some(-1);
+                }
+            }
+            // Channel teardown — loop naturally ends after these.
+            ChannelMsg::Eof | ChannelMsg::Close => {}
+            _ => {}
+        }
+    }
+
+    Ok(ExecResult {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        // Default to 0 if the server closed cleanly without an explicit status.
+        code: code.unwrap_or(0),
+    })
+}

--- a/src-tauri/src/ssh/handler.rs
+++ b/src-tauri/src/ssh/handler.rs
@@ -1,0 +1,117 @@
+//! russh client `Handler` — server-key verification (persistent TOFU pinning).
+//!
+//! From the spike: the `Handler` trait uses native `async fn` (RPITIT), NOT
+//! `#[async_trait]`, and `check_server_key` takes `&russh::keys::ssh_key::PublicKey`.
+//! The *default* `check_server_key` REJECTS ALL keys (`Ok(false)`), so silence
+//! means "connection refused". We MUST override it.
+//!
+//! TOFU (Trust-On-First-Use) policy — mobile has no `~/.ssh/known_hosts`, so we
+//! own the store: a JSON map `{host}:{port} -> fingerprint` under the app data
+//! dir (0600 on Unix).
+//!   * first-seen  -> persist the fingerprint, accept (`Ok(true)`).
+//!   * known match -> accept (`Ok(true)`).
+//!   * MISMATCH    -> REJECT (`Ok(false)`) and flag it (possible MITM); the
+//!                    connection then fails and `ssh_connect` surfaces a clear
+//!                    "host key changed" message.
+//! Store-IO errors never block a connection (treated as empty / best-effort
+//! persist); only a genuine fingerprint mismatch refuses the key.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use russh::keys::ssh_key;
+
+/// SSH client handler implementing persistent Trust-On-First-Use server-key
+/// pinning. One instance per connection attempt; captures the endpoint so the
+/// pinned-key lookup can be keyed by `{host}:{port}`.
+pub struct MobileHandler {
+    pub host: String,
+    pub port: u16,
+    /// Path to the per-app pinned-key store (JSON `{endpoint -> fingerprint}`).
+    pin_store: PathBuf,
+    /// Set to `true` when the offered key did NOT match the pinned one, so
+    /// `ssh_connect` can distinguish a MITM/host-key-change from a generic
+    /// connection failure.
+    pub key_mismatch: Arc<AtomicBool>,
+}
+
+impl MobileHandler {
+    pub fn new(
+        host: String,
+        port: u16,
+        pin_store: PathBuf,
+        key_mismatch: Arc<AtomicBool>,
+    ) -> Self {
+        Self { host, port, pin_store, key_mismatch }
+    }
+}
+
+/// Read the pin store; a missing/unreadable/corrupt file yields an empty map so
+/// the first connection is treated as first-use rather than failing.
+fn load_pins(path: &Path) -> HashMap<String, String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Persist the pin store (best-effort, 0600 on Unix). Errors are logged, never
+/// propagated — a failed persist must not block the connection.
+fn save_pins(path: &Path, pins: &HashMap<String, String>) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_json::to_string_pretty(pins) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(path, json) {
+                log::warn!("[CatGo SSH] could not persist host-key pin store: {e}");
+                return;
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            }
+        }
+        Err(e) => log::warn!("[CatGo SSH] could not serialize host-key pin store: {e}"),
+    }
+}
+
+impl russh::client::Handler for MobileHandler {
+    // Reuse russh's own error so `?` works without a custom conversion.
+    type Error = russh::Error;
+
+    // NOTE: native `async fn` — do NOT add `#[async_trait]` (RPITIT trait).
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        let endpoint = format!("{}:{}", self.host, self.port);
+        let fingerprint = server_public_key.fingerprint(Default::default()).to_string();
+
+        let mut pins = load_pins(&self.pin_store);
+        match pins.get(&endpoint) {
+            // Known host, key matches the pin → trust.
+            Some(pinned) if *pinned == fingerprint => Ok(true),
+            // Known host, key CHANGED → refuse (possible MITM). Flag it so the
+            // caller can surface a clear message instead of a generic failure.
+            Some(pinned) => {
+                self.key_mismatch.store(true, Ordering::SeqCst);
+                log::error!(
+                    "[CatGo SSH] HOST KEY MISMATCH for {endpoint}: pinned {pinned}, offered \
+                     {fingerprint} — refusing (possible MITM)"
+                );
+                Ok(false)
+            }
+            // First sight → pin it and trust (Trust-On-First-Use).
+            None => {
+                pins.insert(endpoint.clone(), fingerprint.clone());
+                save_pins(&self.pin_store, &pins);
+                log::info!("[CatGo SSH] pinned new host key for {endpoint}: {fingerprint}");
+                Ok(true)
+            }
+        }
+    }
+}

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -22,6 +22,7 @@ pub mod auth;
 pub mod exec;
 pub mod handler;
 pub mod otp;
+pub mod pty;
 pub mod state;
 
 // Re-exported for ergonomic `ssh::ssh_connect` use elsewhere. NOTE: `lib.rs`'s

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -1,0 +1,39 @@
+//! SSH foundation for the mobile HPC transport (russh-backed).
+//!
+//! This module is the future mobile SSH transport, but it is INTENTIONALLY NOT
+//! `#[cfg]`-gated: russh compiles on every target, so the module builds (and is
+//! validated) on desktop too. The Tauri commands are registered in BOTH the
+//! `cfg(desktop)` and `cfg(not(desktop))` invoke handlers in `lib.rs`.
+//!
+//! Layout:
+//!   * `state.rs`   — `SshState` registry + per-session `SshSession` wrapper.
+//!   * `handler.rs` — `MobileHandler`: TOFU server-key verification.
+//!   * `auth.rs`    — `ssh_connect` (password / public-key; OTP detection).
+//!   * `otp.rs`     — `ssh_submit_otp` (clearly-marked TODO stub).
+//!   * `exec.rs`    — `ssh_exec` (login-shell exec, never-throw, ~30s timeout).
+//!
+//! Known TODOs (see the respective files for detail):
+//!   * TOFU persistent pinning (handler.rs) — currently accept-and-log only.
+//!   * OTP / keyboard-interactive wiring (auth.rs + otp.rs).
+//!   * ProxyJump / direct-tcpip (not yet implemented; spike documents the API).
+//!   * SFTP file transfer (russh-sftp added, not yet wired).
+
+pub mod auth;
+pub mod exec;
+pub mod handler;
+pub mod otp;
+pub mod state;
+
+// Re-exported for ergonomic `ssh::ssh_connect` use elsewhere. NOTE: `lib.rs`'s
+// `generate_handler!` references the commands via their DEFINING module path
+// (`ssh::auth::ssh_connect`, ...) because the `#[tauri::command]` macro emits a
+// sibling `__cmd__<name>` item that only resolves at the definition site — a
+// plain re-export does not bring that hidden item along. These stay for any
+// non-macro caller; allow(unused) keeps the build warning-free.
+#[allow(unused_imports)]
+pub use auth::ssh_connect;
+#[allow(unused_imports)]
+pub use exec::ssh_exec;
+#[allow(unused_imports)]
+pub use otp::ssh_submit_otp;
+pub use state::SshState;

--- a/src-tauri/src/ssh/otp.rs
+++ b/src-tauri/src/ssh/otp.rs
@@ -1,73 +1,116 @@
-//! Keyboard-interactive / OTP (2FA) submission — STUB (clearly-marked TODO).
+//! Keyboard-interactive / OTP (2FA) submission.
 //!
-//! The real flow (confirmed by the spike) is a start/respond loop driven on the
-//! SAME `Handle` that `ssh_connect` opened:
+//! Resumes the keyboard-interactive handshake that `ssh_connect` began. The
+//! mid-auth `Handle` was parked in `SshState::pending` (see `state.rs`); here we
+//! MOVE it back out, drive one `authenticate_keyboard_interactive_respond`
+//! round, and react to the server's reply:
 //!
-//! ```ignore
-//! let mut resp = handle
-//!     .authenticate_keyboard_interactive_start(user, None /* submethods */)
-//!     .await?;
-//! loop {
-//!     match resp {
-//!         KeyboardInteractiveAuthResponse::Success => break, // authed
-//!         KeyboardInteractiveAuthResponse::Failure { .. } => /* fail */,
-//!         KeyboardInteractiveAuthResponse::InfoRequest { prompts, .. } => {
-//!             // prompts: Vec<Prompt { prompt: String, echo: bool }>
-//!             // echo == false => secret (OTP/password) -> mask in the UI.
-//!             // responses.len() MUST equal prompts.len().
-//!             let answers: Vec<String> = /* one per prompt, from the frontend */;
-//!             resp = handle
-//!                 .authenticate_keyboard_interactive_respond(answers)
-//!                 .await?;
-//!         }
-//!     }
-//! }
-//! ```
+//!   * `Success`     => build + register the live `SshSession`, return
+//!                      `connected: true` + the new `session_id`.
+//!   * `InfoRequest` => the server wants ANOTHER round (multi-round 2FA, e.g.
+//!                      password THEN OTP). Re-stash the SAME handle under a NEW
+//!                      `pending_id` and return `needs_otp: true` + the new
+//!                      prompts so the frontend submits again.
+//!   * `Failure`     => surface "OTP rejected" (never throws across the
+//!                      boundary on an auth failure).
+//!   * `Err`         => surface "OTP error: ..." likewise.
 //!
-//! Why this is deferred and NOT blind-guessed:
-//!   * The handshake spans MULTIPLE Tauri command calls (one `InfoRequest`
-//!     round per `ssh_submit_otp` invocation), so the partially-authed `Handle`
-//!     must survive between calls. That needs a dedicated "pending sessions"
-//!     map in `SshState` (separate from the authed `sessions` map), created in
-//!     `ssh_connect` when `needs_otp` is detected.
-//!   * The frontend contract (how prompts are surfaced, how many rounds, how
-//!     cancel/timeout behave) isn't pinned down yet. Guessing the wiring would
-//!     bake in an API we'd have to break later.
-//!
-//! This stub compiles and returns an explicit "not yet implemented" error so
-//! the command is registerable today without committing to a half-built path.
+//! Because the handle is `&mut self` for `respond`, it is owned exclusively here
+//! for the duration of the call; it is only ever shared once it becomes a live
+//! `SshSession` (behind that session's own `Mutex`).
+
+use std::sync::Arc;
 
 use serde::Deserialize;
 
-use super::state::SshState;
+use russh::client::KeyboardInteractiveAuthResponse;
 
-/// One OTP/keyboard-interactive submission round from the frontend: the answers
-/// for the prompts most recently surfaced by the server.
+use super::auth::{map_prompts, ConnectResult};
+use super::state::{PendingAuth, SshSession, SshState};
+
+/// One OTP / keyboard-interactive submission round from the frontend: the
+/// answers for the prompts most recently surfaced by the server.
 #[derive(Debug, Clone, Deserialize)]
 pub struct OtpSubmission {
-    /// The pending (pre-auth) session id minted by `ssh_connect` when it
-    /// returned `needs_otp = true`.
+    /// The pending (pre-auth) handshake id minted by `ssh_connect` (or by the
+    /// previous `ssh_submit_otp` round, for multi-round 2FA).
     pub pending_id: String,
-    /// One answer per prompt in the current `InfoRequest`, in order.
+    /// One answer per prompt in the current `InfoRequest`, in order. Its length
+    /// must equal the prompt count of that round (russh enforces this).
     pub responses: Vec<String>,
 }
 
-/// Submit OTP / keyboard-interactive responses for a pending session.
+/// Submit OTP / keyboard-interactive responses for a pending handshake.
 ///
-/// TODO(OTP-wiring): implement the start/respond loop documented above against
-/// a pending-handle map in `SshState`. Until then this returns an explicit
-/// error rather than silently failing or guessing the wiring.
+/// Never throws across the Tauri boundary on an auth failure — returns a
+/// `ConnectResult` describing the outcome instead (mirrors `ssh_connect`).
 #[tauri::command]
 pub async fn ssh_submit_otp(
     submission: OtpSubmission,
-    _state: tauri::State<'_, SshState>,
-) -> Result<super::auth::ConnectResult, String> {
-    // Touch the fields so the (intentional) stub still type-checks the payload
-    // shape the frontend will send.
-    let _ = (&submission.pending_id, &submission.responses);
-    Err(
-        "ssh_submit_otp is not yet implemented: keyboard-interactive/OTP wiring \
-         (pending-handle map + start/respond loop) is a TODO. See src-tauri/src/ssh/otp.rs."
-            .to_string(),
-    )
+    state: tauri::State<'_, SshState>,
+) -> Result<ConnectResult, String> {
+    let OtpSubmission { pending_id, responses } = submission;
+
+    // MOVE the mid-auth handle out of the pending map. A missing id means the
+    // handshake expired, was already consumed, or never existed.
+    let PendingAuth { mut handle, host, username } = match state.take_pending(&pending_id).await {
+        Some(p) => p,
+        None => {
+            return Ok(ConnectResult {
+                message: "no pending OTP session (expired or already used)".into(),
+                ..Default::default()
+            });
+        }
+    };
+
+    // Drive exactly ONE round. The server decides whether more rounds follow.
+    match handle
+        .authenticate_keyboard_interactive_respond(responses)
+        .await
+    {
+        Ok(KeyboardInteractiveAuthResponse::Success) => {
+            let session = Arc::new(SshSession::new(handle, host.clone(), username.clone()));
+            let session_id = state.insert(session).await;
+            log::info!(
+                "[CatGo SSH] keyboard-interactive auth complete — session {session_id} \
+                 ({username}@{host})"
+            );
+            Ok(ConnectResult {
+                connected: true,
+                session_id,
+                ..Default::default()
+            })
+        }
+        // Another round (multi-round 2FA): re-park the SAME handle under a NEW
+        // pending_id and ask the frontend for the next set of answers.
+        Ok(KeyboardInteractiveAuthResponse::InfoRequest {
+            instructions,
+            prompts,
+            ..
+        }) => {
+            let wire_prompts = map_prompts(&prompts);
+            let pending = PendingAuth::new(handle, host, username);
+            let next_id = state.insert_pending(pending).await;
+            log::info!(
+                "[CatGo SSH] keyboard-interactive needs another round — pending {next_id} \
+                 ({} prompt(s))",
+                wire_prompts.len()
+            );
+            Ok(ConnectResult {
+                needs_otp: true,
+                pending_id: next_id,
+                prompts: wire_prompts,
+                instructions,
+                ..Default::default()
+            })
+        }
+        Ok(KeyboardInteractiveAuthResponse::Failure { .. }) => Ok(ConnectResult {
+            message: "OTP rejected".into(),
+            ..Default::default()
+        }),
+        Err(e) => Ok(ConnectResult {
+            message: format!("OTP error: {e}"),
+            ..Default::default()
+        }),
+    }
 }

--- a/src-tauri/src/ssh/otp.rs
+++ b/src-tauri/src/ssh/otp.rs
@@ -1,0 +1,73 @@
+//! Keyboard-interactive / OTP (2FA) submission — STUB (clearly-marked TODO).
+//!
+//! The real flow (confirmed by the spike) is a start/respond loop driven on the
+//! SAME `Handle` that `ssh_connect` opened:
+//!
+//! ```ignore
+//! let mut resp = handle
+//!     .authenticate_keyboard_interactive_start(user, None /* submethods */)
+//!     .await?;
+//! loop {
+//!     match resp {
+//!         KeyboardInteractiveAuthResponse::Success => break, // authed
+//!         KeyboardInteractiveAuthResponse::Failure { .. } => /* fail */,
+//!         KeyboardInteractiveAuthResponse::InfoRequest { prompts, .. } => {
+//!             // prompts: Vec<Prompt { prompt: String, echo: bool }>
+//!             // echo == false => secret (OTP/password) -> mask in the UI.
+//!             // responses.len() MUST equal prompts.len().
+//!             let answers: Vec<String> = /* one per prompt, from the frontend */;
+//!             resp = handle
+//!                 .authenticate_keyboard_interactive_respond(answers)
+//!                 .await?;
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Why this is deferred and NOT blind-guessed:
+//!   * The handshake spans MULTIPLE Tauri command calls (one `InfoRequest`
+//!     round per `ssh_submit_otp` invocation), so the partially-authed `Handle`
+//!     must survive between calls. That needs a dedicated "pending sessions"
+//!     map in `SshState` (separate from the authed `sessions` map), created in
+//!     `ssh_connect` when `needs_otp` is detected.
+//!   * The frontend contract (how prompts are surfaced, how many rounds, how
+//!     cancel/timeout behave) isn't pinned down yet. Guessing the wiring would
+//!     bake in an API we'd have to break later.
+//!
+//! This stub compiles and returns an explicit "not yet implemented" error so
+//! the command is registerable today without committing to a half-built path.
+
+use serde::Deserialize;
+
+use super::state::SshState;
+
+/// One OTP/keyboard-interactive submission round from the frontend: the answers
+/// for the prompts most recently surfaced by the server.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OtpSubmission {
+    /// The pending (pre-auth) session id minted by `ssh_connect` when it
+    /// returned `needs_otp = true`.
+    pub pending_id: String,
+    /// One answer per prompt in the current `InfoRequest`, in order.
+    pub responses: Vec<String>,
+}
+
+/// Submit OTP / keyboard-interactive responses for a pending session.
+///
+/// TODO(OTP-wiring): implement the start/respond loop documented above against
+/// a pending-handle map in `SshState`. Until then this returns an explicit
+/// error rather than silently failing or guessing the wiring.
+#[tauri::command]
+pub async fn ssh_submit_otp(
+    submission: OtpSubmission,
+    _state: tauri::State<'_, SshState>,
+) -> Result<super::auth::ConnectResult, String> {
+    // Touch the fields so the (intentional) stub still type-checks the payload
+    // shape the frontend will send.
+    let _ = (&submission.pending_id, &submission.responses);
+    Err(
+        "ssh_submit_otp is not yet implemented: keyboard-interactive/OTP wiring \
+         (pending-handle map + start/respond loop) is a TODO. See src-tauri/src/ssh/otp.rs."
+            .to_string(),
+    )
+}

--- a/src-tauri/src/ssh/pty.rs
+++ b/src-tauri/src/ssh/pty.rs
@@ -1,0 +1,191 @@
+//! Native interactive PTY terminal over an established SSH session (mobile).
+//!
+//! This is SEPARATE from the desktop local-PTY at `src-tauri/src/pty.rs`: that
+//! one spawns a local shell via `portable-pty`; this one drives a remote shell
+//! over the existing russh connection so a phone with no Python sidecar gets a
+//! real interactive terminal.
+//!
+//! Byte flow:
+//!   * stdout/stderr from the remote shell are streamed to xterm.js via a typed
+//!     Tauri `Channel<Vec<u8>>` (NOT a WebSocket). A spawned tokio task drives
+//!     `ChannelReadHalf::wait()` and forwards every `Data`/`ExtendedData` chunk
+//!     into the channel with `onOutput.send(bytes)`.
+//!   * stdin / resize / close are plain `invoke()` commands that act on the
+//!     `ChannelWriteHalf` stored per-session.
+//!
+//! Concurrency (validated against vendored russh 0.54.5):
+//!   `Channel::wait()` is `&mut self` while `data()/window_change()/close()` are
+//!   `&self`. `Channel::split()` (`channels/mod.rs:445`) yields a `ChannelReadHalf`
+//!   (owns `wait`) and a `ChannelWriteHalf<Msg>` (owns the `&self` writers). The
+//!   read half is MOVED into the spawned reader task; the write half is stored
+//!   in the `SshSession` behind an `Arc` (no mutex needed — all methods `&self`).
+//!   This cleanly avoids the `&mut`/`&self` conflict without an mpsc funnel.
+//!
+//! Never panics across the Tauri boundary: every command returns
+//! `Result<_, String>` and maps transport errors to `Err(message)`.
+
+use tauri::ipc::Channel;
+
+use russh::ChannelMsg;
+
+use super::state::{PtyHandle, SshState};
+
+/// `SSH_EXTENDED_DATA_STDERR` — the `ext` discriminator for stderr bytes. The
+/// terminal merges stderr into the same xterm stream (a PTY conflates them).
+const SSH_EXTENDED_DATA_STDERR: u32 = 1;
+
+/// Open an interactive PTY + shell on an established session and start streaming
+/// its output into `on_output`.
+///
+/// Returns an opaque `channel_id` to pass to `ssh_pty_write/resize/close`.
+#[tauri::command]
+pub async fn ssh_pty_open(
+    session_id: String,
+    cols: u16,
+    rows: u16,
+    on_output: Channel<Vec<u8>>,
+    state: tauri::State<'_, SshState>,
+) -> Result<String, String> {
+    let session = state
+        .get(&session_id)
+        .await
+        .ok_or_else(|| format!("No such SSH session: {session_id}"))?;
+    if !session.is_alive() {
+        return Err(format!("SSH session {session_id} is no longer alive"));
+    }
+
+    // Open the channel under the auth-handle lock (channel_open_session is the
+    // only call that touches the handle; we drop the guard right after).
+    let channel = {
+        let handle = session.handle.lock().await;
+        handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("channel_open_session failed: {e}"))?
+    };
+
+    // Request a PTY then a shell. `want_reply: false` for the PTY (we don't wait
+    // on the per-request ack — matches the task spec); `true` for the shell so a
+    // failure surfaces synchronously here rather than as a silent dead channel.
+    channel
+        .request_pty(false, "xterm-256color", cols as u32, rows as u32, 0, 0, &[])
+        .await
+        .map_err(|e| format!("request_pty failed: {e}"))?;
+    channel
+        .request_shell(true)
+        .await
+        .map_err(|e| format!("request_shell failed: {e}"))?;
+
+    // Split into independent owners: read half -> reader task, write half -> map.
+    let (mut read_half, write_half) = channel.split();
+
+    // Spawn the byte pump. It owns `read_half` (`&mut self` wait) and the cloned
+    // Tauri channel. It runs until the remote closes (Eof/Close), `wait()`
+    // returns None, or the task is aborted by `ssh_pty_close`.
+    let reader = tokio::spawn(async move {
+        while let Some(msg) = read_half.wait().await {
+            match msg {
+                ChannelMsg::Data { data } => {
+                    if on_output.send(data.to_vec()).is_err() {
+                        break; // frontend channel gone — stop pumping.
+                    }
+                }
+                ChannelMsg::ExtendedData { data, ext } if ext == SSH_EXTENDED_DATA_STDERR => {
+                    if on_output.send(data.to_vec()).is_err() {
+                        break;
+                    }
+                }
+                // Remote finished / channel torn down: stop the pump.
+                ChannelMsg::Eof | ChannelMsg::Close => break,
+                // ExitStatus/ExitSignal/WindowAdjusted/etc: nothing to forward
+                // for a raw terminal byte stream.
+                _ => {}
+            }
+        }
+    });
+
+    let pty = PtyHandle {
+        write: std::sync::Arc::new(write_half),
+        reader: reader.abort_handle(),
+    };
+    let channel_id = session.insert_pty(pty).await;
+    Ok(channel_id)
+}
+
+/// Write stdin bytes to an open PTY channel.
+#[tauri::command]
+pub async fn ssh_pty_write(
+    session_id: String,
+    channel_id: String,
+    data: Vec<u8>,
+    state: tauri::State<'_, SshState>,
+) -> Result<(), String> {
+    let session = state
+        .get(&session_id)
+        .await
+        .ok_or_else(|| format!("No such SSH session: {session_id}"))?;
+    let write = session
+        .get_pty_write(&channel_id)
+        .await
+        .ok_or_else(|| format!("No such PTY channel: {channel_id}"))?;
+    // `data(R: AsyncRead + Unpin)` — a `&[u8]` implements that bound.
+    write
+        .data(&data[..])
+        .await
+        .map_err(|e| format!("pty write failed: {e}"))
+}
+
+/// Inform the remote of a terminal resize.
+#[tauri::command]
+pub async fn ssh_pty_resize(
+    session_id: String,
+    channel_id: String,
+    cols: u16,
+    rows: u16,
+    state: tauri::State<'_, SshState>,
+) -> Result<(), String> {
+    let session = state
+        .get(&session_id)
+        .await
+        .ok_or_else(|| format!("No such SSH session: {session_id}"))?;
+    let write = session
+        .get_pty_write(&channel_id)
+        .await
+        .ok_or_else(|| format!("No such PTY channel: {channel_id}"))?;
+    write
+        .window_change(cols as u32, rows as u32, 0, 0)
+        .await
+        .map_err(|e| format!("pty resize failed: {e}"))
+}
+
+/// Close an open PTY channel: send eof+close, abort the reader task (no leak),
+/// and drop it from the session map.
+#[tauri::command]
+pub async fn ssh_pty_close(
+    session_id: String,
+    channel_id: String,
+    state: tauri::State<'_, SshState>,
+) -> Result<(), String> {
+    let session = state
+        .get(&session_id)
+        .await
+        .ok_or_else(|| format!("No such SSH session: {session_id}"))?;
+    // Remove first so a concurrent write/resize can't resurrect a half-closed
+    // channel; we own the `PtyHandle` (and its reader AbortHandle) from here.
+    let pty = match session.remove_pty(&channel_id).await {
+        Some(p) => p,
+        // Already gone — idempotent close is not an error.
+        None => return Ok(()),
+    };
+
+    // Best-effort polite teardown; ignore errors (the channel may already be
+    // dead). Both are `&self` on the shared write half.
+    let _ = pty.write.eof().await;
+    let _ = pty.write.close().await;
+
+    // Stop the byte pump so the spawned task does not leak. The reader holds the
+    // only `ChannelReadHalf`; aborting it drops that and lets russh reclaim the
+    // channel even if the remote never sends Eof/Close.
+    pty.reader.abort();
+    Ok(())
+}

--- a/src-tauri/src/ssh/state.rs
+++ b/src-tauri/src/ssh/state.rs
@@ -27,6 +27,30 @@ use super::handler::MobileHandler;
 /// Aliased so the (verbose) generic `Handle<MobileHandler>` is written once.
 pub type SshHandle = russh::client::Handle<MobileHandler>;
 
+/// A partially-authenticated (in-flight) keyboard-interactive / OTP handshake.
+///
+/// The russh keyboard-interactive `respond` call is `&mut self` on the SAME
+/// `Handle` that `start` was called on, and the handshake can span MULTIPLE
+/// Tauri command calls (one `InfoRequest` round per `ssh_submit_otp`). So the
+/// mid-auth `Handle` itself must survive between commands — it is MOVED into
+/// this struct (never cloned) and moved back out by `take_pending` so the next
+/// round can drive it with `&mut`.
+pub struct PendingAuth {
+    /// The mid-auth russh handle (MOVED in/out — not shared, not cloned).
+    pub handle: SshHandle,
+    /// Remote host, carried so the live `SshSession` can be built once authed.
+    pub host: String,
+    /// Authenticated username, carried for the same reason.
+    pub username: String,
+}
+
+impl PendingAuth {
+    /// Construct a pending (mid-auth) handshake holder.
+    pub fn new(handle: SshHandle, host: String, username: String) -> Self {
+        Self { handle, host, username }
+    }
+}
+
 /// A single live SSH connection plus the metadata the frontend needs to render
 /// session state.
 ///
@@ -83,6 +107,13 @@ pub struct SshState {
     /// reference out of the map and drop the outer map lock before doing slow
     /// network I/O on the inner per-session `Mutex`.
     pub sessions: Mutex<HashMap<String, Arc<SshSession>>>,
+    /// pending_id (UUID v4) -> in-flight keyboard-interactive handshake.
+    ///
+    /// Separate from `sessions` because these handles are NOT yet authenticated
+    /// and are MOVED out (not `Arc`-shared) when the next OTP round drives them
+    /// with `&mut self`. Populated by `ssh_connect` on the first `InfoRequest`
+    /// round and drained by `ssh_submit_otp`.
+    pub pending: Mutex<HashMap<String, PendingAuth>>,
 }
 
 impl SshState {
@@ -106,5 +137,23 @@ impl SshState {
     #[allow(dead_code)]
     pub async fn remove(&self, session_id: &str) -> Option<Arc<SshSession>> {
         self.sessions.lock().await.remove(session_id)
+    }
+
+    /// Stash an in-flight keyboard-interactive handshake under a freshly-minted
+    /// `pending_id` and return that id. The `PendingAuth` (and the `Handle` it
+    /// owns) is MOVED into the map — it is not shared.
+    pub async fn insert_pending(&self, pending: PendingAuth) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.pending.lock().await.insert(id.clone(), pending);
+        id
+    }
+
+    /// Remove (and return ownership of) a pending handshake by id, if present.
+    ///
+    /// The `Handle` is MOVED out so the caller can drive its `&mut self`
+    /// `respond` method. A consumed `pending_id` is gone — a re-stash for the
+    /// next round mints a NEW id.
+    pub async fn take_pending(&self, pending_id: &str) -> Option<PendingAuth> {
+        self.pending.lock().await.remove(pending_id)
     }
 }

--- a/src-tauri/src/ssh/state.rs
+++ b/src-tauri/src/ssh/state.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
+use tokio::task::AbortHandle;
 
 use super::handler::MobileHandler;
 
@@ -26,6 +27,28 @@ use super::handler::MobileHandler;
 ///
 /// Aliased so the (verbose) generic `Handle<MobileHandler>` is written once.
 pub type SshHandle = russh::client::Handle<MobileHandler>;
+
+/// The concrete write-half type for an interactive PTY channel.
+///
+/// `russh::ChannelWriteHalf<S>` where `S = russh::client::Msg`. All of its I/O
+/// methods (`data` / `window_change` / `eof` / `close`) take `&self`, so it can
+/// be shared behind an `Arc` and driven from the `ssh_pty_write/resize/close`
+/// commands WITHOUT a mutex — the `&mut self` half (`wait()`) lives entirely in
+/// the spawned reader task (see `pty.rs`).
+pub type PtyWriteHalf = russh::ChannelWriteHalf<russh::client::Msg>;
+
+/// A live interactive PTY channel attached to a session.
+///
+/// Holds the write half (for `ssh_pty_write` / `ssh_pty_resize` / `ssh_pty_close`)
+/// plus the `AbortHandle` of the spawned reader task so `ssh_pty_close` can stop
+/// the byte pump WITHOUT leaking the task (it does not end on its own until the
+/// remote closes the channel).
+pub struct PtyHandle {
+    /// The russh channel write half (shared; `&self` methods, no lock needed).
+    pub write: Arc<PtyWriteHalf>,
+    /// Abort handle for the reader task forwarding bytes into the Tauri channel.
+    pub reader: AbortHandle,
+}
 
 /// A partially-authenticated (in-flight) keyboard-interactive / OTP handshake.
 ///
@@ -71,6 +94,12 @@ pub struct SshSession {
     /// Liveness flag. Set to `false` when a disconnect/error is observed so the
     /// command layer can prune dead sessions without racing the handle.
     pub alive: std::sync::atomic::AtomicBool,
+    /// Interactive PTY channels owned by this session, keyed by an opaque
+    /// `channel_id` (a v4 UUID minted by `ssh_pty_open`). Behind an async
+    /// `Mutex` so the `ssh_pty_*` commands can insert/lookup/remove from async
+    /// contexts. Distinct from `handle`: a PTY's write half is independent of
+    /// the auth handle's lock, so opening/using a PTY never blocks `ssh_exec`.
+    pub ptys: Mutex<HashMap<String, PtyHandle>>,
 }
 
 impl SshSession {
@@ -82,7 +111,28 @@ impl SshSession {
             username,
             connected_at: chrono::Utc::now().timestamp_millis(),
             alive: std::sync::atomic::AtomicBool::new(true),
+            ptys: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Register a freshly-opened PTY channel and return its opaque id.
+    pub async fn insert_pty(&self, pty: PtyHandle) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.ptys.lock().await.insert(id.clone(), pty);
+        id
+    }
+
+    /// Look up a PTY's write half by channel id, cloning the `Arc` so the outer
+    /// map lock is released before any network I/O.
+    pub async fn get_pty_write(&self, channel_id: &str) -> Option<Arc<PtyWriteHalf>> {
+        self.ptys.lock().await.get(channel_id).map(|p| p.write.clone())
+    }
+
+    /// Remove (and return) a PTY channel by id, if present. The caller is
+    /// responsible for aborting the returned reader task and tearing down the
+    /// channel.
+    pub async fn remove_pty(&self, channel_id: &str) -> Option<PtyHandle> {
+        self.ptys.lock().await.remove(channel_id)
     }
 
     /// Whether the session is still believed to be alive.

--- a/src-tauri/src/ssh/state.rs
+++ b/src-tauri/src/ssh/state.rs
@@ -1,0 +1,110 @@
+//! Tauri-managed SSH session registry.
+//!
+//! Holds every live russh client connection keyed by an opaque `session_id`
+//! (a v4 UUID minted at connect time). The whole thing is shared across Tauri
+//! commands via `app.manage(SshState::default())`.
+//!
+//! Concurrency model (from the russh API spike):
+//!   * `russh::client::Handle<H>` is BOTH `Send` AND `Sync` (verified in the
+//!     spike via `assert_send`/`assert_sync`), so it can live inside Tauri's
+//!     `State` without extra wrapping for *sharing*.
+//!   * BUT the auth methods and `Channel::wait()` are `&mut self`, so any code
+//!     that drives auth or reads an exec stream needs exclusive ownership. We
+//!     therefore wrap the `Handle` in a `tokio::sync::Mutex` (async mutex —
+//!     the guard is held across `.await`).
+//!   * The outer `sessions` map is itself behind a `tokio::sync::Mutex` so the
+//!     command layer can insert/lookup/remove sessions from async contexts.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use super::handler::MobileHandler;
+
+/// The concrete russh client handle type used throughout the SSH module.
+///
+/// Aliased so the (verbose) generic `Handle<MobileHandler>` is written once.
+pub type SshHandle = russh::client::Handle<MobileHandler>;
+
+/// A single live SSH connection plus the metadata the frontend needs to render
+/// session state.
+///
+/// `host`/`username`/`connected_at` are populated now and consumed by the
+/// session-listing command in a later step (not yet wired), so they are allowed
+/// to be currently-unread.
+#[allow(dead_code)]
+pub struct SshSession {
+    /// The russh client handle. Wrapped in an async `Mutex` because auth and
+    /// `Channel::wait()` are `&mut self` (see module docs).
+    pub handle: Mutex<SshHandle>,
+    /// Remote host this session is connected to (for display / logging).
+    pub host: String,
+    /// Authenticated username (for display / `bash -l` context).
+    pub username: String,
+    /// Unix-epoch milliseconds when the session was established.
+    pub connected_at: i64,
+    /// Liveness flag. Set to `false` when a disconnect/error is observed so the
+    /// command layer can prune dead sessions without racing the handle.
+    pub alive: std::sync::atomic::AtomicBool,
+}
+
+impl SshSession {
+    /// Construct a new session wrapper around a freshly-authenticated handle.
+    pub fn new(handle: SshHandle, host: String, username: String) -> Self {
+        Self {
+            handle: Mutex::new(handle),
+            host,
+            username,
+            connected_at: chrono::Utc::now().timestamp_millis(),
+            alive: std::sync::atomic::AtomicBool::new(true),
+        }
+    }
+
+    /// Whether the session is still believed to be alive.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Mark the session as dead (called on observed disconnect/error).
+    pub fn mark_dead(&self) {
+        self.alive
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Tauri-managed registry of all live SSH sessions.
+///
+/// Registered with `app.manage(SshState::default())` and accessed from commands
+/// via `tauri::State<'_, SshState>`.
+#[derive(Default)]
+pub struct SshState {
+    /// session_id (UUID v4) -> session. `Arc` so a command can clone the handle
+    /// reference out of the map and drop the outer map lock before doing slow
+    /// network I/O on the inner per-session `Mutex`.
+    pub sessions: Mutex<HashMap<String, Arc<SshSession>>>,
+}
+
+impl SshState {
+    /// Look up a session by id, cloning the `Arc` so the caller can release the
+    /// outer map lock immediately.
+    pub async fn get(&self, session_id: &str) -> Option<Arc<SshSession>> {
+        self.sessions.lock().await.get(session_id).cloned()
+    }
+
+    /// Insert a session under a freshly-generated id and return that id.
+    pub async fn insert(&self, session: Arc<SshSession>) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.sessions.lock().await.insert(id.clone(), session);
+        id
+    }
+
+    /// Remove (and return) a session by id, if present.
+    ///
+    /// Used by the disconnect command (a later step); kept here so the registry
+    /// API is complete.
+    #[allow(dead_code)]
+    pub async fn remove(&self, session_id: &str) -> Option<Arc<SshSession>> {
+        self.sessions.lock().await.remove(session_id)
+    }
+}

--- a/src/lib/api/transport/http.ts
+++ b/src/lib/api/transport/http.ts
@@ -82,6 +82,35 @@ class HttpTransport implements HpcTransport {
       return { stdout: ``, stderr: String(err), code: -1 }
     }
   }
+
+  // Interactive PTY is a mobile (russh) capability only. On desktop the existing
+  // terminal is driven by the local-PTY / Python path, not this transport, so
+  // these throw rather than pretend to stream.
+  async ptyOpen(
+    _sessionId: string,
+    _cols: number,
+    _rows: number,
+    _onData: (bytes: Uint8Array) => void,
+  ): Promise<string> {
+    throw new Error(`http transport: interactive PTY is not supported (mobile russh only)`)
+  }
+
+  async ptyWrite(_sessionId: string, _channelId: string, _data: Uint8Array): Promise<void> {
+    throw new Error(`http transport: interactive PTY is not supported (mobile russh only)`)
+  }
+
+  async ptyResize(
+    _sessionId: string,
+    _channelId: string,
+    _cols: number,
+    _rows: number,
+  ): Promise<void> {
+    throw new Error(`http transport: interactive PTY is not supported (mobile russh only)`)
+  }
+
+  async ptyClose(_sessionId: string, _channelId: string): Promise<void> {
+    // No-op: nothing to tear down on the HTTP path.
+  }
 }
 
 export const httpTransport: HpcTransport = new HttpTransport()

--- a/src/lib/api/transport/http.ts
+++ b/src/lib/api/transport/http.ts
@@ -45,9 +45,13 @@ class HttpTransport implements HpcTransport {
       connected: Boolean(res.session_id),
       sessionId: res.session_id ?? ``,
       // The HTTP/WS connect path signals OTP via a separate `auth_challenge`
-      // WS message handled in hpc.ts; this thin REST shim does not see it.
+      // WS message handled in hpc.ts; this thin REST shim does not see it, so
+      // the OTP fields below stay empty (the russh path owns real OTP wiring).
       needsOtp: res.type === `auth_challenge`,
       message: res.message ?? ``,
+      pendingId: ``,
+      prompts: [],
+      instructions: ``,
     }
   }
 

--- a/src/lib/api/transport/http.ts
+++ b/src/lib/api/transport/http.ts
@@ -1,0 +1,83 @@
+/**
+ * HTTP transport (desktop / browser).
+ *
+ * Thin wrapper that delegates to the EXISTING Python-backend HTTP endpoints —
+ * the same ones `hpc.ts` already uses. This is a minimal scaffold; it is NOT a
+ * full reimplementation of `hpc.ts` (the real WebSocket-driven connect/OTP flow
+ * still lives there). Its job is to satisfy the {@link HpcTransport} contract so
+ * the selection in `index.ts` type-checks and the mobile path has a desktop
+ * counterpart. Migrating the ~46 `hpc.ts` callers onto this is a later step.
+ */
+
+import { API_BASE } from '../config'
+import type {
+  HpcConnectConfig,
+  HpcConnectResult,
+  HpcExecResult,
+  HpcTransport,
+} from './index'
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: `POST`,
+    headers: { 'Content-Type': `application/json` },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ detail: response.statusText }))
+    throw new Error(err.detail || `Request failed: ${response.statusText}`)
+  }
+  return response.json() as Promise<T>
+}
+
+class HttpTransport implements HpcTransport {
+  readonly kind = 'http' as const
+
+  async connect(config: HpcConnectConfig): Promise<HpcConnectResult> {
+    // Delegate to the existing ssh-config connect endpoint. The Python backend
+    // owns the asyncssh session; the returned session_id is opaque to us.
+    const res = await postJson<{
+      type?: string
+      session_id?: string
+      message?: string
+    }>(`/hpc/connect/ssh-config`, config)
+    return {
+      connected: Boolean(res.session_id),
+      sessionId: res.session_id ?? ``,
+      // The HTTP/WS connect path signals OTP via a separate `auth_challenge`
+      // WS message handled in hpc.ts; this thin REST shim does not see it.
+      needsOtp: res.type === `auth_challenge`,
+      message: res.message ?? ``,
+    }
+  }
+
+  async submitOtp(_pendingId: string, _responses: string[]): Promise<HpcConnectResult> {
+    // OTP on the HTTP path is driven over the existing WebSocket in hpc.ts
+    // (`connectHPC(...).submit_otp`), not over REST. This shim does not own that
+    // socket, so it cannot complete the round-trip here.
+    throw new Error(
+      `http transport: submitOtp is handled by hpc.ts's WebSocket flow, not this shim`,
+    )
+  }
+
+  async exec(sessionId: string, cmd: string, timeoutMs?: number): Promise<HpcExecResult> {
+    // Best-effort delegation to a generic remote-exec endpoint. Kept minimal:
+    // never rejects on a remote failure — mirrors the never-throw contract.
+    try {
+      const res = await postJson<Partial<HpcExecResult>>(`/hpc/exec`, {
+        session_id: sessionId,
+        cmd,
+        timeout_ms: timeoutMs,
+      })
+      return {
+        stdout: res.stdout ?? ``,
+        stderr: res.stderr ?? ``,
+        code: typeof res.code === `number` ? res.code : -1,
+      }
+    } catch (err) {
+      return { stdout: ``, stderr: String(err), code: -1 }
+    }
+  }
+}
+
+export const httpTransport: HpcTransport = new HttpTransport()

--- a/src/lib/api/transport/index.ts
+++ b/src/lib/api/transport/index.ts
@@ -1,0 +1,98 @@
+/**
+ * HPC transport abstraction.
+ *
+ * Two interchangeable backends for reaching an HPC cluster:
+ *
+ *   1. `http`      — desktop / browser: the EXISTING behavior, where the
+ *                    Python backend (server/catgo/...) owns the asyncssh
+ *                    connection and the frontend talks to it over HTTP/WS.
+ *   2. `tauri-ssh` — mobile (iOS/Android): there is no Python sidecar, so the
+ *                    Rust `ssh` module (src-tauri/src/ssh) owns the russh
+ *                    connection and the frontend drives it via Tauri `invoke`.
+ *
+ * `transport` is selected once at module load by {@link isMobile}. This is a
+ * SCAFFOLD: it provides the interface, both impls, and the selection. The ~46
+ * existing `hpc.ts` callers are NOT migrated here yet — that is a later step.
+ */
+
+/** Authentication method for an SSH/HPC connection. */
+export type HpcAuthMethod = 'password' | 'publickey' | 'keyboard-interactive'
+
+/** Parameters for opening an HPC connection. */
+export interface HpcConnectConfig {
+  host: string
+  port?: number
+  username: string
+  method: HpcAuthMethod
+  /** Required when `method === 'password'`. */
+  password?: string
+  /** Path to the private key file when `method === 'publickey'`. */
+  keyPath?: string
+  /** Optional passphrase decrypting an encrypted private key. */
+  passphrase?: string
+}
+
+/** Result of a connect attempt. */
+export interface HpcConnectResult {
+  connected: boolean
+  /** Opaque session id used by subsequent `exec`/`submitOtp` calls. */
+  sessionId: string
+  /** True when the server requires a keyboard-interactive / OTP round-trip. */
+  needsOtp: boolean
+  /** Human-readable status / error message (empty on success). */
+  message: string
+}
+
+/** Result of a remote command. */
+export interface HpcExecResult {
+  stdout: string
+  stderr: string
+  /** Process exit code, or -1 on any transport/timeout error. */
+  code: number
+}
+
+/**
+ * A pluggable HPC transport. Both the HTTP (desktop) and Tauri-SSH (mobile)
+ * backends implement this exact surface so callers are backend-agnostic.
+ */
+export interface HpcTransport {
+  /** Human-readable transport id (`'http'` | `'tauri-ssh'`) for diagnostics. */
+  readonly kind: 'http' | 'tauri-ssh'
+
+  /** Open + authenticate an HPC connection. */
+  connect(config: HpcConnectConfig): Promise<HpcConnectResult>
+
+  /**
+   * Submit one round of keyboard-interactive / OTP responses for a connection
+   * that returned `needsOtp: true`.
+   */
+  submitOtp(pendingId: string, responses: string[]): Promise<HpcConnectResult>
+
+  /** Run a command on an established session. Never rejects on a *remote*
+   * failure — surfaces `{ code: -1, stderr }` instead. */
+  exec(sessionId: string, cmd: string, timeoutMs?: number): Promise<HpcExecResult>
+}
+
+/**
+ * Detect whether we are running on a mobile Tauri target (iOS / Android).
+ *
+ * NOTE: the spike suggested `@tauri-apps/api`'s `platform()`, but this project's
+ * `@tauri-apps/api` v2 does NOT export `platform()` (it lives in the separate,
+ * not-installed `@tauri-apps/plugin-os`). To avoid adding a dependency and to
+ * keep `tsc` clean, we detect mobile from the userAgent, which Tauri's mobile
+ * webviews populate with the platform string. Swap this for `plugin-os`'s
+ * `platform()` once that plugin is added (a later step).
+ */
+export function isMobile(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return /android|iphone|ipad|ipod/i.test(navigator.userAgent)
+}
+
+import { httpTransport } from './http'
+import { tauriSshTransport } from './tauri-ssh'
+
+/**
+ * The active transport, selected at module load: Tauri-SSH on mobile, HTTP
+ * everywhere else.
+ */
+export const transport: HpcTransport = isMobile() ? tauriSshTransport : httpTransport

--- a/src/lib/api/transport/index.ts
+++ b/src/lib/api/transport/index.ts
@@ -32,15 +32,33 @@ export interface HpcConnectConfig {
   passphrase?: string
 }
 
+/** A single keyboard-interactive / OTP prompt surfaced by the server. */
+export interface OtpPrompt {
+  /** Prompt text to render (e.g. "One-time password: "). */
+  prompt: string
+  /** Whether the typed answer should be echoed. `false` => mask as a secret
+   * (OTP / password). */
+  echo: boolean
+}
+
 /** Result of a connect attempt. */
 export interface HpcConnectResult {
   connected: boolean
   /** Opaque session id used by subsequent `exec`/`submitOtp` calls. */
   sessionId: string
-  /** True when the server requires a keyboard-interactive / OTP round-trip. */
+  /** True when the server requires a keyboard-interactive / OTP round-trip;
+   * drive {@link HpcTransport.submitOtp} with `pendingId` + answers to
+   * `prompts`. */
   needsOtp: boolean
   /** Human-readable status / error message (empty on success). */
   message: string
+  /** In-flight handshake id to pass to `submitOtp` (set only when `needsOtp`).
+   * Empty otherwise. */
+  pendingId: string
+  /** Prompts the user must answer this round (set only when `needsOtp`). */
+  prompts: OtpPrompt[]
+  /** Server-supplied instructions for this round (may be empty). */
+  instructions: string
 }
 
 /** Result of a remote command. */

--- a/src/lib/api/transport/index.ts
+++ b/src/lib/api/transport/index.ts
@@ -89,6 +89,29 @@ export interface HpcTransport {
   /** Run a command on an established session. Never rejects on a *remote*
    * failure — surfaces `{ code: -1, stderr }` instead. */
   exec(sessionId: string, cmd: string, timeoutMs?: number): Promise<HpcExecResult>
+
+  /**
+   * Open an interactive PTY + shell on an established session and stream its
+   * output bytes to `onData` (UTF-8-agnostic — pass straight to xterm.js).
+   *
+   * Resolves to an opaque `channelId` for {@link ptyWrite}/{@link ptyResize}/
+   * {@link ptyClose}. Mobile (tauri-ssh) only; the HTTP shim throws.
+   */
+  ptyOpen(
+    sessionId: string,
+    cols: number,
+    rows: number,
+    onData: (bytes: Uint8Array) => void,
+  ): Promise<string>
+
+  /** Write stdin bytes to an open PTY channel. */
+  ptyWrite(sessionId: string, channelId: string, data: Uint8Array): Promise<void>
+
+  /** Inform the remote of a terminal resize. */
+  ptyResize(sessionId: string, channelId: string, cols: number, rows: number): Promise<void>
+
+  /** Tear down an open PTY channel (idempotent). */
+  ptyClose(sessionId: string, channelId: string): Promise<void>
 }
 
 /**

--- a/src/lib/api/transport/tauri-ssh.ts
+++ b/src/lib/api/transport/tauri-ssh.ts
@@ -103,6 +103,53 @@ class TauriSshTransport implements HpcTransport {
     })
     return { stdout: r.stdout, stderr: r.stderr, code: r.code }
   }
+
+  async ptyOpen(
+    sessionId: string,
+    cols: number,
+    rows: number,
+    onData: (bytes: Uint8Array) => void,
+  ): Promise<string> {
+    // The Rust `ssh_pty_open` takes `on_output: tauri::ipc::Channel<Vec<u8>>`.
+    // A `Channel<Vec<u8>>` is serialized over IPC as a JSON array of integers,
+    // so each message arrives JS-side as `number[]` — normalize to `Uint8Array`
+    // before handing it to xterm.
+    const { Channel, invoke } = await import(`@tauri-apps/api/core`)
+    const ch = new Channel<number[] | Uint8Array | ArrayBuffer>()
+    ch.onmessage = (msg) => {
+      if (msg instanceof Uint8Array) onData(msg)
+      else if (msg instanceof ArrayBuffer) onData(new Uint8Array(msg))
+      else onData(Uint8Array.from(msg))
+    }
+    return invoke<string>(`ssh_pty_open`, {
+      sessionId,
+      cols,
+      rows,
+      onOutput: ch,
+    })
+  }
+
+  async ptyWrite(sessionId: string, channelId: string, data: Uint8Array): Promise<void> {
+    // Rust `data: Vec<u8>` deserializes from a JSON number array.
+    await invokeTauri<void>(`ssh_pty_write`, {
+      sessionId,
+      channelId,
+      data: Array.from(data),
+    })
+  }
+
+  async ptyResize(
+    sessionId: string,
+    channelId: string,
+    cols: number,
+    rows: number,
+  ): Promise<void> {
+    await invokeTauri<void>(`ssh_pty_resize`, { sessionId, channelId, cols, rows })
+  }
+
+  async ptyClose(sessionId: string, channelId: string): Promise<void> {
+    await invokeTauri<void>(`ssh_pty_close`, { sessionId, channelId })
+  }
 }
 
 export const tauriSshTransport: HpcTransport = new TauriSshTransport()

--- a/src/lib/api/transport/tauri-ssh.ts
+++ b/src/lib/api/transport/tauri-ssh.ts
@@ -1,0 +1,97 @@
+/**
+ * Tauri-SSH transport (mobile: iOS / Android).
+ *
+ * Drives the Rust `ssh` module (src-tauri/src/ssh) via Tauri `invoke`. On
+ * mobile there is no Python sidecar, so russh owns the SSH connection and these
+ * commands are the only path to the cluster.
+ *
+ * Commands (registered in src-tauri/src/lib.rs on BOTH desktop and mobile):
+ *   * `ssh_connect`    -> { connected, session_id, needs_otp, message }
+ *   * `ssh_exec`       -> { stdout, stderr, code }
+ *   * `ssh_submit_otp` -> (TODO stub: returns an explicit error for now)
+ */
+
+import type {
+  HpcConnectConfig,
+  HpcConnectResult,
+  HpcExecResult,
+  HpcTransport,
+} from './index'
+
+/** Lazily import the Tauri core so this module is importable in a browser
+ * (where the selection in index.ts will pick `http` anyway). */
+async function invokeTauri<T>(cmd: string, args: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import(`@tauri-apps/api/core`)
+  return invoke<T>(cmd, args)
+}
+
+/** Shape returned by the Rust `ssh_connect` / `ssh_submit_otp` commands. */
+interface RustConnectResult {
+  connected: boolean
+  session_id: string
+  needs_otp: boolean
+  message: string
+}
+
+/** Shape returned by the Rust `ssh_exec` command. */
+interface RustExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+/** Map the frontend connect config onto the Rust `ConnectConfig` (serde
+ * `#[serde(flatten)]` of the `method`-tagged `AuthConfig`). */
+function toRustConnectConfig(config: HpcConnectConfig): Record<string, unknown> {
+  return {
+    host: config.host,
+    port: config.port ?? 22,
+    username: config.username,
+    // Rust AuthConfig is an internally-tagged enum on `method` with lowercase
+    // variant names: "password" | "publickey" | "keyboard-interactive".
+    method: config.method,
+    password: config.password,
+    key_path: config.keyPath,
+    passphrase: config.passphrase,
+  }
+}
+
+function fromRustConnectResult(r: RustConnectResult): HpcConnectResult {
+  return {
+    connected: r.connected,
+    sessionId: r.session_id,
+    needsOtp: r.needs_otp,
+    message: r.message,
+  }
+}
+
+class TauriSshTransport implements HpcTransport {
+  readonly kind = 'tauri-ssh' as const
+
+  async connect(config: HpcConnectConfig): Promise<HpcConnectResult> {
+    const r = await invokeTauri<RustConnectResult>(`ssh_connect`, {
+      config: toRustConnectConfig(config),
+    })
+    return fromRustConnectResult(r)
+  }
+
+  async submitOtp(pendingId: string, responses: string[]): Promise<HpcConnectResult> {
+    // NOTE: the Rust side is a clearly-marked TODO stub and will reject with an
+    // explicit "not yet implemented" error until the OTP wiring lands.
+    const r = await invokeTauri<RustConnectResult>(`ssh_submit_otp`, {
+      submission: { pending_id: pendingId, responses },
+    })
+    return fromRustConnectResult(r)
+  }
+
+  async exec(sessionId: string, cmd: string, timeoutMs?: number): Promise<HpcExecResult> {
+    const r = await invokeTauri<RustExecResult>(`ssh_exec`, {
+      sessionId,
+      cmd,
+      timeoutMs: timeoutMs ?? null,
+    })
+    return { stdout: r.stdout, stderr: r.stderr, code: r.code }
+  }
+}
+
+export const tauriSshTransport: HpcTransport = new TauriSshTransport()

--- a/src/lib/api/transport/tauri-ssh.ts
+++ b/src/lib/api/transport/tauri-ssh.ts
@@ -6,9 +6,9 @@
  * commands are the only path to the cluster.
  *
  * Commands (registered in src-tauri/src/lib.rs on BOTH desktop and mobile):
- *   * `ssh_connect`    -> { connected, session_id, needs_otp, message }
+ *   * `ssh_connect`    -> { connected, session_id, needs_otp, pending_id, prompts, instructions, message }
  *   * `ssh_exec`       -> { stdout, stderr, code }
- *   * `ssh_submit_otp` -> (TODO stub: returns an explicit error for now)
+ *   * `ssh_submit_otp` -> same shape as ssh_connect (multi-round 2FA: respond, may return more prompts)
  */
 
 import type {
@@ -16,6 +16,7 @@ import type {
   HpcConnectResult,
   HpcExecResult,
   HpcTransport,
+  OtpPrompt,
 } from './index'
 
 /** Lazily import the Tauri core so this module is importable in a browser
@@ -25,12 +26,17 @@ async function invokeTauri<T>(cmd: string, args: Record<string, unknown>): Promi
   return invoke<T>(cmd, args)
 }
 
-/** Shape returned by the Rust `ssh_connect` / `ssh_submit_otp` commands. */
+/** Shape returned by the Rust `ssh_connect` / `ssh_submit_otp` commands. The
+ * OTP fields are `#[serde(skip_serializing_if = ...)]` on the Rust side, so they
+ * are absent (not `null`) on the non-OTP paths — hence optional here. */
 interface RustConnectResult {
   connected: boolean
   session_id: string
   needs_otp: boolean
   message: string
+  pending_id?: string
+  prompts?: OtpPrompt[]
+  instructions?: string
 }
 
 /** Shape returned by the Rust `ssh_exec` command. */
@@ -62,6 +68,9 @@ function fromRustConnectResult(r: RustConnectResult): HpcConnectResult {
     sessionId: r.session_id,
     needsOtp: r.needs_otp,
     message: r.message,
+    pendingId: r.pending_id ?? ``,
+    prompts: r.prompts ?? [],
+    instructions: r.instructions ?? ``,
   }
 }
 
@@ -76,8 +85,10 @@ class TauriSshTransport implements HpcTransport {
   }
 
   async submitOtp(pendingId: string, responses: string[]): Promise<HpcConnectResult> {
-    // NOTE: the Rust side is a clearly-marked TODO stub and will reject with an
-    // explicit "not yet implemented" error until the OTP wiring lands.
+    // The Rust `ssh_submit_otp(submission: OtpSubmission, ...)` command takes a
+    // single `submission` arg (serde-renamed `pending_id`). A `Success` reply
+    // yields a live `sessionId`; an `InfoRequest` reply yields `needsOtp: true`
+    // plus a fresh `pendingId`/`prompts` for the next multi-round 2FA step.
     const r = await invokeTauri<RustConnectResult>(`ssh_submit_otp`, {
       submission: { pending_id: pendingId, responses },
     })

--- a/src/lib/structure/MobileTerminalKeyBar.svelte
+++ b/src/lib/structure/MobileTerminalKeyBar.svelte
@@ -1,0 +1,169 @@
+<!--
+  MobileTerminalKeyBar.svelte — a horizontal, touch-sized key bar for the mobile
+  SSH terminal.
+
+  Soft keyboards on phones lack the keys a terminal needs (Esc, Tab, Ctrl,
+  arrows, page nav, and a few shell punctuation chars). This standalone bar emits
+  the raw escape sequences for them via `on_key(seq)`; the parent forwards `seq`
+  to `transport.ptyWrite(...)`.
+
+  STANDALONE: this component is intentionally NOT mounted anywhere yet — wiring it
+  into the terminal view is a later, careful step. It owns no transport/session
+  state; it is a pure input widget.
+
+  Ctrl is STICKY: tap it to arm, then the next single printable key is folded to
+  its control character (e.g. Ctrl then `c` -> 0x03). Arming auto-disarms after
+  one key, or toggles off on a second tap. Esc/Tab/arrows/etc. consume the armed
+  Ctrl too (they cancel it without emitting a control char of their own beyond
+  their normal sequence) to keep behavior predictable.
+-->
+<script lang="ts">
+  interface Props {
+    /** Emitted with the raw byte sequence (as a string) for the pressed key. */
+    on_key?: (seq: string) => void
+  }
+
+  let { on_key }: Props = $props()
+
+  const ESC = `\x1b`
+
+  // Sticky Ctrl modifier state.
+  let ctrl_armed = $state(false)
+
+  /** Map a printable key to its control char when Ctrl is armed. */
+  function to_control(ch: string): string | null {
+    if (ch.length !== 1) return null
+    const c = ch.toLowerCase()
+    const code = c.charCodeAt(0)
+    // Ctrl-A..Ctrl-Z -> 0x01..0x1a
+    if (code >= 97 && code <= 122) return String.fromCharCode(code - 96)
+    // A handful of standard non-letter control mappings.
+    switch (ch) {
+      case `@`:
+      case ` `:
+        return `\x00`
+      case `[`:
+        return `\x1b`
+      case `\\`:
+        return `\x1c`
+      case `]`:
+        return `\x1d`
+      case `^`:
+        return `\x1e`
+      case `_`:
+      case `/`:
+        return `\x1f`
+      default:
+        return null
+    }
+  }
+
+  function emit(seq: string): void {
+    on_key?.(seq)
+  }
+
+  /** A normal (printable or fixed-sequence) key. Honors armed Ctrl for 1 char. */
+  function press(seq: string): void {
+    if (ctrl_armed) {
+      ctrl_armed = false
+      const ctl = seq.length === 1 ? to_control(seq) : null
+      if (ctl !== null) {
+        emit(ctl)
+        return
+      }
+      // Non-control-mappable (e.g. Esc/arrow/Tab): just emit its own sequence.
+    }
+    emit(seq)
+  }
+
+  function toggle_ctrl(): void {
+    ctrl_armed = !ctrl_armed
+  }
+
+  /** Static, fixed-sequence keys (label + the bytes they send). */
+  interface KeyDef {
+    label: string
+    seq: string
+  }
+
+  const keys: KeyDef[] = [
+    { label: `Esc`, seq: ESC },
+    { label: `Tab`, seq: `\t` },
+    { label: `↑`, seq: `${ESC}[A` },
+    { label: `↓`, seq: `${ESC}[B` },
+    { label: `→`, seq: `${ESC}[C` },
+    { label: `←`, seq: `${ESC}[D` },
+    { label: `Home`, seq: `${ESC}[H` },
+    { label: `End`, seq: `${ESC}[F` },
+    { label: `PgUp`, seq: `${ESC}[5~` },
+    { label: `PgDn`, seq: `${ESC}[6~` },
+    { label: `|`, seq: `|` },
+    { label: `/`, seq: `/` },
+    { label: `~`, seq: `~` },
+    { label: `-`, seq: `-` },
+  ]
+</script>
+
+<div class="keybar" role="toolbar" aria-label="Terminal keys">
+  <button
+    type="button"
+    class="key ctrl"
+    class:armed={ctrl_armed}
+    aria-pressed={ctrl_armed}
+    onclick={toggle_ctrl}
+  >
+    Ctrl
+  </button>
+
+  {#each keys as k (k.label)}
+    <button type="button" class="key" onclick={() => press(k.seq)}>
+      {k.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .keybar {
+    display: flex;
+    flex-direction: row;
+    gap: 6px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 6px 8px;
+    background: var(--keybar-bg, #1e1e1e);
+    border-top: 1px solid var(--keybar-border, #333);
+    /* Keep the bar above an iOS home indicator / nav bar. */
+    padding-bottom: max(6px, env(safe-area-inset-bottom));
+    scrollbar-width: none;
+  }
+  .keybar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .key {
+    flex: 0 0 auto;
+    min-width: 44px; /* Apple HIG touch target. */
+    min-height: 40px;
+    padding: 0 12px;
+    font-size: 15px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--keybar-fg, #e0e0e0);
+    background: var(--key-bg, #2d2d2d);
+    border: 1px solid var(--key-border, #444);
+    border-radius: 8px;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .key:active {
+    background: var(--key-active-bg, #3d3d3d);
+  }
+
+  .key.ctrl.armed {
+    color: #fff;
+    background: var(--key-armed-bg, #0a84ff);
+    border-color: var(--key-armed-bg, #0a84ff);
+  }
+</style>


### PR DESCRIPTION
**Step 2** of the native mobile app: a russh SSH client in the Tauri core so the app can SSH to HPC with **no Python backend**. Built + validated on **desktop** (`cargo check` clean); the frontend will route to these commands on mobile. Stacks on #194.

## Backend — `src-tauri/src/ssh/`
- **`ssh_connect`**: `russh::client::connect` + persistent-TOFU server-key check + full **password** and **public-key** auth (`load_secret_key` + `PrivateKeyWithHashAlg`). Never throws across the boundary on a connection failure.
- **`ssh_exec`**: `bash -l -c` with POSIX shell-quoting, 30 s timeout, never throws (`code=-1`+stderr on error); drains `ChannelMsg` `Data`/`ExtendedData(stderr)`/`ExitStatus`/`ExitSignal` — ports the Python scheduler semantics.
- **`SshState`**: `tokio Mutex<HashMap<session_id, Arc<SshSession>>>`. russh's `Handle` is `Send+Sync`, so the Python event-loop-affinity machinery (`run_on_owner`/ControlMaster/subprocess) is **deleted** — much simpler.
- **Cargo**: `russh = "=0.54.5"` (pinned — avoids the **broken/yanked 0.54.6** and stays within `rust-version 1.77.2`), `russh-sftp`, `flate2`. Keys via **`russh::keys`** (the standalone `russh-keys` crate is obsolete). API confirmed against the **official russh docs/examples**.

## Security — persistent TOFU host-key pinning
Resolves the security review's accept-all **HIGH**. `MobileHandler::check_server_key` stores `{host:port → fingerprint}` in `ssh_known_hosts.json` under the app data dir (`0600`): **first-seen** pins+accepts, **known match** accepts, **MISMATCH rejects** (`Ok(false)`) and surfaces a clear possible-MITM message. Store-IO errors never block a connection; only a genuine mismatch refuses.

## Frontend scaffold — `src/lib/api/transport/`
`HpcTransport` interface + `http`/`tauri-ssh` impls + `isMobile()` selection. The ~46 `hpc.ts` callers are **not** migrated yet (later step).

## Deferred (clearly-marked TODOs — not blind-guessed)
OTP/keyboard-interactive wiring (needs a pending-handle map + frontend round-trip — the confirmed `authenticate_keyboard_interactive_start/respond` loop is documented in the spike), ProxyJump (`channel_open_direct_tcpip`), SFTP. **Password + public-key + exec are complete.**

## Validation
`cargo check`: Finished, zero errors. `tsc`: 6 (baseline). Automated tests can't reach a cluster / OTP, so the real-cluster check is manual — from the Tauri dev devtools console:

```js
const { invoke } = window.__TAURI__.core;
const conn = await invoke('ssh_connect', { config: {
  host:'login.expanse.sdsc.edu', port:22, username:'YOUR_USER',
  method:'password', password:'YOUR_PASSWORD' }});   // or method:'publickey', key_path:'~/.ssh/id_ed25519'
console.log(conn);   // expect { connected:true, session_id:'<uuid>', ... }
const r = await invoke('ssh_exec', { sessionId: conn.session_id,
  cmd:"echo HELLO from $(hostname); which sbatch squeue", timeoutMs:15000 });
console.log(r);      // expect { code:0, stdout:'HELLO from ...\n.../sbatch\n...' }
```
**Pass:** `conn.connected===true` + non-empty `session_id`; `r.code===0` and stdout resolves `sbatch`/`squeue` (proves the `bash -l -c` login shell loaded the module env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)