### PR TITLE
fix(mobile): hide terminal entry on mobile web, point users to the app

### DIFF
--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -15,6 +15,7 @@ const mobile: Record<string, string> = {
   choice_database_desc:   `Search OPTIMADE / Materials Project / PubChem`,
   choice_connect_main:    `Connect to cluster`,
   choice_connect_desc:    `SSH terminal + remote files`,
+  connect_app_only:       `Open the CatGo app to use the terminal — the browser can't open SSH`,
 
   // ── Top bar (MobileWorkspace) ────────────────────────────────────────
   tab_structure:          `Structure`,

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -15,6 +15,7 @@ const mobile: Record<string, string> = {
   choice_database_desc:   `搜索 OPTIMADE / Materials Project / PubChem`,
   choice_connect_main:    `连接到集群`,
   choice_connect_desc:    `SSH 终端 + 远程文件`,
+  connect_app_only:       `请用 CatGo App 使用终端 — 浏览器无法建立 SSH 连接`,
 
   // ── 顶部操作栏 (MobileWorkspace) ─────────────────────────────────────
   tab_structure:          `结构`,

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -29,12 +29,19 @@
   import MobileFiles from './MobileFiles.svelte'
   import KeySetup from './KeySetup.svelte'
   import { loadConnections } from './connections'
+  import { check_tauri } from '$lib/io/tauri'
   import LocaleSwitch from '$lib/i18n/LocaleSwitch.svelte'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module(`mobile`)
 
   type Mode = `choose` | `structure` | `terminal` | `split-h` | `split-v`
+
+  // Mobile WEB (iPhone/Android browser) vs the native app. The terminal needs
+  // the russh transport, which only exists inside the Tauri app (the browser
+  // can't open raw TCP for SSH). On web we hide the terminal entry + layouts and
+  // tell the user to use the app.
+  const is_web = !check_tauri()
 
   let mode = $state<Mode>(`choose`)
   let session_id = $state<string | null>(null)
@@ -194,7 +201,7 @@
     session_id = null
     ks_visible = false
     files_open = false
-    if (!has_content) mode = `terminal`
+    if (!has_content) mode = is_web ? `choose` : `terminal`
   }
 
   function on_connected(id: string): void {
@@ -250,20 +257,30 @@
         <span class="mw-choice-main">{t(`mobile.choice_database_main`)}</span>
         <span class="mw-choice-desc">{t(`mobile.choice_database_desc`)}</span>
       </button>
-      <button type="button" class="mw-choice" onclick={() => (mode = `terminal`)}>
-        <span class="mw-choice-icon">⌨</span>
-        <span class="mw-choice-main">{t(`mobile.choice_connect_main`)}</span>
-        <span class="mw-choice-desc">{t(`mobile.choice_connect_desc`)}</span>
-      </button>
+      {#if is_web}
+        <div class="mw-choice mw-choice-disabled" aria-disabled="true">
+          <span class="mw-choice-icon">⌨</span>
+          <span class="mw-choice-main">{t(`mobile.choice_connect_main`)}</span>
+          <span class="mw-choice-desc">{t(`mobile.connect_app_only`)}</span>
+        </div>
+      {:else}
+        <button type="button" class="mw-choice" onclick={() => (mode = `terminal`)}>
+          <span class="mw-choice-icon">⌨</span>
+          <span class="mw-choice-main">{t(`mobile.choice_connect_main`)}</span>
+          <span class="mw-choice-desc">{t(`mobile.choice_connect_desc`)}</span>
+        </button>
+      {/if}
     </div>
   {:else}
     <!-- Top bar: layout switch + actions -->
     <header class="mw-bar">
       <div class="mw-tabs">
         <button type="button" class:active={mode === `structure`} onclick={() => (mode = `structure`)} title={t(`mobile.tab_structure`)}>⬚</button>
-        <button type="button" class:active={mode === `split-v`} onclick={() => (mode = `split-v`)} title={t(`mobile.tab_split_stacked`)}>⊟</button>
-        <button type="button" class:active={mode === `split-h`} onclick={() => (mode = `split-h`)} title={t(`mobile.tab_split_side`)}>⊞</button>
-        <button type="button" class:active={mode === `terminal`} onclick={() => (mode = `terminal`)} title={t(`mobile.tab_terminal`)}>▭</button>
+        {#if !is_web}
+          <button type="button" class:active={mode === `split-v`} onclick={() => (mode = `split-v`)} title={t(`mobile.tab_split_stacked`)}>⊟</button>
+          <button type="button" class:active={mode === `split-h`} onclick={() => (mode = `split-h`)} title={t(`mobile.tab_split_side`)}>⊞</button>
+          <button type="button" class:active={mode === `terminal`} onclick={() => (mode = `terminal`)} title={t(`mobile.tab_terminal`)}>▭</button>
+        {/if}
       </div>
       <div class="mw-actions">
         <LocaleSwitch />
@@ -417,6 +434,14 @@
   }
   .mw-choice:active {
     border-color: var(--accent-color, #3b82f6);
+  }
+  /* Mobile web: terminal entry shown but inert — the browser can't do SSH. */
+  .mw-choice-disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+  .mw-choice-disabled:active {
+    border-color: rgba(255, 255, 255, 0.12);
   }
   .mw-choice-icon {
     font-size: 22px;


### PR DESCRIPTION
## Problem
On iPhone/Android **Safari (web)**, the mobile UI shows a **Terminal / Connect to cluster** entry, but it can never connect: the terminal uses the russh transport (`transport = tauriSshTransport`), which only exists inside the native Tauri app. A plain browser can't open raw TCP for SSH, so tapping it silently fails.

## Fix
Distinguish mobile **web** from the native app via `is_web = !check_tauri()` (we're already inside the `isMobile()` gate). On mobile web:

- the **"Connect to cluster"** chooser entry is rendered **disabled** with a *"use the CatGo app"* hint, instead of switching to terminal mode;
- the **split / terminal** layout tabs are hidden (structure-only);
- `disconnect()` falls back to the chooser, not terminal mode.

The **native app** (`check_tauri() === true`) is **unchanged** — `is_web` is false there, so terminal/split/connect all behave exactly as before.

Adds `connect_app_only` i18n string (en + zh).

## Scope
- `src/lib/mobile/MobileWorkspace.svelte`
- `src/lib/i18n/en/mobile.ts`, `src/lib/i18n/zh/mobile.ts`

## Verification
- `pnpm check` (svelte-check): touched files clean (0 new errors; the repo's 6 pre-existing errors are in untouched files).
- Confirmed separately that the unrelated "DB search Failed to fetch" some saw in `pnpm dev` is a dev-only artifact (no Python backend + desktop UA), not affected by this change — the CORS relay returns 200 from a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)