### PR TITLE
fix(ios): compliance + doc-type keys via Tauri config (1.1.11)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -108,17 +108,14 @@ jobs:
         # xcodegen regeneration keeps the iOS bundle id.
         run: pnpm tauri ios init --config '{"identifier":"org.catgo.app"}'
 
-      - name: Configure manual code signing + Info.plist
-        # Two things, in this order (order matters):
-        # 1. Inject manual signing into project.yml and regenerate with xcodegen
-        #    (the generated project defaults to automatic signing with no profile
-        #    → "requires a provisioning profile").
-        # 2. ONLY THEN patch Info.plist. xcodegen regenerates Info.plist from
-        #    project.yml, so any plist edits made before xcodegen get wiped — which
-        #    is why an earlier build still showed "Missing Compliance" and the
-        #    ITMS-90737/90788 document-type warnings. `tauri ios build` does not
-        #    re-run xcodegen (the signing inject survives into the build), so this
-        #    is the last regeneration — patches here persist.
+      - name: Configure manual code signing
+        # The generated project.yml has the right bundle id (org.catgo.app) but no
+        # signing settings → automatic signing with no profile → "requires a
+        # provisioning profile". Inject manual signing and regenerate with xcodegen.
+        # (Info.plist keys — export-compliance + document-type LSHandlerRank /
+        # LSSupportsOpeningDocumentsInPlace — are handled at the config layer via
+        # bundle.iOS.infoPlist + fileAssociation rank, which survive the build's
+        # Info.plist regeneration; PlistBuddy here would be wiped by it.)
         if: ${{ inputs.signed }}
         env:
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
@@ -137,25 +134,6 @@ jobs:
           xcodegen generate
           echo "=== pbxproj signing ==="
           grep -hoE "(CODE_SIGN_STYLE|PROVISIONING_PROFILE_SPECIFIER|DEVELOPMENT_TEAM|CODE_SIGN_IDENTITY) = [^;]+;" catgo.xcodeproj/project.pbxproj | sort -u
-          # --- Info.plist patches AFTER xcodegen ---
-          PB=/usr/libexec/PlistBuddy
-          PLIST=$(find . -name Info.plist -path '*_iOS*' -print -quit)
-          [ -n "$PLIST" ] || PLIST=$(find . -name Info.plist -print -quit)
-          if [ -z "$PLIST" ]; then echo "::error::No iOS Info.plist found"; exit 1; fi
-          # Export-compliance: declare standard/exempt encryption → no questionnaire.
-          $PB -c "Add :ITSAppUsesNonExemptEncryption bool false" "$PLIST" 2>/dev/null \
-            || $PB -c "Set :ITSAppUsesNonExemptEncryption false" "$PLIST" 2>/dev/null || true
-          # Document types (from tauri.conf fileAssociations) need these or ITMS-90737/90788.
-          $PB -c "Add :LSSupportsOpeningDocumentsInPlace bool true" "$PLIST" 2>/dev/null \
-            || $PB -c "Set :LSSupportsOpeningDocumentsInPlace true" "$PLIST" 2>/dev/null || true
-          i=0
-          while $PB -c "Print :CFBundleDocumentTypes:$i:CFBundleTypeName" "$PLIST" >/dev/null 2>&1; do
-            $PB -c "Add :CFBundleDocumentTypes:$i:LSHandlerRank string Alternate" "$PLIST" 2>/dev/null \
-              || $PB -c "Set :CFBundleDocumentTypes:$i:LSHandlerRank Alternate" "$PLIST" 2>/dev/null || true
-            i=$((i+1))
-          done
-          echo "=== Info.plist patched ($PLIST): ITSAppUsesNonExemptEncryption + $i doc types ==="
-          $PB -c "Print :ITSAppUsesNonExemptEncryption" "$PLIST" || true
 
       # ---- Unsigned simulator smoke build (no Apple account needed) ----
       - name: Build (simulator, unsigned)

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Merged into the generated iOS Info.plist by Tauri (bundle.iOS.infoPlist).
+	     Survives the build's Info.plist regeneration, unlike post-init PlistBuddy edits. -->
+
+	<!-- Export compliance: CatGo uses only standard, exempt encryption (HTTPS/TLS,
+	     SSH via russh). Declaring this skips the App Store Connect encryption
+	     questionnaire ("Missing Compliance"). -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+
+	<!-- Document-based app: the editor opens local structure files in place.
+	     Required when CFBundleDocumentTypes is declared (ITMS-90737). -->
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",
@@ -51,7 +51,8 @@
       "minimumSystemVersion": "10.15"
     },
     "iOS": {
-      "minimumSystemVersion": "17.0"
+      "minimumSystemVersion": "17.0",
+      "infoPlist": "Info.ios.plist"
     },
     "resources": {
       "icons/document.icns": "./"
@@ -61,31 +62,36 @@
         "ext": ["cif"],
         "name": "CIF Structure",
         "description": "Crystallographic Information File",
-        "role": "Viewer"
+        "role": "Viewer",
+        "rank": "Owner"
       },
       {
         "ext": ["poscar", "vasp", "contcar"],
         "name": "VASP Structure",
         "description": "VASP POSCAR/CONTCAR file",
-        "role": "Viewer"
+        "role": "Viewer",
+        "rank": "Owner"
       },
       {
         "ext": ["xyz", "extxyz"],
         "name": "XYZ Structure",
         "description": "XYZ molecular structure file",
-        "role": "Viewer"
+        "role": "Viewer",
+        "rank": "Owner"
       },
       {
         "ext": ["traj"],
         "name": "ASE Trajectory",
         "description": "ASE trajectory file",
-        "role": "Viewer"
+        "role": "Viewer",
+        "rank": "Owner"
       },
       {
         "ext": ["json"],
         "name": "JSON Structure",
         "description": "JSON structure data",
-        "role": "Viewer"
+        "role": "Viewer",
+        "rank": "Owner"
       }
     ]
   }


### PR DESCRIPTION
PlistBuddy edits get wiped by tauri ios build's Info.plist regeneration. Set ITSAppUsesNonExemptEncryption + LSSupportsOpeningDocumentsInPlace via bundle.iOS.infoPlist, and LSHandlerRank via fileAssociation rank — both survive the build. Fixes Missing Compliance + ITMS-90737/90788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)