### PR TITLE
fix(ios): min deployment target 15.0 (Xcode 26 link)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,6 +50,9 @@
     "macOS": {
       "minimumSystemVersion": "10.15"
     },
+    "iOS": {
+      "minimumSystemVersion": "15.0"
+    },
     "resources": {
       "icons/document.icns": "./"
     },


### PR DESCRIPTION
Xcode 26 link failed on undefined swiftCompatibilityConcurrency symbols (back-deploy lib gone for old targets). Bump bundle.iOS.minimumSystemVersion to 15.0 (concurrency is native there). iOS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)