### PR TITLE
feat(workflow): user-in-the-loop review gate + sync edited inputs to params (#224)

### DIFF
--- a/server/catgo/models/workflow_run.py
+++ b/server/catgo/models/workflow_run.py
@@ -274,6 +274,12 @@ class WorkflowRunConfig(BaseModel):
         default=True,
         description="Use custodian to automatically fix VASP errors and restart",
     )
+    auto_submit: bool = Field(
+        default=False,
+        description="If False (default), HPC tasks pause at PENDING_REVIEW so the user "
+        "can review/edit the generated input files before submission (user-in-the-loop). "
+        "Set True to submit directly without a review gate.",
+    )
     custodian_max_errors: int = Field(
         default=5,
         ge=1,

--- a/server/catgo/routers/workflow.py
+++ b/server/catgo/routers/workflow.py
@@ -965,7 +965,11 @@ def _run_config_to_engine_config(config: WorkflowRunConfig) -> dict:
         },
         "execution_mode": config.execution_mode,
         "default_session_id": config.default_session_id,
-        "auto_submit": True,
+        # Respect the user's review preference. Default False => HPC tasks pause at
+        # PENDING_REVIEW so the user reviews/edits inputs before submission
+        # (user-in-the-loop). Previously hard-coded True, which silently bypassed
+        # the review gate for every V1 "Run".
+        "auto_submit": config.auto_submit,
     }
 
     # Preserve the job script template selected in RunConfigDialog

--- a/server/catgo/routers/workflow_engine_tasks.py
+++ b/server/catgo/routers/workflow_engine_tasks.py
@@ -451,9 +451,59 @@ class FileWriteBody(BaseModel):
     content: str
 
 
+def _sync_input_file_to_params(db, task_id: str, task: dict, rel_path: str, content: str) -> None:
+    """Sync an edited input file back into the task's params (DB).
+
+    After a user edits an input file in the work_dir, the file diverges from the
+    params the engine regenerates inputs from. Parse the edit by filename and write
+    it back to params so (a) the DB stays consistent with the file and (b) the edit
+    survives a later regenerate-from-params. Best-effort: parse failures are logged,
+    never raised (the file write already succeeded).
+    """
+    import os
+    name = os.path.basename(rel_path).upper()
+    try:
+        params = json.loads(task.get("params_json") or "{}")
+        if not isinstance(params, dict):
+            params = {}
+    except Exception:
+        params = {}
+    changed = False
+    try:
+        if name in ("POSCAR", "CONTCAR"):
+            from pymatgen.core import Structure
+            params["structure_json"] = Structure.from_str(content, fmt="poscar").as_dict()
+            changed = True
+        elif name == "INCAR":
+            from pymatgen.io.vasp.inputs import Incar
+            for k, v in Incar.from_str(content).items():
+                params[str(k).upper()] = v
+            changed = True
+        elif name == "KPOINTS":
+            from pymatgen.io.vasp.inputs import Kpoints
+            kp = Kpoints.from_str(content)
+            if kp.kpts and len(kp.kpts[0]) == 3:
+                params["kpoints"] = " ".join(str(int(x)) for x in kp.kpts[0])
+                changed = True
+        # POTCAR + unknown files are not synced (POTCAR is regenerated from potcar_root).
+    except Exception as exc:
+        logger.warning("Task %s: could not sync edited %s into params: %s", task_id, name, exc)
+        return
+    if changed:
+        try:
+            db.update_task(task_id, params_json=json.dumps(params, default=str))
+            logger.info("Task %s: synced edited %s back into params", task_id, name)
+        except Exception as exc:
+            logger.warning("Task %s: failed to persist synced params for %s: %s", task_id, name, exc)
+
+
 @router.put("/{task_id}/file-content")
 async def put_task_file_content(task_id: str, body: FileWriteBody):
-    """Write a file to the task's work_dir (local preview or HPC)."""
+    """Write a file to the task's work_dir (local preview or HPC).
+
+    On success the edited input file is synced back into the task params (DB) so the
+    DB matches the file and the edit survives regeneration.
+    """
     if ".." in body.path or body.path.startswith("/"):
         raise HTTPException(400, "Path must be relative and cannot contain '..'")
 
@@ -472,6 +522,7 @@ async def put_task_file_content(task_id: str, body: FileWriteBody):
         local_path = Path(work_dir) / body.path
         local_path.parent.mkdir(parents=True, exist_ok=True)
         local_path.write_text(body.content, encoding="utf-8")
+        _sync_input_file_to_params(db, task_id, task, body.path, body.content)
         return {"path": body.path, "success": True}
 
     # HPC path — use SSH connection
@@ -489,6 +540,7 @@ async def put_task_file_content(task_id: str, body: FileWriteBody):
             ok = await write_remote_file(hpc.conn, full_path, body.content)
         if not ok:
             raise HTTPException(500, "Write returned failure")
