### PR TITLE
fix(workflow): pass arbitrary INCAR tags + custom_incar through to VASP (#224)

### DIFF
--- a/server/tests/test_vasp_incar_passthrough.py
+++ b/server/tests/test_vasp_incar_passthrough.py
@@ -1,0 +1,51 @@
+"""Regression: arbitrary VASP INCAR tags must reach the generated INCAR.
+
+Bug (2026-06-05): generate_vasp_input_files only copied a fixed param_mapping
+(ENCUT, ISMEAR, LWAVE, LCHARG, ...) into the VASPInputRequest; any other INCAR
+tag the user set (e.g. LH5 to disable HDF5 output on a build whose parallel-HDF5
+is broken) was silently dropped, and an explicit ``custom_incar`` dict was
+ignored. Now uppercase-and-unmapped keys + ``custom_incar`` pass through.
+"""
+
+from workflow.engines.vasp import generate_vasp_input_files
+
+_PT_POSCAR = """Pt
+1.0
+0.0 1.96 1.96
+1.96 0.0 1.96
+1.96 1.96 0.0
+Pt
+1
+Direct
+0.0 0.0 0.0
+"""
+
+
+def _incar(params):
+    files, _, _ = generate_vasp_input_files("single_point", params, _PT_POSCAR)
+    return files["INCAR"]
+
+
+def test_uppercase_incar_tag_passes_through():
+    incar = _incar({"software": "vasp", "system_type": "periodic", "ENCUT": 300,
+                    "kpoints": "5 5 5", "LH5": False})
+    assert "LH5" in incar  # previously silently dropped
+    # value written as a false logical (VASP reads the leading char, so either form works)
+    lh5_val = incar.split("LH5", 1)[1].split("\n", 1)[0]
+    assert "F" in lh5_val.upper()
+
+
+def test_explicit_custom_incar_passes_through():
+    incar = _incar({"software": "vasp", "system_type": "periodic", "ENCUT": 300,
+                    "kpoints": "5 5 5", "custom_incar": {"ICHARG": 1, "MAGMOM": "1*0.6"}})
+    assert "ICHARG" in incar
+    assert "MAGMOM" in incar
+
+
+def test_lowercase_control_keys_not_leaked_as_incar_tags():
+    # control keys must NOT appear as INCAR tags
+    incar = _incar({"software": "vasp", "system_type": "periodic", "ENCUT": 300,
+                    "kpoints": "5 5 5"})
+    assert "software" not in incar
+    assert "system_type" not in incar
+    assert "kpoints" not in incar.lower().replace("kpoints =", "")  # no stray 'kpoints' tag

--- a/server/workflow/engines/vasp.py
+++ b/server/workflow/engines/vasp.py
@@ -226,6 +226,27 @@ def generate_vasp_input_files(
                 val = str(val)
             request_data[request_key] = val
 
+    # Pass through any OTHER INCAR tags so users can set arbitrary INCAR options
+    # (e.g. LH5, MAGMOM, ICHARG, AMIX, LDAU*) that aren't in param_mapping above.
+    # VASP INCAR tags are UPPERCASE; CatGo control keys (software, kpoints,
+    # freeze_mode, system_type, ...) are lowercase, so route uppercase-and-unmapped
+    # keys plus an explicit `custom_incar` dict into request.custom_incar.
+    extra_incar: dict[str, Any] = dict(params.get("custom_incar") or {})
+    for k, v in params.items():
+        if v is None or k in param_mapping or k == "KPOINTS":
+            continue
+        if isinstance(k, str) and len(k) >= 2 and k.isupper():
+            if isinstance(v, str):
+                try:
+                    v = float(v) if ("." in v or "e" in v.lower()) else int(v)
+                except ValueError:
+                    pass
+            extra_incar.setdefault(k, v)
+    if extra_incar:
+        request_data.setdefault("custom_incar", {})
+        for k, v in extra_incar.items():
+            request_data["custom_incar"].setdefault(k, v)
+
     # Handle optimizer
     ibrion = params.get("IBRION")
     if ibrion == 3:


### PR DESCRIPTION
## Bug (found during the live Expanse end-to-end test)
`generate_vasp_input_files` copied only a fixed `param_mapping` (ENCUT, ISMEAR, LWAVE, LCHARG, …) into the `VASPInputRequest`. **Any other INCAR tag the user set was silently dropped, and an explicit `custom_incar` dict was ignored.**

This bit us live: gliu3's VASP 6.5.1 build's parallel-HDF5 fails on Expanse Lustre — VASP's SCF converged but the job died at `H5Fcreate` writing `vaspout.h5`. The natural workaround is `LH5=.FALSE.` (disable HDF5 output, collect from OUTCAR), but CatGo dropped `LH5` (and `custom_incar`), so it couldn't be set.

## Fix
After the `param_mapping` copy, route **uppercase-and-unmapped** param keys + an explicit **`custom_incar`** dict into `request.custom_incar`. VASP INCAR tags are uppercase; CatGo control keys (software, kpoints, freeze_mode, system_type, …) are lowercase, so the heuristic is safe.

## Verified
`LH5` and `custom_incar` (ICHARG/MAGMOM) now appear in the generated INCAR; control keys don't leak. 3 regression tests (`test_vasp_incar_passthrough.py`), all pass.

Refs #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)