### PR TITLE
chore(mobile): bump version to 1.1.8 for the jump-host Android build

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Bump tauri.conf.json 1.1.7 → 1.1.8 for the new sideload APK carrying mobile SSH jump-host / ProxyJump (#210). Mobile-only build; no desktop release tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)