### PR TITLE
fix(mobile): hide backend-only Analysis entry on mobile

### DIFF
--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -69,7 +69,9 @@
   // gesture (MediaPipe hand-tracking via camera) is dropped on mobile: the
   // front camera + hand model + the 3D editor together exhaust the WebView and
   // crash the app on this hardware.
-  const HIDDEN_TOOLBAR = [`server`, `terminal`, `workflow`, `plugin_hub`, `chat`, `gesture`]
+  // analysis: AnalysisPane fetches /api/plugins/analyzers from the Python backend,
+  // which mobile doesn't run — a visible-but-503 entry point Apple App Review flags.
+  const HIDDEN_TOOLBAR = [`server`, `terminal`, `workflow`, `plugin_hub`, `chat`, `gesture`, `analysis`]
 
   // SSH-key passwordless onboarding (shown once per endpoint after first connect).
   let ks_visible = $state(false)

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -456,6 +456,7 @@
       </span>
 
       <!-- === Analysis Tools === -->
+      {#if !hidden_toolbar_items.includes('analysis')}
       <span class="struct-toolbar-tooltip-wrap">
         <button
           type="button"
@@ -467,6 +468,7 @@
         </button>
         <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.analysis_tools')}</span>
       </span>
+      {/if}
 
       {#if !hidden_toolbar_items.includes('workflow') && !STATIC_ONLY}
       <!-- === Workflow === -->


### PR DESCRIPTION
AnalysisPane hits /api/plugins/analyzers (Python backend, absent on mobile → 503). Gate the Analysis toolbar button on hidden_toolbar_items and add `analysis` to the mobile HIDDEN_TOOLBAR so App Review doesn't see a broken entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)