+        _sync_input_file_to_params(db, task_id, task, body.path, body.content)
         return {"path": body.path, "success": True}
     except HTTPException:
         raise

--- a/server/catgo/workflow/skills/SKILL.md
+++ b/server/catgo/workflow/skills/SKILL.md
@@ -108,6 +108,8 @@ catgo_workflow_engine(action="add_task", params={
 
 **Never submit a workflow without explicit user confirmation of the HPC target, a known (user-confirmed) pseudopotential/POTCAR path, AND a known (user-confirmed) way to load/invoke the compute binary.**
 
+**Default to a review gate — user-in-the-loop.** Do NOT auto-submit a freshly built workflow. Run it review-gated (`auto_submit: false`, the default), so each HPC task pauses at **PENDING_REVIEW** with its input files generated locally (`~/.catgo/preview/<node>/`). Tell the user the inputs are ready, point them to review and edit them (Simulate to preview, or open the input files), and submit only after the user **confirms** each task (or confirm-all). Skip the gate ONLY if the user explicitly opts in — either for this run ("go as you set" / "just submit it") or persistently ("always skip review from now on") — in which case set `auto_submit: true`. Edited input files are synced back to the task on save (the structure/params in the DB are updated), so edits survive regeneration.
+
 ### 6. Connect tasks with output references
 
 Never hardcode intermediate values. Always chain:

--- a/server/tests/test_input_file_sync.py
+++ b/server/tests/test_input_file_sync.py
@@ -1,0 +1,46 @@
+"""Edited input files must sync back into task params (DB) so they survive regenerate."""
+import json, tempfile
+from catgo.routers.workflow_engine_tasks import _sync_input_file_to_params
+from catgo.workflow.db import WorkflowDB
+from catgo.workflow import service
+
+
+def _setup():
+    db = WorkflowDB(tempfile.mktemp(suffix=".db"))
+    wf = service.create_workflow(db, "sync-test", None)
+    t = service.add_task(db, wf["workflow_id"], "single_point", software="vasp")
+    return db, t["task_id"]
+
+
+def _params(db, tid):
+    return json.loads(db.get_task(tid)["params_json"] or "{}")
+
+
+def test_poscar_sync_updates_structure_json():
+    db, tid = _setup()
+    poscar = "Pt\n1.0\n0 1.96 1.96\n1.96 0 1.96\n1.96 1.96 0\nPt\n1\nDirect\n0 0 0\n"
+    _sync_input_file_to_params(db, tid, db.get_task(tid), "POSCAR", poscar)
+    p = _params(db, tid)
+    assert "structure_json" in p
+    assert p["structure_json"]["sites"][0]["species"][0]["element"] == "Pt"
+
+
+def test_incar_sync_updates_params():
+    db, tid = _setup()
+    _sync_input_file_to_params(db, tid, db.get_task(tid), "INCAR", "ENCUT = 450\nISMEAR = 1\nLH5 = .FALSE.\n")
+    p = _params(db, tid)
+    assert p.get("ENCUT") == 450
+    assert "LH5" in p
+
+
+def test_kpoints_sync_updates_kpoints():
+    db, tid = _setup()
+    _sync_input_file_to_params(db, tid, db.get_task(tid), "KPOINTS", "Auto\n0\nGamma\n5 5 5\n0 0 0\n")
+    assert _params(db, tid).get("kpoints") == "5 5 5"
+
+
+def test_unknown_file_not_synced():
+    db, tid = _setup()
+    before = _params(db, tid)
+    _sync_input_file_to_params(db, tid, db.get_task(tid), "POTCAR", "junk")
+    assert _params(db, tid) == before  # POTCAR/unknown not synced


### PR DESCRIPTION
Makes user-in-the-loop the default for workflow submission, and stops edited inputs from being silently lost.

## 1. Review gate by default
- `WorkflowRunConfig` gains `auto_submit` (default **False**).
- The V1 `/run` path (`_run_config_to_engine_config`) no longer hard-codes `auto_submit=True` — that silently bypassed the engine's **PENDING_REVIEW** gate for every GUI "Run". Now HPC tasks pause at PENDING_REVIEW (inputs generated locally), and the user **confirms** before submission. `auto_submit=True` skips the gate (per-run "go as you set", or a persistent "always skip").

## 2. SKILL guidance
Master-router policy 5: build → present inputs for the user to **review/edit** → submit only after the user confirms; skip only on explicit opt-in.

## 3. Sync edited inputs back to the DB
`PUT /engine/tasks/{id}/file-content` was a raw file write, so editing POSCAR/INCAR/KPOINTS diverged from `params` and was **clobbered on regenerate**. It now parses the edit and writes it back: POSCAR/CONTCAR → `structure_json`, INCAR tags → params, KPOINTS → `kpoints`. DB stays consistent with the file and edits survive regeneration. Best-effort (parse failures logged, file write still succeeds). +4 tests.

Refs #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)