### PR TITLE
fix(trajectory): stream XDATCAR like XYZ — fixes OOM on a second file

### DIFF
--- a/server/catgo/routers/trajectory_stream.py
+++ b/server/catgo/routers/trajectory_stream.py
@@ -51,7 +51,7 @@ class _TrajIndex:
     frame count is stored in ``_total`` (ASE handles random access itself).
     """
 
-    __slots__ = ("fmt", "offsets", "file_size", "n_atoms", "_total")
+    __slots__ = ("fmt", "offsets", "file_size", "n_atoms", "_total", "elements", "lattices")
 
     def __init__(
         self,
@@ -60,12 +60,19 @@ class _TrajIndex:
         file_size: int,
         n_atoms: int,
         total: int | None = None,
+        elements: list[str] | None = None,
+        lattices: list[list[list[float]]] | None = None,
     ) -> None:
         self.fmt = fmt
         self.offsets = offsets
         self.file_size = file_size
         self.n_atoms = n_atoms
         self._total = total if total is not None else len(offsets)
+        # XDATCAR-only: element list (constant — VASP can't vary composition)
+        # and per-frame 3x3 lattice (constant cell repeats the same matrix;
+        # NPT carries the cell that was in effect for each frame).
+        self.elements = elements or []
+        self.lattices = lattices or []
 
     @property
     def total_frames(self) -> int:
@@ -84,12 +91,16 @@ _CACHE_LOCK = threading.Lock()
 
 
 def _detect_format(p: Path) -> str:
-    """Map a file extension to a reader format."""
+    """Map a file extension / name to a reader format."""
     suffix = p.suffix.lower()
     if suffix == ".lammpstrj":
         return "lammpstrj"
     if suffix == ".traj":
         return "traj"
+    # VASP XDATCAR usually has no extension; match by name (XDATCAR,
+    # XDATCAR.bz2 already decompressed, my_run.XDATCAR, ...).
+    if "xdatcar" in p.name.lower():
+        return "xdatcar"
     return "xyz"  # .xyz / .extxyz / default
 
 # Property patterns for the plot panel. Word boundaries + a MANDATORY `=`/`:`
@@ -196,6 +207,97 @@ def _build_traj_index(p: Path) -> _TrajIndex:
     return _TrajIndex("traj", [], p.stat().st_size, n_atoms, total=total)
 
 
+def _parse_xdatcar_header(lines: list[str], start: int) -> tuple[list[list[float]], list[str], int] | None:
+    """Parse a header block at ``lines[start]`` (title line). Returns
+    ``(lattice 3x3, expanded element list, next_line_index)`` or ``None`` if
+    the block is not a valid header. Mirrors the frontend parser layout:
+    start=title, +1=scale, +2..4=lattice, +5=element names, +6=counts.
+    """
+    if start + 6 >= len(lines):
+        return None
+    try:
+        scale = float(lines[start + 1].split()[0])
+    except (ValueError, IndexError):
+        return None
+    lattice: list[list[float]] = []
+    for r in range(2, 5):
+        parts = lines[start + r].split()
+        if len(parts) < 3:
+            return None
+        try:
+            lattice.append([float(parts[0]) * scale, float(parts[1]) * scale, float(parts[2]) * scale])
+        except ValueError:
+            return None
+    names = lines[start + 5].split()
+    try:
+        counts = [int(x) for x in lines[start + 6].split()]
+    except ValueError:
+        return None
+    if not names or len(counts) != len(names) or any(c <= 0 for c in counts):
+        return None
+    elements: list[str] = []
+    for name, c in zip(names, counts):
+        elements.extend([name] * c)
+    return lattice, elements, start + 7
+
+
+def _build_xdatcar_index(p: Path) -> _TrajIndex:
+    """Index an XDATCAR: byte offset of each ``configuration=`` line plus the
+    lattice in effect for that frame (constant cell, or per-frame for NPT).
+
+    The element list and per-frame lattice are stored so a single frame can be
+    read and converted from fractional to Cartesian coordinates without
+    re-reading the whole file.
+    """
+    text = p.read_text(errors="replace")
+    lines = text.split("\n")
+
+    top = _parse_xdatcar_header(lines, 0)
+    if top is None:
+        raise HTTPException(status_code=400, detail="XDATCAR: bad header")
+    cur_lattice, elements, _ = top
+
+    # Byte offset of each line (so we can return the configuration line's
+    # offset). Building the prefix once is O(lines); seek uses these offsets.
+    line_byte_offsets: list[int] = [0] * len(lines)
+    acc = 0
+    enc = text.encode("utf-8", "replace")
+    # Recompute per-line byte offsets from the encoded text to stay exact for
+    # multibyte content (rare in XDATCAR, but correct).
+    b = 0
+    for i, ln in enumerate(lines):
+        line_byte_offsets[i] = b
+        b += len(ln.encode("utf-8", "replace")) + 1  # +1 for the '\n'
+    del enc, acc
+
+    offsets: list[int] = []
+    lattices: list[list[list[float]]] = []
+    i = top[2]
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "":
+            i += 1
+            continue
+        if "configuration=" not in line:
+            rep = _parse_xdatcar_header(lines, i)
+            if rep is not None:  # NPT: cell changed for the next frame
+                cur_lattice, elements, nxt = rep
+                i = nxt
+                continue
+            i += 1
+            continue
+        offsets.append(line_byte_offsets[i])
+        lattices.append(cur_lattice)
+        # skip the configuration line + its n_atoms coordinate lines
+        i += 1 + len(elements)
+
+    file_size = p.stat().st_size
+    return _TrajIndex(
+        "xdatcar", offsets, file_size, len(elements),
+        elements=elements, lattices=lattices,
+    )
+
+
 def _get_index(path: str) -> tuple[Path, _TrajIndex]:
     """Return the cached index for ``path``, building it on first access."""
     p = _resolve_path(path)
@@ -210,6 +312,8 @@ def _get_index(path: str) -> tuple[Path, _TrajIndex]:
             idx = _build_lammps_index(p)
         elif fmt == "traj":
             idx = _build_traj_index(p)
+        elif fmt == "xdatcar":
+            idx = _build_xdatcar_index(p)
         else:
             idx = _build_xyz_index(p)
         with _CACHE_LOCK:
@@ -224,6 +328,8 @@ def _read_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
         return _read_lammps_frame(p, idx, n)
     if idx.fmt == "traj":
         return _read_traj_frame(p, idx, n)
+    if idx.fmt == "xdatcar":
+        return _read_xdatcar_frame(p, idx, n)
     return _read_xyz_frame(p, idx, n)
 
 
@@ -313,6 +419,56 @@ def _read_xyz_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
         "positions": positions,
         "comment": comment,
         "properties": _parse_comment(comment),
+    }
+
+
+def _read_xdatcar_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:
+    """Read XDATCAR frame ``n``: seek to its configuration line, read the
+    fractional coords, convert to Cartesian with that frame's lattice, and
+    return Cartesian positions + the lattice (so the viewer gets the cell).
+    """
+    n_atoms = idx.n_atoms
+    lattice = idx.lattices[n] if n < len(idx.lattices) else (idx.lattices[0] if idx.lattices else None)
+    elements = idx.elements
+
+    start = idx.offsets[n]
+    # The frame body is the configuration line + n_atoms coord lines; bound the
+    # read generously (no coord line exceeds a few dozen bytes).
+    end = idx.offsets[n + 1] if n + 1 < len(idx.offsets) else idx.file_size
+    with p.open("rb") as fh:
+        fh.seek(start)
+        raw = fh.read(end - start)
+    lines = raw.decode("utf-8", "replace").splitlines()
+
+    # lines[0] is the configuration line; coords start at lines[1].
+    # Lattice rows = a,b,c (VASP convention) ⇒ cart = fracᵀ·M summed per row:
+    #   cart_k = fa*a_k + fb*b_k + fc*c_k.
+    a, b, c = (lattice or [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    positions: list[list[float]] = []
+    for k in range(n_atoms):
+        li = 1 + k
+        if li >= len(lines):
+            break
+        parts = lines[li].split()
+        if len(parts) < 3:
+            continue
+        try:
+            fa, fb, fc = float(parts[0]), float(parts[1]), float(parts[2])
+        except ValueError:
+            continue
+        positions.append([
+            fa * a[0] + fb * b[0] + fc * c[0],
+            fa * a[1] + fb * b[1] + fc * c[1],
+            fa * a[2] + fb * b[2] + fc * c[2],
+        ])
+
+    return {
+        "frame_number": n,
+        "elements": list(elements),
+        "positions": positions,
+        "lattice": lattice,
+        "comment": "",
+        "properties": {},
     }
 
 
@@ -432,7 +588,14 @@ async def trajectory_upload(file: UploadFile = File(...)) -> dict:
     """
     cache_dir = Path.home() / ".catgoat" / "cache" / "traj"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    ext = os.path.splitext(file.filename or "upload.xyz")[1] or ".xyz"
