### PR TITLE
fix(mobile): SSH password field digits-only keyboard

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",

--- a/src/lib/mobile/OtpDialog.svelte
+++ b/src/lib/mobile/OtpDialog.svelte
@@ -73,7 +73,7 @@
           <input
             class="otp-input"
             type={p.echo ? `text` : `password`}
-            inputmode={p.echo ? `text` : `numeric`}
+            inputmode="text"
             autocomplete="one-time-code"
             autocapitalize="off"
             autocorrect="off"


### PR DESCRIPTION
OtpDialog forced numeric keyboard for non-echo prompts → SSH password couldn't be typed on iOS. Use inputmode=text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)