### PR TITLE
Revert today's rotate changes (#207, #212) — back to TrackballControls

### DIFF
--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2377,11 +2377,6 @@
     get_scene_props: () => settings.scene_props,
     set_scene_props_rotation: (r) => { settings.scene_props.rotation = r },
     get_rotation_target_ref: () => rotation_target_ref,
-    // Orbit camera + target around the structure center (box center for periodic,
-    // centroid for molecules), preserving any pan offset. Reuses the same math as
-    // the hand-gesture rotate so a custom touch-drag can rotate about the
-    // structure center instead of TrackballControls' pan-shifted target.
-    rotate_around_center: (axis, angle) => gesture_api.rotate(axis, angle),
     push_to_undo,
     push_atom_entry: (inv) => { sel_state.push_atom_entry(inv); pencil.push_bond_undo() },
     undo,
@@ -3913,7 +3908,6 @@
             {reset_camera_up_trigger}
             repaint_trigger={webgl_repaint_trigger}
             external_dragging={interaction.is_dragging_atom || interaction.is_rotating_atoms}
-            external_view_rotation={true}
             is_box_selecting={interaction.is_box_selecting}
             is_rotating_atoms={interaction.is_rotating_atoms}
             is_dragging_atom={interaction.is_dragging_atom}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -498,11 +498,6 @@
     reset_camera_up_trigger = 0, // Increment to reset camera.up to [0,0,1] (Z-up) after slab cut
     repaint_trigger = 0, // Increment to force ONE WebGL repaint (no side effects) — used when the large-system overlay closes and autoRender resumes
     external_dragging = false,
-    // When true, the parent owns view rotation via a custom handler (mouse
-    // left-drag / one-finger touch → orbit around the structure center), so
-    // TrackballControls' native rotate must be disabled (its pan-shifted target
-    // would rotate off-center). Pan/zoom stay on. Off by default (preview).
-    external_view_rotation = false,
     is_box_selecting = false,
     is_rotating_atoms = false,
     is_dragging_atom = false,
@@ -756,7 +751,6 @@
     hidden_prop_vals?: Set<number | string> // Track hidden property values (e.g. coordination numbers, Wyckoff positions, charges)
     axis_lock_active?: boolean // Disable OrbitControls when axis-locked rotation is active
     external_dragging?: boolean // External dragging state (from parent component)
-    external_view_rotation?: boolean // Parent owns view rotation (mobile custom touch rotate) → disable TB native rotate
     on_reset_rotation?: () => void // Called when gizmo clicked to reset structure rotation
     on_atom_context_menu?: (
       site_idx: number,
@@ -4245,8 +4239,7 @@
     // - is_box_selecting (box selection in progress)
     // - is_rotating_atoms (atom rotation via Shift+drag in progress)
     noRotate: rotate_speed === 0 || axis_lock_active ||
-      external_dragging || is_box_selecting || is_rotating_atoms ||
-      external_view_rotation,
+      external_dragging || is_box_selecting || is_rotating_atoms,
     noZoom: zoom_speed === 0 || axis_lock_active || external_dragging,
     // Disable pan when atom operations are in progress
     noPan: pan_speed === 0 || axis_lock_active || external_dragging ||

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -1437,9 +1437,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
         const dy = event.clientY - view_rot_last.y
         view_rot_last = { x: event.clientX, y: event.clientY }
         // 水平拖 → yaw (绕世界 Y)，垂直拖 → pitch (绕屏幕右轴)。
-        // gesture_api.rotate 转的是相机，结构看起来朝反方向 → yaw 取负，让结构
-        // "跟手"转 (拖右=结构右转)，与旧 TrackballControls 手感一致。pitch 已跟手。
-        if (dx) deps.rotate_around_center('y', -dx * VIEW_ROTATE_SENSITIVITY)
+        if (dx) deps.rotate_around_center('y', dx * VIEW_ROTATE_SENSITIVITY)
         if (dy) deps.rotate_around_center('x', dy * VIEW_ROTATE_SENSITIVITY)
       }
       event.preventDefault()

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -71,9 +71,6 @@ export interface InteractionDeps {
   get_scene_props: () => any
   set_scene_props_rotation: (r: [number, number, number]) => void
   get_rotation_target_ref: () => [number, number, number] | undefined
-  /** Orbit camera + target around the structure center, preserving pan offset.
-   *  Optional: present on the main editor, absent on lightweight viewers. */
-  rotate_around_center?: (axis: 'x' | 'y' | 'z', angle: number) => void
 
   // ── Undo 系统 ──
   push_to_undo: () => void
@@ -331,19 +328,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
   let keyboard_rotation_timeout: ReturnType<typeof setTimeout> | null = null
   const KEYBOARD_ROTATION_STEP = 0.05 // ~3 degrees per key press
   const AXIS_LOCK_DEADZONE_PX = 4 // left-drag must exceed this before an axis locks
-
-  // ═══════════════════════════════════════════════════════════════════
-  // 自定义视图旋转 — 绕结构中心而非 TrackballControls 的 pan 偏移点
-  // ═══════════════════════════════════════════════════════════════════
-  // TrackballControls 旋转绕 `target`，而 pan 会把 target 移走 → 平移后旋转就不
-  // 绕结构中心了。主编辑器禁用 TB 旋转 (StructureScene external_view_rotation →
-  // noRotate)，改由这里的左键拖拽经 deps.rotate_around_center 绕盒子中心/质心旋转
-  // (保留 pan 偏移)。鼠标左键 + 触屏单指都生效；触屏双指交给 TB 做 pan/zoom；
-  // 中键/滚轮仍是 TB pan/zoom。
-  let is_view_rotating = false
-  let view_rot_last: { x: number; y: number } | null = null
-  const VIEW_ROTATE_SENSITIVITY = 0.006 // rad per pixel
-  const active_touch_pointers = new Set<number>()
 
   // ═══════════════════════════════════════════════════════════════════
   // 框选状态 — Cmd/Ctrl+拖拽矩形选择多个原子
@@ -1176,18 +1160,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
     // a fired long-press already cleared it.
     cancel_long_press()
 
-    // 视图旋转：抬指/松鼠标清理。触屏需所有手指离开才结束。
-    if (event.pointerType === 'touch') {
-      active_touch_pointers.delete(event.pointerId)
-      if (active_touch_pointers.size === 0) {
-        is_view_rotating = false
-        view_rot_last = null
-      }
-    } else {
-      is_view_rotating = false
-      view_rot_last = null
-    }
-
     // 裁剪区域完成
     if (crop_drawing && crop_draw_start && crop_draw_end) {
       event.stopPropagation()
@@ -1268,22 +1240,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
         event.preventDefault()
       }
       return
-    }
-
-    // 自定义视图旋转 — 绕结构中心。其它模式 (框选/移动/转原子/裁剪) 已在上面
-    // return，到这里说明是普通拖拽。左键单指/单鼠标生效；触屏第二指出现则交还
-    // TrackballControls 做双指 pan/zoom。中键 (button 1) 走 TB pan，不在此处理。
-    const is_touch = event.pointerType === 'touch'
-    if (is_touch) active_touch_pointers.add(event.pointerId)
-    if (is_touch && active_touch_pointers.size >= 2) {
-      // 第二指落下 → 双指手势 (pan/zoom)，交给 TrackballControls。
-      is_view_rotating = false
-      view_rot_last = null
-    } else if (touch_mode === 'none' && event.button === 0 &&
-        deps.rotate_around_center && deps.get_structure() && deps.get_camera() &&
-        !axis_lock_key && !crop_mode_active) {
-      is_view_rotating = true
-      view_rot_last = { x: event.clientX, y: event.clientY }
     }
   }
 
