### PR TITLE
Mobile/iOS: run CatGo on a physical iPhone (icons, viewer, terminal, LAN backend)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CatGo — repo guide for Claude & contributors
+
+CatGo is an **AI-driven workbench for computational materials science**: a 3D
+structure/trajectory editor + workflow engine, shipped as a Tauri desktop app
+(and a Tauri **mobile** build) with a Python backend.
+
+## Stack & layout
+
+- **Frontend:** SvelteKit 2 / **Svelte 5 (runes)** + Vite 7 — `src/`
+- **Desktop/mobile shell:** Tauri 2 — `src-tauri/`. Mobile projects live in
+  `src-tauri/gen/{apple,android}` and are machine-local / regenerated (not committed).
+- **Backend:** FastAPI (Python) — `server/main.py`. An agent sidecar (`pnpm agent:dev`)
+  serves `/api/agent/*`.
+- **WASM / native:** `extensions/rust-wasm` (ferrox — bonds/geometry), `crates/`.
+- **3D viewer:** Three.js. The purpose-built mobile UI lives in `src/lib/mobile/`.
+
+## Commands
+
+- `pnpm desktop:serve` — full dev stack (Vite frontend + Python backend + agent), desktop
+- `pnpm tauri ios dev "<device>"` — run on a connected iPhone (see **Mobile / iOS** below)
+- `pnpm check` — type-check (`svelte-check`)
+- `pnpm test` — unit tests (`vitest run`)
+- `pnpm desktop:build` — production desktop build
+
+## Conventions
+
+- **Formatting is enforced by a local pre-commit hook** (`deno fmt`): single quotes,
+  **no semicolons**, 2-space indent, 90-col (`deno.jsonc`). `.svelte` / `.md` / `.yaml`
+  are excluded from `deno fmt`. Don't fight it — let the hook format, then re-stage.
+- **Svelte 5 runes** (`$state` / `$derived` / `$effect` / `$props`) — not legacy
+  stores or `export let`.
+- **i18n:** `src/lib/i18n/{en,zh}/*.ts` — keep the **en and zh key sets in parity**.
+- **CI gates (PR → `main`):** `test.yml` (`vitest`) is the real one. `lint.yml` is
+  `continue-on-error` (non-blocking) and skips eslint. Type-check is **not** a CI gate.
+
+## Mobile / iOS
+
+The mobile app reuses the desktop Svelte UI inside a Tauri **WKWebView**. iOS surfaced
+several WKWebView-specific issues; the fixes are **gated on mobile** (`TAURI_DEV_HOST`)
+so desktop / production behaviour is unchanged.
+
+**Before changing mobile code, read `deploy/ios/LOCAL-TESTING-PROGRESS.md`** — it has the
+build/run flow plus a table mapping every iOS change to its file and the knob to adjust.
+
+Key invariants — these look odd but fix real iOS bugs, so don't silently revert them:
+
+- Launch with `TAURI_DEV_HOST=<Mac LAN IP>` (`ipconfig getifaddr en0`) — the phone is not
+  `localhost`, so the backend URL, CORS origin, and HMR all derive from it.
+- `src/lib/Icon.svelte` uses `height: 1em` (not `auto`) — iOS collapses `auto` viewBox
+  SVGs to 0px (blank squares).
+- Don't `display:none` the mobile 3D-viewer pane — it zeroes the WebGL canvas (keep-warm
+  off-screen instead).
+- Use `<Icon>` SVG (`src/lib/icons.ts`) for mobile icons, never raw Unicode glyphs
+  (no iOS font glyph → tofu squares).
+- `vite.desktop.config.ts` sets `emitCss:false` on mobile dev (avoids a cold-load PostCSS
+  race; the trade-off is losing CSS-only HMR on mobile).
+
+A shipped `.ipa` (mobile *production*) still needs work the dev build papers over: the
+backend must not be `localhost`, the chat agent's relative URL needs a real host, and the
+structure formats should be declared as UTTypes in `Info.plist`. See the notes file.

--- a/deploy/ios/LOCAL-TESTING-PROGRESS.md
+++ b/deploy/ios/LOCAL-TESTING-PROGRESS.md
@@ -16,9 +16,9 @@ The app runs as a live dev session loading its frontend from the Mac over the LA
 To run it again (device plugged in + unlocked + trusted):
 
 ```bash
-# from repo root, on branch feat/mobile-app-456:
-TAURI_DEV_HOST=192.168.12.236 pnpm tauri ios dev "Jenedith's phone"
-#               ^ this Mac's current LAN IP (check: ipconfig getifaddr en0)
+# from repo root:
+TAURI_DEV_HOST=<MAC_LAN_IP> pnpm tauri ios dev "<your device name>"
+#              ^ this Mac's current LAN IP (check: ipconfig getifaddr en0)
 ```
 
 That builds CatGo and launches it on the connected device. Keep this process running —
@@ -35,10 +35,10 @@ the phone loads the UI from `http://<LAN-IP>:3100` and HMR pushes edits live.
 
 2. **First launch failed: "…has not been explicitly trusted by the user" (CoreDeviceError 10002).**
    The app installs fine but iOS quarantines the first launch from an untrusted dev cert.
