### PR TITLE
fix(mcp): document V2 workflow task wiring (_ref), drop dead 'connect' action (#224)

### DIFF
--- a/server/catgo/mcp_tools/server_claude_code.py
+++ b/server/catgo/mcp_tools/server_claude_code.py
@@ -467,11 +467,22 @@ TOOLS = [
     Tool(
         name="catgo_workflow_engine",
         description=(
-            "State-machine workflow engine for HPC execution. "
-            "Actions: create, add_task, submit, status, list, modify_params, retry, "
-            "pause, resume, reset, get_result, get_dag. "
-            "Pass workflow_id, task_id, task_type inside params. "
-            "Ask user which HPC cluster before submit."
+            "State-machine workflow engine (V2) for HPC execution. Build: create -> "
+            "add_task (one per calculation node) -> submit. "
+            "WIRE TASKS by data flow, NOT a connect action: pass an upstream task's "
+            "output as an input param of the downstream add_task, using an output "
+            "reference {\"_ref\": \"<upstream_task_id>\", \"_key\": \"<output_key>\"}. "
+            "e.g. add_task geo_opt with params {\"structure\": {\"_ref\": \"<slab_task_id>\", "
+            "\"_key\": \"structure\"}} links slab.structure -> geo_opt.structure (creates "
+            "the edge). add_task returns the new task_id to reference next. "
+            "Task ids are namespaced '{workflow_id}:{node_id}'. For per-task actions "
+            "(get_result, modify_params, retry, status) pass either an explicit 'task_id' "
+            "or 'workflow_id' + 'node_id' -- do NOT hand-build the namespaced id. "
+            "HPC job params (partition, account, walltime, ntasks) are set per-task via "
+            "add_task params. "
+            "IMPORTANT: before action='submit' you MUST ask the user which HPC cluster "
+            "(Expanse, Shaheen, local) and confirm job parameters; never submit without "
+            "confirmation."
         ),
         inputSchema={
             "type": "object",
@@ -487,7 +498,12 @@ TOOLS = [
                 },
                 "params": {
                     "type": "object",
-                    "description": "Action-specific parameters",
+                    "description": (
+                        "Action-specific parameters. add_task: workflow_id, task_type, "
+                        "and input params (use {\"_ref\":\"<task_id>\",\"_key\":\"<key>\"} "
+                        "values to wire from upstream tasks). Per-task actions: task_id OR "
+                        "workflow_id + node_id."
+                    ),
                 },
             },
             "required": ["action"],

--- a/server/catgo/workflow/mcp_tools.py
+++ b/server/catgo/workflow/mcp_tools.py
@@ -29,9 +29,16 @@ def get_tool_definition() -> dict:
     return {
         "name": "catgo_workflow_engine",
         "description": (
-            "Create and manage computational chemistry workflows. "
-            "Actions: create, add_task, connect, submit, status, list, "
-            "modify_params, retry, pause, resume, reset, get_result, get_dag. "
+            "Create and manage computational chemistry workflows. Build: create -> "
+            "add_task (one per node) -> submit. "
+            "Actions: create, add_task, submit, status, list, modify_params, retry, "
+            "pause, resume, reset, get_result, get_dag. "
+            "WIRE TASKS by data flow (there is no separate connect action): pass an "
+            "upstream task's output as an input param of the downstream add_task, using "
+            "an output reference {'_ref': '<upstream_task_id>', '_key': '<output_key>'}. "
+            "e.g. add_task geo_opt with params {'structure': {'_ref': '<slab_task_id>', "
+            "'_key': 'structure'}} creates the slab.structure -> geo_opt.structure edge. "
+            "add_task returns the new task_id. "
             "IMPORTANT: Before using action='submit', you MUST ask the user which HPC "
             "cluster to use (e.g., Expanse, Shaheen, local) and confirm job parameters "
             "(partition, account, walltime, ntasks). Never submit without user confirmation. "
@@ -46,7 +53,7 @@ def get_tool_definition() -> dict:
                 "action": {
                     "type": "string",
                     "enum": [
-                        "create", "add_task", "connect", "submit",
+                        "create", "add_task", "submit",
                         "status", "list", "modify_params", "retry",
                         "pause", "resume", "reset", "get_result", "get_dag",
                     ],
@@ -54,10 +61,11 @@ def get_tool_definition() -> dict:
                 "params": {
                     "type": "object",
                     "description": (
-                        "Action-specific parameters. For per-task actions "
-                        "(get_result, modify_params, retry), provide either 'task_id' "
-                        "(already namespaced as '{workflow_id}:{node_id}') or "
-                        "'workflow_id' + 'node_id' (the graph node id)."
+                        "Action-specific parameters. add_task: workflow_id, task_type, and "
+                        "input params (use {'_ref':'<task_id>','_key':'<key>'} values to wire "
+                        "from upstream tasks). For per-task actions (get_result, "
+                        "modify_params, retry), provide either 'task_id' (already namespaced "
+                        "as '{workflow_id}:{node_id}') or 'workflow_id' + 'node_id'."
                     ),
                 },
             },


### PR DESCRIPTION
While checking whether the MCP needs updating so future agents can build the V2 workflow engine correctly, found that the `catgo_workflow_engine` tool (both the canonical `workflow/mcp_tools.py` def and the separate `mcp_tools/server_claude_code.py` Claude Code def) was misleading:

- It listed a **`connect` action that the dispatch never implements** (`_dispatch_sync` → `Unknown action: connect`).
- It gave **no guidance on how to chain tasks** — so an agent building a multi-task workflow via MCP had no working way to create edges.

## Real mechanism (verified)
Tasks are wired by **data flow**, not a connect action: pass an upstream task's output as a downstream `add_task` input param via an output reference `{"_ref": "<upstream_task_id>", "_key": "<output_key>"}`. `Workflow.add_task` (workflow.py:160-214, "OutputReference values create links") turns it into a `task_link`.

Verified end-to-end (temp DB): `add_task slab_gen` → `add_task geo_opt {structure: {_ref: <slab_id>, _key: "structure"}}` → 2 tasks + **1 link** (slab.structure → geo_opt.structure).

## Change
- Document the `_ref` wiring (with example) in both tool descriptions + param help.
- Remove the dead `connect` from both action enums.
- Handler unchanged (already delegates to the service layer).

No behavior change — purely the tool schema/description an agent reads. Refs #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)