### PR TITLE
feat(mobile-ssh): support a jump host (ProxyJump) on the russh transport

### DIFF
--- a/src-tauri/src/ssh/auth.rs
+++ b/src-tauri/src/ssh/auth.rs
@@ -11,6 +11,7 @@
 //! and return `needs_otp = true` + `pending_id` + `prompts`; the response
 //! rounds are driven by [`super::otp::ssh_submit_otp`].
 
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -21,7 +22,7 @@ use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse, Prompt};
 use russh::keys::{load_secret_key, HashAlg, PrivateKeyWithHashAlg};
 
 use super::handler::MobileHandler;
-use super::state::{PendingAuth, SshSession, SshState};
+use super::state::{PendingAuth, PendingStage, SshHandle, SshSession, SshState, TargetPlan};
 
 /// One keyboard-interactive / OTP prompt surfaced to the frontend.
 ///
@@ -65,6 +66,20 @@ pub enum AuthConfig {
     KeyboardInteractive,
 }
 
+/// Optional jump host (ProxyJump / bastion) to tunnel through before reaching
+/// the target. Authenticated first; then a `direct-tcpip` channel to the target
+/// carries the target's SSH handshake. The jump may itself need any auth method
+/// (password / public-key / keyboard-interactive OTP), independent of the target.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JumpConfig {
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    pub username: String,
+    #[serde(flatten)]
+    pub auth: AuthConfig,
+}
+
 /// Connection request from the frontend.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConnectConfig {
