### PR TITLE
chore(download): bump page to 1.1.13

### DIFF
--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.1.9";
+  const VERSION = "1.1.13";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;


### PR DESCRIPTION
Update the download page VERSION to match the 1.1.13 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)