### PR TITLE
fix(ios): install wasm-pack before build

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -52,6 +52,16 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 
+      - name: Install wasm-pack
+        # The Tauri beforeBuildCommand (pnpm desktop:build → build:wasm) compiles
+        # the ferrox/chgdiff/catrender WASM crates and hard-fails if wasm-pack is
+        # missing. Desktop CI installs it too; mirror that here.
+        run: |
+          if ! command -v wasm-pack >/dev/null 2>&1; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+          wasm-pack --version
+
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Signed iOS build failed in `beforeBuildCommand` (`pnpm desktop:build` → `build:wasm`) because wasm-pack wasn't installed on the runner. Add the install step (mirrors desktop CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)