### PR TITLE
refactor(workflow): V1→V2 convergence Phase 1 (decouple ORCA) + Phase 2 batch (additive V2 endpoints) (#224)

### DIFF
--- a/server/catgo/routers/workflow_engine.py
+++ b/server/catgo/routers/workflow_engine.py
@@ -90,6 +90,29 @@ def get_dag(workflow_id: str):
     return db.get_dag(workflow_id)
 
 
+@router.get("/{workflow_id}/results-enriched")
+async def get_results_enriched(workflow_id: str):
+    """V2-native dashboard aggregation (#224 Phase 2).
+
+    Mirrors the V1 ``GET /api/workflow/{workflow_id}/results-enriched`` response
+    shape (``{"results": [...], "count": N}``), but reads exclusively from the
+    V2 ``WorkflowDB`` (tasks + task_results + provenance) instead of the legacy
+    ase_db / ``workflow_steps`` tables. Additive — the V1 endpoint is untouched.
+    """
+    db = _get_db()
+    _ensure_exists(db, workflow_id)
+    from catgo.services.workflow_results import build_enriched_results_for_workflow
+    try:
+        results = await asyncio.to_thread(
+            build_enriched_results_for_workflow, db, workflow_id
+        )
+    except KeyError:
+        raise HTTPException(404, f"Workflow {workflow_id} not found")
+    except Exception as e:
+        raise HTTPException(500, str(e))
+    return {"results": results, "count": len(results)}
+
+
 def _ensure_exists(db: WorkflowDB, workflow_id: str):
     try:
         db.get_workflow(workflow_id)

--- a/server/catgo/routers/workflow_engine_tasks.py
+++ b/server/catgo/routers/workflow_engine_tasks.py
@@ -12,6 +12,7 @@ Endpoints:
   GET  /api/engine/tasks/{id}/file-content — read a file from work_dir
   PUT  /api/engine/tasks/{id}/file-content — write a file in work_dir
   GET  /api/engine/tasks/{id}/frequencies  — parse vibrational frequencies
+  GET  /api/engine/tasks/{id}/forces       — per-ionic-step force vectors
 """
 
 from __future__ import annotations
@@ -460,6 +461,33 @@ async def get_task_frequencies(task_id: str):
         return data
     except Exception as exc:
         return {"success": False, "message": str(exc)}
+
+
+@router.get("/{task_id}/forces")
+async def get_task_forces(task_id: str, ionic_step: int = Query(0, description="Ionic step (0 = last)")):
+    """Per-atom force vectors for one ionic step from the task's VASP output.
+
+    V2-native mirror of V1 ``GET /api/workflow/{wf}/forces/{step}``. Resolves the
+    task (and its HPC connection) via ``WorkflowDB.get_task`` / ``_get_task_hpc``
+    instead of the legacy ``workflow_steps`` table, then delegates the actual
+    OUTCAR/vaspout.h5 parsing to the SAME V1 helpers
+    (``parse_vasp_forces_h5`` then ``parse_vasp_forces``) — this is additive
+    convergence work, not a re-implementation.
+
+    ``_get_task_hpc`` raises a clean 404 when the task is unknown or has no
+    ``work_dir``, and a 404 when no HPC connection is available.
+    """
+    task, hpc = _get_task_hpc(task_id)
+    work_dir = task["work_dir"]
+
+    from catgo.utils.job_parser import parse_vasp_forces, parse_vasp_forces_h5
+
+    # Try H5 first (VASP 6.4+ vaspout.h5), fall back to OUTCAR AWK — same order
+    # the V1 handler uses.
+    h5_result = await parse_vasp_forces_h5(hpc.conn, work_dir, ionic_step)
+    if h5_result and h5_result.get("success"):
+        return h5_result
+    return await parse_vasp_forces(hpc.conn, work_dir, ionic_step)
 
 
 def _freqs_from_v2_result(result: dict) -> tuple[list[float], list[float]]:

--- a/server/catgo/routers/workflow_engine_tasks.py
+++ b/server/catgo/routers/workflow_engine_tasks.py
@@ -25,6 +25,8 @@ from pydantic import BaseModel
 from catgo.workflow.states import TaskState
 from catgo.workflow import service
 from catgo.workflow.engine.advancer import PREVIEW_DIR_PREFIX
+# Reuse the V1 request schema rather than redefining it (additive convergence).
+from catgo.routers.workflow import GibbsRequest
 
 logger = logging.getLogger(__name__)
 
@@ -458,3 +460,89 @@ async def get_task_frequencies(task_id: str):
         return data
     except Exception as exc:
         return {"success": False, "message": str(exc)}
+
+
+def _freqs_from_v2_result(result: dict) -> tuple[list[float], list[float]]:
+    """Extract real/imag frequency lists (cm⁻¹) from a V2 task_results row.
+
+    The V2 engine stores frequencies in the dedicated ``real_freqs_json`` /
+    ``imag_freqs_json`` columns (lists of floats, or lists of dicts carrying a
+    ``frequency_cm`` key). For robustness we also fall back to a nested
+    ``outputs_json`` blob using the same legacy key names the V1 path reads
+    (``real_freqs`` / ``imag_freqs``).
+    """
+    def _coerce(raw) -> list[float]:
+        if raw is None:
+            return []
+        data = json.loads(raw) if isinstance(raw, str) else raw
+        if not isinstance(data, list):
+            return []
+        return [f["frequency_cm"] if isinstance(f, dict) else f for f in data]
+
+    real_cm = _coerce(result.get("real_freqs_json"))
+    imag_cm = _coerce(result.get("imag_freqs_json"))
+
+    # Fallback: legacy-shaped frequencies nested in outputs_json.
+    if not real_cm and not imag_cm:
+        outputs_raw = result.get("outputs_json")
+        if outputs_raw:
+            outputs = json.loads(outputs_raw) if isinstance(outputs_raw, str) else outputs_raw
+            if isinstance(outputs, dict):
+                real_cm = _coerce(outputs.get("real_freqs"))
+                imag_cm = _coerce(outputs.get("imag_freqs"))
+
+    return real_cm, imag_cm
+
+
+@router.post("/{task_id}/gibbs")
+def calculate_task_gibbs(task_id: str, req: GibbsRequest):
+    """Calculate Gibbs free-energy correction from a V2 task's stored frequencies.
+
+    V2-native mirror of V1 ``POST /api/workflow/{wf}/gibbs/{step}``. Reads the
+    task's frequency data from the ``task_results`` table (via
+    ``WorkflowDB.get_result``) — the V1 path is broken for V2 because
+    ``task_results`` has no ``result_json`` mirror. The Gibbs/thermo physics is
+    delegated to the same shared helpers the V1 handler calls
+    (``catgo.utils.gibbs_calculator.calc_adsorbed`` / ``calc_gas``).
+    """
+    db = _get_db()
+    try:
+        db.get_task(task_id)
+    except KeyError:
+        raise HTTPException(404, f"Task {task_id} not found")
+
+    result = db.get_result(task_id)
+    if not result:
+        raise HTTPException(404, f"No result for task {task_id}")
+
+    real_cm, imag_cm = _freqs_from_v2_result(result)
+    if not real_cm:
+        return {"success": False, "message": "No frequency data available"}
+
+    from catgo.utils.gibbs_calculator import calc_adsorbed, calc_gas
+
+    if req.mode == "adsorbed":
+        return calc_adsorbed(real_cm, imag_cm, req.temperature, req.freq_cutoff)
+    elif req.mode == "gas":
+        positions = _coerce_json_list(result.get("positions_json"))
+        masses = _coerce_json_list(result.get("masses_json"))
+        atom_types = _coerce_json_list(result.get("atom_types_json"))
+
+        if not positions or not masses:
+            return {"success": False, "message": "Position/mass data required for gas mode"}
+
+        return calc_gas(
+            real_cm, imag_cm, positions, masses, atom_types,
+            T=req.temperature, P=req.pressure,
+            n_unpaired=req.n_unpaired,
+        )
+    else:
+        return {"success": False, "message": f"Unknown mode: {req.mode}"}
+
+
+def _coerce_json_list(raw):
+    """Decode a JSON-encoded list column, returning [] for missing/blank."""
+    if raw is None:
+        return []
+    data = json.loads(raw) if isinstance(raw, str) else raw
+    return data if isinstance(data, list) else []

--- a/server/catgo/routers/workflow_engine_tasks.py
+++ b/server/catgo/routers/workflow_engine_tasks.py
@@ -13,6 +13,7 @@ Endpoints:
   PUT  /api/engine/tasks/{id}/file-content — write a file in work_dir
   GET  /api/engine/tasks/{id}/frequencies  — parse vibrational frequencies
   GET  /api/engine/tasks/{id}/forces       — per-ionic-step force vectors
+  GET  /api/engine/tasks/{id}/mlp-progress — MLP optimizer live progress
 """
 
 from __future__ import annotations