@@ -74,6 +89,9 @@ pub struct ConnectConfig {
     pub username: String,
     #[serde(flatten)]
     pub auth: AuthConfig,
+    /// Optional jump host to tunnel through. `None` => direct connect (unchanged).
+    #[serde(default)]
+    pub jump: Option<JumpConfig>,
 }
 
 fn default_port() -> u16 {
@@ -107,6 +125,148 @@ pub struct ConnectResult {
     pub instructions: String,
 }
 
+/// Outcome of one authentication attempt on a russh handle.
+enum AuthOutcome {
+    /// Authenticated — the now-authed handle is returned for use.
+    Authed(SshHandle),
+    /// The server wants a keyboard-interactive / OTP round. The mid-auth handle
+    /// plus the prompts to surface; the caller parks the handle and returns
+    /// `needs_otp` so the frontend drives `ssh_submit_otp`.
+    NeedsOtp { handle: SshHandle, prompts: Vec<OtpPrompt>, instructions: String },
+    /// Authentication failed or errored — human-readable message.
+    Failed(String),
+}
+
+/// Run ONE authentication attempt for `auth` against `handle`. Shared by the
+/// jump-host leg, the target leg, and the direct (no-jump) path. Keyboard-
+/// interactive only STARTS here (one round); the OTP loop is driven by
+/// `super::otp::ssh_submit_otp`.
+async fn authenticate(mut handle: SshHandle, username: &str, auth: &AuthConfig) -> AuthOutcome {
+    match auth {
+        AuthConfig::Password { password } => {
+            match handle.authenticate_password(username, password.clone()).await {
+                Ok(AuthResult::Success) => AuthOutcome::Authed(handle),
+                Ok(AuthResult::Failure { .. }) => {
+                    AuthOutcome::Failed("Password authentication rejected".into())
+                }
+                Err(e) => AuthOutcome::Failed(format!("Password auth error: {e}")),
+            }
+        }
+        AuthConfig::Publickey { key_path, passphrase } => {
+            let pass_ref = passphrase.as_deref().filter(|s| !s.is_empty());
+            let key = match load_secret_key(key_path, pass_ref) {
+                Ok(k) => k,
+                Err(e) => {
+                    return AuthOutcome::Failed(format!("Could not load private key {key_path}: {e}"))
+                }
+            };
+            let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key), Some(HashAlg::Sha512));
+            match handle.authenticate_publickey(username, key_with_alg).await {
+                Ok(AuthResult::Success) => AuthOutcome::Authed(handle),
+                Ok(AuthResult::Failure { .. }) => {
+                    AuthOutcome::Failed("Public-key authentication rejected".into())
+                }
+                Err(e) => AuthOutcome::Failed(format!("Public-key auth error: {e}")),
+            }
+        }
+        AuthConfig::KeyboardInteractive => {
+            match handle
+                .authenticate_keyboard_interactive_start(username, None)
+                .await
+            {
+                Ok(KeyboardInteractiveAuthResponse::Success) => AuthOutcome::Authed(handle),
+                Ok(KeyboardInteractiveAuthResponse::InfoRequest { instructions, prompts, .. }) => {
+                    AuthOutcome::NeedsOtp { handle, prompts: map_prompts(&prompts), instructions }
+                }
+                Ok(KeyboardInteractiveAuthResponse::Failure { .. }) => {
+                    AuthOutcome::Failed("Keyboard-interactive auth rejected".into())
+                }
+                Err(e) => AuthOutcome::Failed(format!("Keyboard-interactive auth error: {e}")),
+            }
+        }
+    }
+}
+
+/// After the jump host is authenticated, open a `direct-tcpip` tunnel to the
+/// target and run the target's SSH handshake + auth over it. Registers a
+/// tunnelled session (keeping `jump_handle` alive) or parks a `Target`-stage
+/// pending handshake when the target needs OTP. Shared by the synchronous jump
+/// path (`ssh_connect`) and the jump-OTP path (`ssh_submit_otp`).
+pub(super) async fn proceed_to_target(
+    jump_handle: SshHandle,
+    target: TargetPlan,
+    pin_store: PathBuf,
+    ssh_config: Arc<client::Config>,
+    state: &SshState,
+) -> ConnectResult {
+    let channel = match jump_handle
+        .channel_open_direct_tcpip(target.host.clone(), target.port as u32, "127.0.0.1", 0)
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return ConnectResult {
+                message: format!(
+                    "Jump: could not open tunnel to {}:{}: {e}",
+                    target.host, target.port
+                ),
+                ..Default::default()
+            }
+        }
+    };
+
+    let key_mismatch = Arc::new(AtomicBool::new(false));
+    let handler =
+        MobileHandler::new(target.host.clone(), target.port, pin_store, key_mismatch.clone());
+    let target_handle =
+        match client::connect_stream(ssh_config, channel.into_stream(), handler).await {
+            Ok(h) => h,
+            Err(e) => {
+                let message = if key_mismatch.load(Ordering::SeqCst) {
+                    format!(
+                        "Target host key for {}:{} CHANGED — refusing to connect \
+                         (possible man-in-the-middle).",
+                        target.host, target.port
+                    )
+                } else {
+                    format!(
+                        "SSH connect to target {}:{} over jump host failed: {e}",
+                        target.host, target.port
+                    )
+                };
+                return ConnectResult { message, ..Default::default() };
+            }
+        };
+
+    match authenticate(target_handle, &target.username, &target.auth).await {
+        AuthOutcome::Authed(h) => {
+            let session = Arc::new(SshSession::new_tunnelled(
+                h,
+                target.host.clone(),
+                target.username.clone(),
+                jump_handle,
+            ));
+            let session_id = state.insert(session).await;
+            log::info!(
+                "[CatGo SSH] connected tunnelled session {session_id} ({}@{} via jump)",
+                target.username, target.host
+            );
+            ConnectResult { connected: true, session_id, ..Default::default() }
+        }
+        AuthOutcome::NeedsOtp { handle, prompts, instructions } => {
+            let pending = PendingAuth::new(
+                handle,
+                target.host.clone(),
+                target.username.clone(),
+                PendingStage::Target { jump: jump_handle },
+            );
+            let pending_id = state.insert_pending(pending).await;
+            ConnectResult { needs_otp: true, pending_id, prompts, instructions, ..Default::default() }
+        }
+        AuthOutcome::Failed(message) => ConnectResult { message, ..Default::default() },
+    }
+}
+
 /// Open + authenticate an SSH session.
 ///
 /// NEVER throws across the Tauri boundary on a *connection* failure: returns a
@@ -124,17 +284,16 @@ pub async fn ssh_connect(
         port,
         username,
         auth,
+        jump,
     } = config;
 
-    // 1. Open TCP + SSH transport and run the persistent-TOFU server-key check.
-    //    The pinned-key store lives under the app data dir; a key MISMATCH there
-    //    refuses the connection (possible MITM).
+    // The pinned-key TOFU store (shared file, keyed per host) lives under the app
+    // data dir; a key MISMATCH there refuses the connection (possible MITM).
     let pin_store = app
         .path()
         .app_data_dir()
         .map_err(|e| format!("could not resolve app data dir: {e}"))?
         .join("ssh_known_hosts.json");
-    let key_mismatch = Arc::new(AtomicBool::new(false));
 
     // Keepalive so an idle session stays alive for ControlMaster-style reuse
     // (the frontend re-picks a still-live connection instead of re-authenticating).
@@ -143,10 +302,57 @@ pub async fn ssh_connect(
         keepalive_max: 3,
         ..Default::default()
     });
-    let handler = MobileHandler::new(host.clone(), port, pin_store, key_mismatch.clone());
-    let addr = (host.as_str(), port);
 
