### PR TITLE
fix(ios): Tauri native manual signing

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -100,41 +100,18 @@ jobs:
         if: ${{ !inputs.signed }}
         run: pnpm tauri ios build --target aarch64-sim --config '{"identifier":"org.catgo.app"}'
 
-      # ---- Signed device IPA (needs the Apple secrets above) ----
-      - name: Import signing assets
-        if: ${{ inputs.signed }}
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-        run: |
-          set -euo pipefail
-          # Keychain for the distribution signing cert.
-          KEYCHAIN=$RUNNER_TEMP/signing.keychain-db
-          security create-keychain -p ci "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p ci "$KEYCHAIN"
-          echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/cert.p12
-          security import $RUNNER_TEMP/cert.p12 -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN"
-          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
-          # App Store Connect API key in the standard search path. This lets
-          # `tauri ios build` pass -allowProvisioningUpdates so Xcode creates the
-          # distribution provisioning profile automatically (no Apple ID login, no
-          # pre-made profile — fixes "No Accounts" / "No profiles were found").
-          mkdir -p ~/.appstoreconnect/private_keys
-          printf '%s' "$APPLE_API_KEY_P8" > ~/".appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
-
+      # ---- Signed device IPA ----
+      # Manual signing via Tauri's native env vars: Tauri imports the cert into a
+      # temp keychain, installs the provisioning profile, configures the Xcode
+      # project for manual signing, and writes a matching ExportOptions.plist. This
+      # is deterministic — no Apple ID login and no cloud-signing permission issues.
       - name: Build (signed device IPA)
         if: ${{ inputs.signed }}
         env:
+          IOS_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
-          # App Store Connect API key → Tauri enables -allowProvisioningUpdates so
-          # Xcode auto-creates the signing profile for org.catgo.app via the key.
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
-          APPLE_API_KEY_PATH: /Users/runner/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           # Production (no Mac/LAN, no Python sidecar on mobile): build static-only
           # so stray backend fetches return a friendly 503 instead of hanging on
           # localhost. Mobile-native paths still work — local structure view/edit,


### PR DESCRIPTION
Cloud/API-key signing failed at exportArchive (Cloud signing permission error / No profiles). Switch to Tauri's documented manual signing env vars (IOS_CERTIFICATE / IOS_CERTIFICATE_PASSWORD / IOS_MOBILE_PROVISION / APPLE_DEVELOPMENT_TEAM); drop the hand-rolled keychain + API-key signing. API key kept only for the upload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)