### PR TITLE
fix(ios): cat app icon + drop doc types (warnings)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -92,13 +92,6 @@ jobs:
         # fails with "Could not resolve ./docs-chunks.json".
         run: pnpm run build:doc-chunks
 
-      - name: Generate app icons (CatGo cat)
-        # tauri ios init builds gen/apple/Assets.xcassets/AppIcon from src-tauri/icons.
-        # The iOS AppIcon set (src-tauri/icons/ios) isn't committed, so without this
-        # init falls back to the default Tauri icon (the cyan/yellow "8"). Regenerate
-        # all icons from the cat logo first so the iOS app ships the CatGo icon.
-        run: pnpm tauri icon desktop/logo.png
-
       - name: Initialise the iOS project
         # Generates src-tauri/gen/apple (xcodegen-based Xcode project). Idempotent.
         # com.catgo.app (the tauri.conf identifier, kept for Android) is taken on the
@@ -106,7 +99,14 @@ jobs:
         # for the iOS commands via --config; Android builds from gen/android with the
         # unchanged tauri.conf identifier. Pass the SAME override on build so any
         # xcodegen regeneration keeps the iOS bundle id.
-        run: pnpm tauri ios init --config '{"identifier":"org.catgo.app"}'
+        run: pnpm tauri ios init --config '{"identifier":"org.catgo.app","bundle":{"fileAssociations":[]}}'
+
+      - name: Generate app icons (CatGo cat)
+        # MUST run AFTER `ios init`: `tauri icon` only fills the gen/apple
+        # Assets.xcassets AppIcon when the iOS project already exists. Run before
+        # init and the cat icons land only in src-tauri/icons/ios while init seeds
+        # Assets.xcassets with the default Tauri icon (the cyan/yellow "8").
+        run: pnpm tauri icon desktop/logo.png
 
       - name: Configure manual code signing
         # The generated project.yml has the right bundle id (org.catgo.app) but no
@@ -138,7 +138,7 @@ jobs:
       # ---- Unsigned simulator smoke build (no Apple account needed) ----
       - name: Build (simulator, unsigned)
         if: ${{ !inputs.signed }}
-        run: pnpm tauri ios build --target aarch64-sim --config '{"identifier":"org.catgo.app"}'
+        run: pnpm tauri ios build --target aarch64-sim --config '{"identifier":"org.catgo.app","bundle":{"fileAssociations":[]}}'
 
       # ---- Signed device IPA ----
       # Manual signing via Tauri's native env vars: Tauri imports the cert into a
@@ -159,7 +159,7 @@ jobs:
           # terminal/files (russh over Tauri invoke, not HTTP). Backend-only UI
           # (chat/workflow/plugin_hub) is already hidden on mobile.
           VITE_STATIC_ONLY: '1'
-        run: pnpm tauri ios build --export-method app-store-connect --config '{"identifier":"org.catgo.app"}'
+        run: pnpm tauri ios build --export-method app-store-connect --config '{"identifier":"org.catgo.app","bundle":{"fileAssociations":[]}}'
 
       # ---- Upload the signed IPA to App Store Connect (TestFlight) ----
       # Needs an App Store Connect API key (App Store Connect → Users and Access →


### PR DESCRIPTION
Two iOS fixes: (1) run `tauri icon` after `ios init` so the AppIcon is the CatGo cat (was shipping the default Tauri 8). (2) drop iOS fileAssociations via --config so there's no CFBundleDocumentTypes → clears ITMS-90737/90788 (Tauri's `rank` only emits LSHandlerRank on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)