### PR TITLE
fix(server): Windows .exe crash on direct launch (NoneType isatty)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -9,6 +9,20 @@ import warnings
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+# PyInstaller windowed build (console=False) leaves sys.stdout/sys.stderr as None
+# on Windows when the .exe is launched directly (e.g. double-clicked). That makes
+# the port-handshake print() and uvicorn's ColourizedFormatter crash —
+# ColourizedFormatter.__init__ calls sys.stdout.isatty(), raising
+# "AttributeError: 'NoneType' object has no attribute 'isatty'". Restore writable
+# streams so logging and uvicorn start cleanly. (When launched by the desktop app
+# the streams are real pipes, so this guard is a no-op.)
+if sys.stdout is None or sys.stderr is None:
+    _devnull = open(os.devnull, "w")  # noqa: SIM115
+    if sys.stdout is None:
+        sys.stdout = _devnull
+    if sys.stderr is None:
+        sys.stderr = _devnull
+
 # Configure root logger so workflow engine logs are visible
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Problem

Users running the Windows server bundle (`catgo-server-win-x64.exe`) by **double-clicking it directly** hit:

```
Failed to execute script 'main' due to unhandled exception:
Unable to configure formatter 'default'
...
  File "uvicorn\logging.py", line 42, in __init__
AttributeError: 'NoneType' object has no attribute 'isatty'
```

## Root cause

The exe is packaged with PyInstaller `console=False` (`server/catgo_server.spec:226`). In that windowed mode Windows leaves `sys.stdout`/`sys.stderr` as `None` when the process has no console. uvicorn's default log config builds `ColourizedFormatter`, whose `__init__` calls `sys.stdout.isatty()` → crash. (Launched by the desktop app the streams are real pipes, so it only bites direct double-click.)

## Fix

At the top of `server/main.py`, before logging is configured, replace any `None` `sys.stdout`/`sys.stderr` with an `os.devnull` writer. No-op when real streams exist (desktop-app launch).

## Note

The shipped exe must be **rebuilt** for this to take effect (code-only fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)