### PR TITLE
chore(release): bump to 1.1.10

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump so a fresh iOS build (CatGo icon + analysis hidden + document-type keys) can upload to TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)