-   The signing cert is **`Apple Development: ijennheart@gmail.com`** (NOT the "Jenedith
-   Pascasio Personal Team" in the old notes below — automatic signing picked this identity).
+   The signing cert is whatever **`Apple Development: <your-apple-id>`** identity Xcode's
+   automatic signing picked (it may differ from your Personal Team's display name).
    **Fix (one-time per cert, on the phone):** Settings → General → VPN & Device Management →
-   tap the `ijennheart@gmail.com` profile → Trust. Then re-run the command above.
+   tap your `Apple Development: <your-apple-id>` profile → Trust. Then re-run the command above.
 
 ---
 
@@ -54,7 +54,7 @@ the phone loads the UI from `http://<LAN-IP>:3100` and HMR pushes edits live.
 | `pnpm tauri ios init` | generated `src-tauri/gen/apple/catgo.xcodeproj` |
 | Info.plist patch | `ITSAppUsesNonExemptEncryption=false` set in `src-tauri/gen/apple/catgo_iOS/Info.plist` |
 | iOS 26.5 platform | downloaded (8.5 GB) — device SDK `iphoneos26.5` + simulator runtime both present |
-| Signing | Xcode → automatic signing ON, Team = **Jenedith Pascasio (Personal Team)**, bundle id `com.catgo.app` accepted |
+| Signing | Xcode → automatic signing ON, Team = **your Personal Team**, bundle id `com.catgo.app` accepted |
 
 ## ⬜ Remaining (start here tomorrow)
 
@@ -66,7 +66,7 @@ the phone loads the UI from `http://<LAN-IP>:3100` and HMR pushes edits live.
    go green. *(Those errors are expected with no device attached — not a real problem.)*
 3. Run `pnpm tauri ios dev`.
 4. First launch on the device: **Settings → General → VPN & Device Management →
-   trust the developer cert** (the "Jenedith Pascasio" developer profile).
+   trust the developer cert** (your developer profile).
 
 ---
 

--- a/deploy/ios/LOCAL-TESTING-PROGRESS.md
+++ b/deploy/ios/LOCAL-TESTING-PROGRESS.md
@@ -90,6 +90,28 @@ the phone loads the UI from `http://<LAN-IP>:3100` and HMR pushes edits live.
   change the bundle id to something unique (e.g. `com.<yourname>.catgo`) and mirror
   it in `src-tauri/tauri.conf.json`. (Not needed here — `com.catgo.app` was accepted.)
 
+## Mobile/iOS code changes — map & adjustable knobs
+
+For anyone (or Claude) picking this up: every change below is **gated on mobile**
+(mostly `TAURI_DEV_HOST` being set), so desktop + production behaviour is unchanged.
+If you need to tweak the mobile build, start here. Each file also has inline `why`
+comments at the change site.
+
+| Area | File(s) | What & why | Knob to adjust |
+|------|---------|------------|----------------|
+| LAN backend routing | `vite.shared.ts`, `scripts/tauri-dev.mjs` | The phone isn't `localhost`; bake the Mac's LAN IP into `SERVER_URL` and whitelist the phone origin for the backend's CORS (`CATGO_ALLOWED_ORIGINS`). | Set `TAURI_DEV_HOST=<your Mac LAN IP>` at launch (`ipconfig getifaddr en0`). Both halves derive from it. |
+| Vite dev (LAN/HMR/CSS) | `vite.desktop.config.ts` | Binds Vite to the LAN, pins HMR `clientPort`, and `emitCss:false` on mobile to dodge a cold-load PostCSS race. | `emitCss:false` disables CSS-only HMR on mobile dev (style edits reload the whole component). Drop it if that race no longer bites. |
+| Icon rendering | `src/lib/Icon.svelte` | `height: 1em` (not `auto`) — iOS WKWebView collapses a `height:auto` + viewBox inline SVG to 0px (blank squares). | Do NOT revert to `height: auto`. |
+| Tofu glyph icons | `MobileWorkspace.svelte`, `MobileFiles.svelte`, `LocaleSwitch.svelte` | iOS has no font glyph for `⬚ ⊟ ⊞ ▭ ⟳ ↰`; replaced with `<Icon>` SVG. `LocaleSwitch` gained a `compact` (icon-only) mode. | For any new mobile icon use `<Icon>` (from `src/lib/icons.ts`), never a raw Unicode symbol. |
+| 3D viewer keep-warm | `MobileWorkspace.svelte` (`.mw-pane.mw-struct.hidden`) | `display:none` zeroes the WebGL canvas → blank viewer on return from the terminal. The struct pane stays laid out (off-screen, `visibility:hidden`) when inactive. | Do NOT `display:none` the structure pane. |
+| Action bar overflow | `MobileWorkspace.svelte` | Compact locale switch + scrollable/shrinkable `.mw-actions` so the buttons (up to 6 when connected) never clip. | — |
+| Terminal | `MobileTerminal.svelte` | Hides the OSC7 cwd-setup echo via a render-gate (private OSC 99 sentinel); registers the cwd hook for **zsh** (`precmd_functions`, not bash `PROMPT_COMMAND`); adds left/right padding. | — |
+| Local file picker | `MobileWorkspace.svelte` (`accept="*/*"`) | iOS greys out unknown extensions (`.xyz`, `.cif`, …); `*/*` lets you pick any file and the handler parses by content. | Production fix: declare the formats as UTTypes in `src-tauri/gen/apple/.../Info.plist`. |
+
+App icon: regenerated locally via `pnpm tauri icon src-tauri/icons/icon.png`, but
+`gen/apple` is machine-local — the durable fix is a 1024×1024 master so `tauri icon` /
+`ios init` always emit the real CatGo icon instead of the Tauri placeholder.
+
 ## Build prerequisites recap (all satisfied on this Mac)
 
 - Xcode 26.5, license accepted · iOS 26.5 SDK + simulator runtime

--- a/deploy/ios/LOCAL-TESTING-PROGRESS.md
+++ b/deploy/ios/LOCAL-TESTING-PROGRESS.md
@@ -1,0 +1,106 @@
+# CatGo iOS — local device testing, progress & resume notes
+
+**Goal:** build the CatGo iPhone/iPad app and run it on *our own* devices for testing
+(free Apple ID, no $99 yet). Distribution decision (TestFlight / ad-hoc) deferred.
+
+**Branch:** `feat/mobile-app-456`  ·  **Machine:** this Mac (Apple Silicon)
+**Last worked:** 2026-06-02
+
+---
+
+## TL;DR — where we stopped
+
+**✅ 2026-06-04: CatGo built, installed, and LAUNCHED on the iPhone (iPhone 17 Pro Max, iOS 26.4.2).**
+The app runs as a live dev session loading its frontend from the Mac over the LAN.
+
+To run it again (device plugged in + unlocked + trusted):
+
+```bash
+# from repo root, on branch feat/mobile-app-456:
+TAURI_DEV_HOST=192.168.12.236 pnpm tauri ios dev "Jenedith's phone"
+#               ^ this Mac's current LAN IP (check: ipconfig getifaddr en0)
+```
+
+That builds CatGo and launches it on the connected device. Keep this process running —
+the phone loads the UI from `http://<LAN-IP>:3100` and HMR pushes edits live.
+
+### Two gotchas we hit on 2026-06-04 (both now solved)
+
+1. **`tauri ios dev` hung forever on "Waiting for your frontend dev server".**
+   Cause: `vite.desktop.config.ts` bound the dev server to `127.0.0.1` only, which the
+   phone (a separate device on the LAN) can't reach. **Fix (now committed in the config):**
+   the `server.host` now honors `TAURI_DEV_HOST`. You MUST pass `TAURI_DEV_HOST=<Mac LAN IP>`
+   when running, or Vite stays on localhost and the phone can't load anything.
+   *If the Mac's LAN IP changed, update it (`ipconfig getifaddr en0`).*
+
+2. **First launch failed: "…has not been explicitly trusted by the user" (CoreDeviceError 10002).**
+   The app installs fine but iOS quarantines the first launch from an untrusted dev cert.
+   The signing cert is **`Apple Development: ijennheart@gmail.com`** (NOT the "Jenedith
+   Pascasio Personal Team" in the old notes below — automatic signing picked this identity).
+   **Fix (one-time per cert, on the phone):** Settings → General → VPN & Device Management →
+   tap the `ijennheart@gmail.com` profile → Trust. Then re-run the command above.
+
+---
+
+## ✅ Done
+
+| Step | Notes |
+|------|-------|
+| Checked out `feat/mobile-app-456` | mobile/iOS code lives here (not on `main`) |
+| Rust iOS targets | `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `x86_64-apple-ios` |
+| `pnpm install` | deps present |
+| **Full Xcode 26.5** | installed; license accepted (`sudo xcodebuild -license accept`) |
+| `xcodegen` + CocoaPods | installed via Homebrew (Tauri needs both) |
+| `pnpm tauri ios init` | generated `src-tauri/gen/apple/catgo.xcodeproj` |
+| Info.plist patch | `ITSAppUsesNonExemptEncryption=false` set in `src-tauri/gen/apple/catgo_iOS/Info.plist` |
+| iOS 26.5 platform | downloaded (8.5 GB) — device SDK `iphoneos26.5` + simulator runtime both present |
+| Signing | Xcode → automatic signing ON, Team = **Jenedith Pascasio (Personal Team)**, bundle id `com.catgo.app` accepted |
+
+## ⬜ Remaining (start here tomorrow)
+
+1. **Connect the iPhone/iPad** via USB → unlock → **Trust This Computer**.
+   - Device must have **Developer Mode ON**: Settings → Privacy & Security → Developer Mode → On → restart.
+2. In Xcode signing screen, click **Try Again** — with a device attached, the
+   Personal Team generates the provisioning profile and the two red errors
+   ("Communication with Apple failed / no devices", "No profiles for com.catgo.app")
+   go green. *(Those errors are expected with no device attached — not a real problem.)*
+3. Run `pnpm tauri ios dev`.
+4. First launch on the device: **Settings → General → VPN & Device Management →
+   trust the developer cert** (the "Jenedith Pascasio" developer profile).
+
+---
+
+## Gotchas / things to remember
+
+- **Free Personal Team limits:** the app **expires after 7 days** (just re-run
+  `pnpm tauri ios dev` / rebuild to refresh), max 3 sideloaded apps per Apple ID.
+  This is the price of not paying the $99/yr — fine for personal testing.
+- **`src-tauri/gen/apple/` is NOT committed** (machine-local, like `gen/android/`).
+  After a fresh clone you must re-run `pnpm tauri ios init` **and re-apply the
+  Info.plist patch** (`ITSAppUsesNonExemptEncryption=false`).
+- **GitHub does NOT solve iOS distribution.** Unlike the desktop `.dmg`, an iPhone
+  refuses to install an unsigned `.ipa` from a download. Real distribution needs
+  either ad-hoc (paid, pre-registered device UDIDs) or TestFlight (paid $99/yr).
+  See `deploy/ios/README.md`. Apple refs:
+  - https://developer.apple.com/documentation/xcode/distributing-your-app-to-registered-devices
+  - https://developer.apple.com/testflight/
+- **Xcode 26 ships no iOS platform by default** — it's an on-demand ~8.5 GB
+  download (`xcodebuild -downloadPlatform iOS`). Already done on this machine.
+- If signing shows *"Failed to register bundle identifier"* on another machine/Apple ID,
+  change the bundle id to something unique (e.g. `com.<yourname>.catgo`) and mirror
+  it in `src-tauri/tauri.conf.json`. (Not needed here — `com.catgo.app` was accepted.)
+
+## Build prerequisites recap (all satisfied on this Mac)
+
+- Xcode 26.5, license accepted · iOS 26.5 SDK + simulator runtime
+- Rust iOS targets · xcodegen · CocoaPods 1.16.2 · libimobiledevice (auto-installed)
+- Node/pnpm 10.28.2 · Tauri CLI v2.9.6
+
+## Reference docs in repo
+
+- `deploy/ios/README.md` — full iOS build guide (toolchain, signing, Keychain plan)
+- `.github/workflows/ios-build.yml` — CI build on a GitHub macOS runner (simulator
+  smoke build by default; signed IPA when `APPLE_*` secrets are set)
+
+---
+*Session notes — a resume guide for building and testing CatGo on iOS.*

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -45,7 +45,12 @@ if (is_dev) {
   // would otherwise reject that cross-origin — whitelist it via the env var
   // main.py reads (CATGO_ALLOWED_ORIGINS). Inherited by beforeDevCommand → python.
   if (process.env.TAURI_DEV_HOST) {
-    const mobile_origin = `http://${process.env.TAURI_DEV_HOST}:${desktop_port}`
+    const raw_host = process.env.TAURI_DEV_HOST
+    // Wrap a bare IPv6 literal in [] so the origin stays valid (http://[::1]:port).
+    const host = raw_host.includes(`:`) && !raw_host.startsWith(`[`)
+      ? `[${raw_host}]`
+      : raw_host
+    const mobile_origin = `http://${host}:${desktop_port}`
     // main.py reads CATGO_ALLOWED_ORIGINS as a comma-separated list — append to any
     // existing value rather than clobber it, so other allowed origins survive.
     extra_env.CATGO_ALLOWED_ORIGINS = [process.env.CATGO_ALLOWED_ORIGINS, mobile_origin]

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -24,33 +24,53 @@ function worktree_offset() {
 }
 
 const args = process.argv.slice(2)
-const subcommand = args[0]
 const extra_env = {}
 let final_args = args
 
-if (subcommand === 'dev') {
+// `dev` is args[0] for desktop (`tauri dev`) but args[1] for mobile
+// (`tauri ios dev` / `tauri android dev`). Handle both.
+const dev_index = args.indexOf('dev')
+const is_desktop_dev = dev_index === 0
+const is_dev = dev_index === 0 || dev_index === 1
+
+if (is_dev) {
   const offset = worktree_offset()
   const desktop_port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3100 + offset
-  const dev_url = `http://localhost:${desktop_port}`
-  // Drop externalBin in dev: beforeDevCommand starts the Python backend
-  // separately (pnpm desktop:serve), so Tauri doesn't need a sidecar exe to exist.
-  const config_override = JSON.stringify({
-    build: { devUrl: dev_url },
-    bundle: { externalBin: [] },
-  })
 
-  // Write to a temp file so Windows cmd.exe doesn't strip the JSON's quotes
-  // when spawn runs with shell: true. Tauri's --config accepts a file path.
-  const config_path = join(tmpdir(), `catgo-tauri-dev-${process.pid}.json`)
-  writeFileSync(config_path, config_override)
-
-  console.log(`[tauri-dev] worktree offset=${offset}, devUrl=${dev_url}`)
-
-  // Ensure Vite picks the same port via process.env.PORT
+  // Ensure Vite picks the same port via process.env.PORT (web + mobile).
   extra_env.PORT = String(desktop_port)
 
-  // Insert --config right after `dev`; user's original args follow.
-  final_args = ['dev', '--config', config_path, ...args.slice(1)]
+  // Mobile dev: the phone loads the SPA from the Mac's LAN IP, so its page
+  // origin is http://<LAN-IP>:<desktop_port>. The backend (bound to 0.0.0.0)
+  // would otherwise reject that cross-origin — whitelist it via the env var
+  // main.py reads (CATGO_ALLOWED_ORIGINS). Inherited by beforeDevCommand → python.
+  if (process.env.TAURI_DEV_HOST) {
+    extra_env.CATGO_ALLOWED_ORIGINS =
+      `http://${process.env.TAURI_DEV_HOST}:${desktop_port}`
+    console.log(
+      `[tauri-dev] mobile: allow backend origin ${extra_env.CATGO_ALLOWED_ORIGINS}`,
+    )
+  }
+
+  // Desktop `tauri dev` needs its devUrl pinned to the worktree port via
+  // --config. Mobile gets devUrl from tauri.conf.json + TAURI_DEV_HOST, so we
+  // leave its args untouched (only the env above applies).
+  if (is_desktop_dev) {
+    const dev_url = `http://localhost:${desktop_port}`
+    // Drop externalBin in dev: beforeDevCommand starts the Python backend
+    // separately (pnpm desktop:serve), so Tauri doesn't need a sidecar exe.
+    const config_override = JSON.stringify({
+      build: { devUrl: dev_url },
+      bundle: { externalBin: [] },
+    })
+    // Write to a temp file so Windows cmd.exe doesn't strip the JSON's quotes
+    // when spawn runs with shell: true. Tauri's --config accepts a file path.
+    const config_path = join(tmpdir(), `catgo-tauri-dev-${process.pid}.json`)
+    writeFileSync(config_path, config_override)
+    console.log(`[tauri-dev] worktree offset=${offset}, devUrl=${dev_url}`)
+    // Insert --config right after `dev`; user's original args follow.
+    final_args = ['dev', '--config', config_path, ...args.slice(1)]
+  }
 }
 
 const child = spawn('tauri', final_args, {

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -45,11 +45,13 @@ if (is_dev) {
   // would otherwise reject that cross-origin — whitelist it via the env var
   // main.py reads (CATGO_ALLOWED_ORIGINS). Inherited by beforeDevCommand → python.
   if (process.env.TAURI_DEV_HOST) {
-    extra_env.CATGO_ALLOWED_ORIGINS =
-      `http://${process.env.TAURI_DEV_HOST}:${desktop_port}`
-    console.log(
-      `[tauri-dev] mobile: allow backend origin ${extra_env.CATGO_ALLOWED_ORIGINS}`,
-    )
+    const mobile_origin = `http://${process.env.TAURI_DEV_HOST}:${desktop_port}`
+    // main.py reads CATGO_ALLOWED_ORIGINS as a comma-separated list — append to any
+    // existing value rather than clobber it, so other allowed origins survive.
+    extra_env.CATGO_ALLOWED_ORIGINS = [process.env.CATGO_ALLOWED_ORIGINS, mobile_origin]
+      .filter(Boolean)
+      .join(`,`)
+    console.log(`[tauri-dev] mobile: allow backend origin ${mobile_origin}`)
   }
 
   // Desktop `tauri dev` needs its devUrl pinned to the worktree port via

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -24,7 +24,12 @@
 <style>
   svg {
     width: 1em;
-    height: auto;
+    /* Explicit height (not `auto`): iOS WKWebView fails to derive an inline
+       SVG's intrinsic height from its viewBox when height is `auto` and the
+       element carries no width/height attributes — it collapses to 0px and
+       renders as an empty/blank square. All icon viewBoxes are square; the
+       default preserveAspectRatio keeps any non-square art centered. */
+    height: 1em;
     display: inline-block;
     vertical-align: middle;
   }

--- a/src/lib/i18n/LocaleSwitch.svelte
+++ b/src/lib/i18n/LocaleSwitch.svelte
@@ -10,9 +10,12 @@
 
   let {
     onchange,
+    compact = false,
     ...rest
   }: Omit<HTMLAttributes<HTMLSelectElement>, `onchange`> & {
     onchange?: (pref: LocalePreference) => void
+    /** Icon-only options — collapses to just the flag/globe (tight toolbars). */
+    compact?: boolean
   } = $props()
 
   let current = $state<LocalePreference>(get_preference())
@@ -38,7 +41,7 @@
   class="locale-control {rest.class ?? ``}"
 >
   {#each options as { value, label, icon } (value)}
-    <option {value}>{icon}&ensp;{label}</option>
+    <option {value}>{compact ? icon : `${icon} ${label}`}</option>
   {/each}
 </select>
 

--- a/src/lib/i18n/LocaleSwitch.svelte
+++ b/src/lib/i18n/LocaleSwitch.svelte
@@ -37,6 +37,7 @@
 <select
   bind:value={current}
   onchange={handle_change}
+  aria-label="Language"
   {...rest}
   class="locale-control {rest.class ?? ``}"
 >

--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -27,6 +27,12 @@ const mobile: Record<string, string> = {
   action_import_database: `Import from database`,
   action_save_structure:  `Save structure`,
   action_disconnect:      `Disconnect`,
+  // Short labels shown under the top-bar action icons (keep them ~8 chars).
+  action_remote_files_short:    `Files`,
+  action_open_local_short:      `Open`,
+  action_import_database_short: `Database`,
+  action_save_structure_short:  `Save`,
+  action_disconnect_short:      `Leave`,
 
   // ── Structure pane (MobileWorkspace) ─────────────────────────────────
   no_structure_loaded:    `No structure loaded.`,

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -27,6 +27,12 @@ const mobile: Record<string, string> = {
   action_import_database: `从数据库导入`,
   action_save_structure:  `保存结构`,
   action_disconnect:      `断开连接`,
+  // 顶部操作栏图标下方的简短标签
+  action_remote_files_short:    `文件`,
+  action_open_local_short:      `打开`,
+  action_import_database_short: `数据库`,
+  action_save_structure_short:  `保存`,
+  action_disconnect_short:      `断开`,
 
   // ── 结构面板 (MobileWorkspace) ───────────────────────────────────────
   no_structure_loaded:    `未加载结构。`,

--- a/src/lib/mobile/MobileFiles.svelte
+++ b/src/lib/mobile/MobileFiles.svelte
@@ -18,6 +18,7 @@
   import { transport, type SftpEntry } from '$lib/api/transport'
   import MobileFileViewer from './MobileFileViewer.svelte'
   import { humanSize, joinPath, parentPath, isStructureName } from './files-util'
+  import Icon from '$lib/Icon.svelte'
   import { t } from '$lib/i18n/index.svelte'
 
   interface Props {
@@ -195,7 +196,7 @@
       onclick={refresh}
       disabled={status === `loading`}
     >
-      ⟳
+      <Icon icon="Reset" />
     </button>
   </header>
 
@@ -228,7 +229,7 @@
         {#if !at_root}
           <li>
             <button type="button" class="mf-row mf-up" onclick={go_up}>
-              <span class="mf-icon">↰</span>
+              <span class="mf-icon"><Icon icon="ArrowUp" /></span>
               <span class="mf-name">..</span>
               <span class="mf-meta">{t(`mobile.parent`)}</span>
             </button>

--- a/src/lib/mobile/MobileTerminal.svelte
+++ b/src/lib/mobile/MobileTerminal.svelte
@@ -147,7 +147,7 @@
             return
           }
           // Setup window: scan (don't render) for the cwd + completion sentinel.
-          setup_scan += decoder.decode(bytes)
+          setup_scan += decoder.decode(bytes, { stream: true })
           const cwd = /\x1b\]7;file:\/\/[^/]*(\/[^\x07\x1b]*)/.exec(setup_scan)
           if (cwd) {
             try {

--- a/src/lib/mobile/MobileTerminal.svelte
+++ b/src/lib/mobile/MobileTerminal.svelte
@@ -114,9 +114,51 @@
         const cols = term.cols > 0 ? term.cols : 80
         const rows = term.rows > 0 ? term.rows : 24
 
-        // Open the remote PTY; stream bytes straight into xterm.
+        // Hide the OSC 7 setup injection (sent below): a PTY unavoidably echoes
+        // the command we "type", so rather than let it paint and then clear it,
+        // we DON'T paint the terminal until the setup finishes — signalled by a
+        // private OSC 99 sentinel the setup prints. During this window we still
+        // scan the raw stream for the initial cwd (OSC 7). Falls open after 1.5s
+        // if the sentinel never arrives, so the screen can't get stuck blank.
+        const decoder = new TextDecoder()
+        let gate_open = false
+        let setup_scan = ``
+        const open_gate = () => {
+          if (gate_open || disposed) return
+          gate_open = true
+          clearTimeout(gate_timer)
+          setup_scan = ``
+          try {
+            term.reset()
+          } catch { /* term may be disposing */ }
+        }
+        const gate_timer = setTimeout(open_gate, 1500)
+
+        // Open the remote PTY; stream bytes into xterm once the gate is open.
         const ch = await transport.ptyOpen(session_id, cols, rows, (bytes) => {
-          if (!disposed) term.write(bytes)
+          if (disposed) return
+          if (gate_open) {
+            term.write(bytes)
+            return
+          }
+          // Setup window: scan (don't render) for the cwd + completion sentinel.
+          setup_scan += decoder.decode(bytes)
+          const cwd = /\x1b\]7;file:\/\/[^/]*(\/[^\x07\x1b]*)/.exec(setup_scan)
+          if (cwd) {
+            try {
+              on_cwd?.(decodeURIComponent(cwd[1]))
+            } catch {
+              on_cwd?.(cwd[1])
+            }
+          }
+          const sentinel = `\x1b]99;catgo`
+          const at = setup_scan.indexOf(sentinel)
+          if (at !== -1) {
+            // Anything after the sentinel is real session output — render it.
+            const rest = setup_scan.slice(at + sentinel.length).replace(/^\x07/, ``)
+            open_gate()
+            if (rest) term.write(rest)
+          }
         })
         if (disposed) {
           transport.ptyClose(session_id, ch).catch(() => {})
@@ -199,12 +241,18 @@
           }
           return true
         })
-        // Ask the shell to emit OSC 7 on every prompt. Leading space keeps it out
-        // of history (HISTCONTROL=ignorespace); bash/zsh honor PROMPT_COMMAND, a
-        // shell without it just never reports (Files then stays at $HOME).
+        // Ask the shell to emit OSC 7 on every prompt so the Files tab can follow
+        // the cwd. Register per shell — zsh uses precmd_functions (it ignores
+        // bash's PROMPT_COMMAND), bash uses PROMPT_COMMAND. Emit the cwd once, then
+        // print the private OSC 99 sentinel that opens the render gate above — so
+        // this whole (echoed) line is never painted. Leading space keeps it out of
+        // bash history; the sentinel uses a real ESC so the echoed source (literal
+        // backslashes) can't false-match it.
         const osc7_setup =
-          ` export PROMPT_COMMAND='printf "\\033]7;file://%s%s\\a" "$HOSTNAME" "$PWD"'` +
-          `\${PROMPT_COMMAND:+;$PROMPT_COMMAND}\n`
+          ` _catgo_osc7(){ printf '\\033]7;file://%s%s\\a' "\${HOSTNAME:-\$HOST}" "\$PWD"; };` +
+          ` if [ -n "\$ZSH_VERSION" ]; then typeset -ga precmd_functions; precmd_functions+=(_catgo_osc7);` +
+          ` else PROMPT_COMMAND="_catgo_osc7\${PROMPT_COMMAND:+;\$PROMPT_COMMAND}"; fi;` +
+          ` _catgo_osc7; printf '\\033]99;catgo\\a'\n`
         transport.ptyWrite(session_id, ch, encoder.encode(osc7_setup)).catch(() => {})
 
         // Selection = copy: in a touch UI there's no right-click/Ctrl-C, so push
@@ -264,6 +312,10 @@
     min-height: 0;
     overflow: hidden;
     position: relative;
+    /* Horizontal breathing room so the first/last column isn't clipped at the
+       screen edge. FitAddon measures this padded content box, so column count
+       stays correct. */
+    padding: 2px 8px;
   }
   .mt-body :global(.xterm),
   .mt-body :global(.xterm-viewport),

--- a/src/lib/mobile/MobileTerminal.svelte
+++ b/src/lib/mobile/MobileTerminal.svelte
@@ -123,16 +123,21 @@
         const decoder = new TextDecoder()
         let gate_open = false
         let setup_scan = ``
-        const open_gate = () => {
+        const open_gate = (flush = false) => {
           if (gate_open || disposed) return
           gate_open = true
           clearTimeout(gate_timer)
+          const buffered = setup_scan
           setup_scan = ``
           try {
             term.reset()
+            // Sentinel path discards the (hidden) setup echo; the timeout fallback
+            // flushes the buffer so a shell that never emits the sentinel (e.g. fish,
+            // or a startup error) still shows its output instead of losing it.
+            if (flush && buffered) term.write(buffered)
           } catch { /* term may be disposing */ }
         }
-        const gate_timer = setTimeout(open_gate, 1500)
+        const gate_timer = setTimeout(() => open_gate(true), 1500)
 
         // Open the remote PTY; stream bytes into xterm once the gate is open.
         const ch = await transport.ptyOpen(session_id, cols, rows, (bytes) => {

--- a/src/lib/mobile/MobileTerminal.svelte
+++ b/src/lib/mobile/MobileTerminal.svelte
@@ -143,7 +143,10 @@
         const ch = await transport.ptyOpen(session_id, cols, rows, (bytes) => {
           if (disposed) return
           if (gate_open) {
-            term.write(bytes)
+            // Decode through the SAME decoder used during the gate window, so a
+            // partial UTF-8 sequence buffered across the gate boundary completes
+            // instead of being dropped/corrupted.
+            term.write(decoder.decode(bytes, { stream: true }))
             return
           }
           // Setup window: scan (don't render) for the cwd + completion sentinel.

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -276,11 +276,11 @@
     <!-- Top bar: layout switch + actions -->
     <header class="mw-bar">
       <div class="mw-tabs">
-        <button type="button" class:active={mode === `structure`} onclick={() => (mode = `structure`)} title={t(`mobile.tab_structure`)}><Icon icon="Atom" /></button>
+        <button type="button" class:active={mode === `structure`} onclick={() => (mode = `structure`)} title={t(`mobile.tab_structure`)} aria-label={t(`mobile.tab_structure`)}><Icon icon="Atom" /></button>
         {#if !is_web}
-          <button type="button" class:active={mode === `split-v`} onclick={() => (mode = `split-v`)} title={t(`mobile.tab_split_stacked`)}><Icon icon="Layers" /></button>
-          <button type="button" class:active={mode === `split-h`} onclick={() => (mode = `split-h`)} title={t(`mobile.tab_split_side`)}><Icon icon="TwoColumns" /></button>
-          <button type="button" class:active={mode === `terminal`} onclick={() => (mode = `terminal`)} title={t(`mobile.tab_terminal`)}><Icon icon="Terminal" /></button>
+          <button type="button" class:active={mode === `split-v`} onclick={() => (mode = `split-v`)} title={t(`mobile.tab_split_stacked`)} aria-label={t(`mobile.tab_split_stacked`)}><Icon icon="Layers" /></button>
+          <button type="button" class:active={mode === `split-h`} onclick={() => (mode = `split-h`)} title={t(`mobile.tab_split_side`)} aria-label={t(`mobile.tab_split_side`)}><Icon icon="TwoColumns" /></button>
+          <button type="button" class:active={mode === `terminal`} onclick={() => (mode = `terminal`)} title={t(`mobile.tab_terminal`)} aria-label={t(`mobile.tab_terminal`)}><Icon icon="Terminal" /></button>
         {/if}
       </div>
       <div class="mw-actions">

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -31,6 +31,7 @@
   import { loadConnections } from './connections'
   import { check_tauri } from '$lib/io/tauri'
   import LocaleSwitch from '$lib/i18n/LocaleSwitch.svelte'
+  import Icon from '$lib/Icon.svelte'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module(`mobile`)
@@ -248,24 +249,24 @@
       </div>
       <div class="mw-choose-sub">{t(`mobile.choose_prompt`)}</div>
       <button type="button" class="mw-choice" onclick={open_local}>
-        <span class="mw-choice-icon">⬚</span>
+        <span class="mw-choice-icon"><Icon icon="Atom" /></span>
         <span class="mw-choice-main">{t(`mobile.choice_structure_main`)}</span>
         <span class="mw-choice-desc">{t(`mobile.choice_structure_desc`)}</span>
       </button>
       <button type="button" class="mw-choice" onclick={() => (db_visible = true)}>
-        <span class="mw-choice-icon">🗄</span>
+        <span class="mw-choice-icon"><Icon icon="Database" /></span>
         <span class="mw-choice-main">{t(`mobile.choice_database_main`)}</span>
         <span class="mw-choice-desc">{t(`mobile.choice_database_desc`)}</span>
       </button>
       {#if is_web}
         <div class="mw-choice mw-choice-disabled" aria-disabled="true">
-          <span class="mw-choice-icon">⌨</span>
+          <span class="mw-choice-icon"><Icon icon="Terminal" /></span>
           <span class="mw-choice-main">{t(`mobile.choice_connect_main`)}</span>
           <span class="mw-choice-desc">{t(`mobile.connect_app_only`)}</span>
         </div>
       {:else}
         <button type="button" class="mw-choice" onclick={() => (mode = `terminal`)}>
-          <span class="mw-choice-icon">⌨</span>
+          <span class="mw-choice-icon"><Icon icon="Terminal" /></span>
           <span class="mw-choice-main">{t(`mobile.choice_connect_main`)}</span>
           <span class="mw-choice-desc">{t(`mobile.choice_connect_desc`)}</span>
         </button>
@@ -275,25 +276,40 @@
     <!-- Top bar: layout switch + actions -->
     <header class="mw-bar">
       <div class="mw-tabs">
-        <button type="button" class:active={mode === `structure`} onclick={() => (mode = `structure`)} title={t(`mobile.tab_structure`)}>⬚</button>
+        <button type="button" class:active={mode === `structure`} onclick={() => (mode = `structure`)} title={t(`mobile.tab_structure`)}><Icon icon="Atom" /></button>
         {#if !is_web}
-          <button type="button" class:active={mode === `split-v`} onclick={() => (mode = `split-v`)} title={t(`mobile.tab_split_stacked`)}>⊟</button>
-          <button type="button" class:active={mode === `split-h`} onclick={() => (mode = `split-h`)} title={t(`mobile.tab_split_side`)}>⊞</button>
-          <button type="button" class:active={mode === `terminal`} onclick={() => (mode = `terminal`)} title={t(`mobile.tab_terminal`)}>▭</button>
+          <button type="button" class:active={mode === `split-v`} onclick={() => (mode = `split-v`)} title={t(`mobile.tab_split_stacked`)}><Icon icon="Layers" /></button>
+          <button type="button" class:active={mode === `split-h`} onclick={() => (mode = `split-h`)} title={t(`mobile.tab_split_side`)}><Icon icon="TwoColumns" /></button>
+          <button type="button" class:active={mode === `terminal`} onclick={() => (mode = `terminal`)} title={t(`mobile.tab_terminal`)}><Icon icon="Terminal" /></button>
         {/if}
       </div>
       <div class="mw-actions">
-        <LocaleSwitch />
+        <LocaleSwitch compact />
         {#if session_id}
-          <button type="button" class="mw-act" onclick={() => (files_open = true)} title={t(`mobile.action_remote_files`)}>📁</button>
+          <button type="button" class="mw-act" onclick={() => (files_open = true)} title={t(`mobile.action_remote_files`)}>
+            <Icon icon="Directory" />
+            <span class="mw-act-label">{t(`mobile.action_remote_files_short`)}</span>
+          </button>
         {/if}
-        <button type="button" class="mw-act" onclick={open_local} title={t(`mobile.action_open_local`)}>⬆</button>
-        <button type="button" class="mw-act" onclick={() => (db_visible = true)} title={t(`mobile.action_import_database`)}>🗄</button>
+        <button type="button" class="mw-act" onclick={open_local} title={t(`mobile.action_open_local`)}>
+          <Icon icon="Upload" />
+          <span class="mw-act-label">{t(`mobile.action_open_local_short`)}</span>
+        </button>
+        <button type="button" class="mw-act" onclick={() => (db_visible = true)} title={t(`mobile.action_import_database`)}>
+          <Icon icon="Database" />
+          <span class="mw-act-label">{t(`mobile.action_import_database_short`)}</span>
+        </button>
         {#if can_save}
-          <button type="button" class="mw-act save" onclick={save} title={t(`mobile.action_save_structure`)}>💾</button>
+          <button type="button" class="mw-act save" onclick={save} title={t(`mobile.action_save_structure`)}>
+            <Icon icon="Download" />
+            <span class="mw-act-label">{t(`mobile.action_save_structure_short`)}</span>
+          </button>
         {/if}
         {#if session_id}
-          <button type="button" class="mw-act disconnect" onclick={disconnect} title={t(`mobile.action_disconnect`)}>⏏</button>
+          <button type="button" class="mw-act disconnect" onclick={disconnect} title={t(`mobile.action_disconnect`)}>
+            <Icon icon="Close" />
+            <span class="mw-act-label">{t(`mobile.action_disconnect_short`)}</span>
+          </button>
         {/if}
       </div>
     </header>
@@ -472,6 +488,22 @@
     display: flex;
     gap: 4px;
   }
+  /* Tabs stay put; the action group may shrink and scroll horizontally so its
+     buttons (up to 6 when connected) never hard-clip on a narrow screen — worst
+     case they become swipeable instead of cut off. */
+  .mw-tabs {
+    flex-shrink: 0;
+  }
+  .mw-actions {
+    gap: 2px;
+    flex-shrink: 1;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .mw-actions::-webkit-scrollbar {
+    display: none;
+  }
   .mw-tabs button,
   .mw-act {
     min-width: 40px;
@@ -482,6 +514,26 @@
     border: 1px solid transparent;
     border-radius: 8px;
     cursor: pointer;
+  }
+  /* Action buttons: SVG icon stacked over a short text label. The icon sizes
+     off the button's font-size (Icon.svelte uses width: 1em); the label sets
+     its own smaller size. Both inherit `color`, so .save/.disconnect tints
+     flow through to the SVG via fill="currentColor". */
+  .mw-act {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 2px 4px;
+    line-height: 1;
+    min-width: 34px;
+    flex-shrink: 0; /* keep button size; the group scrolls instead of squashing */
+  }
+  .mw-act-label {
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
   }
   .mw-tabs button.active {
     color: var(--accent-color, #3b82f6);
@@ -525,6 +577,7 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
+    position: relative; /* containing block for the kept-warm structure pane */
   }
   .mw-body.split-h {
     flex-direction: row;
@@ -542,6 +595,20 @@
   /* Kept mounted but hidden (preserves the terminal PTY/cwd across layouts). */
   .mw-pane.hidden {
     display: none;
+  }
+  /* The 3D viewer's <canvas> blanks if it ever hits display:none on iOS: while
+     hidden it measures 0×0, and on return the size doesn't reliably restore, so
+     the renderer can paint once at 0×0 and never recover (intermittent blank
+     structure after visiting the terminal). Keep the structure pane laid out at
+     full size — just visually hidden behind the active pane — so its canvas
+     never zeroes. (Render-on-demand means no real battery cost while parked.) */
+  .mw-pane.mw-struct.hidden {
+    display: flex;
+    visibility: hidden;
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    z-index: -1;
   }
   /* The editor's root (.structure-main) defaults to height:500px via
      --struct-height; override it so it fills the pane (no black gap / clipping

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -235,7 +235,7 @@
 <input
   bind:this={file_input}
   type="file"
-  accept=".cif,.poscar,.vasp,.xyz,.extxyz,.json,.cube,.lammps,.data,*"
+  accept="*/*"
   onchange={on_local_file}
   hidden
 />

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -32,6 +32,10 @@ import { Buffer } from 'node:buffer'
 const offset = worktree_offset()
 const desktop_port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3100 + offset
 const srv_port = server_port(offset)
+// On mobile, the device reaches the dev server over the LAN, not localhost.
+// `tauri ios/android dev` sets TAURI_DEV_HOST to the Mac's LAN IP — bind Vite there
+// (and point HMR at it) so the phone can load the frontend. Desktop leaves it unset.
+const tauri_dev_host = process.env.TAURI_DEV_HOST
 
 // Ensure .svelte-kit/tsconfig.json stub exists so the root tsconfig.json
 // "extends" doesn't cause hard errors in Vite 7.x esbuild transforms.
@@ -328,9 +332,17 @@ export default defineConfig({
             try {
               const ext = (p.split(`.`).pop() || ``).toLowerCase()
               const mime: Record<string, string> = {
-                png: `image/png`, jpg: `image/jpeg`, jpeg: `image/jpeg`, gif: `image/gif`,
-                webp: `image/webp`, bmp: `image/bmp`, svg: `image/svg+xml`, ico: `image/x-icon`,
-                tif: `image/tiff`, tiff: `image/tiff`, pdf: `application/pdf`,
+                png: `image/png`,
+                jpg: `image/jpeg`,
+                jpeg: `image/jpeg`,
+                gif: `image/gif`,
+                webp: `image/webp`,
+                bmp: `image/bmp`,
+                svg: `image/svg+xml`,
+                ico: `image/x-icon`,
+                tif: `image/tiff`,
+                tiff: `image/tiff`,
+                pdf: `application/pdf`,
               }
               res.setHeader(`Content-Type`, mime[ext] || `application/octet-stream`)
               res.setHeader(`Cache-Control`, `no-cache`)
@@ -732,7 +744,13 @@ export default defineConfig({
       },
     } satisfies Plugin,
     agentBridgePlugin(srv_port),
-    svelte(),
+    // On mobile dev, inject component CSS via JS (emitCss: false) instead of
+    // separate `?type=style&lang.css` chunks. Those split-CSS chunks race on
+    // cold load over the LAN — the browser can request a component's CSS before
+    // its transform has populated the CSS cache, so vite-plugin-svelte hands
+    // PostCSS the *script* → "[postcss] Unknown word" overlay (e.g. on the large,
+    // lazily-loaded NodeConfigPanel). Desktop + production keep emitCss on.
+    svelte(tauri_dev_host ? { emitCss: false } : {}),
     yaml(),
     {
       name: `vite-plugin-cloudflare-redirects`,
@@ -777,10 +795,16 @@ export default defineConfig({
   },
 
   server: {
-    host: `127.0.0.1`,
+    host: tauri_dev_host || `127.0.0.1`,
     port: desktop_port,
     strictPort: true,
     fs: { strict: false },
+    // Point the HMR client at the LAN dev server explicitly — without an
+    // explicit clientPort it tries port 80 (ws://<host>/) first, fails, and
+    // only then falls back. clientPort pins it to the actual dev-server port.
+    ...(tauri_dev_host
+      ? { hmr: { protocol: `ws`, host: tauri_dev_host, clientPort: desktop_port } }
+      : {}),
   },
 
   define: {

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -55,8 +55,13 @@ export function server_port(offset: number): number {
  * Desktop config extends this with `__CATGO_DESKTOP__`.
  */
 export function shared_define(srv_port: number): Record<string, string> {
+  // On mobile (`tauri ios/android dev` sets TAURI_DEV_HOST to the Mac's LAN IP),
+  // the SPA runs on the phone, so `localhost` is the phone — not the backend.
+  // Bake the LAN IP into the backend URL so API/SSE/WS calls reach the Mac.
+  // (The Python backend already binds 0.0.0.0; CORS is whitelisted in tauri-dev.mjs.)
+  const host = process.env.TAURI_DEV_HOST || `localhost`
   return {
-    __CATGO_SERVER_URL__: JSON.stringify(`http://localhost:${srv_port}`),
+    __CATGO_SERVER_URL__: JSON.stringify(`http://${host}:${srv_port}`),
   }
 }
 

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -59,7 +59,11 @@ export function shared_define(srv_port: number): Record<string, string> {
   // the SPA runs on the phone, so `localhost` is the phone — not the backend.
   // Bake the LAN IP into the backend URL so API/SSE/WS calls reach the Mac.
   // (The Python backend already binds 0.0.0.0; CORS is whitelisted in tauri-dev.mjs.)
-  const host = process.env.TAURI_DEV_HOST || `localhost`
+  const raw_host = process.env.TAURI_DEV_HOST || `localhost`
+  // Wrap a bare IPv6 literal in [] so the URL stays valid (http://[::1]:port).
+  const host = raw_host.includes(`:`) && !raw_host.startsWith(`[`)
+    ? `[${raw_host}]`
+    : raw_host
   return {
     __CATGO_SERVER_URL__: JSON.stringify(`http://${host}:${srv_port}`),
   }


### PR DESCRIPTION
## What & why

Gets the CatGo Tauri **mobile** build working on a physical iPhone. The mobile app
reuses the desktop Svelte UI inside a WKWebView, which surfaced several iOS-only
issues. **All fixes are gated on mobile** (mostly `TAURI_DEV_HOST`) so desktop +
production behaviour is unchanged. Tested on-device (iPhone, iOS 26.4.2) throughout.

## Changes

- **LAN backend routing** (`vite.shared.ts`, `scripts/tauri-dev.mjs`): the phone isn't
  `localhost` — bake the Mac's LAN IP into `SERVER_URL` and whitelist the phone origin
  for CORS (`CATGO_ALLOWED_ORIGINS`); recognise the `ios dev` subcommand.
- **Vite dev** (`vite.desktop.config.ts`): bind to the LAN, pin HMR `clientPort`,
  `emitCss:false` on mobile (dodges a cold-load PostCSS race).
- **Icon rendering** (`Icon.svelte`): `height:1em` (not `auto`) — iOS WKWebView collapses
  an `auto` + viewBox inline SVG to 0px (blank squares).
- **Tofu glyph icons** → `<Icon>` SVG in the mobile chooser / tabs / file browser;
  `LocaleSwitch` gains a compact (icon-only) mode.
- **Keep-warm 3D viewer**: don't `display:none` the structure pane — it zeroes the WebGL
  canvas (blank viewer after visiting the terminal).
- **Terminal**: hide the OSC7 cwd-setup echo (render-gate); fix the cwd hook for zsh
  (`precmd_functions`, not bash `PROMPT_COMMAND`); add padding.
- **File picker**: `accept="*/*"` so iOS lets you select `.xyz`/`.cif`/etc. (greyed out by
  UTType filtering otherwise).
- **Docs**: root `CLAUDE.md` + `deploy/ios/` notes — build/run flow plus a
  file → why → knob table and the mobile invariants ("looks wrong, don't revert").

## Out of scope (mobile *production* / a shipped `.ipa`)

The dev build papers these over; a real `.ipa` still needs: backend not on `localhost`,
the chat agent's relative URL to use a real host, and structure formats declared as
UTTypes in `Info.plist`. Captured in `deploy/ios/LOCAL-TESTING-PROGRESS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
