### PR TITLE
feat(deploy): self-hosted download landing page

### DIFF
--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CatGo — Download</title>
+<meta name="description" content="CatGo — a computational-chemistry workbench: structure viewer/editor, OPTIMADE database browser, and an SSH terminal to your HPC cluster. Download for Android, Windows, macOS, and Linux." />
+<link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/Hello-QM/catgo-LRG/main/static/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,700;12..96,800&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --navy-0: #070d1f;
+    --navy-1: #0b1430;
+    --navy-2: #122046;
+    --ink: #eaf0ff;
+    --ink-dim: #93a4cc;
+    --ink-faint: #5d6e96;
+    --cyan: #34d9ee;
+    --cyan-deep: #1aa7c4;
+    --gold: #f3c64a;
+    --line: rgba(120, 150, 220, 0.14);
+    --card: rgba(18, 30, 64, 0.55);
+    --radius: 18px;
+    --mono: "IBM Plex Mono", ui-monospace, monospace;
+    --sans: "IBM Plex Sans", system-ui, sans-serif;
+    --display: "Bricolage Grotesque", var(--sans);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html { -webkit-text-size-adjust: 100%; }
+
+  body {
+    font-family: var(--sans);
+    color: var(--ink);
+    background: var(--navy-0);
+    min-height: 100vh;
+    line-height: 1.5;
+    overflow-x: hidden;
+    position: relative;
+  }
+
+  /* Atmospheric layered background: deep navy radial glows + a faint
+     crystalline node-lattice that nods to the app's structure viewer. */
+  .bg {
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background:
+      radial-gradient(900px 600px at 78% -8%, rgba(52, 217, 238, 0.16), transparent 60%),
+      radial-gradient(800px 700px at 12% 108%, rgba(63, 92, 220, 0.18), transparent 55%),
+      linear-gradient(160deg, var(--navy-1) 0%, var(--navy-0) 60%);
+  }
+  .lattice {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background-image: radial-gradient(rgba(120, 160, 230, 0.16) 1px, transparent 1.4px);
+    background-size: 30px 30px;
+    -webkit-mask-image: radial-gradient(circle at 50% 35%, #000 0%, transparent 72%);
+    mask-image: radial-gradient(circle at 50% 35%, #000 0%, transparent 72%);
+    opacity: 0.6;
+  }
+  .grain {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.035;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+
+  .wrap {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: clamp(28px, 7vw, 72px) 22px 56px;
+    position: relative;
+  }
+
+  /* ---- top bar ---- */
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: clamp(40px, 9vw, 96px);
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    color: var(--ink-faint);
+    text-transform: uppercase;
+    animation: rise 0.7s 0.05s both;
+  }
+  .topbar a { color: var(--ink-dim); text-decoration: none; transition: color 0.2s; }
+  .topbar a:hover { color: var(--cyan); }
+  .ver {
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 4px 11px;
+    color: var(--cyan);
+  }
+
+  /* ---- hero ---- */
+  .hero { text-align: center; }
+
+  .logo {
+    width: 96px; height: 96px;
+    border-radius: 24px;
+    display: block;
+    margin: 0 auto 26px;
+    box-shadow:
+      0 0 0 1px rgba(120, 160, 230, 0.18),
+      0 24px 60px -18px rgba(52, 217, 238, 0.5),
+      0 10px 30px -10px rgba(0, 0, 0, 0.6);
+    animation: rise 0.7s 0.1s both, float 7s ease-in-out 0.8s infinite;
+  }
+
+  h1 {
+    font-family: var(--display);
+    font-weight: 800;
+    font-size: clamp(54px, 13vw, 104px);
+    line-height: 0.92;
+    letter-spacing: -0.035em;
+    margin-bottom: 18px;
+    background: linear-gradient(180deg, #ffffff 0%, #b9ccff 92%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: rise 0.7s 0.16s both;
+  }
+  h1 .dot { color: var(--cyan); -webkit-text-fill-color: var(--cyan); }
+
+  .tagline {
+    font-size: clamp(16px, 2.4vw, 20px);
+    color: var(--ink-dim);
+    max-width: 30ch;
+    margin: 0 auto 8px;
+    animation: rise 0.7s 0.22s both;
+  }
+  .subline {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    letter-spacing: 0.04em;
+    color: var(--ink-faint);
+    margin-bottom: 40px;
+    animation: rise 0.7s 0.26s both;
+  }
+
+  /* ---- primary download ---- */
+  .cta { animation: rise 0.7s 0.32s both; }
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 13px;
+    padding: 17px 30px;
+    border-radius: 14px;
+    background: linear-gradient(180deg, var(--cyan) 0%, var(--cyan-deep) 100%);
+    color: #04121a;
+    font-family: var(--display);
+    font-weight: 700;
+    font-size: 18px;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 16px 38px -12px rgba(52, 217, 238, 0.7);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s;
+  }
+  .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 22px 46px -12px rgba(52, 217, 238, 0.85); filter: saturate(1.08); }
+  .btn-primary:active { transform: translateY(0); }
+  .btn-primary svg { width: 22px; height: 22px; }
+  .btn-sub {
+    margin-top: 13px;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--ink-faint);
+    letter-spacing: 0.03em;
+  }
+  .btn-sub b { color: var(--ink-dim); font-weight: 600; }
+
+  /* ---- platform grid ---- */
+  .platforms {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+    margin-top: 52px;
+    animation: rise 0.7s 0.4s both;
+  }
+  .plat {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 18px 16px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+    backdrop-filter: blur(6px);
+    text-decoration: none;
+    color: var(--ink);
+    transition: border-color 0.2s, transform 0.2s, background 0.2s;
+  }
+  .plat:hover { border-color: rgba(52, 217, 238, 0.5); transform: translateY(-3px); background: rgba(20, 34, 72, 0.7); }
+  .plat .pico { font-size: 22px; line-height: 1; }
+  .plat .pname { font-family: var(--display); font-weight: 700; font-size: 16px; }
+  .plat .pmeta { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); letter-spacing: 0.02em; }
+  .plat.is-target { border-color: rgba(52, 217, 238, 0.55); box-shadow: 0 0 0 1px rgba(52,217,238,0.25), 0 18px 40px -22px rgba(52,217,238,0.6); }
+  .plat .ptag { font-family: var(--mono); font-size: 10px; color: var(--cyan); letter-spacing: 0.08em; text-transform: uppercase; }
+
+  /* ---- install steps ---- */
+  .steps {
+    margin-top: 52px;
+    text-align: left;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+    backdrop-filter: blur(6px);
+    padding: 26px 24px;
+    animation: rise 0.7s 0.48s both;
+  }
+  .steps h2 {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--cyan);
+    margin-bottom: 18px;
+  }
+  ol { list-style: none; counter-reset: s; display: grid; gap: 14px; }
+  ol li {
+    counter-increment: s;
+    display: grid;
+    grid-template-columns: 30px 1fr;
+    gap: 14px;
+    align-items: start;
+    font-size: 14.5px;
+    color: var(--ink-dim);
+  }
+  ol li::before {
+    content: counter(s);
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--cyan);
+    width: 30px; height: 30px;
+    display: grid; place-items: center;
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    background: rgba(52, 217, 238, 0.06);
+  }
+  ol li b { color: var(--ink); font-weight: 600; }
+  .note {
+    margin-top: 18px;
+    padding: 12px 14px;
+    border-left: 2px solid var(--gold);
+    background: rgba(243, 198, 74, 0.07);
+    border-radius: 0 10px 10px 0;
+    font-size: 13px;
+    color: #e8d9a8;
+  }
+
+  /* ---- footer ---- */
+  footer {
+    margin-top: 56px;
+    text-align: center;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--ink-faint);
+    letter-spacing: 0.03em;
+    animation: rise 0.7s 0.56s both;
+  }
+  footer a { color: var(--ink-dim); text-decoration: none; }
+  footer a:hover { color: var(--cyan); }
+  footer .sep { opacity: 0.4; margin: 0 8px; }
+
+  @keyframes rise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+  @keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-7px); } }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<div class="bg"></div>
+<div class="lattice"></div>
+<div class="grain"></div>
+
+<div class="wrap">
+  <nav class="topbar">
+    <span>CatGo</span>
+    <span class="ver" id="ver">v1.1.9</span>
+    <a href="https://github.com/Hello-QM/catgo-LRG" target="_blank" rel="noopener">GitHub ↗</a>
+  </nav>
+
+  <header class="hero">
+    <img class="logo" src="https://raw.githubusercontent.com/Hello-QM/catgo-LRG/main/static/favicon.svg" alt="CatGo logo" />
+    <h1>CatGo<span class="dot">.</span></h1>
+    <p class="tagline">A computational-chemistry workbench in your pocket and on your desktop.</p>
+    <p class="subline">structure viewer · OPTIMADE database · SSH terminal to your HPC cluster</p>
+
+    <div class="cta">
+      <a class="btn-primary" id="primaryBtn" href="#android">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20.5a1.5 1.5 0 0 1-1.5-1.5V9.5a1.5 1.5 0 0 1 3 0V19A1.5 1.5 0 0 1 5 20.5Zm14 0A1.5 1.5 0 0 1 17.5 19V9.5a1.5 1.5 0 0 1 3 0V19a1.5 1.5 0 0 1-1.5 1.5ZM7.5 21.5V9h9v12.5a1 1 0 0 1-1 1H14V19h-1.5v3.5h-1V19H10v3.5H8.5a1 1 0 0 1-1-1ZM7.6 8a4.4 4.4 0 0 1 8.8 0Zm2.15-3.3-.9-1.3a.3.3 0 0 1 .5-.34l.95 1.37a5 5 0 0 1 3.4 0l.95-1.37a.3.3 0 1 1 .5.34l-.9 1.3A4.4 4.4 0 0 0 9.75 4.7Z"/></svg>
+        <span id="primaryLabel">Download for Android</span>
+      </a>
+      <p class="btn-sub" id="primarySub"><b>.apk</b> · 185 MB · Android 7.0+</p>
+    </div>
+
+    <div class="platforms">
+      <a class="plat" id="plat-android" href="https://github.com/Hello-QM/catgo-LRG/releases/download/v1.1.9/CatGo-v1.1.9-android-universal.apk">
+        <span class="pico">🤖</span>
+        <span class="pname">Android</span>
+        <span class="pmeta">universal .apk</span>
+      </a>
+      <a class="plat" id="plat-windows" href="https://github.com/Hello-QM/catgo-LRG/releases/latest">
+        <span class="pico">🪟</span>
+        <span class="pname">Windows</span>
+        <span class="pmeta">.msi / .exe</span>
+      </a>
+      <a class="plat" id="plat-macos" href="https://github.com/Hello-QM/catgo-LRG/releases/latest">
+        <span class="pico">🍎</span>
+        <span class="pname">macOS</span>
+        <span class="pmeta">.dmg · Apple Silicon</span>
+      </a>
+      <a class="plat" id="plat-linux" href="https://github.com/Hello-QM/catgo-LRG/releases/latest">
+        <span class="pico">🐧</span>
+        <span class="pname">Linux</span>
+        <span class="pmeta">.deb / .rpm</span>
+      </a>
+    </div>
+
+    <section class="steps" id="android">
+      <h2>Install on Android</h2>
+      <ol>
+        <li><span>Tap <b>Download for Android</b> above to get the <b>.apk</b>.</span></li>
+        <li><span>Open it. Android will ask to allow <b>“Install unknown apps”</b> for your browser or Files app — turn it on.</span></li>
+        <li><span>Tap <b>Install</b>, then open CatGo. Done.</span></li>
+      </ol>
+      <p class="note">Upgrading from v1.1.8 or earlier? Those builds used a different signing key — uninstall the old CatGo first, then install this one.</p>
+    </section>
+  </header>
+
+  <footer>
+    <a href="https://github.com/Hello-QM/catgo-LRG/releases/latest" target="_blank" rel="noopener">All releases &amp; changelog</a>
+    <span class="sep">·</span>
+    <a href="https://github.com/Hello-QM/catgo-LRG" target="_blank" rel="noopener">Source on GitHub</a>
+    <span class="sep">·</span>
+    <span>iOS — App Store (coming soon)</span>
+  </footer>
+</div>
+
+<script>
+  // Single source of truth for the current release — bump on each release.
+  const VERSION = "1.1.9";
+  const REPO = "https://github.com/Hello-QM/catgo-LRG";
+  const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
+  const LATEST = `${REPO}/releases/latest`;
+
+  document.getElementById("ver").textContent = "v" + VERSION;
+  document.getElementById("plat-android").href = APK;
+
+  // Detect the visitor's OS and promote the matching download.
+  const ua = navigator.userAgent || "";
+  const isAndroid = /Android/i.test(ua);
+  const isIOS = /iPhone|iPad|iPod/i.test(ua) || (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
+  const isWin = /Windows/i.test(ua);
+  const isMac = /Macintosh|Mac OS X/i.test(ua) && !isIOS;
+  const isLinux = /Linux/i.test(ua) && !isAndroid;
+
+  const btn = document.getElementById("primaryBtn");
+  const label = document.getElementById("primaryLabel");
+  const sub = document.getElementById("primarySub");
+
+  function highlight(id) { const el = document.getElementById(id); if (el) el.classList.add("is-target"); }
+
+  if (isAndroid) {
+    btn.href = APK; label.textContent = "Download for Android";
+    sub.innerHTML = "<b>.apk</b> · 185 MB · Android 7.0+";
+    highlight("plat-android");
+  } else if (isIOS) {
+    btn.href = REPO; label.textContent = "iOS — coming to the App Store";
+    btn.style.background = "linear-gradient(180deg,#3a4a73 0%,#27314f 100%)";
+    btn.style.color = "#dce6ff";
+    btn.style.boxShadow = "none";
+    sub.innerHTML = "iOS requires the App Store — not yet available. Try desktop or Android.";
+  } else if (isWin) {
+    btn.href = LATEST; label.textContent = "Download for Windows";
+    sub.innerHTML = "<b>.msi</b> installer · 64-bit";
+    highlight("plat-windows");
+  } else if (isMac) {
+    btn.href = LATEST; label.textContent = "Download for macOS";
+    sub.innerHTML = "<b>.dmg</b> · Apple Silicon (M-series)";
+    highlight("plat-macos");
+  } else if (isLinux) {
+    btn.href = LATEST; label.textContent = "Download for Linux";
+    sub.innerHTML = "<b>.deb</b> / <b>.rpm</b> · 64-bit";
+    highlight("plat-linux");
+  } else {
+    highlight("plat-android");
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
A single self-contained `deploy/download/index.html` to host on a custom domain (or GitHub Pages) as the public download page.

- Dark, on-brand design (navy + cyan node accent from the app icon, Bricolage Grotesque + IBM Plex Mono).
- **OS detection** promotes the matching download (Android → APK; Windows/macOS/Linux → latest desktop installer; iOS → "App Store coming soon").
- Links Android APK + desktop builds to **GitHub Releases** (no large binaries on the page/repo).
- Android **sideload steps** + the "uninstall old build first" signing-change note.
- `VERSION` is a single JS const — bump per release.

Verified rendering via headless screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)