### PR TITLE
feat(vscode): right-click "Open with CatGo" + viewer language switch

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -35,6 +35,11 @@
         "command": "catgo.report_bug",
         "title": "Report Bug",
         "category": "CatGo"
+      },
+      {
+        "command": "catgo.open_with_catgo",
+        "title": "Open with CatGo",
+        "category": "CatGo"
       }
     ],
     "keybindings": [
@@ -48,8 +53,9 @@
     "menus": {
       "explorer/context": [
         {
-          "command": "catgo.render_structure",
-          "when": "catgo.supported_resource"
+          "command": "catgo.open_with_catgo",
+          "group": "navigation@99",
+          "when": "!explorerResourceIsFolder && (resourceFilename =~ /\\.(cif|mcif|mmcif|poscar|vasp|lmp|lammps|lammpstrj|data|dump|pdb|mol|mol2|sdf|inp|restart|traj|xtc|trr|dcd|xyz|extxyz|cube|cub|h5|hdf5)(\\.(gz|bz2|xz|zst))?$/i || resourceFilename =~ /(^|[._-])(poscar|contcar|potcar|incar|kpoints|outcar|xdatcar|chgcar|chgdiff|aeccar|locpot|elfcar|parchg)([._-]|$)/i || resourceFilename =~ /vasprun.*\\.xml$/i)"
         }
       ]
     },
@@ -91,6 +97,21 @@
           ],
           "default": "auto",
           "description": "Theme for CatGo visualizations. 'auto' follows VSCode's theme."
