### PR TITLE
feat(viewer): default to cell-edge stub bonds (VESTA mode), stub 0.15

### DIFF
--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -115,12 +115,12 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       description: `Color for bonds (hex color code)`,
     },
     incomplete_periodic_edge_mode: {
-      value: false,
+      value: true,
       description:
         `Render cross-cell bonds as a single stub on atom A's side instead of paired stubs (VESTA Mode 1)`,
     },
     incomplete_edge_length_scale: {
-      value: 0.5,
+      value: 0.15,
       description:
         `Length of the visible stub for cross-cell bonds in incomplete-edge mode (fraction of half-bond length)`,
       minimum: 0.05,


### PR DESCRIPTION
Change initial viewer bond defaults:
- `incomplete_periodic_edge_mode`: false → **true** (cross-cell bonds render as single cell-edge stubs, VESTA mode 1)
- `incomplete_edge_length_scale`: 0.5 → **0.15** (shorter stub)

Bonding strategy stays **Solid Angle** (already the default — no change).

These are `src/lib/settings/config.ts` defaults → apply to a fresh install on all platforms; existing users keep saved settings. Requested for the mobile app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)