### PR TITLE
chore(mobile): bump version to 1.1.7 for the Android build

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Bump tauri.conf.json version 1.1.6 → 1.1.7 for the new sideload APK (carries #204 delete, #207 rotate-around-center, #208 stub-bond defaults). Mobile-only build; no desktop release tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)