@@ -488,6 +489,121 @@ async def get_task_forces(task_id: str, ionic_step: int = Query(0, description="
     if h5_result and h5_result.get("success"):
         return h5_result
     return await parse_vasp_forces(hpc.conn, work_dir, ionic_step)
+
+
+@router.get("/{task_id}/mlp-progress")
+async def get_task_mlp_progress(task_id: str):
+    """Per-iteration live progress from an MLP optimizer log for a V2 task.
+
+    V2-native mirror of V1 ``GET /api/workflow/{wf}/mlp-progress/{step}``
+    (``catgo.routers.workflow.api_get_mlp_progress``). Resolves the task via
+    ``WorkflowDB.get_task`` (V2 store) for its ``work_dir`` / ``task_type`` /
+    ``params_json`` instead of the legacy ``workflow_steps`` table, then reuses
+    the SAME V1 parser (``catgo.utils.job_parser.parse_ase_opt_log``) and emits
+    the identical ``{points, converged, message}`` shape the frontend's
+    ``NormalizedConvergence`` adapter renders — this is additive convergence
+    work, not a re-implementation.
+
+    This is what the frontend task-adapter's ``mode:'task'`` branch (currently a
+    placeholder message) calls to make live MLP progress real.
+
+    Local-only, same as V1: an HPC-remote MLP task returns a deferred message
+    rather than SSH-tailing the log. Unknown task -> clean 404; no work_dir or
+    no log yet -> clean empty result (never a 500).
+    """
+    db = _get_db()
+    try:
+        task = db.get_task(task_id)
+    except KeyError:
+        raise HTTPException(404, f"Task {task_id} not found")
+
+    work_dir = task.get("work_dir")
+    if not work_dir:
+        return {"points": [], "converged": False, "message": "No work directory yet"}
+
+    # Only local work dirs are readable here. HPC work dirs would need SSH
+    # tailing — deferred until the MLP+HPC path is tested (mirrors V1).
+    if task.get("hpc_session_id"):
+        return {
+            "points": [], "converged": False,
+            "message": "MLP progress over HPC is not yet wired",
+        }
+
+    import os
+    # Pick opt.log for relax/vibrations, neb.log for NEB / ts_search. Match the
+    # V1 contract: only the log files ASE actually writes, no os.listdir
+    # fallback (OS-dependent ordering could shadow the current log with a stale
+    # one from an aborted run).
+    task_type = (task.get("task_type") or "").lower()
+    candidates = []
+    if "neb" in task_type or task_type == "ts_search":
+        candidates.append(os.path.join(work_dir, "neb.log"))
+    candidates.append(os.path.join(work_dir, "opt.log"))
+
+    log_path = next((p for p in candidates if os.path.isfile(p)), None)
+    if not log_path:
+        return {"points": [], "converged": False, "message": "Log file not created yet"}
+
+    # Resolve the per-task fmax target from params_json (the V2 analog of V1's
+    # config_json). We DON'T silently default to 0.05 — a wrong target could
+    # flip a still-running node to converged=True and prematurely complete it.
+    # When unresolvable, return converged=None so the frontend status-sync
+    # short-circuits and keeps the node "running" (mirrors V1 exactly).
+    fmax_target: float | None = None
+    try:
+        params = json.loads(task.get("params_json") or "{}")
+        if isinstance(params, dict) and "fmax" in params:
+            fmax_target = float(params["fmax"])
+    except (ValueError, TypeError) as exc:
+        logger.warning(
+            "Could not parse fmax from task %s params_json: %s — "
+            "convergence flag will be reported as null.",
+            task_id, exc,
+        )
+    if fmax_target is None:
+        # No known target -> parse points but skip the converged check. The
+        # parser uses a sentinel fmax that's never reached so converged stays
+        # False; we override to null below.
+        fmax_target = -1.0
+
+    from catgo.utils.job_parser import parse_ase_opt_log
+    # Parser is synchronous & reads a local file — offload so the event loop
+    # doesn't block on large log tails.
+    try:
+        conv_data = await asyncio.to_thread(parse_ase_opt_log, log_path, fmax_target)
+    except Exception:
+        logger.exception("Error parsing MLP progress for task %s", task_id)
+        raise HTTPException(500, f"Error reading MLP progress for task {task_id}")
+
+    if not conv_data.success:
+        return {"points": [], "converged": False, "message": conv_data.message}
+
+    # If fmax_target was unresolvable, null out converged so the frontend
+    # status-sync branch in NodeStatusPanel can't use it.
+    unresolved_fmax = fmax_target < 0
+
+    prev_energy = None
+    points = []
+    for pt in conv_data.points:
+        dE = (pt.energy - prev_energy) if prev_energy is not None else 0.0
+        points.append({
+            "step": pt.step,
+            "energy": pt.energy,
+            "dE": dE,
+            "energy_sigma0": pt.energy_sigma0,
+            "max_force": pt.max_force,
+            "rms_force": pt.rms_force,
+        })
+        prev_energy = pt.energy
+
+    converged_value = None if unresolved_fmax else conv_data.converged
+    message = conv_data.message
+    if unresolved_fmax and points:
+        message = (
+            f"step {points[-1]['step']} · fmax={points[-1]['max_force']:.3f} eV/Å "
+            f"(target fmax not in params — convergence flag suppressed)"
+        )
+    return {"points": points, "converged": converged_value, "message": message}
 
 
 def _freqs_from_v2_result(result: dict) -> tuple[list[float], list[float]]:

--- a/server/catgo/services/workflow_results.py
+++ b/server/catgo/services/workflow_results.py
@@ -435,3 +435,154 @@ def build_part_c_results(task_rows: list[dict]) -> list[dict]:
 
     logger.debug(f"build_part_c_results: built {len(results)} enriched results from {len(task_rows)} rows")
     return results
+
+
+# ─── V2-native enriched results (#224 Phase 2) ───────────────────────────────
+
+
+def build_enriched_results_for_workflow(db, workflow_id: str) -> list[dict]:
+    """Build dashboard-enriched results for a workflow from the V2 store ONLY.
+
+    Mirrors the response shape of the V1 ``GET /api/workflow/{id}/results-enriched``
+    endpoint (see catgo/routers/workflow.py), but reads exclusively from the V2
+    ``WorkflowDB`` instead of the legacy ase_db / ``workflow_steps`` tables:
+
+      * iterate the workflow's tasks via ``db.get_all_tasks``
+      * join each task's stored result via ``db.get_result``
+      * attach provenance via ``db.get_provenance`` (best-effort, additive)
+
+    Unlike :func:`fetch_v2_task_results_by_workflow` (which filters to
+    ``software = 'orca'`` for the V1 Part-C merge), this V2-native path surfaces
+    *every* task with a stored result regardless of engine (vasp / cp2k / orca /
+    mlp / …). ORCA tasks are formatted via :func:`build_part_c_results` so the
+    engine-specific fields (frequencies, convergence_points, NEB/IRC, UV-Vis)
+    stay identical to the V1 merge; all other engines get the generic enriched
+    base row.
+
+    Each returned dict carries the same keys the FE dashboard expects:
+    ``id, formula, energy, energy_per_atom, natoms, volume, a, b, c, alpha,
+    beta, gamma, workflow_id, workflow_name, step_id, step_label, node_type``.
+    """
+    try:
+        wf = db.get_workflow(workflow_id)
+        wf_name = wf.get("name") or workflow_id
+    except KeyError:
+        raise
+    except Exception:
+        wf_name = workflow_id
+
+    tasks = db.get_all_tasks(workflow_id)
+
+    # Rows destined for the ORCA-aware formatter, shaped like the SQL join in
+    # fetch_v2_task_results_by_workflow so build_part_c_results works unchanged.
+    orca_rows: list[dict] = []
+    generic_results: list[dict] = []
+
+    for task in tasks:
+        task_id = task.get("id")
+        try:
+            result = db.get_result(task_id)
+        except Exception:
+            result = None
+        if not result:
+            continue  # task has no stored result yet — nothing to enrich
+
+        try:
+            outputs = json.loads(result.get("outputs_json") or "{}")
+        except Exception:
+            outputs = {}
+        if outputs.get("error"):
+            continue
+
+        try:
+            params = json.loads(task.get("params_json") or "{}")
+        except Exception:
+            params = {}
+
+        software = (task.get("software") or params.get("software") or "").lower()
+
+        common_row = {
+            "task_id": task_id,
+            "workflow_id": result.get("workflow_id") or workflow_id,
+            "energy": result.get("energy"),
+            "outputs_json": result.get("outputs_json") or "{}",
+            "task_type": task.get("task_type"),
+            "task_name": task.get("name"),
+            "params_json": task.get("params_json") or "{}",
+            "system_name": task.get("system_name"),
+            "wf_name": wf_name,
+        }
+
+        if software == "orca" or outputs.get("type", "").startswith("orca"):
+            orca_rows.append(common_row)
+            continue
+
+        # Generic (non-ORCA) enriched base row — same key set as build_part_c.
+        task_type = task.get("task_type")
+        step_label = task.get("name") or params.get("label") or task_type
+        formula = (
+            task.get("system_name")
+            or params.get("system_name")
+            or params.get("formula")
+            or outputs.get("formula")
+        )
+        energy = result.get("energy")
+        if energy is None:
+            energy = outputs.get("energy_ev") or outputs.get("energy")
+        natoms = outputs.get("natoms")
+        energy_per_atom = None
+        if energy is not None and isinstance(natoms, (int, float)) and natoms:
+            energy_per_atom = energy / natoms
+
+        base_result = {
+            "id": None,
+            "formula": formula,
+            "energy": energy,
+            "energy_per_atom": energy_per_atom,
+            "natoms": natoms,
+            "volume": outputs.get("volume"),
+            "a": outputs.get("a"), "b": outputs.get("b"), "c": outputs.get("c"),
+            "alpha": outputs.get("alpha"), "beta": outputs.get("beta"),
+            "gamma": outputs.get("gamma"),
+            "workflow_id": result.get("workflow_id") or workflow_id,
+            "workflow_name": wf_name,
+            "step_id": task_id,
+            "step_label": step_label,
+            "node_type": task_type,
+            "energy_eh": outputs.get("energy_eh"),
+        }
+
+        convergence_points = outputs.get("convergence_points", [])
+        if convergence_points:
+            base_result["convergence_points"] = convergence_points
+            if base_result["energy"] is None:
+                final_energy = convergence_points[-1].get("energy")
+                if final_energy is not None:
+                    base_result["energy"] = final_energy
+
+        # Provenance (best-effort, additive — never blocks the row).
+        try:
+            prov = db.get_provenance(task_id)
+            if prov:
+                base_result["provenance"] = prov
+        except Exception:
+            pass
+
+        generic_results.append(base_result)
+
+    enriched = build_part_c_results(orca_rows) if orca_rows else []
+
+    # Attach provenance to ORCA rows too (best-effort) so the shape is uniform.
+    for row in enriched:
+        sid = row.get("step_id")
+        if not sid:
+            continue
+        try:
+            prov = db.get_provenance(sid)
+            if prov:
+                row["provenance"] = prov
+        except Exception:
+            pass
+
+    enriched.extend(generic_results)
+    return enriched

--- a/server/catgo/workflow/engine/orca_progress.py
+++ b/server/catgo/workflow/engine/orca_progress.py
@@ -1,0 +1,80 @@
+"""Pure ORCA stdout-tail parsers for calculation-stage progress.
+
+Engine-internal helpers with no FE/wire-format dependencies. Used by the
+poller to derive a coarse-grained progress stage from the tail of an ORCA
+output file (geometry-opt/freq via :func:`get_orca_stage`, IRC via
+:func:`get_orca_irc_stage`).
+"""
+
+from __future__ import annotations
+import re
+
+
+def get_orca_stage(tail_text: str) -> dict:
+    """Parse ORCA output tail to determine current calculation stage.
+
+    Markers are listed in chronological order. Returns the latest stage found.
+    """
+    stage_markers = [
+        ("SCF ITERATIONS", "scf", "Converging SCF..."),
+        ("Hessian", "hessian", "Setting up Hessian..."),
+        ("Calculating the COSX Hessian", "hessian_cosx", "Computing Hessian (slowest step, ~54% of runtime)..."),
+        ("Calculating normal modes", "normal_modes", "Deriving normal modes..."),
+        ("VIBRATIONAL FREQUENCIES", "frequencies", "Computing vibrational frequencies..."),
+        ("Thermochemistry", "thermochem", "Calculating thermochemistry..."),
+        ("ORCA TERMINATED NORMALLY", "done", "Calculation complete"),
+    ]
+    current: dict = {"stage": "starting", "message": "Starting calculation..."}
+    for marker, stage_key, message in stage_markers:
+        if marker in tail_text:
+            current = {"stage": stage_key, "message": message}
+    return current
+
+
+def get_orca_irc_stage(tail_text: str) -> dict:
+    """Parse ORCA IRC output tail to determine current phase and step counts.
+
+    Returns a dict with stage, message, and optional progress fields:
+      hessian_current / hessian_total  — during numerical Hessian
+      forward_steps / backward_steps   — during IRC path following
+    """
+    # Check phases in reverse chronological order so we return the latest
+    if "BACKWARD IRC" in tail_text:
+        # Count completed backward steps from the last step-data line pattern
+        steps = re.findall(
+            r"^\s+(\d+)\s+[-\d.]+\s+[-\d.]+\s+[\d.]+\s+[\d.]+",
+            tail_text[tail_text.rfind("BACKWARD IRC"):],
+            re.MULTILINE,
+        )
+        n = int(steps[-1]) + 1 if steps else 0
+        return {"stage": "irc_backward", "message": f"Backward IRC: {n} step(s)", "backward_steps": n}
+
+    if "FORWARD IRC" in tail_text:
+        steps = re.findall(
+            r"^\s+(\d+)\s+[-\d.]+\s+[-\d.]+\s+[\d.]+\s+[\d.]+",
+            tail_text[tail_text.rfind("FORWARD IRC"):],
+            re.MULTILINE,
+        )
+        n = int(steps[-1]) + 1 if steps else 0
+        return {"stage": "irc_forward", "message": f"Forward IRC: {n} step(s)", "forward_steps": n}
+
+    if "Calculating gradient on displaced geometry" in tail_text:
+        # Find the highest displacement number seen so far
+        matches = re.findall(
+            r"Calculating gradient on displaced geometry\s+(\d+) \(of\s+(\d+)\)",
+            tail_text,
+        )
+        if matches:
+            current_n, total_n = int(matches[-1][0]), int(matches[-1][1])
+            return {
+                "stage": "irc_hessian",
+                "message": f"Computing Hessian ({current_n}/{total_n})...",
+                "hessian_current": current_n,
+                "hessian_total": total_n,
+            }
+        return {"stage": "irc_hessian", "message": "Computing Hessian..."}
+
+    if "Energy+Gradient Calculation" in tail_text:
+        return {"stage": "irc_initial", "message": "Computing initial TS energy..."}
+
+    return {"stage": "starting", "message": "Starting IRC calculation..."}

--- a/server/catgo/workflow/engine/poller.py
+++ b/server/catgo/workflow/engine/poller.py
@@ -12,7 +12,7 @@ from catgo.workflow.db import WorkflowDB
 from catgo.workflow.states import TaskState
 from catgo.workflow.engine.hpc_utils import get_hpc_connection
 from catgo.workflow.engine.broadcast import broadcast_stage_message
-from catgo.workflow.engine.v1_monitor import get_orca_stage, get_orca_irc_stage
+from catgo.workflow.engine.orca_progress import get_orca_stage, get_orca_irc_stage
 from catgo.workflow.engine.result_handler import on_task_completed
 
 logger = logging.getLogger(__name__)

--- a/server/catgo/workflow/engine/v1_monitor.py
+++ b/server/catgo/workflow/engine/v1_monitor.py
@@ -13,80 +13,9 @@ V2 broadcast format (from broadcast.py):
 
 from __future__ import annotations
 from typing import Any
-import re
 
 from catgo.workflow.state_map import v2_to_v1_status
 from catgo.workflow.task_ids import node_id_from_task_id
-
-
-def get_orca_stage(tail_text: str) -> dict:
-    """Parse ORCA output tail to determine current calculation stage.
-
-    Markers are listed in chronological order. Returns the latest stage found.
-    """
-    stage_markers = [
-        ("SCF ITERATIONS", "scf", "Converging SCF..."),
-        ("Hessian", "hessian", "Setting up Hessian..."),
-        ("Calculating the COSX Hessian", "hessian_cosx", "Computing Hessian (slowest step, ~54% of runtime)..."),
-        ("Calculating normal modes", "normal_modes", "Deriving normal modes..."),
-        ("VIBRATIONAL FREQUENCIES", "frequencies", "Computing vibrational frequencies..."),
-        ("Thermochemistry", "thermochem", "Calculating thermochemistry..."),
-        ("ORCA TERMINATED NORMALLY", "done", "Calculation complete"),
-    ]
-    current: dict = {"stage": "starting", "message": "Starting calculation..."}
-    for marker, stage_key, message in stage_markers:
-        if marker in tail_text:
-            current = {"stage": stage_key, "message": message}
-    return current
-
-
-def get_orca_irc_stage(tail_text: str) -> dict:
-    """Parse ORCA IRC output tail to determine current phase and step counts.
-
-    Returns a dict with stage, message, and optional progress fields:
-      hessian_current / hessian_total  — during numerical Hessian
-      forward_steps / backward_steps   — during IRC path following
-    """
-    # Check phases in reverse chronological order so we return the latest
-    if "BACKWARD IRC" in tail_text:
-        # Count completed backward steps from the last step-data line pattern
-        steps = re.findall(
-            r"^\s+(\d+)\s+[-\d.]+\s+[-\d.]+\s+[\d.]+\s+[\d.]+",
-            tail_text[tail_text.rfind("BACKWARD IRC"):],
-            re.MULTILINE,
-        )
-        n = int(steps[-1]) + 1 if steps else 0
-        return {"stage": "irc_backward", "message": f"Backward IRC: {n} step(s)", "backward_steps": n}
-
-    if "FORWARD IRC" in tail_text:
-        steps = re.findall(
-            r"^\s+(\d+)\s+[-\d.]+\s+[-\d.]+\s+[\d.]+\s+[\d.]+",
-            tail_text[tail_text.rfind("FORWARD IRC"):],
-            re.MULTILINE,
-        )
-        n = int(steps[-1]) + 1 if steps else 0
-        return {"stage": "irc_forward", "message": f"Forward IRC: {n} step(s)", "forward_steps": n}
-
-    if "Calculating gradient on displaced geometry" in tail_text:
-        # Find the highest displacement number seen so far
-        matches = re.findall(
-            r"Calculating gradient on displaced geometry\s+(\d+) \(of\s+(\d+)\)",
-            tail_text,
-        )
-        if matches:
-            current_n, total_n = int(matches[-1][0]), int(matches[-1][1])
-            return {
-                "stage": "irc_hessian",
-                "message": f"Computing Hessian ({current_n}/{total_n})...",
-                "hessian_current": current_n,
-                "hessian_total": total_n,
-            }
-        return {"stage": "irc_hessian", "message": "Computing Hessian..."}
-
-    if "Energy+Gradient Calculation" in tail_text:
-        return {"stage": "irc_initial", "message": "Computing initial TS energy..."}
-
-    return {"stage": "starting", "message": "Starting IRC calculation..."}
 
 
 def build_initial_state(

--- a/server/tests/test_orca_progress.py
+++ b/server/tests/test_orca_progress.py
@@ -1,0 +1,49 @@
+"""Tests for pure ORCA stdout-tail progress parsers (#224 Phase 1)."""
+
+from catgo.workflow.engine.orca_progress import get_orca_stage, get_orca_irc_stage
+
+
+def test_get_orca_stage_returns_latest_marker():
+    tail = (
+        "SCF ITERATIONS\n"
+        "...converged...\n"
+        "VIBRATIONAL FREQUENCIES\n"
+        "Thermochemistry\n"
+    )
+    stage = get_orca_stage(tail)
+    assert stage == {"stage": "thermochem", "message": "Calculating thermochemistry..."}
+
+
+def test_get_orca_stage_starting_when_no_markers():
+    assert get_orca_stage("nothing useful here") == {
+        "stage": "starting",
+        "message": "Starting calculation...",
+    }
+
+
+def test_get_orca_irc_stage_hessian_progress():
+    tail = (
+        "Energy+Gradient Calculation\n"
+        "Calculating gradient on displaced geometry   3 (of   18)\n"
+    )
+    stage = get_orca_irc_stage(tail)
+    assert stage == {
+        "stage": "irc_hessian",
+        "message": "Computing Hessian (3/18)...",
+        "hessian_current": 3,
+        "hessian_total": 18,
+    }
+
+
+def test_get_orca_irc_stage_forward_steps():
+    tail = (
+        "FORWARD IRC\n"
+        "    0   -100.123456   0.000000   0.001000   0.002000\n"
+        "    1   -100.234567   0.111111   0.001500   0.002500\n"
+    )
+    stage = get_orca_irc_stage(tail)
+    assert stage == {
+        "stage": "irc_forward",
+        "message": "Forward IRC: 2 step(s)",
+        "forward_steps": 2,
+    }

--- a/server/tests/test_v2_results_endpoints.py
+++ b/server/tests/test_v2_results_endpoints.py
@@ -1,0 +1,176 @@
+"""Tests for the V2-native dashboard aggregation endpoint (#224 Phase 2).
+
+Covers:
+  GET /api/engine/workflows/{workflow_id}/results-enriched
+
+This endpoint mirrors the V1 ``GET /api/workflow/{workflow_id}/results-enriched``
+shape but reads the V2 store (WorkflowDB.get_all_tasks + get_result +
+provenance) instead of the legacy ase_db / workflow_steps tables.
+
+These tests build a temporary WorkflowDB, convert a tiny graph into V2 tasks,
+store a result on a task, and assert the enriched fields appear via both the
+service function and the HTTP endpoint. Temp DBs only — never ~/.catgo/catgo.db.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_server_dir = str(Path(__file__).resolve().parent.parent)
+if _server_dir not in sys.path:
+    sys.path.insert(0, _server_dir)
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from catgo.workflow.db import WorkflowDB
+from catgo.workflow.graph_converter import convert_graph_json
+import catgo.routers.workflow_engine as wfe
+
+
+SAMPLE_GRAPH = json.dumps({
+    "nodes": [
+        {"id": "n1", "type": "structure_input", "x": 0, "y": 0,
+         "params": {"label": "Pt4"}},
+        {"id": "n2", "type": "geo_opt", "x": 300, "y": 0,
+         "params": {"software": "vasp", "ENCUT": 520}},
+    ],
+    "edges": [
+        {"id": "e1", "from": "n1", "to": "n2", "fromH": "out-0", "toH": "in-0"},
+    ],
+})
+
+
+def _make_db_with_result():
+    """Build a temp WorkflowDB, convert a tiny graph, store a result on geo_opt.
+
+    Returns (db, db_path, workflow_id, geo_opt_task_id).
+    """
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+
+    workflow_id = convert_graph_json(db, "v2-enriched-wf", SAMPLE_GRAPH)
+    tasks = db.get_all_tasks(workflow_id)
+    geo_opt = next(t for t in tasks if t["task_type"] == "geo_opt")
+    task_id = geo_opt["id"]
+
+    # Mark completed + store a result the way the engine collector would.
+    db.update_task(task_id, status="COMPLETED", system_name="Pt4")
+    db.store_result(
+        task_id,
+        workflow_id,
+        energy=-24.6,
+        structure_json=None,
+        outputs_json=json.dumps({
+            "energy_ev": -24.6,
+            "natoms": 4,
+            "formula": "Pt4",
+            "convergence_points": [
+                {"step": 1, "energy": -24.0, "dE": 0.0},
+                {"step": 2, "energy": -24.6, "dE": -0.6},
+            ],
+        }),
+    )
+    return db, db_path, workflow_id, task_id
+
+
+def _make_app(db: WorkflowDB) -> TestClient:
+    wfe.set_db(db)
+    app = FastAPI()
+    app.include_router(wfe.router)
+    return TestClient(app)
+
+
+def test_service_builds_enriched_rows_from_v2_store():
+    """The V2-native service iterates tasks+results and returns enriched dicts."""
+    from catgo.services.workflow_results import build_enriched_results_for_workflow
+
+    db, db_path, workflow_id, task_id = _make_db_with_result()
+    try:
+        results = build_enriched_results_for_workflow(db, workflow_id)
+        assert isinstance(results, list)
+        assert len(results) >= 1
+
+        row = next(r for r in results if r.get("step_id") == task_id)
+        # Same enriched-shape keys the V1 endpoint / FE dashboard expects.
+        for key in (
+            "id", "formula", "energy", "energy_per_atom", "natoms",
+            "volume", "a", "b", "c", "alpha", "beta", "gamma",
+            "workflow_id", "workflow_name", "step_id", "step_label", "node_type",
+        ):
+            assert key in row, f"missing enriched key: {key}"
+
+        assert row["workflow_id"] == workflow_id
+        assert row["workflow_name"] == "v2-enriched-wf"
+        assert row["formula"] == "Pt4"
+        assert row["energy"] == pytest.approx(-24.6)
+        assert row["natoms"] == 4
+        assert row["energy_per_atom"] == pytest.approx(-24.6 / 4)
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_endpoint_returns_enriched_results():
+    """GET /api/engine/workflows/{id}/results-enriched returns the V1-shaped payload."""
+    db, db_path, workflow_id, task_id = _make_db_with_result()
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/workflows/{workflow_id}/results-enriched")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        assert "results" in data
+        assert "count" in data
+        assert data["count"] == len(data["results"])
+        assert data["count"] >= 1
+
+        row = next(r for r in data["results"] if r.get("step_id") == task_id)
+        assert row["workflow_id"] == workflow_id
+        assert row["workflow_name"] == "v2-enriched-wf"
+        assert row["formula"] == "Pt4"
+        assert row["energy"] == pytest.approx(-24.6)
+        assert row["node_type"] == "geo_opt"
+    finally:
+        wfe.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_endpoint_unknown_workflow_404():
+    """Unknown workflow id returns 404, not a 500."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+    try:
+        client = _make_app(db)
+        resp = client.get("/api/engine/workflows/does-not-exist/results-enriched")
+        assert resp.status_code == 404
+    finally:
+        wfe.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_endpoint_no_results_empty_list():
+    """A workflow with tasks but no stored results returns an empty results list."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+    try:
+        workflow_id = convert_graph_json(db, "empty-results-wf", SAMPLE_GRAPH)
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/workflows/{workflow_id}/results-enriched")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["results"] == []
+        assert data["count"] == 0
+    finally:
+        wfe.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)

--- a/server/tests/test_v2_task_analysis.py
+++ b/server/tests/test_v2_task_analysis.py
@@ -1,0 +1,164 @@
+"""Tests for the V2-native task analysis endpoint (#224 Phase 2).
+
+Covers:
+  POST /api/engine/tasks/{task_id}/gibbs
+
+This endpoint mirrors the V1 ``POST /api/workflow/{wf}/gibbs/{step}`` shape but
+reads the V2 task's stored frequency data from the ``task_results`` table (via
+``WorkflowDB.get_result``) instead of ``workflow_steps.result_json`` (the V1
+path is broken for V2 — task_results has no result_json mirror). It reuses the
+same Gibbs/thermo physics (``catgo.utils.gibbs_calculator.calc_adsorbed`` /
+``calc_gas``) the V1 handler calls.
+
+Temp DBs only — never ~/.catgo/catgo.db.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_server_dir = str(Path(__file__).resolve().parent.parent)
+if _server_dir not in sys.path:
+    sys.path.insert(0, _server_dir)
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from catgo.workflow.db import WorkflowDB
+from catgo.workflow.graph_converter import convert_graph_json
+import catgo.routers.workflow_engine_tasks as wfet
+
+
+SAMPLE_GRAPH = json.dumps({
+    "nodes": [
+        {"id": "n1", "type": "structure_input", "x": 0, "y": 0,
+         "params": {"label": "COOH"}},
+        {"id": "n2", "type": "freq", "x": 300, "y": 0,
+         "params": {"software": "vasp"}},
+    ],
+    "edges": [
+        {"id": "e1", "from": "n1", "to": "n2", "fromH": "out-0", "toH": "in-0"},
+    ],
+})
+
+# Real vibrational frequencies (cm^-1) for an adsorbed species.
+REAL_FREQS = [3200.0, 1600.0, 1100.0, 800.0, 600.0, 400.0]
+IMAG_FREQS = [120.0]
+
+
+def _make_db_with_freq_result():
+    """Build a temp WorkflowDB, convert a tiny graph, store a freq result.
+
+    Frequencies are stored the way the V2 engine collector / scanner stores
+    them: as JSON lists in the dedicated real_freqs_json / imag_freqs_json
+    columns of task_results.
+
+    Returns (db, db_path, workflow_id, freq_task_id).
+    """
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+
+    workflow_id = convert_graph_json(db, "v2-gibbs-wf", SAMPLE_GRAPH)
+    tasks = db.get_all_tasks(workflow_id)
+    freq_task = next(t for t in tasks if t["task_type"] == "freq")
+    task_id = freq_task["id"]
+
+    db.update_task(task_id, status="COMPLETED", system_name="COOH")
+    db.store_result(
+        task_id,
+        workflow_id,
+        energy=-12.3,
+        real_freqs_json=json.dumps(REAL_FREQS),
+        imag_freqs_json=json.dumps(IMAG_FREQS),
+    )
+    return db, db_path, workflow_id, task_id
+
+
+def _make_app(db: WorkflowDB) -> TestClient:
+    wfet.set_db(db)
+    app = FastAPI()
+    app.include_router(wfet.router)
+    return TestClient(app)
+
+
+def test_gibbs_endpoint_returns_value_for_adsorbed():
+    """POST .../gibbs returns a Gibbs correction computed from stored freqs."""
+    db, db_path, workflow_id, task_id = _make_db_with_freq_result()
+    try:
+        client = _make_app(db)
+        resp = client.post(
+            f"/api/engine/tasks/{task_id}/gibbs",
+            json={"mode": "adsorbed", "temperature": 298.15, "freq_cutoff": 50.0},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        assert data["mode"] == "adsorbed"
+        # A real Gibbs correction value must be present and finite.
+        assert "g_corr_ev" in data
+        assert data["g_corr_ev"] is not None
+        assert isinstance(data["g_corr_ev"], (int, float))
+        # ZPE for these frequencies is positive and non-trivial.
+        assert data["zpe_ev"] > 0
+        assert data["n_real"] == len(REAL_FREQS)
+        assert data["n_imag"] == len(IMAG_FREQS)
+
+        # Cross-check the value against the shared physics helper directly.
+        from catgo.utils.gibbs_calculator import calc_adsorbed
+        expected = calc_adsorbed(REAL_FREQS, IMAG_FREQS, 298.15, 50.0)
+        assert data["g_corr_ev"] == pytest.approx(expected["g_corr_ev"])
+        assert data["zpe_ev"] == pytest.approx(expected["zpe_ev"])
+    finally:
+        wfet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_gibbs_endpoint_unknown_task_404():
+    """Unknown task id returns 404, not a 500."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+    try:
+        client = _make_app(db)
+        resp = client.post(
+            "/api/engine/tasks/does-not-exist/gibbs",
+            json={"mode": "adsorbed"},
+        )
+        assert resp.status_code == 404
+    finally:
+        wfet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_gibbs_endpoint_no_freqs_reports_gracefully():
+    """A completed task without frequency data returns success=False, not 500."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+    try:
+        workflow_id = convert_graph_json(db, "no-freq-wf", SAMPLE_GRAPH)
+        tasks = db.get_all_tasks(workflow_id)
+        freq_task = next(t for t in tasks if t["task_type"] == "freq")
+        task_id = freq_task["id"]
+        db.update_task(task_id, status="COMPLETED")
+        db.store_result(task_id, workflow_id, energy=-12.3)
+
+        client = _make_app(db)
+        resp = client.post(
+            f"/api/engine/tasks/{task_id}/gibbs",
+            json={"mode": "adsorbed"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data.get("success") is False
+    finally:
+        wfet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)

--- a/server/tests/test_v2_task_forces.py
+++ b/server/tests/test_v2_task_forces.py
@@ -1,0 +1,164 @@
+"""Tests for the V2-native per-ionic-step forces endpoint (#224 Phase 2).
+
+Covers:
+  GET /api/engine/tasks/{task_id}/forces
+
+This endpoint mirrors the V1 ``GET /api/workflow/{wf}/forces/{step}`` shape but
+resolves the task via ``WorkflowDB.get_task`` (V2 store) instead of the legacy
+``workflow_steps`` table. The actual OUTCAR/vaspout.h5 parsing is delegated to
+the SAME V1 helpers (``catgo.utils.job_parser.parse_vasp_forces`` /
+``parse_vasp_forces_h5``) — this task is additive and must not re-implement them.
+
+Temp DBs only — never ~/.catgo/catgo.db. The HPC connection + remote file parse
+are mocked so the test runs offline with no fixture OUTCAR.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_server_dir = str(Path(__file__).resolve().parent.parent)
+if _server_dir not in sys.path:
+    sys.path.insert(0, _server_dir)
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from catgo.workflow.db import WorkflowDB
+import catgo.routers.workflow_engine_tasks as wet
+
+
+def _make_db_with_task(*, work_dir: str | None):
+    """Build a temp WorkflowDB with a single geo_opt task.
+
+    Returns (db, db_path, workflow_id, task_id).
+    """
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+
+    workflow_id = db.create_workflow("v2-forces-wf")
+    task_id = db.create_task(workflow_id, "geo_opt", task_id=f"{workflow_id}:opt")
+    db.update_task(task_id, status="COMPLETED")
+    if work_dir is not None:
+        db.update_task(task_id, work_dir=work_dir)
+    return db, db_path, workflow_id, task_id
+
+
+def _make_app(db: WorkflowDB) -> TestClient:
+    wet.set_db(db)
+    app = FastAPI()
+    app.include_router(wet.router)
+    return TestClient(app)
+
+
+def test_forces_endpoint_resolves_task_and_returns_shape(monkeypatch):
+    """Happy path: endpoint resolves the task, calls the V1 parser, returns shape."""
+    db, db_path, workflow_id, task_id = _make_db_with_task(work_dir="/scratch/run1")
+
+    class _FakeHpc:
+        conn = object()  # opaque; the parser is mocked so it is never used
+
+    # Stub the task+connection resolver so no real HPC/SSH is touched.
+    monkeypatch.setattr(wet, "_get_task_hpc", lambda tid: (db.get_task(tid), _FakeHpc()))
+
+    parsed = {
+        "success": True,
+        "forces": [[0.0, 0.0, 0.01], [0.0, 0.0, -0.01]],
+        "positions": [[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]],
+        "step": 3,
+        "total_steps": 3,
+        "structure_content": "POSCAR-text",
+    }
+
+    async def _fake_forces(conn, work_dir, ionic_step=0):
+        # Assert the endpoint forwarded the task's work_dir + ionic_step.
+        assert work_dir == "/scratch/run1"
+        assert ionic_step == 2
+        return parsed
+
+    async def _fake_forces_h5(conn, work_dir, ionic_step=0):
+        return None  # force fallback to OUTCAR parser
+
+    import catgo.utils.job_parser as jp
+    monkeypatch.setattr(jp, "parse_vasp_forces", _fake_forces)
+    monkeypatch.setattr(jp, "parse_vasp_forces_h5", _fake_forces_h5)
+
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/forces?ionic_step=2")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        for key in ("forces", "positions", "step", "total_steps"):
+            assert key in data, f"missing key: {key}"
+        assert data["forces"] == parsed["forces"]
+        assert data["step"] == 3
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_forces_endpoint_prefers_h5_when_available(monkeypatch):
+    """If the H5 parser succeeds, the OUTCAR fallback is not used (mirrors V1)."""
+    db, db_path, workflow_id, task_id = _make_db_with_task(work_dir="/scratch/run2")
+
+    class _FakeHpc:
+        conn = object()
+
+    monkeypatch.setattr(wet, "_get_task_hpc", lambda tid: (db.get_task(tid), _FakeHpc()))
+
+    h5_result = {"success": True, "forces": [[1.0, 2.0, 3.0]], "positions": [[0, 0, 0]],
+                 "step": 1, "total_steps": 1, "structure_content": None}
+
+    async def _fake_forces_h5(conn, work_dir, ionic_step=0):
+        return h5_result
+
+    async def _boom(conn, work_dir, ionic_step=0):
+        raise AssertionError("OUTCAR parser should not run when H5 succeeds")
+
+    import catgo.utils.job_parser as jp
+    monkeypatch.setattr(jp, "parse_vasp_forces_h5", _fake_forces_h5)
+    monkeypatch.setattr(jp, "parse_vasp_forces", _boom)
+
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/forces")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["forces"] == [[1.0, 2.0, 3.0]]
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_forces_endpoint_unknown_task_404():
+    """Unknown task id returns a clean 404."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+    try:
+        client = _make_app(db)
+        resp = client.get("/api/engine/tasks/does-not-exist/forces")
+        assert resp.status_code == 404
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_forces_endpoint_no_work_dir_404():
+    """A task without a work_dir returns a clean 404 (no work directory yet)."""
+    db, db_path, workflow_id, task_id = _make_db_with_task(work_dir=None)
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/forces")
+        assert resp.status_code == 404
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)

--- a/server/tests/test_v2_task_mlp_progress.py
+++ b/server/tests/test_v2_task_mlp_progress.py
@@ -1,0 +1,205 @@
+"""Tests for the V2-native MLP live-progress endpoint (#224 Phase 2).
+
+Covers:
+  GET /api/engine/tasks/{task_id}/mlp-progress
+
+This endpoint mirrors the V1 ``GET /api/workflow/{wf}/mlp-progress/{step}`` shape
+but resolves the task via ``WorkflowDB.get_task`` (V2 store) instead of the legacy
+``workflow_steps`` table. The actual ASE opt.log/neb.log parsing is delegated to
+the SAME V1 helper (``catgo.utils.job_parser.parse_ase_opt_log``) — this task is
+additive and must not re-implement it. It also makes the frontend task-adapter's
+``mode:'task'`` path real (it currently returns a placeholder message).
+
+Temp DBs only — never ~/.catgo/catgo.db. The optimizer log is written to a real
+temp dir so the (local-only) parser runs offline with no HPC connection.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_server_dir = str(Path(__file__).resolve().parent.parent)
+if _server_dir not in sys.path:
+    sys.path.insert(0, _server_dir)
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from catgo.workflow.db import WorkflowDB
+import catgo.routers.workflow_engine_tasks as wet
+
+
+# A minimal ASE BFGS opt.log. parse_ase_opt_log keys off the iteration lines.
+_OPT_LOG = """      Step     Time          Energy         fmax
+BFGS:    0 12:00:00     -10.000000        0.5000
+BFGS:    1 12:00:01     -10.500000        0.2000
+BFGS:    2 12:00:02     -10.700000        0.0080
+"""
+
+
+def _make_db_with_task(*, work_dir, task_type="geo_opt", params=None):
+    """Build a temp WorkflowDB with a single MLP-capable task.
+
+    Returns (db, db_path, workflow_id, task_id).
+    """
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+
+    workflow_id = db.create_workflow("v2-mlp-progress-wf")
+    task_id = db.create_task(
+        workflow_id, task_type, task_id=f"{workflow_id}:opt", params=params or {}
+    )
+    db.update_task(task_id, status="RUNNING")
+    if work_dir is not None:
+        db.update_task(task_id, work_dir=work_dir)
+    return db, db_path, workflow_id, task_id
+
+
+def _make_app(db: WorkflowDB) -> TestClient:
+    wet.set_db(db)
+    app = FastAPI()
+    app.include_router(wet.router)
+    return TestClient(app)
+
+
+def test_mlp_progress_resolves_task_and_returns_shape():
+    """Happy path: endpoint resolves task work_dir, parses opt.log, returns shape."""
+    tmp = tempfile.mkdtemp(prefix="catgo-mlp-")
+    (Path(tmp) / "opt.log").write_text(_OPT_LOG)
+    db, db_path, workflow_id, task_id = _make_db_with_task(
+        work_dir=tmp, task_type="geo_opt", params={"fmax": 0.01}
+    )
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/mlp-progress")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # Same shape the V1 endpoint + frontend NormalizedConvergence expect.
+        assert set(("points", "converged", "message")) <= set(data.keys())
+        assert len(data["points"]) == 3
+        first = data["points"][0]
+        for key in ("step", "energy", "dE", "energy_sigma0", "max_force", "rms_force"):
+            assert key in first, f"missing point key: {key}"
+        # Last fmax (0.008) is at/below the resolved target (0.01) → converged.
+        assert data["converged"] is True
+        assert data["points"][-1]["max_force"] == pytest.approx(0.008)
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_mlp_progress_unresolved_fmax_suppresses_converged():
+    """No fmax in params → converged is nulled (mirrors V1 status-sync guard)."""
+    tmp = tempfile.mkdtemp(prefix="catgo-mlp-")
+    (Path(tmp) / "opt.log").write_text(_OPT_LOG)
+    db, db_path, workflow_id, task_id = _make_db_with_task(
+        work_dir=tmp, task_type="geo_opt", params={}
+    )
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/mlp-progress")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data["points"]) == 3
+        assert data["converged"] is None
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_mlp_progress_neb_picks_neb_log():
+    """A ts_search/NEB task reads neb.log when present."""
+    tmp = tempfile.mkdtemp(prefix="catgo-mlp-")
+    (Path(tmp) / "neb.log").write_text(_OPT_LOG)
+    db, db_path, workflow_id, task_id = _make_db_with_task(
+        work_dir=tmp, task_type="ts_search", params={"fmax": 0.05}
+    )
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/mlp-progress")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data["points"]) == 3
+        assert data["converged"] is True
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_mlp_progress_no_log_clean_empty():
+    """work_dir exists but no log yet → clean empty result, not a 500."""
+    tmp = tempfile.mkdtemp(prefix="catgo-mlp-")  # empty dir
+    db, db_path, workflow_id, task_id = _make_db_with_task(
+        work_dir=tmp, task_type="geo_opt", params={"fmax": 0.01}
+    )
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/mlp-progress")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["points"] == []
+        assert data["converged"] in (False, None)
+        assert "message" in data
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_mlp_progress_hpc_session_not_wired():
+    """HPC-remote MLP step returns the deferred message (mirrors V1), not a crash."""
+    db, db_path, workflow_id, task_id = _make_db_with_task(
+        work_dir="/scratch/run1", task_type="geo_opt", params={"fmax": 0.01}
+    )
+    db.update_task(task_id, hpc_session_id="sess-123")
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/mlp-progress")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["points"] == []
+        assert "HPC" in (data.get("message") or "")
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_mlp_progress_unknown_task_404():
+    """Unknown task id returns a clean 404."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = WorkflowDB(db_path)
+    try:
+        client = _make_app(db)
+        resp = client.get("/api/engine/tasks/does-not-exist/mlp-progress")
+        assert resp.status_code == 404
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_mlp_progress_no_work_dir_clean_empty():
+    """A task without a work_dir returns a clean empty result (no work dir yet)."""
+    db, db_path, workflow_id, task_id = _make_db_with_task(
+        work_dir=None, task_type="geo_opt", params={"fmax": 0.01}
+    )
+    try:
+        client = _make_app(db)
+        resp = client.get(f"/api/engine/tasks/{task_id}/mlp-progress")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["points"] == []
+        assert "message" in data
+    finally:
+        wet.set_db(None)
+        if os.path.exists(db_path):
+            os.unlink(db_path)

--- a/src/lib/api/task-adapter.ts
+++ b/src/lib/api/task-adapter.ts
@@ -97,10 +97,16 @@ export async function get_mlp_progress(ref: TaskRef): Promise<NormalizedConverge
     const data = await v1.get_mlp_progress(ref.workflow_id, ref.node_id)
     return { points: data.points, converged: data.converged, message: data.message }
   }
+  // V2 task-mode: hit the V2-native endpoint, which parses the SAME ASE
+  // optimizer log via the V1 parser. `converged` may come back null when the
+  // task's fmax target is unresolvable — pass it through unchanged so the
+  // status-sync branch in NodeStatusPanel keeps the node "running" rather than
+  // treating it as converged (the V1 step-mode path above does the same).
+  const data = await v2.get_engine_task_mlp_progress(ref.task_id)
   return {
-    points: [],
-    converged: false,
-    message: `Live progress is only available from the workflow editor view. Open the step via its workflow to see iteration-by-iteration convergence.`,
+    points: data.points,
+    converged: data.converged as NormalizedConvergence['converged'],
+    message: data.message,
   }
 }
 

--- a/src/lib/api/workflow-v2.ts
+++ b/src/lib/api/workflow-v2.ts
@@ -218,6 +218,18 @@ export async function get_engine_task_convergence(task_id: string): Promise<Task
   return handle(await fetch(`${API_BASE}/engine/tasks/${task_id}/convergence`))
 }
 
+export interface TaskMlpProgressResponse {
+  points: ConvergencePoint[]
+  // null when the per-task fmax target is unresolvable — the frontend
+  // status-sync must NOT treat the node as converged in that case.
+  converged: boolean | null
+  message: string
+}
+
+export async function get_engine_task_mlp_progress(task_id: string): Promise<TaskMlpProgressResponse> {
+  return handle(await fetch(`${API_BASE}/engine/tasks/${task_id}/mlp-progress`))
+}
+
 export async function get_engine_task_file_content(task_id: string, path: string): Promise<TaskFileContentResponse> {
   return handle(await fetch(`${API_BASE}/engine/tasks/${task_id}/file-content?path=${encodeURIComponent(path)}`))
 }


### PR DESCRIPTION
Next steps of the V1→V2 convergence (#224, analysis: `docs/superpowers/specs/2026-06-05-workflow-v2-convergence-analysis.md`). Built via an orchestrated workflow (sequential + TDD) + a final review pass. **Purely additive — no V1 code or endpoint removed/broken** (V1 `routers/workflow.py` untouched).

## Phase 1 — decouple engine internals from the V1 monitor
`get_orca_stage`/`get_orca_irc_stage` were the only engine-internal users of `v1_monitor.py` (imported by `engine/poller.py`), blocking later removal of that FE-facing module. Moved them verbatim into a new `engine/orca_progress.py`; `poller.py` imports from there; `v1_monitor.py` keeps only its FE functions (`build_initial_state`, `translate_broadcast_message`). Tests: `test_orca_progress.py`.

## Phase 2 (batch 1) — additive V2-native FE endpoints
Read EXCLUSIVELY from the V2 store (`tasks`/`task_results`/work_dir) and **reuse the existing V1 physics/parsing helpers** (no duplicated logic):
- `GET /api/engine/workflows/{id}/results-enriched` — V2 dashboard aggregation (new `services/workflow_results.py`).
- `POST /api/engine/tasks/{id}/gibbs` — Gibbs from the task's frequencies (reuses V1 calc).
- `GET /api/engine/tasks/{id}/forces` — per-ionic-step forces (reuses `parse_vasp_forces`/H5).
- `GET /api/engine/tasks/{id}/mlp-progress` — real MLP progress (reuses `parse_ase_opt_log`); the FE task-adapter stub now calls the real endpoint.

These mirror V1 endpoints that were broken/missing on V2-executed workflows (e.g. V1 `gibbs`/`vasp_frequencies` read `workflow_steps.result_json`, which the V2 scanner never populates).

FE: additive `get_engine_task_mlp_progress` + task-mode wiring in `task-adapter.ts`/`workflow-v2.ts`.

## Verification
- 22 new tests + 10 regression = **32 passed** (`catgo` env). Independent review pass: APPROVE.
- V1 `routers/workflow.py` diff empty; routers already mounted (main.py untouched); no DB schema/migration; no writes to `~/.catgo/catgo.db`.

## Known follow-up (non-blocking, noted by review)
- V2 `gibbs` gas branch omits `free_indices` (selective-dynamics) that V1 passes to `calc_gas` — benign fallback (treats all atoms free); exact parity for selectively-frozen gas-mode Gibbs needs a `free_indices` surfaced in `task_results` (collector/schema change). Deferred.

Refs #224 (Phase 1 + Phase 2 batch 1; does not close — Phase 2 authoring/projects/db-switch + Phase 3-5 remain, per the analysis doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)