### PR TITLE
fix(viewer): correct rotate direction (yaw was inverted)

### DIFF
--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -1437,7 +1437,9 @@ export function create_interaction_controller(deps: InteractionDeps) {
         const dy = event.clientY - view_rot_last.y
         view_rot_last = { x: event.clientX, y: event.clientY }
         // 水平拖 → yaw (绕世界 Y)，垂直拖 → pitch (绕屏幕右轴)。
-        if (dx) deps.rotate_around_center('y', dx * VIEW_ROTATE_SENSITIVITY)
+        // gesture_api.rotate 转的是相机，结构看起来朝反方向 → yaw 取负，让结构
+        // "跟手"转 (拖右=结构右转)，与旧 TrackballControls 手感一致。pitch 已跟手。
+        if (dx) deps.rotate_around_center('y', -dx * VIEW_ROTATE_SENSITIVITY)
         if (dy) deps.rotate_around_center('x', dy * VIEW_ROTATE_SENSITIVITY)
       }
       event.preventDefault()


### PR DESCRIPTION
The custom center-rotation (#207) rotates the camera around the pivot, so the structure appears to move opposite to the drag. **Horizontal drag was inverted** — dragging right spun the structure left.

Fix: negate the yaw angle so a horizontal drag turns the structure **with** the finger (drag right → front rotates right), matching the old TrackballControls feel. Pitch already followed the finger (unchanged).

One-line sign flip in the custom touch/mouse rotate handler (`interaction.svelte.ts`). Affects desktop + mobile + web (shared handler).

Verified on desktop via Playwright: drag right now swings +Z to the right (was left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)