### PR TITLE
fix(ui): propagate selective_dynamics (freeze) through the frontend workflow pipeline (#222)

### DIFF
--- a/src/lib/api/adsorbate.ts
+++ b/src/lib/api/adsorbate.ts
@@ -295,6 +295,11 @@ export function place_adsorbate_local(
   const inv_lat = lat ? mat3_inverse(lat) : null
 
   const slab_count = slab.sites.length
+  // If the slab carries selective_dynamics (frozen layers), mark the adsorbate
+  // atoms as fully free so the fixity stays consistent downstream — issue #222.
+  const slab_has_sd = slab.sites.some((s: any) => s.properties?.selective_dynamics)
+  const ads_props = (): Record<string, unknown> =>
+    slab_has_sd ? { selective_dynamics: [true, true, true] } : {}
   const merged_sites = [
     ...slab.sites,
     ...adsorbate_atoms.map((atom, i) => {
@@ -305,7 +310,7 @@ export function place_adsorbate_local(
         abc,
         xyz,
         label: atom.symbol,
-        properties: {} as Record<string, unknown>,
+        properties: ads_props(),
       }
     }),
   ]

--- a/src/lib/workflow/AdsorbatePlacePanel.svelte
+++ b/src/lib/workflow/AdsorbatePlacePanel.svelte
@@ -806,6 +806,11 @@
 
     // Build merged structure
     const lat = slab.lattice?.matrix
+    // If the slab carries selective_dynamics (frozen layers), mark the adsorbate
+    // atoms as fully free so the fixity stays consistent downstream — issue #222.
+    const slab_has_sd = slab.sites.some((s: any) => s.properties?.selective_dynamics)
+    const ads_props = (): Record<string, unknown> =>
+      slab_has_sd ? { selective_dynamics: [true, true, true] } : {}
     const new_sites = [
       ...slab.sites,
       ...manual_adsorbate_cart.map((atom: CustomAtom, i: number) => {
@@ -815,7 +820,7 @@
           species: [{ element: atom.symbol, occu: 1 }],
           abc, xyz,
           label: atom.symbol,
-          properties: {} as Record<string, unknown>,
+          properties: ads_props(),
         }
       }),
     ]

--- a/src/lib/workflow/SlabGenPreview.svelte
+++ b/src/lib/workflow/SlabGenPreview.svelte
@@ -9,6 +9,7 @@
   import { matrix_to_params, ensure_right_handed } from '$lib/structure/lattice-ops'
   import { deduplicate_periodic_images } from '$lib/structure/pbc'
   import { parse_slab_gen_params } from './graph-model'
+  import { apply_freeze_to_structure } from './freeze'
 
   load_i18n_module(`workflow`)
 
@@ -162,9 +163,15 @@
         if (gen_counter !== my_gen) return
         if (is_ok(result)) {
           const slab = postprocess_slab(result.ok)
-          preview_structure = slab
+          // Persist selective_dynamics onto the generated slab so the fixity
+          // flows downstream (Adsorbate / geo_opt) — issue #222. The supercell
+          // is already folded into the geometry, so freezing after generation
+          // covers the tiled cell. Falls back to the raw slab if no freeze.
+          const slab_json = JSON.stringify(slab)
+          const frozen_json = apply_freeze_to_structure(slab_json, node_params) ?? slab_json
+          preview_structure = JSON.parse(frozen_json)
           error_msg = null
-          onstructure_generated?.(JSON.stringify(slab))
+          onstructure_generated?.(frozen_json)
         } else {
           preview_structure = null
           error_msg = result.error

--- a/src/lib/workflow/WorkflowEditor.svelte
+++ b/src/lib/workflow/WorkflowEditor.svelte
@@ -17,6 +17,7 @@
   import NodeConfigPanel from './NodeConfigPanel.svelte'
   import NodeStatusPanel from './NodeStatusPanel.svelte'
   import SlabGenPreview from './SlabGenPreview.svelte'
+  import { apply_freeze_to_structure } from './freeze'
   import CalcStructurePreview from './CalcStructurePreview.svelte'
   import BatchPanel from './BatchPanel.svelte'
   import GestureProvider from '$lib/gesture/GestureProvider.svelte'
@@ -615,78 +616,6 @@
     const indices_str = indices.join(`,`)
     update_node_param(freeze_edit_node_id, `freeze_indices`, indices_str)
     schedule_save()
-  }
-
-  /** Apply freeze params to a structure JSON, setting selective_dynamics on sites */
-  function apply_freeze_to_structure(struct_json: string | null, params: Record<string, unknown>): string | null {
-    if (!struct_json) return null
-    // Tolerate every spelling: explicit freeze_mode, or a bare frozen_layers /
-    // freeze_layers / freeze_n_layers (the geo_opt/slab convention) which implies
-    // bottom-layer freezing. Mirrors the backend's _freeze_n_bottom_layers.
-    const n_bottom = Number(params.frozen_layers ?? params.freeze_layers ?? params.freeze_n_layers ?? 0)
-    let mode = params.freeze_mode as string
-    if ((!mode || mode === `none`) && n_bottom > 0) mode = `layers`
-    if (!mode || mode === `none`) return struct_json
-
-    try {
-      const struct = JSON.parse(struct_json)
-      if (!struct.sites?.length) return struct_json
-      const n = struct.sites.length
-      const frozen = new Set<number>()
-
-      if (mode === `z_range`) {
-        const z_lo = Number(params.freeze_z_below ?? 0)
-        for (let i = 0; i < n; i++) {
-          const z = struct.sites[i].xyz?.[2] ?? 0
-          if (z < z_lo) frozen.add(i)
-        }
-      } else if (mode === `element`) {
-        const elems = new Set(String(params.freeze_elements ?? ``).split(`,`).map(s => s.trim()).filter(Boolean))
-        for (let i = 0; i < n; i++) {
-          const el = struct.sites[i].species?.[0]?.element ?? struct.sites[i].label ?? ``
-          if (elems.has(el)) frozen.add(i)
-        }
-      } else if (mode === `indices` || mode === `manual`) {
-        for (const part of String(params.freeze_indices ?? ``).split(`,`)) {
-          const t = part.trim()
-          if (!t) continue
-          if (t.includes(`-`)) {
-            const [a, b] = t.split(`-`).map(Number)
-            for (let i = a; i <= b; i++) frozen.add(i)
-          } else {
-            const v = parseInt(t)
-            if (!isNaN(v)) frozen.add(v)
-          }
-        }
-      } else if (mode === `layers` || mode === `bottom`) {
-        const n_layers = n_bottom > 0 ? n_bottom : Number(params.freeze_layers ?? 0)
-        if (n_layers > 0) {
-          const zs = ([...new Set(struct.sites.map((s: any) => Math.round((s.xyz?.[2] ?? 0) * 100) / 100))] as number[]).sort((a, b) => a - b)
-          const threshold = n_layers < zs.length ? (zs[n_layers - 1] + zs[n_layers]) / 2 : zs[zs.length - 1] + 0.1
-          for (let i = 0; i < n; i++) {
-            if ((struct.sites[i].xyz?.[2] ?? 0) < threshold) frozen.add(i)
-          }
-        }
-      }
-
-      // Apply invert
-      let final_frozen = frozen
-      if (params.freeze_invert && mode !== `none`) {
-        final_frozen = new Set(Array.from({ length: n }, (_, i) => i).filter(i => !frozen.has(i)))
-      }
-
-      // Set selective_dynamics on sites
-      for (let i = 0; i < n; i++) {
-        const free = !final_frozen.has(i)
-        struct.sites[i].properties = {
-          ...(struct.sites[i].properties ?? {}),
-          selective_dynamics: [free, free, free],
-        }
-      }
-      return JSON.stringify(struct)
-    } catch {
-      return struct_json
-    }
   }
 
   // Non-reactive cache for trajectory objects (avoids Svelte reactivity + serialization overhead)
@@ -3077,7 +3006,7 @@
                 {#if _has_input}
                   {@const _upstream_structures = resolve_input_structures(nd.id)}
                   {@const _raw_struct = resolve_input_structure(nd.id)}
-                  {@const _preview_struct = (nd.type === `freq` || nd.type === `geo_opt` || nd.type === `slab_gen`) ? apply_freeze_to_structure(_raw_struct, nd.params) : _raw_struct}
+                  {@const _preview_struct = (nd.type === `freq` || nd.type === `geo_opt`) ? apply_freeze_to_structure(_raw_struct, nd.params) : _raw_struct}
                   <CalcStructurePreview
                     upstream_structure_json={_preview_struct}
                     upstream_structures_json={_upstream_structures && _upstream_structures.length > 1 ? _upstream_structures : null}

--- a/src/lib/workflow/__tests__/freeze.test.ts
+++ b/src/lib/workflow/__tests__/freeze.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { apply_freeze_to_structure } from '../freeze'
+
+/**
+ * Behavior-lock tests for apply_freeze_to_structure (issue #222).
+ *
+ * The function writes pymatgen-style selective_dynamics onto every site:
+ *   true  = free   → [true, true, true]
+ *   frozen        → [false, false, false]
+ * It must mirror the backend's bottom-layer freezing semantics and preserve
+ * all the modes (z_range / element / indices|manual / layers|bottom + invert).
+ *
+ * These tests exist so the extraction from WorkflowEditor.svelte into freeze.ts
+ * does not silently change behavior, and so the "freeze drops at the Adsorbate
+ * node" leak stays fixed.
+ */
+
+/** A 4-atom slab spread across 4 distinct z-layers (z = 0, 1, 2, 3). */
+function make_slab(): string {
+  return JSON.stringify({
+    lattice: { matrix: [[5, 0, 0], [0, 5, 0], [0, 0, 20]] },
+    sites: [
+      { species: [{ element: `Cu`, occu: 1 }], abc: [0, 0, 0.0], xyz: [0, 0, 0], label: `Cu`, properties: {} },
+      { species: [{ element: `Cu`, occu: 1 }], abc: [0, 0, 0.05], xyz: [0, 0, 1], label: `Cu`, properties: {} },
+      { species: [{ element: `Cu`, occu: 1 }], abc: [0, 0, 0.10], xyz: [0, 0, 2], label: `Cu`, properties: {} },
+      { species: [{ element: `Au`, occu: 1 }], abc: [0, 0, 0.15], xyz: [0, 0, 3], label: `Au`, properties: {} },
+    ],
+  })
+}
+
+function sd(json: string): boolean[][] {
+  return JSON.parse(json).sites.map((s: any) => s.properties.selective_dynamics)
+}
+
+describe(`apply_freeze_to_structure`, () => {
+  it(`freezes the bottom layer for frozen_layers=1 (free elsewhere)`, () => {
+    const out = apply_freeze_to_structure(make_slab(), { frozen_layers: 1 })
+    expect(out).not.toBeNull()
+    const flags = sd(out!)
+    // Bottom layer (z=0) frozen → all-false
+    expect(flags[0]).toEqual([false, false, false])
+    // Everything above is free → all-true
+    expect(flags[1]).toEqual([true, true, true])
+    expect(flags[2]).toEqual([true, true, true])
+    expect(flags[3]).toEqual([true, true, true])
+  })
+
+  it(`freezes the two bottom layers for frozen_layers=2`, () => {
+    const out = apply_freeze_to_structure(make_slab(), { frozen_layers: 2 })
+    const flags = sd(out!)
+    expect(flags[0]).toEqual([false, false, false])
+    expect(flags[1]).toEqual([false, false, false])
+    expect(flags[2]).toEqual([true, true, true])
+    expect(flags[3]).toEqual([true, true, true])
+  })
+
+  it(`returns the input unchanged when no freeze params are given`, () => {
+    const input = make_slab()
+    const out = apply_freeze_to_structure(input, {})
+    // No mode → returns input verbatim (no selective_dynamics added)
+    expect(out).toBe(input)
+  })
+
+  it(`returns null for a null input`, () => {
+    expect(apply_freeze_to_structure(null, { frozen_layers: 1 })).toBeNull()
+  })
+
+  it(`freezes by element`, () => {
+    const out = apply_freeze_to_structure(make_slab(), { freeze_mode: `element`, freeze_elements: `Au` })
+    const flags = sd(out!)
+    expect(flags[0]).toEqual([true, true, true])
+    expect(flags[1]).toEqual([true, true, true])
+    expect(flags[2]).toEqual([true, true, true])
+    expect(flags[3]).toEqual([false, false, false]) // the lone Au
+  })
+
+  it(`freezes by explicit indices (incl. ranges)`, () => {
+    const out = apply_freeze_to_structure(make_slab(), { freeze_mode: `indices`, freeze_indices: `0,2-3` })
+    const flags = sd(out!)
+    expect(flags[0]).toEqual([false, false, false])
+    expect(flags[1]).toEqual([true, true, true])
+    expect(flags[2]).toEqual([false, false, false])
+    expect(flags[3]).toEqual([false, false, false])
+  })
+
+  it(`freezes by z_range (below threshold)`, () => {
+    const out = apply_freeze_to_structure(make_slab(), { freeze_mode: `z_range`, freeze_z_below: 1.5 })
+    const flags = sd(out!)
+    expect(flags[0]).toEqual([false, false, false]) // z=0
+    expect(flags[1]).toEqual([false, false, false]) // z=1
+    expect(flags[2]).toEqual([true, true, true])    // z=2
+    expect(flags[3]).toEqual([true, true, true])    // z=3
+  })
+
+  it(`inverts the frozen set when freeze_invert is set`, () => {
+    const out = apply_freeze_to_structure(make_slab(), { frozen_layers: 1, freeze_invert: true })
+    const flags = sd(out!)
+    // Inverted: bottom layer now free, everything else frozen
+    expect(flags[0]).toEqual([true, true, true])
+    expect(flags[1]).toEqual([false, false, false])
+    expect(flags[2]).toEqual([false, false, false])
+    expect(flags[3]).toEqual([false, false, false])
+  })
+})

--- a/src/lib/workflow/freeze.ts
+++ b/src/lib/workflow/freeze.ts
@@ -1,0 +1,84 @@
+/**
+ * Apply freeze params to a structure JSON, writing pymatgen-style
+ * `selective_dynamics` onto every site so that the fixity flows through the
+ * frontend workflow pipeline (issue #222).
+ *
+ * Site-property shape mirrors the backend:
+ *   site.properties.selective_dynamics = [boolean, boolean, boolean]
+ *   true = free   → [true, true, true]
+ *   frozen        → [false, false, false]
+ *
+ * Pure function — no Svelte / DOM deps. Extracted verbatim from
+ * WorkflowEditor.svelte so the same logic can be unit-tested and reused at
+ * slab-generation time (SlabGenPreview) as well as in the run-time overlay.
+ */
+export function apply_freeze_to_structure(struct_json: string | null, params: Record<string, unknown>): string | null {
+  if (!struct_json) return null
+  // Tolerate every spelling: explicit freeze_mode, or a bare frozen_layers /
+  // freeze_layers / freeze_n_layers (the geo_opt/slab convention) which implies
+  // bottom-layer freezing. Mirrors the backend's _freeze_n_bottom_layers.
+  const n_bottom = Number(params.frozen_layers ?? params.freeze_layers ?? params.freeze_n_layers ?? 0)
+  let mode = params.freeze_mode as string
+  if ((!mode || mode === `none`) && n_bottom > 0) mode = `layers`
+  if (!mode || mode === `none`) return struct_json
+
+  try {
+    const struct = JSON.parse(struct_json)
+    if (!struct.sites?.length) return struct_json
+    const n = struct.sites.length
+    const frozen = new Set<number>()
+
+    if (mode === `z_range`) {
+      const z_lo = Number(params.freeze_z_below ?? 0)
+      for (let i = 0; i < n; i++) {
+        const z = struct.sites[i].xyz?.[2] ?? 0
+        if (z < z_lo) frozen.add(i)
+      }
+    } else if (mode === `element`) {
+      const elems = new Set(String(params.freeze_elements ?? ``).split(`,`).map(s => s.trim()).filter(Boolean))
+      for (let i = 0; i < n; i++) {
+        const el = struct.sites[i].species?.[0]?.element ?? struct.sites[i].label ?? ``
+        if (elems.has(el)) frozen.add(i)
+      }
+    } else if (mode === `indices` || mode === `manual`) {
+      for (const part of String(params.freeze_indices ?? ``).split(`,`)) {
+        const t = part.trim()
+        if (!t) continue
+        if (t.includes(`-`)) {
+          const [a, b] = t.split(`-`).map(Number)
+          for (let i = a; i <= b; i++) frozen.add(i)
+        } else {
+          const v = parseInt(t)
+          if (!isNaN(v)) frozen.add(v)
+        }
+      }
+    } else if (mode === `layers` || mode === `bottom`) {
+      const n_layers = n_bottom > 0 ? n_bottom : Number(params.freeze_layers ?? 0)
+      if (n_layers > 0) {
+        const zs = ([...new Set(struct.sites.map((s: any) => Math.round((s.xyz?.[2] ?? 0) * 100) / 100))] as number[]).sort((a, b) => a - b)
+        const threshold = n_layers < zs.length ? (zs[n_layers - 1] + zs[n_layers]) / 2 : zs[zs.length - 1] + 0.1
+        for (let i = 0; i < n; i++) {
+          if ((struct.sites[i].xyz?.[2] ?? 0) < threshold) frozen.add(i)
+        }
+      }
+    }
+
+    // Apply invert
+    let final_frozen = frozen
+    if (params.freeze_invert && mode !== `none`) {
+      final_frozen = new Set(Array.from({ length: n }, (_, i) => i).filter(i => !frozen.has(i)))
+    }
+
+    // Set selective_dynamics on sites
+    for (let i = 0; i < n; i++) {
+      const free = !final_frozen.has(i)
+      struct.sites[i].properties = {
+        ...(struct.sites[i].properties ?? {}),
+        selective_dynamics: [free, free, free],
+      }
+    }
+    return JSON.stringify(struct)
+  } catch {
+    return struct_json
+  }
+}


### PR DESCRIPTION
A frozen slab's `selective_dynamics` did not flow through the **frontend** workflow pipeline, so downstream node previews (Adsorbate, geo_opt) showed no fixed atoms ("freeze drops at the Adsorbate node"). The viewer (`FrozenAtomIndicators`) renders fixity by reading `site.properties.selective_dynamics`; structures flow node→node as `params.structure_json`. The freeze was only ever a display-only overlay, never written onto the flowing structure.

Fix (treat `selective_dynamics` as a real structure property that survives transforms, matching the backend):
- Extract `apply_freeze_to_structure` into shared `src/lib/workflow/freeze.ts` (+ vitest, 8 cases) — single source of truth.
- `SlabGenPreview` now applies freeze to the generated slab and **emits** `selective_dynamics` in `structure_json` (was emitting none).
- `WorkflowEditor` imports the shared helper; drops `slab_gen` from the display-only overlay (now persisted at source).
- Adsorbate placement (`place_adsorbate_local`, `append_manual_adsorbate`) tags adsorbate atoms `[true,true,true]` when the slab carries SD (slab sites already pass through unchanged) — backend-consistent.

Result: freeze set at slab_gen now persists onto the structure and shows on every downstream node automatically, matching the backend run.

Verification: `freeze.test.ts` 8/8 pass; `svelte-check --threshold error` introduces no new errors in the touched files. (Full slab_gen→adsorbate browser walkthrough is a manual check.)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)