### PR TITLE
fix(ios): min iOS 17 (drop Swift compat shims for Xcode 26)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,7 @@
       "minimumSystemVersion": "10.15"
     },
     "iOS": {
-      "minimumSystemVersion": "15.0"
+      "minimumSystemVersion": "17.0"
     },
     "resources": {
       "icons/document.icns": "./"


### PR DESCRIPTION
min 15 still hard-failed on undefined swiftCompatibility56 (Xcode 26 removed the back-deploy libs). Target iOS 17 so the Swift runtime is native and no compatibility force-loads are emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)