### PR TITLE
fix(workflow): sanitize ':' from remote work_dir name (MPI-IO/HDF5) (#224)

### DIFF
--- a/server/catgo/workflow/engine/hpc_utils.py
+++ b/server/catgo/workflow/engine/hpc_utils.py
@@ -80,10 +80,17 @@ def resolve_work_dir(task: dict, workflow_id: str, config: dict) -> str:
     _logger.info(f"[resolve_work_dir] config.hpc.base_work_dir={config.get('hpc', {}).get('base_work_dir')}")
     _logger.info(f"[resolve_work_dir] Using base_dir={base_dir}")
     _logger.info(f"[resolve_work_dir] template={template}")
+    # Prefer the bare node_id; fall back to the (namespaced) task id. EITHER way,
+    # sanitize ':' out of the final path component: the namespaced task id is
+    # "{workflow_id}:{node_id}", and a ':' in a directory name breaks MPI-IO/ROMIO
+    # (it mis-parses "prefix:" as a filesystem-driver hint), which makes parallel
+    # HDF5 file creation fail (e.g. VASP's vaspout.h5: "H5Fcreate: unable to create
+    # file") even though plain POSIX writes like OUTCAR succeed.
+    dir_id = (task.get("node_id") or task["id"]).replace(":", "_")
     work_dir = template.format(
         base_dir=base_dir,
         workflow_id=workflow_id,
-        task_id=task.get("node_id") or task["id"],
+        task_id=dir_id,
     )
     _logger.info(f"[resolve_work_dir] Final work_dir={work_dir}")
     return work_dir


### PR DESCRIPTION
## Bug (found via a real Expanse end-to-end test)
Submitted a tiny Pt single_point through the engine. Everything worked — inputs generated (incl. POTCAR), uploaded, sbatch'd, VASP ran and **SCF converged (E0 = -6.57 eV)** — but the job failed writing `vaspout.h5`:
```
HDF5-DIAG: H5Fcreate(): unable to synchronously create file (File accessibility)
```
POSIX writes (OUTCAR, vasp.out) succeeded; only the **parallel-HDF5 (MPI-IO) write** failed.

## Root cause
The remote work_dir was named `.../{workflow_id}:{node_id}` — i.e. the namespaced task id (`#227`), which contains a **colon**. A `:` in a directory name breaks **MPI-IO/ROMIO** (it mis-parses `prefix:` as a filesystem-driver hint), so parallel-HDF5 file creation fails. (`resolve_work_dir` prefers `node_id`, but the task dict reaching it lacked `node_id`, so it fell back to `task["id"]` = the colon-bearing namespaced id.)

This breaks **any** MPI-IO-writing job (most real VASP runs, since CatGo collects `vaspout.h5`).

## Fix
Sanitize `:` → `_` in the final work_dir path component in `resolve_work_dir` (single chokepoint for all submit paths). Robust regardless of whether `node_id` or the full id is used.

Verifying live on Expanse (re-run of the same Pt single_point) — the colon-free work_dir should let the h5 write succeed → COMPLETED.

Follow-up (not in this PR): the task dict reaching `resolve_work_dir` lacks `node_id` (so the dir is `{wf}_{node}` rather than the cleaner `{node}`) — cosmetic; worth fixing the task source later.

Refs #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)