+    orig_name = file.filename or "upload.xyz"
+    # The cached filename drives _detect_format. VASP XDATCAR has no extension,
+    # so preserve an "xdatcar" marker in the suffix; otherwise keep the real
+    # extension (defaulting to .xyz).
+    if "xdatcar" in orig_name.lower():
+        ext = ".xdatcar"
+    else:
+        ext = os.path.splitext(orig_name)[1] or ".xyz"
 
     tmp = cache_dir / f".upload-{os.getpid()}-{id(file)}{ext}.part"
     sha = hashlib.sha1()

--- a/src/lib/trajectory/parsers/vasp.ts
+++ b/src/lib/trajectory/parsers/vasp.ts
@@ -1,64 +1,166 @@
 // VASP XDATCAR trajectory parser
-import type { ElementSymbol, Vec3 } from '$lib'
+import type { ElementSymbol, Pbc, Vec3 } from '$lib'
 import type { Matrix3x3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { TrajectoryFrame, TrajectoryType } from '../index'
 import { create_trajectory_frame } from './common'
 
-export const parse_vasp_xdatcar = (content: string, filename?: string): TrajectoryType => {
-  const lines = content.trim().split(/\r?\n/)
-  if (lines.length < 10) throw new Error(`XDATCAR file too short`)
+// A parsed XDATCAR header block: scale, lattice (already scaled), element
+// names + counts. NPT runs repeat this block before every frame; constant-cell
+// runs write it only once at the top.
+interface XdatcarHeader {
+  lattice: Matrix3x3
+  element_names: string[]
+  element_counts: number[]
+  elements: ElementSymbol[]
+}
 
-  const scale = parseFloat(lines[1])
-  if (isNaN(scale)) throw new Error(`Invalid scale factor`)
+const WHITESPACE = /\s+/
 
-  const lattice_matrix = lines.slice(2, 5).map((line) =>
-    line.trim().split(/\s+/).map((x) => parseFloat(x) * scale)
-  ) as Matrix3x3
+/** Parse one 3x3 lattice from `lines[start..start+3]`, multiplied by `scale`. */
+function parse_lattice(lines: string[], start: number, scale: number): Matrix3x3 {
+  const m: number[][] = []
+  for (let r = 0; r < 3; r++) {
+    const parts = lines[start + r].trim().split(WHITESPACE)
+    m.push([
+      parseFloat(parts[0]) * scale,
+      parseFloat(parts[1]) * scale,
+      parseFloat(parts[2]) * scale,
+    ])
+  }
+  return m as Matrix3x3
+}
 
-  const element_names = lines[5].trim().split(/\s+/)
-  const element_counts = lines[6].trim().split(/\s+/).map(Number)
+/**
+ * Parse a header block starting at `line_idx` (the title line). Returns the
+ * header plus the index of the line immediately after the counts line, or
+ * null if the block at `line_idx` is not a valid header (so the caller can
+ * tell a "frame separator" from a "repeated NPT header").
+ *
+ *   line_idx       : title (free text)
+ *   line_idx + 1   : scale factor (single float)
+ *   line_idx + 2..4: lattice vectors
+ *   line_idx + 5   : element names (e.g. "O H")
+ *   line_idx + 6   : element counts (e.g. "64 128")
+ */
+function parse_header(lines: string[], line_idx: number): { header: XdatcarHeader; next: number } | null {
+  if (line_idx + 6 >= lines.length) return null
+  const scale = parseFloat(lines[line_idx + 1])
+  if (!Number.isFinite(scale)) return null
+
+  // Lattice rows must be three numeric triples.
+  for (let r = 2; r <= 4; r++) {
+    const parts = lines[line_idx + r].trim().split(WHITESPACE)
+    if (parts.length < 3 || parts.slice(0, 3).some((p) => !Number.isFinite(parseFloat(p)))) {
+      return null
+    }
+  }
+  const lattice = parse_lattice(lines, line_idx + 2, scale)
+
+  const element_names = lines[line_idx + 5].trim().split(WHITESPACE)
+  const element_counts = lines[line_idx + 6].trim().split(WHITESPACE).map(Number)
+  // Counts line must be all positive integers and match the names count.
+  if (
+    element_names.length === 0 ||
+    element_counts.length !== element_names.length ||
+    element_counts.some((c) => !Number.isInteger(c) || c <= 0)
+  ) {
+    return null
+  }
+
   const elements: ElementSymbol[] = element_names.flatMap((name, idx) =>
     Array(element_counts[idx]).fill(name as ElementSymbol)
   )
+  return { header: { lattice, element_names, element_counts, elements }, next: line_idx + 7 }
+}
 
+export const parse_vasp_xdatcar = (content: string, filename?: string): TrajectoryType => {
+  const lines = content.split(/\r?\n/)
+  if (lines.length < 8) throw new Error(`XDATCAR file too short`)
+
+  // The top header is mandatory. For constant-cell runs it is the only one;
+  // for NPT runs an identical block precedes every "configuration=" line, and
+  // we re-read it each time so the per-frame cell is honored instead of being
+  // silently dropped.
+  const top = parse_header(lines, 0)
+  if (!top) throw new Error(`XDATCAR: could not parse header (scale / lattice / element lines)`)
+
+  const pbc: Pbc = [true, true, true]
   const frames: TrajectoryFrame[] = []
-  let line_idx = 7
+  const warnings: string[] = []
 
-  while (line_idx < lines.length) {
-    const config_line = lines.find((line, idx) =>
-      idx >= line_idx && line.includes(`Direct configuration=`)
-    )
-    if (!config_line) break
+  // Cache the transpose per distinct lattice. Coordinates are fractional and
+  // converted via `frac · latticeᵀ`; recomputing the transpose for every atom
+  // (the old code's hot-loop cost) is pure waste when the cell is constant.
+  let active = top.header
+  let active_lattice_T = math.transpose_3x3_matrix(active.lattice)
 
-    line_idx = lines.indexOf(config_line) + 1
-    const step_match = config_line.match(/configuration=\s*(\d+)/)
-    const step = step_match ? parseInt(step_match[1]) : frames.length + 1
+  let i = top.next
+  let auto_step = 0
 
-    const positions = []
-    for (let idx = 0; idx < elements.length && line_idx < lines.length; idx++) {
-      const coords = lines[line_idx].trim().split(/\s+/).slice(0, 3).map(Number)
-      if (coords.length === 3 && !coords.some(isNaN)) {
-        positions.push(
-          math.mat3x3_vec3_multiply(
-            math.transpose_3x3_matrix(lattice_matrix),
-            coords as Vec3,
-          ),
-        )
+  // Single forward pass — O(total lines). Each iteration either consumes a
+  // repeated NPT header or one configuration block. No re-scanning from the
+  // top (the old find()/indexOf() made this O(frames × lines) and could jump
+  // back to the first frame when two configuration lines were identical).
+  while (i < lines.length) {
+    const line = lines[i]
+    if (line.trim() === ``) { i++; continue }
+
+    // NPT: a repeated header block appears before the next configuration line.
+    // Detect it in place (no rescan) by trying to parse a header right here.
+    if (!line.includes(`configuration=`)) {
+      const rep = parse_header(lines, i)
+      if (rep) {
+        active = rep.header
+        active_lattice_T = math.transpose_3x3_matrix(active.lattice)
+        i = rep.next
+        continue
       }
-      line_idx++
+      // Not a header and not a configuration line — skip stray line.
+      i++
+      continue
     }
 
-    if (positions.length === elements.length) {
+    // Configuration line: read the next n_atoms coordinate lines.
+    const step_match = line.match(/configuration=\s*(\d+)/)
+    const step = step_match ? parseInt(step_match[1], 10) : auto_step + 1
+    auto_step = step
+    i++
+
+    const n_atoms = active.elements.length
+    const positions: number[][] = []
+    for (let a = 0; a < n_atoms; a++) {
+      if (i >= lines.length) break
+      const parts = lines[i].trim().split(WHITESPACE)
+      i++
+      if (parts.length < 3) continue
+      const fx = parseFloat(parts[0])
+      const fy = parseFloat(parts[1])
+      const fz = parseFloat(parts[2])
+      if (!Number.isFinite(fx) || !Number.isFinite(fy) || !Number.isFinite(fz)) continue
+      positions.push(
+        math.mat3x3_vec3_multiply(active_lattice_T, [fx, fy, fz] as Vec3),
+      )
+    }
+
+    if (positions.length === n_atoms) {
       frames.push(create_trajectory_frame(
         positions,
-        elements,
-        lattice_matrix,
-        [true, true, true],
+        active.elements,
+        active.lattice,
+        pbc,
         step,
-        { volume: math.calc_lattice_params(lattice_matrix).volume },
+        { volume: math.calc_lattice_params(active.lattice).volume },
       ))
+    } else if (positions.length > 0) {
+      // Don't silently drop a short frame — surface it so the user knows the
+      // file was truncated rather than seeing a frame count that's quietly off.
+      warnings.push(`frame ${step}: expected ${n_atoms} atoms, got ${positions.length} (truncated?)`)
     }
+  }
+
+  if (frames.length === 0) {
+    throw new Error(`XDATCAR: no configuration frames found`)
   }
 
   return {
@@ -67,10 +169,11 @@ export const parse_vasp_xdatcar = (content: string, filename?: string): Trajecto
       filename,
       source_format: `vasp_xdatcar`,
       frame_count: frames.length,
-      total_atoms: elements.length,
-      periodic_boundary_conditions: [true, true, true],
-      elements: element_names,
-      element_counts,
+      total_atoms: top.header.elements.length,
+      periodic_boundary_conditions: pbc,
+      elements: top.header.element_names,
+      element_counts: top.header.element_counts,
+      ...(warnings.length > 0 ? { warnings } : {}),
     },
   }
 }

--- a/src/lib/trajectory/remote-frame-loader.ts
+++ b/src/lib/trajectory/remote-frame-loader.ts
@@ -9,6 +9,7 @@
 // in-memory content) and addresses frames by the file path instead.
 
 import type { ElementSymbol } from '$lib'
+import type { Matrix3x3 } from '$lib/math'
 import { API_BASE } from '$lib/api/config'
 import { create_trajectory_frame } from './parsers/common'
 import type {
@@ -25,6 +26,9 @@ interface BackendFrame {
   positions: number[][]
   comment?: string
   properties?: Record<string, number>
+  // Present for periodic formats (XDATCAR): the 3x3 cell for this frame.
+  // Absent for cell-less formats (CP2K *-pos*.xyz).
+  lattice?: number[][] | null
 }
 
 /** Cap plot sampling so the metadata fetch stays small for 10k+ frames. */
@@ -36,11 +40,17 @@ const BATCH = 16
 const CACHE_CAP = 400
 
 function backend_frame_to_trajectory_frame(bf: BackendFrame): TrajectoryFrame {
+  // Periodic formats (XDATCAR) carry a per-frame cell; pass it through so the
+  // viewer draws the box and bonds are PBC-aware. Cell-less formats (CP2K
+  // *-pos*.xyz) send no lattice and stay non-periodic.
+  const lattice = (bf.lattice && bf.lattice.length === 3)
+    ? bf.lattice as unknown as Matrix3x3
+    : undefined
   return create_trajectory_frame(
     bf.positions,
     bf.elements as ElementSymbol[],
-    undefined, // lattice — CP2K pos files carry no cell
-    undefined, // pbc
+    lattice,
+    lattice ? [true, true, true] : undefined,
     bf.frame_number,
     { comment: bf.comment ?? ``, ...(bf.properties ?? {}) },
   )
@@ -51,8 +61,19 @@ function frames_url(path: string, start: number, count: number): string {
     `&start=${start}&count=${count}`
 }
 
-/** Extensions the backend trajectory streamer can index. */
-const STREAMABLE_RE = /\.(xyz|extxyz|lammpstrj|traj)$/i
+/** Files the backend trajectory streamer can index. XDATCAR is matched by
+ *  name (VASP trajectories usually have no extension). */
+const STREAMABLE_RE = /\.(xyz|extxyz|lammpstrj|traj)$|xdatcar/i
+
+/** XDATCAR parses ~100× its byte size into JS site objects (fractional text →
+ *  nested objects), so it must stream at a much lower size than text XYZ — a
+ *  2-3 MB XDATCAR already balloons to hundreds of MB and OOMs the webview when
+ *  a second one is opened. Stream XDATCAR above 1 MB; keep the 20 MB default
+ *  for the lighter text formats. */
+const XDATCAR_STREAM_MIN_BYTES = 1 * 1024 * 1024
+function stream_min_bytes_for(filename: string): number {
+  return /xdatcar/i.test(filename) ? XDATCAR_STREAM_MIN_BYTES : 20 * 1024 * 1024
+}
 
 export interface StreamProbe {
   stream: boolean
@@ -72,9 +93,10 @@ export interface StreamProbe {
 export async function probe_streamable_trajectory(
   path: string,
   filename: string,
-  min_bytes = 20 * 1024 * 1024,
+  min_bytes?: number,
 ): Promise<StreamProbe | null> {
   if (!STREAMABLE_RE.test(filename)) return null
+  const limit = min_bytes ?? stream_min_bytes_for(filename)
   try {
     const resp = await fetch(
       `${API_BASE}/trajectory/index?path=${encodeURIComponent(path)}`,
@@ -83,7 +105,7 @@ export async function probe_streamable_trajectory(
     const idx = await resp.json()
     const total_frames = idx?.total_frames ?? 0
     const file_size = idx?.file_size ?? 0
-    return { stream: total_frames >= 2 && file_size > min_bytes, total_frames, file_size }
+    return { stream: total_frames >= 2 && file_size > limit, total_frames, file_size }
   } catch {
     return null
   }
@@ -101,9 +123,10 @@ export async function materialize_remote_if_large(
   remote_path: string,
   filename: string,
   size_bytes: number,
-  min_bytes = 20 * 1024 * 1024,
+  min_bytes?: number,
 ): Promise<string | null> {
-  if (!STREAMABLE_RE.test(filename) || (size_bytes ?? 0) <= min_bytes) return null
+  const limit = min_bytes ?? stream_min_bytes_for(filename)
+  if (!STREAMABLE_RE.test(filename) || (size_bytes ?? 0) <= limit) return null
   try {
     const { materializeRemoteTrajectory } = await import('$lib/api/hpc')
     const mat = await materializeRemoteTrajectory(session_id, remote_path)
@@ -122,9 +145,10 @@ export async function materialize_remote_if_large(
  */
 export async function materialize_file_if_large(
   file: File,
-  min_bytes = 20 * 1024 * 1024,
+  min_bytes?: number,
 ): Promise<string | null> {
-  if (!STREAMABLE_RE.test(file.name) || file.size <= min_bytes) return null
+  const limit = min_bytes ?? stream_min_bytes_for(file.name)
+  if (!STREAMABLE_RE.test(file.name) || file.size <= limit) return null
   try {
     const fd = new FormData()
     fd.append('file', file, file.name)


### PR DESCRIPTION
Closes #217.

Opening a 2-3 MB XDATCAR worked; opening a **second** one OOM-crashed the webview. XDATCAR wasn't in the streaming allow-list, so it always took the in-memory path — every frame eagerly materialized into nested JS site objects, and a few-MB fractional-coord file balloons ~100× into hundreds of MB. Two at once exhaust the heap. (XYZ never hit this because it streams.)

This routes XDATCAR through the **same backend frame-streamer XYZ uses**, so the webview holds only the current frame + a small prefetch window.

### Backend — `trajectory_stream.py`
- `_detect_format` recognizes XDATCAR by name (VASP files have no extension).
- `_build_xdatcar_index`: single pass recording each frame's byte offset + the cell in effect (constant, or per-frame for NPT) + the element list.
- `_read_xdatcar_frame`: seek one frame, read fractional coords, convert to Cartesian with that frame's lattice; wire frame now carries `lattice`.
- Upload cache preserves an `xdatcar` marker so detection survives the pathless web-drop upload.

### Frontend — `remote-frame-loader.ts`
- `STREAMABLE_RE` matches XDATCAR; per-format threshold streams XDATCAR above **1 MB** (vs 20 MB for text XYZ) since its memory blow-up is far larger.
- `backend_frame_to_trajectory_frame` passes the per-frame lattice through (was hard-coded `undefined`), so the box renders and bonds stay PBC-aware.

### Also — `parsers/vasp.ts` (in-memory fast path for small files)
Rewritten to single-pass **O(N)** (was O(frames × lines) via `find()`/`indexOf()`, which also mis-read frames when two `configuration=` lines matched), with per-frame lattice for NPT and no silent frame drops.

### Test plan
- [x] Backend compiles; frontend `svelte-check` clean on changed files.
- [x] Live backend (TestClient), **2.93 MB / 1000-frame / 100-atom XDATCAR**: index instant; frames 0-7 fetch in ~9 ms with `lattice` present and frac→cart correct; random deep-frame (999) seek reads only that frame.
- [x] NPT synthetic file: per-frame cell varies (11→13 Å) instead of being locked to frame 0.
- [x] Reviewer: restart backend, drag two 2-3 MB XDATCARs — both open, no OOM.
