### PR TITLE
fix(keybinds): drop Ctrl+B sidebar toggle (collides with Claude Code)

### DIFF
--- a/desktop/lib/keyboard-shortcuts.ts
+++ b/desktop/lib/keyboard-shortcuts.ts
@@ -53,12 +53,8 @@ export function create_handle_keydown(deps: KeyboardShortcutDeps) {
       return
     }
 
-    // Ctrl+B — toggle sidebar
-    if (ctrl && event.key === `b`) {
-      event.preventDefault()
-      deps.toggle_sidebar()
-      return
-    }
+    // Ctrl+B intentionally NOT bound: it collides with Claude Code's prefix
+    // key. Toggle the sidebar with the in-app toolbar button instead.
 
     // Ctrl+T — new structure tab
     if (ctrl && event.key === `t`) {


### PR DESCRIPTION
Ctrl+B is Claude Code's prefix key; the sidebar-toggle binding made the embedded terminal unusable. Removes the shortcut; sidebar still toggles via the toolbar button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)