### PR TITLE
fix(workflow): two V2-workflow FE bugs — All Workflows crash + monitor WS path (#224)

### DIFF
--- a/desktop/WorkflowView.svelte
+++ b/desktop/WorkflowView.svelte
@@ -167,7 +167,16 @@
       task_count: ewf.task_count,
       created_at: ewf.created_at ?? ``,
     }))
-    return [...gui, ...engine].sort((a, b) => {
+    // A uuid present in BOTH DBs (V1 graph_json skin + V2 tasks) is the SAME
+    // workflow — dedup by id so it appears once. GUI is listed first so it wins
+    // (it carries graph_json + step counts and loads in the editor). Without this
+    // the keyed {#each ... (wf.id)} below throws each_key_duplicate and crashes the
+    // "All Workflows" view.
+    const by_id = new Map<string, UnifiedWorkflow>()
+    for (const w of [...gui, ...engine]) {
+      if (!by_id.has(w.id)) by_id.set(w.id, w)
+    }
+    return [...by_id.values()].sort((a, b) => {
       if (!a.created_at && !b.created_at) return 0
       if (!a.created_at) return 1
       if (!b.created_at) return -1

--- a/src/lib/api/workflow-v2.ts
+++ b/src/lib/api/workflow-v2.ts
@@ -321,9 +321,18 @@ export interface V2MonitorCallbacks {
   on_initial_state?: (dag: V2DAG) => void
 }
 
+/** Build the V2 monitor WebSocket URL. The engine router is mounted at
+ *  /api/engine/workflows (workflow_engine.py prefix), so the monitor lives at
+ *  /api/engine/workflows/{id}/monitor — NOT a /v2 alias (none exists in the
+ *  backend; the old /v2/workflows path silently failed and the DAG viewer only
+ *  worked via its REST seed). */
+export function v2_monitor_ws_url(api_base: string, workflow_id: string): string {
+  const ws_base = api_base.replace(/^http/, 'ws')
+  return `${ws_base}/engine/workflows/${encodeURIComponent(workflow_id)}/monitor`
+}
+
 export function connect_v2_monitor(workflow_id: string, callbacks: V2MonitorCallbacks): { close: () => void } {
-  const WS_BASE = API_BASE.replace(/^http/, 'ws')
-  const url = `${WS_BASE}/v2/workflows/${workflow_id}/monitor`
+  const url = v2_monitor_ws_url(API_BASE, workflow_id)
 
   let ws: WebSocket | null = null
   let closed = false

--- a/tests/vitest/api/workflow-v2.url.test.ts
+++ b/tests/vitest/api/workflow-v2.url.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { v2_monitor_ws_url } from '$lib/api/workflow-v2'
+
+describe('v2_monitor_ws_url', () => {
+  it('targets the engine router mount, not a /v2 alias', () => {
+    const url = v2_monitor_ws_url('http://localhost:8000/api', 'wf_abc')
+    expect(url).toBe('ws://localhost:8000/api/engine/workflows/wf_abc/monitor')
+  })
+
+  it('encodes the workflow id and converts https→wss', () => {
+    const url = v2_monitor_ws_url('https://h:8000/api', 'a b:c')
+    expect(url).toBe('wss://h:8000/api/engine/workflows/a%20b%3Ac/monitor')
+  })
+})


### PR DESCRIPTION
Two real bugs found while working on #224 (both confirmed live in the running app).

## 1. "All Workflows" view crashes
A workflow uuid present in BOTH the V1 (`catgo_results.db`) and V2 (`~/.catgo/catgo.db`) stores produced two entries with the same id, so the keyed `{#each unified_workflows as wf (wf.id)}` threw Svelte `each_key_duplicate` and crashed the whole view (reproduced live). Dedup by id (GUI entry wins — it carries `graph_json` + step counts) before rendering. `desktop/WorkflowView.svelte`.

## 2. V2 monitor WebSocket path is wrong
`connect_v2_monitor` built `ws://host/api/v2/workflows/{id}/monitor`, but the engine router is mounted at `/api/engine/workflows` — there is **no `/v2` alias**. The WS silently failed; the DAG viewer only worked via its REST seed (no live updates). Extracted a tested `v2_monitor_ws_url()` helper and fixed the path. `src/lib/api/workflow-v2.ts` (+ vitest).

## Verification
- `v2_monitor_ws_url`: 2 vitest pass (TDD red→green).
- `svelte-check`: no new errors in touched files.

Refs #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)