-    let mut handle = match client::connect(ssh_config, addr, handler).await {
+    // ── ProxyJump path: authenticate the jump host first, then tunnel. ──
+    if let Some(jump) = jump {
+        let key_mismatch = Arc::new(AtomicBool::new(false));
+        let handler = MobileHandler::new(
+            jump.host.clone(),
+            jump.port,
+            pin_store.clone(),
+            key_mismatch.clone(),
+        );
+        let jump_handle =
+            match client::connect(ssh_config.clone(), (jump.host.as_str(), jump.port), handler).await
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    let message = if key_mismatch.load(Ordering::SeqCst) {
+                        format!(
+                            "Jump host key for {}:{} CHANGED — refusing to connect \
+                             (possible man-in-the-middle).",
+                            jump.host, jump.port
+                        )
+                    } else {
+                        format!("SSH connect to jump host {}:{} failed: {e}", jump.host, jump.port)
+                    };
+                    return Ok(ConnectResult { message, ..Default::default() });
+                }
+            };
+
+        let target = TargetPlan { host, port, username, auth };
+        return Ok(match authenticate(jump_handle, &jump.username, &jump.auth).await {
+            AuthOutcome::Authed(jh) => {
+                proceed_to_target(jh, target, pin_store, ssh_config, state.inner()).await
+            }
+            AuthOutcome::NeedsOtp { handle, prompts, instructions } => {
+                let pending = PendingAuth::new(
+                    handle,
+                    jump.host.clone(),
+                    jump.username.clone(),
+                    PendingStage::Jump { target, pin_store, ssh_config },
+                );
+                let pending_id = state.insert_pending(pending).await;
+                ConnectResult { needs_otp: true, pending_id, prompts, instructions, ..Default::default() }
+            }
+            AuthOutcome::Failed(message) => ConnectResult { message, ..Default::default() },
+        });
+    }
+
+    // ── Direct path (no jump host) — original behavior via the shared helper. ──
+    let key_mismatch = Arc::new(AtomicBool::new(false));
+    let handler = MobileHandler::new(host.clone(), port, pin_store, key_mismatch.clone());
+    let handle = match client::connect(ssh_config, (host.as_str(), port), handler).await {
         Ok(h) => h,
         Err(e) => {
             let message = if key_mismatch.load(Ordering::SeqCst) {
@@ -162,121 +368,24 @@ pub async fn ssh_connect(
         }
     };
 
-    // 2. Authenticate per the requested method.
-    match auth {
-        AuthConfig::Password { password } => {
-            match handle.authenticate_password(&username, password).await {
-                Ok(AuthResult::Success) => {}
-                Ok(AuthResult::Failure { .. }) => {
-                    return Ok(ConnectResult {
-                        message: "Password authentication rejected".into(),
-                        ..Default::default()
-                    });
-                }
-                Err(e) => {
-                    return Ok(ConnectResult {
-                        message: format!("Password auth error: {e}"),
-                        ..Default::default()
-                    });
-                }
-            }
+    Ok(match authenticate(handle, &username, &auth).await {
+        AuthOutcome::Authed(h) => {
+            let session = Arc::new(SshSession::new(h, host.clone(), username.clone()));
+            let session_id = state.insert(session).await;
+            log::info!("[CatGo SSH] connected session {session_id} ({username}@{host}:{port})");
+            ConnectResult { connected: true, session_id, ..Default::default() }
         }
-        AuthConfig::Publickey {
-            key_path,
-            passphrase,
-        } => {
-            // load_secret_key wants Option<&str> for the passphrase.
-            let pass_ref = passphrase.as_deref().filter(|s| !s.is_empty());
-            let key = match load_secret_key(&key_path, pass_ref) {
-                Ok(k) => k,
-                Err(e) => {
-                    return Ok(ConnectResult {
-                        message: format!("Could not load private key {key_path}: {e}"),
-                        ..Default::default()
-                    });
-                }
-            };
-            // hash_alg only matters for RSA (Sha512 here); ignored & forced to
-            // None for ed25519/ecdsa by PrivateKeyWithHashAlg::new.
-            let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key), Some(HashAlg::Sha512));
-            match handle.authenticate_publickey(&username, key_with_alg).await {
-                Ok(AuthResult::Success) => {}
-                Ok(AuthResult::Failure { .. }) => {
-                    return Ok(ConnectResult {
-                        message: "Public-key authentication rejected".into(),
-                        ..Default::default()
-                    });
-                }
-                Err(e) => {
-                    return Ok(ConnectResult {
-                        message: format!("Public-key auth error: {e}"),
-                        ..Default::default()
-                    });
-                }
-            }
+        AuthOutcome::NeedsOtp { handle, prompts, instructions } => {
+            let pending =
+                PendingAuth::new(handle, host.clone(), username.clone(), PendingStage::Direct);
+            let pending_id = state.insert_pending(pending).await;
+            log::info!(
+                "[CatGo SSH] keyboard-interactive challenge for {username}@{host}:{port} — \
+                 pending {pending_id} ({} prompt(s))",
+                prompts.len()
+            );
+            ConnectResult { needs_otp: true, pending_id, prompts, instructions, ..Default::default() }
         }
-        AuthConfig::KeyboardInteractive => {
-            // Start the keyboard-interactive handshake. The server may answer
-            // immediately (Success, e.g. no actual prompts), reject (Failure),
-            // or — the common 2FA case — return an `InfoRequest` round of
-            // prompts (password, then OTP, ...). Because the start/respond loop
-            // is `&mut self` on the SAME handle and can span MULTIPLE rounds,
-            // each `InfoRequest` is handed back to the frontend and the mid-auth
-            // handle is parked in the `pending` map for `ssh_submit_otp` to
-            // resume. `None` submethods => let the server choose.
-            match handle
-                .authenticate_keyboard_interactive_start(&username, None)
-                .await
-            {
-                // Authed in one shot — fall through to "register live session".
-                Ok(KeyboardInteractiveAuthResponse::Success) => {}
-                Ok(KeyboardInteractiveAuthResponse::InfoRequest {
-                    instructions,
-                    prompts,
-                    ..
-                }) => {
-                    let wire_prompts = map_prompts(&prompts);
-                    let pending = PendingAuth::new(handle, host.clone(), username.clone());
-                    let pending_id = state.insert_pending(pending).await;
-                    log::info!(
-                        "[CatGo SSH] keyboard-interactive challenge for {username}@{host}:{port} \
-                         — pending {pending_id} ({} prompt(s))",
-                        wire_prompts.len()
-                    );
-                    return Ok(ConnectResult {
-                        needs_otp: true,
-                        pending_id,
-                        prompts: wire_prompts,
-                        instructions,
-                        ..Default::default()
-                    });
-                }
-                Ok(KeyboardInteractiveAuthResponse::Failure { .. }) => {
-                    return Ok(ConnectResult {
-                        message: "Keyboard-interactive auth rejected".into(),
-                        ..Default::default()
-                    });
-                }
-                Err(e) => {
-                    return Ok(ConnectResult {
-                        message: format!("Keyboard-interactive auth error: {e}"),
-                        ..Default::default()
-                    });
-                }
-            }
-        }
-    }
-
-    // 3. Authenticated — register the live session.
-    let session = Arc::new(SshSession::new(handle, host.clone(), username.clone()));
-    let session_id = state.insert(session).await;
-    log::info!(
-        "[CatGo SSH] connected session {session_id} ({username}@{host}:{port})"
-    );
-
-    Ok(ConnectResult {
-        connected: true,
-        session_id,
-        ..Default::default()
+        AuthOutcome::Failed(message) => ConnectResult { message, ..Default::default() },
     })
 }

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -13,10 +13,14 @@
 //!   * `exec.rs`    — `ssh_exec` (login-shell exec, never-throw, ~30s timeout).
 //!   * `sftp.rs`    — `sftp_*` file-browser ops over a per-call SFTP subsystem.
 //!
+//! ProxyJump (jump host / bastion) is supported: `ssh_connect` takes an optional
+//! `jump` config; the jump host is authenticated first, then a `direct-tcpip`
+//! channel carries the target handshake over `connect_stream` (auth.rs's
+//! `proceed_to_target`). Both hops support password / public-key / keyboard-
+//! interactive OTP independently; the staged handshake is driven by `otp.rs`.
+//!
 //! Known TODOs (see the respective files for detail):
 //!   * TOFU persistent pinning (handler.rs) — currently accept-and-log only.
-//!   * OTP / keyboard-interactive wiring (auth.rs + otp.rs).
-//!   * ProxyJump / direct-tcpip (not yet implemented; spike documents the API).
 
 pub mod auth;
 pub mod exec;

--- a/src-tauri/src/ssh/otp.rs
+++ b/src-tauri/src/ssh/otp.rs
@@ -25,8 +25,8 @@ use serde::Deserialize;
 
 use russh::client::KeyboardInteractiveAuthResponse;
 
-use super::auth::{map_prompts, ConnectResult};
-use super::state::{PendingAuth, SshSession, SshState};
+use super::auth::{map_prompts, proceed_to_target, ConnectResult};
+use super::state::{PendingAuth, PendingStage, SshSession, SshState};
 
 /// One OTP / keyboard-interactive submission round from the frontend: the
 /// answers for the prompts most recently surfaced by the server.
@@ -53,15 +53,16 @@ pub async fn ssh_submit_otp(
 
     // MOVE the mid-auth handle out of the pending map. A missing id means the
     // handshake expired, was already consumed, or never existed.
-    let PendingAuth { mut handle, host, username } = match state.take_pending(&pending_id).await {
-        Some(p) => p,
-        None => {
-            return Ok(ConnectResult {
-                message: "no pending OTP session (expired or already used)".into(),
-                ..Default::default()
-            });
-        }
-    };
+    let PendingAuth { mut handle, host, username, stage } =
+        match state.take_pending(&pending_id).await {
+            Some(p) => p,
+            None => {
+                return Ok(ConnectResult {
+                    message: "no pending OTP session (expired or already used)".into(),
+                    ..Default::default()
+                });
+            }
+        };
 
     // Drive exactly ONE round. The server decides whether more rounds follow.
     match handle
@@ -69,27 +70,51 @@ pub async fn ssh_submit_otp(
         .await
     {
         Ok(KeyboardInteractiveAuthResponse::Success) => {
-            let session = Arc::new(SshSession::new(handle, host.clone(), username.clone()));
-            let session_id = state.insert(session).await;
-            log::info!(
-                "[CatGo SSH] keyboard-interactive auth complete — session {session_id} \
-                 ({username}@{host})"
-            );
-            Ok(ConnectResult {
-                connected: true,
-                session_id,
-                ..Default::default()
-            })
+            // The hop authenticated. What happens next depends on the stage:
+            match stage {
+                // Direct connect, or the TARGET leg of a jump — register the
+                // session (carrying the jump handle alive for the Target stage).
+                PendingStage::Direct => {
+                    let session = Arc::new(SshSession::new(handle, host.clone(), username.clone()));
+                    let session_id = state.insert(session).await;
+                    log::info!(
+                        "[CatGo SSH] keyboard-interactive auth complete — session {session_id} \
+                         ({username}@{host})"
+                    );
+                    Ok(ConnectResult { connected: true, session_id, ..Default::default() })
+                }
+                PendingStage::Target { jump } => {
+                    let session = Arc::new(SshSession::new_tunnelled(
+                        handle,
+                        host.clone(),
+                        username.clone(),
+                        jump,
+                    ));
+                    let session_id = state.insert(session).await;
+                    log::info!(
+                        "[CatGo SSH] tunnelled keyboard-interactive auth complete — session \
+                         {session_id} ({username}@{host} via jump)"
+                    );
+                    Ok(ConnectResult { connected: true, session_id, ..Default::default() })
+                }
+                // The JUMP host just finished authenticating — `handle` is now the
+                // authed jump handle. Open the tunnel and start the target leg
+                // (which may itself return another `needs_otp`).
+                PendingStage::Jump { target, pin_store, ssh_config } => {
+                    log::info!("[CatGo SSH] jump host {host} authenticated — opening tunnel");
+                    Ok(proceed_to_target(handle, target, pin_store, ssh_config, state.inner()).await)
+                }
+            }
         }
-        // Another round (multi-round 2FA): re-park the SAME handle under a NEW
-        // pending_id and ask the frontend for the next set of answers.
+        // Another round (multi-round 2FA): re-park the SAME handle + stage under a
+        // NEW pending_id and ask the frontend for the next set of answers.
         Ok(KeyboardInteractiveAuthResponse::InfoRequest {
             instructions,
             prompts,
             ..
         }) => {
             let wire_prompts = map_prompts(&prompts);
-            let pending = PendingAuth::new(handle, host, username);
+            let pending = PendingAuth::new(handle, host, username, stage);
             let next_id = state.insert_pending(pending).await;
             log::info!(
                 "[CatGo SSH] keyboard-interactive needs another round — pending {next_id} \

--- a/src-tauri/src/ssh/state.rs
+++ b/src-tauri/src/ssh/state.rs
@@ -16,11 +16,13 @@
 //!     command layer can insert/lookup/remove sessions from async contexts.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
 use tokio::task::AbortHandle;
 
+use super::auth::AuthConfig;
 use super::handler::MobileHandler;
 
 /// The concrete russh client handle type used throughout the SSH module.
@@ -59,18 +61,50 @@ pub struct PtyHandle {
 /// this struct (never cloned) and moved back out by `take_pending` so the next
 /// round can drive it with `&mut`.
 pub struct PendingAuth {
-    /// The mid-auth russh handle (MOVED in/out — not shared, not cloned).
+    /// The mid-auth russh handle (MOVED in/out — not shared, not cloned). This is
+    /// the handle of whichever hop is currently being authenticated (jump host
+    /// for a `Jump` stage, target login node for `Target`/`Direct`).
     pub handle: SshHandle,
-    /// Remote host, carried so the live `SshSession` can be built once authed.
+    /// Remote host of `handle`, carried so the live `SshSession` can be built
+    /// once authed (the TARGET host, even for the `Jump` stage — see `stage`).
     pub host: String,
-    /// Authenticated username, carried for the same reason.
+    /// Authenticated username of `handle`.
     pub username: String,
+    /// What to do when `handle` finishes authenticating — see [`PendingStage`].
+    pub stage: PendingStage,
+}
+
+/// Everything needed to authenticate the TARGET login node once the jump host is
+/// reached. Carried through the (possibly multi-round) jump-host OTP handshake.
+pub struct TargetPlan {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub auth: AuthConfig,
+}
+
+/// What a pending (mid keyboard-interactive) handshake should do on Success.
+pub enum PendingStage {
+    /// No jump host: `handle` is the target itself → register the session.
+    Direct,
+    /// `handle` is the JUMP host being authenticated. On success, open a
+    /// `direct-tcpip` tunnel to the target and start the target auth leg.
+    Jump {
+        target: TargetPlan,
+        /// TOFU pinned-host store path for the TARGET's `MobileHandler`.
+        pin_store: PathBuf,
+        /// Shared russh client config (keepalive etc.) reused for the target.
+        ssh_config: Arc<russh::client::Config>,
+    },
+    /// `handle` is the TARGET (already tunnelled through the jump). On success,
+    /// register the session, moving `jump` into it so the tunnel stays alive.
+    Target { jump: SshHandle },
 }
 
 impl PendingAuth {
-    /// Construct a pending (mid-auth) handshake holder.
-    pub fn new(handle: SshHandle, host: String, username: String) -> Self {
-        Self { handle, host, username }
+    /// Construct a pending (mid-auth) handshake holder with an explicit stage.
+    pub fn new(handle: SshHandle, host: String, username: String, stage: PendingStage) -> Self {
+        Self { handle, host, username, stage }
     }
 }
 
@@ -100,11 +134,31 @@ pub struct SshSession {
     /// contexts. Distinct from `handle`: a PTY's write half is independent of
     /// the auth handle's lock, so opening/using a PTY never blocks `ssh_exec`.
     pub ptys: Mutex<HashMap<String, PtyHandle>>,
+    /// For a tunnelled (ProxyJump) session: the authenticated JUMP-host handle.
+    /// Held only to keep the SSH connection — and thus the `direct-tcpip` tunnel
+    /// carrying `handle` — alive for the lifetime of this session. Never used
+    /// directly; dropping it would tear down the tunnel. `None` for direct
+    /// (no-jump) sessions.
+    pub _jump: Mutex<Option<SshHandle>>,
 }
 
 impl SshSession {
-    /// Construct a new session wrapper around a freshly-authenticated handle.
+    /// Construct a new direct (no-jump) session wrapper.
     pub fn new(handle: SshHandle, host: String, username: String) -> Self {
+        Self::new_inner(handle, host, username, None)
+    }
+
+    /// Construct a tunnelled session that keeps its jump-host handle alive.
+    pub fn new_tunnelled(
+        handle: SshHandle,
+        host: String,
+        username: String,
+        jump: SshHandle,
+    ) -> Self {
+        Self::new_inner(handle, host, username, Some(jump))
+    }
+
+    fn new_inner(handle: SshHandle, host: String, username: String, jump: Option<SshHandle>) -> Self {
         Self {
             handle: Mutex::new(handle),
             host,
@@ -112,6 +166,7 @@ impl SshSession {
             connected_at: chrono::Utc::now().timestamp_millis(),
             alive: std::sync::atomic::AtomicBool::new(true),
             ptys: Mutex::new(HashMap::new()),
+            _jump: Mutex::new(jump),
         }
     }
 

--- a/src/lib/api/transport/index.ts
+++ b/src/lib/api/transport/index.ts
@@ -19,7 +19,7 @@
 export type HpcAuthMethod = 'password' | 'publickey' | 'keyboard-interactive'
 
 /** Parameters for opening an HPC connection. */
-export interface HpcConnectConfig {
+export interface HpcHostConfig {
   host: string
   port?: number
   username: string
@@ -30,6 +30,14 @@ export interface HpcConnectConfig {
   keyPath?: string
   /** Optional passphrase decrypting an encrypted private key. */
   passphrase?: string
+}
+
+export interface HpcConnectConfig extends HpcHostConfig {
+  /** Optional jump host (ProxyJump / bastion) to tunnel through. When set, the
+   * jump host is authenticated first (any method, incl. its own OTP), then a
+   * `direct-tcpip` tunnel carries the target handshake. Omit => direct connect.
+   * Mobile (tauri-ssh) only — the HTTP transport ignores it. */
+  jump?: HpcHostConfig
 }
 
 /** A single keyboard-interactive / OTP prompt surfaced by the server. */

--- a/src/lib/api/transport/tauri-ssh.ts
+++ b/src/lib/api/transport/tauri-ssh.ts
@@ -61,19 +61,38 @@ function fromRustSftpEntry(e: RustSftpEntry): SftpEntry {
   return { name: e.name, path: e.path, isDir: e.is_dir, size: e.size }
 }
 
-/** Map the frontend connect config onto the Rust `ConnectConfig` (serde
- * `#[serde(flatten)]` of the `method`-tagged `AuthConfig`). */
-function toRustConnectConfig(config: HpcConnectConfig): Record<string, unknown> {
+/** Map one host's fields (host/port/user + flattened `method`-tagged auth) onto
+ * the Rust serde shape. Shared by the top-level target and the nested jump host. */
+function toRustHost(h: {
+  host: string
+  port?: number
+  username: string
+  method: HpcConnectConfig[`method`]
+  password?: string
+  keyPath?: string
+  passphrase?: string
+}): Record<string, unknown> {
   return {
-    host: config.host,
-    port: config.port ?? 22,
-    username: config.username,
+    host: h.host,
+    port: h.port ?? 22,
+    username: h.username,
     // Rust AuthConfig is an internally-tagged enum on `method` with lowercase
     // variant names: "password" | "publickey" | "keyboard-interactive".
-    method: config.method,
-    password: config.password,
-    key_path: config.keyPath,
-    passphrase: config.passphrase,
+    method: h.method,
+    password: h.password,
+    key_path: h.keyPath,
+    passphrase: h.passphrase,
+  }
+}
+
+/** Map the frontend connect config onto the Rust `ConnectConfig` (serde
+ * `#[serde(flatten)]` of the `method`-tagged `AuthConfig`, plus optional
+ * `jump` for ProxyJump). */
+function toRustConnectConfig(config: HpcConnectConfig): Record<string, unknown> {
+  return {
+    ...toRustHost(config),
+    // `jump` => Rust `Option<JumpConfig>`; omitted/undefined => direct connect.
+    jump: config.jump ? toRustHost(config.jump) : undefined,
   }
 }
 

--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -59,6 +59,7 @@ const mobile: Record<string, string> = {
   field_private_key_path: `Private key path`,
   field_passphrase:       `Passphrase (optional)`,
   keyboard_hint:          `You'll be prompted for any codes after connecting.`,
+  use_jump_host:          `Use a jump host (ProxyJump)`,
   connecting:             `Connecting…`,
   connect_action:         `Connect`,
   connection_failed:      `Connection failed.`,

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -59,6 +59,7 @@ const mobile: Record<string, string> = {
   field_private_key_path: `私钥路径`,
   field_passphrase:       `私钥口令（可选）`,
   keyboard_hint:          `连接后系统会提示你输入所需的验证码。`,
+  use_jump_host:          `使用跳板机 (ProxyJump)`,
   connecting:             `连接中…`,
   connect_action:         `连接`,
   connection_failed:      `连接失败。`,

--- a/src/lib/mobile/MobileConnect.svelte
+++ b/src/lib/mobile/MobileConnect.svelte
@@ -48,6 +48,18 @@
   let key_path = $state(``)
   let passphrase = $state(``)
 
+  // Optional jump host (ProxyJump / bastion). When `jump_enabled`, the jump host
+  // is authenticated first, then a tunnel carries the target handshake. The jump
+  // host has its own independent auth method (incl. its own OTP).
+  let jump_enabled = $state(false)
+  let jump_host = $state(``)
+  let jump_port = $state(22)
+  let jump_username = $state(``)
+  let jump_method = $state<HpcAuthMethod>(`password`)
+  let jump_password = $state(``)
+  let jump_key_path = $state(``)
+  let jump_passphrase = $state(``)
+
   // ─── Flow state ───
   let connecting = $state(false)
   let error_msg = $state(``)
@@ -255,6 +267,17 @@
         password: method === `password` ? password : undefined,
         keyPath: method === `publickey` ? key_path.trim() || undefined : undefined,
         passphrase: method === `publickey` ? passphrase || undefined : undefined,
+        jump: jump_enabled && jump_host.trim()
+          ? {
+              host: jump_host.trim(),
+              port: jump_port,
+              username: jump_username.trim(),
+              method: jump_method,
+              password: jump_method === `password` ? jump_password : undefined,
+              keyPath: jump_method === `publickey` ? jump_key_path.trim() || undefined : undefined,
+              passphrase: jump_method === `publickey` ? jump_passphrase || undefined : undefined,
+            }
+          : undefined,
       })
       apply_result(r)
     } catch (e: unknown) {
@@ -444,6 +467,74 @@
       {:else}
         <div class="method-hint">
           {t(`mobile.keyboard_hint`)}
+        </div>
+      {/if}
+
+      <!-- Optional jump host (ProxyJump / bastion) -->
+      <label class="field jump-toggle">
+        <input type="checkbox" bind:checked={jump_enabled} />
+        <span>{t(`mobile.use_jump_host`)}</span>
+      </label>
+
+      {#if jump_enabled}
+        <div class="jump-section">
+          <label class="field">
+            <span>{t(`mobile.field_host`)}</span>
+            <input
+              type="text"
+              autocapitalize="off"
+              autocorrect="off"
+              spellcheck="false"
+              placeholder="bastion.example.edu"
+              bind:value={jump_host}
+            />
+          </label>
+          <label class="field">
+            <span>{t(`mobile.field_port`)}</span>
+            <input type="number" min="1" max="65535" bind:value={jump_port} />
+          </label>
+          <label class="field">
+            <span>{t(`mobile.field_username`)}</span>
+            <input
+              type="text"
+              autocapitalize="off"
+              autocorrect="off"
+              spellcheck="false"
+              bind:value={jump_username}
+            />
+          </label>
+          <label class="field">
+            <span>{t(`mobile.field_auth_method`)}</span>
+            <select bind:value={jump_method}>
+              <option value="password">{t(`mobile.method_password`)}</option>
+              <option value="publickey">{t(`mobile.method_publickey`)}</option>
+              <option value="keyboard-interactive">{t(`mobile.method_keyboard`)}</option>
+            </select>
+          </label>
+          {#if jump_method === `password`}
+            <label class="field">
+              <span>{t(`mobile.field_password`)}</span>
+              <input type="password" autocomplete="off" bind:value={jump_password} />
+            </label>
+          {:else if jump_method === `publickey`}
+            <label class="field">
+              <span>{t(`mobile.field_private_key_path`)}</span>
+              <input
+                type="text"
+                autocapitalize="off"
+                autocorrect="off"
+                spellcheck="false"
+                placeholder="~/.ssh/id_ed25519"
+                bind:value={jump_key_path}
+              />
+            </label>
+            <label class="field">
+              <span>{t(`mobile.field_passphrase`)}</span>
+              <input type="password" autocomplete="off" bind:value={jump_passphrase} />
+            </label>
+          {:else}
+            <div class="method-hint">{t(`mobile.keyboard_hint`)}</div>
+          {/if}
         </div>
       {/if}
 


### PR DESCRIPTION
Mobile SSH (russh) could only connect directly — no jump host. Adds an optional **jump host / bastion (ProxyJump)** tunnelled through before reaching the target login node. **Both** the jump host and the target independently support password / public-key / keyboard-interactive **OTP (Duo)**.

## How (russh `direct-tcpip` + `connect_stream`)
1. Connect + authenticate the **jump** host.
2. `jump_handle.channel_open_direct_tcpip(target, port, …)` → `into_stream()`.
3. `client::connect_stream(cfg, stream, target_handler)` → target handle.
4. Authenticate the target; register the session, **keeping the jump handle alive** (the tunnel rides on it).

## Rust (`src-tauri/src/ssh`)
- **auth.rs**: shared `authenticate()` → `Authed | NeedsOtp | Failed`; new `proceed_to_target()`; `ssh_connect` gains optional `jump`.
- **state.rs**: `PendingAuth.stage: PendingStage` (`Direct | Jump{target,pin_store,ssh_config} | Target{jump}`); `SshSession._jump` keeps the bastion connection alive.
- **otp.rs**: on keyboard-interactive Success, dispatch by stage (register, or open tunnel + start target auth); multi-round 2FA re-parks the same stage. Handles **OTP on either or both hops**.

## Frontend
- `HpcConnectConfig.jump?` (+ `HpcHostConfig`); `tauri-ssh.ts` maps it to the Rust serde shape.
- `MobileConnect.svelte`: **"Use a jump host"** toggle revealing host/port/user + its own auth method. OTP for whichever hop challenges reuses the existing `OtpDialog`.

## Safety / verification
- **Additive**: no `jump` ⇒ `ssh_connect` is byte-for-byte the old direct path. Existing connections cannot regress.
- `cargo check` ✅ (validates the russh `direct-tcpip` / `connect_stream` / `into_stream` API usage — the main blind spot).
- `svelte-check` ✅ on touched files.
- ⚠️ **Needs on-device testing** against a real jump + target (incl. Duo on either/both hops). SSH can't be headless-tested. Isolated + revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)