### PR TITLE
fix(ios): automatic signing via App Store Connect API key

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -106,9 +106,11 @@ jobs:
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
         run: |
-          # Keychain for the signing cert.
+          set -euo pipefail
+          # Keychain for the distribution signing cert.
           KEYCHAIN=$RUNNER_TEMP/signing.keychain-db
           security create-keychain -p ci "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
@@ -116,17 +118,22 @@ jobs:
           echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/cert.p12
           security import $RUNNER_TEMP/cert.p12 -P "$APPLE_CERTIFICATE_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN"
-          security list-keychain -d user -s "$KEYCHAIN"
-          # Provisioning profile.
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode \
-            > ~/Library/MobileDevice/Provisioning\ Profiles/catgo.mobileprovision
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          # App Store Connect API key in the standard search path. This lets
+          # `tauri ios build` pass -allowProvisioningUpdates so Xcode creates the
+          # distribution provisioning profile automatically (no Apple ID login, no
+          # pre-made profile — fixes "No Accounts" / "No profiles were found").
+          mkdir -p ~/.appstoreconnect/private_keys
+          printf '%s' "$APPLE_API_KEY_P8" > ~/".appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
 
       - name: Build (signed device IPA)
         if: ${{ inputs.signed }}
         env:
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # App Store Connect API key → Tauri enables -allowProvisioningUpdates so
+          # Xcode auto-creates the signing profile for org.catgo.app via the key.
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
           # Production (no Mac/LAN, no Python sidecar on mobile): build static-only
           # so stray backend fetches return a friendly 503 instead of hanging on
           # localhost. Mobile-native paths still work — local structure view/edit,


### PR DESCRIPTION
xcodebuild failed with "No Accounts" / "No profiles for org.catgo.app" (automatic signing needs an Apple ID login CI lacks). Supply the App Store Connect API key so `tauri ios build` uses `-allowProvisioningUpdates` and Xcode auto-generates the distribution profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)