### PR TITLE
fix(viewer): always rotate around the structure center, even after panning

### DIFF
--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -1075,6 +1075,32 @@
     })
   }
 
+  // Keep the rotation pivot locked to the structure's geometric center.
+  //
+  // TrackballControls couples pan and rotation: a pan translates BOTH the camera
+  // and `target`, so after panning, `target` no longer sits at the structure
+  // center and subsequent rotation orbits the panned point — the structure
+  // visibly swings in an arc instead of spinning about its own center.
+  //
+  // We re-pin `target` to the structure center (get_rotation_center → lattice-box
+  // center for periodic, atom centroid for molecules) after every camera change.
+  // The camera is left where it is, so a pan becomes a pure camera translation
+  // (the view still shifts) while rotation always pivots about the structure
+  // center. Rotation itself never moves `target`, so this only corrects pan.
+  function pin_target_to_center() {
+    untrack(() => {
+      if (!orbit_controls?.target || !structure) return
+      const c = rotation_target
+      if (!c) return
+      const dx = orbit_controls.target.x - c[0]
+      const dy = orbit_controls.target.y - c[1]
+      const dz = orbit_controls.target.z - c[2]
+      // Skip when already centered (rotation/zoom) to avoid disturbing damping.
+      if (dx * dx + dy * dy + dz * dz < 1e-10) return
+      orbit_controls.target.set(c[0], c[1], c[2])
+    })
+  }
+
   // Set camera.up to Z-axis once camera + controls are both ready.
   // MUST be declared BEFORE the orbit target effect below — Svelte 5 fires effects
   // in declaration order, and orbit_controls.update() calls camera.lookAt() which
@@ -4263,6 +4289,7 @@
     },
     onend: () => {
       camera_is_moving = false
+      pin_target_to_center()
       snapshot_view()
       // Sync reset reference points with current state after every camera operation
       // This prevents Ctrl+click or any other operation from snapping back to an old position
@@ -4282,6 +4309,7 @@
       }
     },
     onchange: () => {
+      pin_target_to_center()
       snapshot_view()
       // Continuously sync reset reference points during camera movement
       // TrackballControls uses _target0, _eye0, and _up0 as reset reference points


### PR DESCRIPTION
## Problem
Rotating a structure doesn't pivot around its center once the structure has been panned away from the screen center — it swings in an arc instead of spinning in place. Reported on mobile (one-finger rotate after a two-finger pan); the same coupling affects desktop middle-drag pan.

**Root cause:** TrackballControls couples pan and rotation. A pan translates **both** the camera and `target`, and rotation orbits `target`. So after a pan, `target` no longer sits at the structure center, and rotation orbits the panned point. (The code already documents this: `StructureScene.svelte` onchange/onend continuously sync `_target0` to the panned target.)

## Fix
Re-pin `orbit_controls.target` to the structure center — `get_rotation_center(structure)`, which is the **lattice-box center for periodic bulk** and the **atom centroid for molecules** — in the controls' `onchange`/`onend` hooks. The camera is left where it is, so:
- a **pan** becomes a pure camera translation (the view still shifts);
- **rotation always pivots about the structure center** (bulk → box center, molecule → centroid).

## Why it's safe for normal rotation
Pure rotation never moves `target`, and an epsilon guard (`drift² < 1e-10`) skips the re-pin when already centered. So when the view hasn't been panned, rotation is **byte-identical** to before — only the post-pan pivot drift is corrected.

## Scope
- `src/lib/structure/StructureScene.svelte` — adds `pin_target_to_center()`, called from the existing `onchange`/`onend` TrackballControls hooks.

## Verification
- `pnpm check` (svelte-check): StructureScene clean — 0 new errors (repo's 6 pre-existing errors are in untouched files).
- Loaded a structure in dev + confirmed no runtime errors from the new code path.
- ⚠️ **Needs on-device confirmation**: pan-then-rotate on a phone (bulk pivots about box center; molecule about its centroid). The change is isolated and trivially revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)