@@ -1422,26 +1378,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
       const dx = event.clientX - long_press_origin.x
       const dy = event.clientY - long_press_origin.y
       if (Math.hypot(dx, dy) > LONG_PRESS_MOVE_TOLERANCE_PX) cancel_long_press()
-    }
-
-    // 自定义单指视图旋转 — 绕结构中心 (touch only)。
-    if (is_view_rotating) {
-      if (active_touch_pointers.size >= 2) {
-        // 第二指出现 → 双指 pan/zoom，停掉旋转交给 TrackballControls。
-        is_view_rotating = false
-        view_rot_last = null
-        return
-      }
-      if (view_rot_last && deps.rotate_around_center) {
-        const dx = event.clientX - view_rot_last.x
-        const dy = event.clientY - view_rot_last.y
-        view_rot_last = { x: event.clientX, y: event.clientY }
-        // 水平拖 → yaw (绕世界 Y)，垂直拖 → pitch (绕屏幕右轴)。
-        if (dx) deps.rotate_around_center('y', dx * VIEW_ROTATE_SENSITIVITY)
-        if (dy) deps.rotate_around_center('x', dy * VIEW_ROTATE_SENSITIVITY)
-      }
-      event.preventDefault()
-      return
     }
 
     // 裁剪预览更新
@@ -1661,11 +1597,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
         box_select_end = null
       }
       if (is_rotating) is_rotating = false
-      if (is_view_rotating) {
-        is_view_rotating = false
-        view_rot_last = null
-        active_touch_pointers.clear()
-      }
     }
 
     function on_visibility_change() {
@@ -1685,18 +1616,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
     }
 
     // 注册 document-level 事件 (支持多 Structure 实例共存)
-    // 触屏指针取消 (手势被系统打断) → 清理单指旋转跟踪，避免计数泄漏。
-    function on_pointer_cancel(event: PointerEvent) {
-      if (event.pointerType !== 'touch') return
-      active_touch_pointers.delete(event.pointerId)
-      if (active_touch_pointers.size === 0) {
-        is_view_rotating = false
-        view_rot_last = null
-      }
-    }
-
     document.addEventListener('pointerdown', on_pointerdown_track, true)
-    document.addEventListener('pointercancel', on_pointer_cancel, true)
     document.addEventListener('keydown', onkeydown)
     document.addEventListener('keyup', onkeyup)
     document.addEventListener('mousemove', onmousemove)
@@ -1708,7 +1628,6 @@ export function create_interaction_controller(deps: InteractionDeps) {
       window.removeEventListener('blur', reset_drag_state)
       document.removeEventListener('visibilitychange', on_visibility_change)
       document.removeEventListener('pointerdown', on_pointerdown_track, true)
-      document.removeEventListener('pointercancel', on_pointer_cancel, true)
       document.removeEventListener('keydown', onkeydown)
       document.removeEventListener('keyup', onkeyup)
       document.removeEventListener('mousemove', onmousemove)


### PR DESCRIPTION
Reverts the custom center-rotation work merged today — **#207** (custom mouse/touch rotate orbiting the structure center via gesture_api.rotate) and **#212** (its yaw-direction fix). Rotation returns to the original three.js **TrackballControls** behavior.

Reason: the custom rotation still doesn't feel right to the user. Rather than keep iterating on a half-right replacement, restore the known TrackballControls behavior and track the original request (rotate around the structure center even after panning) in a dedicated issue.

Net effect: removes `external_view_rotation` / `rotate_around_center` / the custom view-rotate pointer handler; `noRotate` and pan/zoom are back to their pre-#207 state. (#205 was already reverted earlier by #206.)

`pnpm check`: no new errors (same pre-existing baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)