### PR TITLE
ci(ios): auto-upload to App Store Connect + static-only prod build

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -23,6 +23,10 @@ on:
         description: 'Build a signed device IPA (needs Apple secrets) instead of a simulator smoke build'
         type: boolean
         default: false
+      upload:
+        description: 'After a signed build, upload the IPA to App Store Connect / TestFlight (needs App Store Connect API key secrets)'
+        type: boolean
+        default: false
 
 jobs:
   ios:
@@ -96,7 +100,42 @@ jobs:
         env:
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # Production (no Mac/LAN, no Python sidecar on mobile): build static-only
+          # so stray backend fetches return a friendly 503 instead of hanging on
+          # localhost. Mobile-native paths still work — local structure view/edit,
+          # database import (rerouted via isMobile() direct fetch), and the SSH
+          # terminal/files (russh over Tauri invoke, not HTTP). Backend-only UI
+          # (chat/workflow/plugin_hub) is already hidden on mobile.
+          VITE_STATIC_ONLY: '1'
         run: pnpm tauri ios build --export-method app-store-connect
+
+      # ---- Upload the signed IPA to App Store Connect (TestFlight) ----
+      # Needs an App Store Connect API key (App Store Connect → Users and Access →
+      # Integrations → App Store Connect API). Add these repo secrets:
+      #   APPLE_API_KEY_ID      the key's Key ID
+      #   APPLE_API_ISSUER_ID   the Issuer ID shown on that page
+      #   APPLE_API_KEY_P8      the full contents of the downloaded AuthKey_*.p8
+      - name: Upload to App Store Connect (TestFlight)
+        if: ${{ inputs.signed && inputs.upload }}
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_API_KEY_ID}" ] || [ -z "${APPLE_API_ISSUER_ID}" ] || [ -z "${APPLE_API_KEY_P8}" ]; then
+            echo "::error::Upload requested but App Store Connect API key secrets are missing (APPLE_API_KEY_ID / APPLE_API_ISSUER_ID / APPLE_API_KEY_P8)."
+            exit 1
+          fi
+          # altool/xcrun looks the key up by ID under these well-known dirs.
+          mkdir -p ~/.appstoreconnect/private_keys
+          printf '%s' "${APPLE_API_KEY_P8}" > ~/".appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          IPA=$(find src-tauri/gen/ios/build -name '*.ipa' -print -quit)
+          if [ -z "${IPA}" ]; then echo "::error::No .ipa found to upload"; exit 1; fi
+          echo "Uploading ${IPA} to App Store Connect…"
+          xcrun altool --upload-app -f "${IPA}" -t ios \
+            --apiKey "${APPLE_API_KEY_ID}" --apiIssuer "${APPLE_API_ISSUER_ID}"
+          rm -f ~/".appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Makes the iOS CI workflow able to actually **publish** (not just produce an artifact), and makes the production mobile build behave sanely without a backend.

1. **App Store Connect upload** — new `upload` input + a step that uploads the signed `.ipa` to App Store Connect / TestFlight via `xcrun altool` with an App Store Connect API key. Gated on `signed && upload`; fails fast if the key secrets are missing.
2. **Static-only production build** — the signed device build now sets `VITE_STATIC_ONLY=1`. Mobile has no Python sidecar and (off the dev Mac) no LAN backend, so stray backend fetches now return a friendly 503 instead of hanging on `localhost`. Mobile-native paths are unaffected: local structure view/edit, database import (rerouted via `isMobile()`), and the russh SSH terminal/files. Backend-only UI (chat/workflow/plugin_hub) is already hidden on mobile.

## Required repo secrets (you add these)

Signing (already documented in the workflow): `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_PROVISIONING_PROFILE`, `APPLE_DEVELOPMENT_TEAM`.

Upload (new): `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `APPLE_API_KEY_P8` (App Store Connect → Users and Access → Integrations → App Store Connect API).

## Still required outside this PR

- Apple Developer Program ($99/yr) + an App Store Connect app record for `com.catgo.app`.
- Known follow-up: declare structure formats as UTTypes in the iOS `Info.plist` (the `accept="*/*"` picker already works; UTTypes add "Open in CatGo" association).

🤖 Generated with [Claude Code](https://claude.com/claude-code)