### PR TITLE
feat(mobile): add a Delete button to the touch toolbar

### DIFF
--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -922,6 +922,8 @@ const structure: Record<string, string> = {
   touch_box_select_hint: `Box-select mode: drag to select atoms (replaces Ctrl/Cmd-drag)`,
   touch_move_atoms_hint: `Move mode: drag to move selected atoms (replaces Shift+Alt-drag)`,
   touch_rotate_atoms_hint: `Rotate mode: drag to rotate selected atoms (replaces Shift-drag)`,
+  touch_delete_atoms: `Delete`,
+  touch_delete_atoms_hint: `Delete the selected atoms (replaces the Delete key)`,
   add_atoms: `Add single atoms`,
   add_fragments: `Add molecular fragments`,
   fragments: `Fragments`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -922,6 +922,8 @@ const structure: Record<string, string> = {
   touch_box_select_hint: `框选模式：拖拽框选原子（替代 Ctrl/Cmd 拖拽）`,
   touch_move_atoms_hint: `移动模式：拖拽移动选中原子（替代 Shift+Alt 拖拽）`,
   touch_rotate_atoms_hint: `旋转模式：拖拽旋转选中原子（替代 Shift 拖拽）`,
+  touch_delete_atoms: `删除`,
+  touch_delete_atoms_hint: `删除选中的原子（替代 Delete 键）`,
   add_atoms: `添加单个原子`,
   add_fragments: `添加分子片段`,
   fragments: `片段`,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2984,6 +2984,7 @@
       bind:current_continuous_measurement_sites={meas_state.current_continuous_measurement_sites}
       {reset_camera}
       {delete_measurement}
+      delete_selected_atoms={() => gesture_api.delete_selected()}
     >
       {#if !hide_extra_tools}
         <BuildPane

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -85,6 +85,7 @@
     // ── 回调函数 ──
     reset_camera = () => {},
     delete_measurement = (_id: string) => {},
+    delete_selected_atoms = () => {},
     on_popout_chat = undefined as (() => void) | undefined,
 
     // ── 子组件 snippet (面板组件从 Structure.svelte 传入) ──
@@ -141,6 +142,7 @@
     // 回调
     reset_camera?: () => void
     delete_measurement?: (id: string) => void
+    delete_selected_atoms?: () => void
     on_popout_chat?: () => void
 
     // 子组件 snippet
@@ -281,6 +283,16 @@
             onclick={() => interaction.touch_mode = interaction.touch_mode === `rotate` ? `none` : `rotate`}
           >{t('structure.touch_rotate_atoms')}</button>
           <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.touch_rotate_atoms_hint')}</span>
+        </span>
+        <span class="struct-toolbar-tooltip-wrap">
+          <button
+            type="button"
+            class="touch-mode-toggle touch-delete"
+            disabled={selected_sites.length === 0}
+            aria-label={t('structure.touch_delete_atoms')}
+            onclick={() => delete_selected_atoms()}
+          >{t('structure.touch_delete_atoms')}</button>
+          <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.touch_delete_atoms_hint')}</span>
         </span>
       </div>
     {/if}
@@ -988,6 +1000,14 @@
     color: var(--accent-color, #007acc);
     border-color: var(--accent-color, #007acc);
     background-color: color-mix(in srgb, var(--accent-color, #007acc) 18%, transparent);
+  }
+  .touch-mode-toggle.touch-delete:not(:disabled) {
+    color: var(--error-color, #ef4444);
+    border-color: color-mix(in srgb, var(--error-color, #ef4444) 45%, transparent);
+  }
+  .touch-mode-toggle:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
 
   /* === 手势控制切换 === */


### PR DESCRIPTION
## Problem
On a phone, the mobile workspace mounts the real structure editor, but there's **no way to delete atoms**: desktop deletes via the **Delete/Backspace key**, and mobile has no keyboard and no delete UI.

## Fix
Add a **🗑 Delete** button to the touch-mode toolbar row (alongside box / move / rotate). It's enabled only when atoms are selected and calls the existing `gesture_api.delete_selected()` — the same sparse-undo path used by the Delete key and the context menu, so undo and bond-reindex behave identically. No new delete logic, just a touch entry point.

Adds `touch_delete_atoms` (+ hint) i18n strings (en + zh). Red tint + disabled-dim styling.

## Scope
- `src/lib/structure/StructureToolbar.svelte` (button + prop + CSS)
- `src/lib/structure/Structure.svelte` (wire `delete_selected_atoms={() => gesture_api.delete_selected()}`)
- `src/lib/i18n/en/structure.ts`, `src/lib/i18n/zh/structure.ts`

Desktop is unaffected — the touch toolbar only renders on touch devices (`has_touch`).

## Verification
`pnpm check` (svelte-check): touched files clean — 0 new errors (repo's 6 pre-existing errors are in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)