+        },
+        "catgo.language": {
+          "type": "string",
+          "enum": [
+            "system",
+            "en",
+            "zh"
+          ],
+          "enumDescriptions": [
+            "Follow VS Code's display language",
+            "English",
+            "中文 (Chinese)"
+          ],
+          "default": "system",
+          "description": "Language for the CatGo viewer UI. 'system' follows VS Code's display language."
         },
         "catgo.auto_render": {
           "type": "boolean",

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -62,6 +62,7 @@ interface WebviewData {
   type: `trajectory` | `structure`
   data: FileData
   theme: ThemeName
+  locale?: `en` | `zh` // webview UI language (resolved from catgo.language)
   defaults?: DefaultSettings
   wasm_binary?: string // base64-encoded ferrox WASM binary
   moyo_wasm_binary?: string // base64-encoded moyo WASM binary
@@ -224,6 +225,15 @@ export const get_file = async (uri?: vscode.Uri): Promise<FileData> => {
   )
 }
 
+// Resolve the webview UI language from the `catgo.language` setting.
+// 'system' (default) follows VS Code's display language (vscode.env.language,
+// e.g. "zh-cn"); otherwise the explicit 'en'/'zh' choice wins.
+export const get_locale = (): `en` | `zh` => {
+  const pref = vscode.workspace.getConfiguration(`catgo`).get<string>(`language`, `system`)
+  if (pref === `en` || pref === `zh`) return pref
+  return /^zh\b/i.test(vscode.env.language) ? `zh` : `en`
+}
+
 // Detect VSCode theme and user preference
 export const get_theme = (): ThemeName => {
   const config = vscode.workspace.getConfiguration(`catgo`)
@@ -330,6 +340,7 @@ export const create_html = (
   const data_with_wasm: WebviewData & { server_port?: number } = {
     ...data,
     server_port: get_server_port() ?? undefined,
+    locale: data.locale ?? get_locale(),
   }
   try {
     const assets_dir = path.join(context.extensionUri.fsPath, `dist`, `assets`)
@@ -957,6 +968,13 @@ export const activate = (context: vscode.ExtensionContext) => {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       `catgo.render_structure`,
+      (uri?: vscode.Uri) => render(context, uri),
+    ),
+    // Explorer right-click "Open with CatGo" — render the clicked file directly
+    // from disk (no need to open it in an editor first). Explorer context menu
+    // passes the clicked resource URI as the first arg.
+    vscode.commands.registerCommand(
+      `catgo.open_with_catgo`,
       (uri?: vscode.Uri) => render(context, uri),
     ),
     vscode.commands.registerCommand(

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -24,6 +24,7 @@ import { parse_cube_header, cube_atoms_to_molecule } from '$lib/cube/parse-cube'
 import { chgcar_to_cube } from '$lib/electronic/chgdiff-wasm'
 import Structure from '$lib/structure/Structure.svelte'
 import { apply_theme_to_dom, is_valid_theme_name, type ThemeName } from '$lib/theme/index'
+import { set_locale } from '$lib/i18n/index.svelte'
 import '$lib/theme/themes'
 import { ensure_ferrox_wasm_ready } from '$lib/structure/ferrox-wasm'
 import { ensure_moyo_wasm_ready } from '$lib/symmetry'
@@ -52,6 +53,7 @@ export interface CatGoData {
   type: ViewType
   data: FileData
   theme: ThemeName
+  locale?: `en` | `zh` // webview UI language, resolved from catgo.language by the extension
   defaults?: DefaultSettings
   wasm_binary?: string // base64-encoded ferrox WASM binary from extension
   moyo_wasm_binary?: string // base64-encoded moyo WASM binary from extension
@@ -787,6 +789,17 @@ async function initialize() {
 
   // Apply theme early
   if (theme) apply_theme_to_dom(theme)
+
+  // Apply UI language before components mount, so t() resolves in the chosen
+  // locale instead of the webview's navigator.language (always 'en' here).
+  const locale = catgo_data?.locale
+  if (locale) {
+    try {
+      await set_locale(locale)
+    } catch (err) {
+      console.warn(`[CatGO Webview] Failed to set locale "${locale}":`, err)
+    }
+  }
 
   // Initialize ferrox WASM with binary data if provided by extension
   if (wasm_binary) {

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -19,6 +19,7 @@
   import Select from 'svelte-multiselect'
   import { tooltip } from 'svelte-multiselect/attachments'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import LocaleSwitch from '$lib/i18n/LocaleSwitch.svelte'
 
   // Lazy-load structure translations
   load_i18n_module('structure')
@@ -76,6 +77,13 @@
     pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
     toggle_props?: ComponentProps<typeof DraggablePane>[`toggle_props`]
   } = $props()
+
+  // Only the VS Code / Antigravity extension webview sets `window.catgoData`
+  // (injected by the extension's create_html). The desktop app and web build
+  // don't, and they already expose a language switch in the top bar. So show
+  // the in-panel language switch only inside the extension viewer.
+  const in_vscode_webview = typeof window !== `undefined` &&
+    !!(window as { catgoData?: unknown }).catgoData
 
   // Color scheme selection state
   let color_scheme_selected = $state([color_scheme])
@@ -210,6 +218,14 @@
   }}
   {...rest}
 >
+  {#if in_vscode_webview}
+    <!-- Language switch (extension webview only — desktop/web use the top bar) -->
+    <div style="display: flex; align-items: center; gap: 8px; padding: 4px 2px 8px;">
+      <span style="opacity: 0.7;">🌐</span>
+      <LocaleSwitch style="flex: 1;" />
+    </div>
+  {/if}
+
   {#if !check_tauri()}
     <!-- Backend connection (web mode only — desktop Tauri uses the bundled sidecar) -->
     <div class="backend-connect-section">


### PR DESCRIPTION
Three UX additions to the VS Code / Antigravity extension. All changes are scoped to the extension — the desktop/web app is unchanged.

## ✨ Changes
1. **Explorer right-click → "Open with CatGo"** — new `catgo.open_with_catgo` command renders the clicked file straight from disk (no need to open it in an editor first). The menu's `when` now matches the **clicked** file via a filename regex over supported structure/trajectory types, replacing the old entry that keyed off the active editor.
2. **Viewer UI language** — new `catgo.language` setting (`system` | `en` | `zh`). `system` follows VS Code's display language (`vscode.env.language`); the extension injects the resolved `locale` into the webview, which calls `set_locale()` before mount. (The webview's `navigator.language` is always `en`, so the UI was stuck in English.)
3. **In-panel language switch** — `StructureControls` shows a `LocaleSwitch` dropdown, gated on `window.catgoData` so it only appears in the extension webview (desktop/web already have the top-bar switch).

## Files
- `extensions/vscode/package.json` — `open_with_catgo` command + explorer/context menu + `catgo.language` config
- `extensions/vscode/src/extension.ts` — register command + `get_locale()` + inject `locale`
- `extensions/vscode/src/webview/main.ts` — apply `locale` via `set_locale()` at init
- `src/lib/structure/StructureControls.svelte` — webview-only `LocaleSwitch`

## Notes / out of scope
- WebGPU **large-system mode** stays unavailable in the webview: Electron webviews can't obtain a WebGPU adapter (`requestAdapter()` → null). Large structures still render via the WebGL path; only the GPU-accelerated toggle is disabled.
- Verified locally by building a vsix and installing into Antigravity: right-click menu appears on supported files, language switch works live.
- Extension version unchanged here; CI syncs it from the root `package.json` at publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)