### PR TITLE
chore(release): v1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump to 1.1.6. Bundles the slab oxygen fix (#201), terminal font fix (#199), and AppImage sidecar fix (#200). Merging then tagging `v1.1.6` triggers the desktop release build (Win/macOS/Linux, fresh wasm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)