### PR TITLE
Fix custom provider chat routing and settings input shortcuts

### DIFF
--- a/server/catgo/routers/chat.py
+++ b/server/catgo/routers/chat.py
@@ -388,8 +388,16 @@ def _resolve_api_key(provider_id: str, api_key: Optional[str]) -> Optional[str]:
     return api_key or (os.environ.get(env_key) if env_key else None)
 
 
+def _normalize_provider_base_url(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    for suffix in ("/chat/completions", "/messages", "/models"):
+        if base.lower().endswith(suffix):
+            return base[: -len(suffix)].rstrip("/")
+    return base
+
+
 def _resolve_base_url(provider_id: str, base_url: Optional[str]) -> str:
-    return (base_url or _API_BASE_URLS.get(provider_id, "")).rstrip("/")
+    return _normalize_provider_base_url(base_url or _API_BASE_URLS.get(provider_id, ""))
 
 
 def _resolve_api_format(provider_id: str, api_format: Optional[str], base_url: str) -> str:

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -3,7 +3,7 @@
   import { Icon } from '$lib'
   import type { AnyStructure } from '$lib'
   import { t } from '$lib/i18n/index.svelte'
-  import { API_BASE } from '$lib/api/config'
+  import { API_BASE, STATIC_ONLY } from '$lib/api/config'
   import {
     get_chat_slice,
     chat_config,
@@ -33,7 +33,7 @@
   import { SDK_PROVIDERS, default_mode_for } from './types'
   import { fetch_providers } from './llm-client'
   import { PROVIDER_BASE_URLS } from './client-llm'
-import { is_client_direct, relay_fetch } from './provider-routing'
+import { is_client_direct, normalize_provider_base_url, relay_fetch } from './provider-routing'
   import { TTSEngine } from '$lib/gesture/tts-engine'
   import {
     FALLBACK_MODELS, CLI_INSTALL_INFO, PROVIDER_META, AGENT_LABELS, VOICE_LANGUAGES,
@@ -98,7 +98,7 @@ import { is_client_direct, relay_fetch } from './provider-routing'
 
     // Client-direct (STATIC_ONLY / no backend): ping the provider's /models
     // endpoint from the browser to validate base_url + API key.
-    if (is_client_direct(chat_config)) {
+    if (STATIC_ONLY && is_client_direct(chat_config)) {
       try {
         const base = resolved_base_url()
         if (!base) throw new Error(`no base_url`)
@@ -144,7 +144,7 @@ import { is_client_direct, relay_fetch } from './provider-routing'
 
   /** Resolve the OpenAI-compatible base URL for the current provider (client-direct). */
   function resolved_base_url(): string {
-    return (chat_config.base_url || PROVIDER_BASE_URLS[chat_config.provider] || ``).replace(/\/$/, ``)
+    return normalize_provider_base_url(chat_config.base_url || PROVIDER_BASE_URLS[chat_config.provider] || ``)
   }
 
   async function fetch_provider_models() {
@@ -153,7 +153,7 @@ import { is_client_direct, relay_fetch } from './provider-routing'
 
     // Client-direct (STATIC_ONLY / no backend): query the provider's /models
     // endpoint straight from the browser instead of the absent backend.
-    if (is_client_direct(chat_config)) {
+    if (STATIC_ONLY && is_client_direct(chat_config)) {
       try {
         const base = resolved_base_url()
         if (!base) throw new Error(`no base_url`)

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -147,6 +147,17 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
     return normalize_provider_base_url(chat_config.base_url || PROVIDER_BASE_URLS[chat_config.provider] || ``)
   }
 
+  function handle_text_input_keydown(event: KeyboardEvent) {
+    const target = event.currentTarget as HTMLInputElement
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === `a`) {
+      event.preventDefault()
+      event.stopPropagation()
+      target.select()
+      return
+    }
+    event.stopPropagation()
+  }
+
   async function fetch_provider_models() {
     fetch_models_status = `loading`
     fetch_models_message = ``
@@ -1208,6 +1219,7 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
             type="password"
             value={chat_config.api_key}
             placeholder={t('chat.api_key_placeholder')}
+            onkeydown={handle_text_input_keydown}
             oninput={(e) => update_config({ api_key: (e.target as HTMLInputElement).value.trim() })}
           />
         </div>
@@ -1221,6 +1233,7 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
             type="text"
             value={chat_config.base_url}
             placeholder={t('chat.base_url_placeholder')}
+            onkeydown={handle_text_input_keydown}
             oninput={(e) => update_config({ base_url: (e.target as HTMLInputElement).value.trim() })}
           />
         </div>

--- a/src/lib/chat/__tests__/provider-routing.test.ts
+++ b/src/lib/chat/__tests__/provider-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { needs_relay, normalize_provider_base_url, relay_url, RELAY_URL } from '../provider-routing'
+import { is_client_direct, needs_relay, normalize_provider_base_url, relay_url, RELAY_URL, requires_backend_chat } from '../provider-routing'
+import type { ChatConfig } from '../types'
 
 describe(`needs_relay`, () => {
   it(`flags Materials Project OPTIMADE host`, () => {
@@ -26,5 +27,44 @@ describe(`normalize_provider_base_url`, () => {
     expect(normalize_provider_base_url(`https://integrate.api.nvidia.com/v1/`)).toBe(`https://integrate.api.nvidia.com/v1`)
     expect(normalize_provider_base_url(`https://integrate.api.nvidia.com/v1/chat/completions`)).toBe(`https://integrate.api.nvidia.com/v1`)
     expect(normalize_provider_base_url(`https://integrate.api.nvidia.com/v1/models`)).toBe(`https://integrate.api.nvidia.com/v1`)
+  })
+})
+
+describe(`provider chat routing`, () => {
+  const base_config: ChatConfig = {
+    provider: `custom`,
+    model: `model`,
+    temperature: 0.2,
+    max_tokens: 1024,
+    api_key: `sk-test`,
+    base_url: `https://api.example.com/v1`,
+    api_format: `openai`,
+    fetched_models: {},
+    mode: `universal`,
+  }
+
+  it(`routes NVIDIA chat through the backend in local/desktop builds`, () => {
+    const config = {
+      ...base_config,
+      base_url: `https://integrate.api.nvidia.com/v1/chat/completions`,
+    }
+    expect(requires_backend_chat(config)).toBe(true)
+    expect(is_client_direct(config)).toBe(false)
+  })
+
+  it(`routes ordinary custom OpenAI-compatible providers through the backend by default`, () => {
+    expect(requires_backend_chat(base_config)).toBe(false)
+    expect(is_client_direct(base_config)).toBe(false)
+  })
+
+  it(`keeps built-in OpenAI-compatible providers client-direct by default`, () => {
+    const config = {
+      ...base_config,
+      provider: `deepseek`,
+      model: `deepseek-chat`,
+      base_url: `https://api.deepseek.com`,
+    } satisfies ChatConfig
+    expect(requires_backend_chat(config)).toBe(false)
+    expect(is_client_direct(config)).toBe(true)
   })
 })

--- a/src/lib/chat/__tests__/provider-routing.test.ts
+++ b/src/lib/chat/__tests__/provider-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { needs_relay, relay_url, RELAY_URL } from '../provider-routing'
+import { needs_relay, normalize_provider_base_url, relay_url, RELAY_URL } from '../provider-routing'
 
 describe(`needs_relay`, () => {
   it(`flags Materials Project OPTIMADE host`, () => {
@@ -9,11 +9,22 @@ describe(`needs_relay`, () => {
     expect(needs_relay(`https://alexandria.icams.rub.de/pbe/v1/structures`)).toBe(false)
     expect(needs_relay(`https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound`)).toBe(false)
   })
+  it(`routes NVIDIA's OpenAI-compatible API through the relay`, () => {
+    expect(needs_relay(`https://integrate.api.nvidia.com/v1/models`)).toBe(true)
+  })
 })
 
 describe(`relay_url`, () => {
   it(`wraps a target URL as a relay query param`, () => {
     const wrapped = relay_url(`https://optimade.materialsproject.org/v1/structures?x=1`)
     expect(wrapped).toBe(`${RELAY_URL}/?url=${encodeURIComponent(`https://optimade.materialsproject.org/v1/structures?x=1`)}`)
+  })
+})
+
+describe(`normalize_provider_base_url`, () => {
+  it(`accepts provider base URLs and trims complete endpoint URLs`, () => {
+    expect(normalize_provider_base_url(`https://integrate.api.nvidia.com/v1/`)).toBe(`https://integrate.api.nvidia.com/v1`)
+    expect(normalize_provider_base_url(`https://integrate.api.nvidia.com/v1/chat/completions`)).toBe(`https://integrate.api.nvidia.com/v1`)
+    expect(normalize_provider_base_url(`https://integrate.api.nvidia.com/v1/models`)).toBe(`https://integrate.api.nvidia.com/v1`)
   })
 })

--- a/src/lib/chat/client-llm.ts
+++ b/src/lib/chat/client-llm.ts
@@ -1,5 +1,5 @@
 import type { ChatConfig, ChatMessage, ClientTool, ToolCall, ToolUseBlock, ToolResultBlock, LLMProvider } from './types'
-import { needs_relay, relay_url } from './provider-routing'
+import { needs_relay, normalize_provider_base_url, relay_url } from './provider-routing'
 
 /** Default OpenAI-compatible base URLs for known API providers, mirrored from
  *  the backend (server/catgo/routers/chat.py). Used in client-direct mode where
@@ -97,7 +97,7 @@ export async function* stream_client_llm(
   tools: ClientTool[],
   signal?: AbortSignal,
 ): AsyncGenerator<LlmEvent> {
-  const base = (config.base_url || PROVIDER_BASE_URLS[config.provider] || ``).replace(/\/$/, ``)
+  const base = normalize_provider_base_url(config.base_url || PROVIDER_BASE_URLS[config.provider] || ``)
   if (!base) {
     yield { type: `error`, message: `No base URL configured for provider "${config.provider}". Set a base URL in CatBot settings.` }
     return

--- a/src/lib/chat/provider-routing.ts
+++ b/src/lib/chat/provider-routing.ts
@@ -15,6 +15,9 @@ export const RELAY_URL: string =
 const RELAY_HOSTS = new Set<string>([
   `optimade.materialsproject.org`,
   `api.materialsproject.org`,
+  // NVIDIA's OpenAI-compatible endpoint does not allow browser CORS for direct
+  // CatBot model/test/chat requests, so desktop/web client-direct mode must relay.
+  `integrate.api.nvidia.com`,
 ])
 
 export function needs_relay(url: string): boolean {
@@ -27,6 +30,14 @@ export function needs_relay(url: string): boolean {
 
 export function relay_url(url: string): string {
   return `${RELAY_URL}/?url=${encodeURIComponent(url)}`
+}
+
+export function normalize_provider_base_url(base_url: string): string {
+  const base = base_url.replace(/\/$/, ``)
+  for (const suffix of [`/chat/completions`, `/messages`, `/models`]) {
+    if (base.toLowerCase().endsWith(suffix)) return base.slice(0, -suffix.length).replace(/\/$/, ``)
+  }
+  return base
 }
 
 /** A fetch wrapper that transparently routes CORS-blocked hosts via the relay. */

--- a/src/lib/chat/provider-routing.ts
+++ b/src/lib/chat/provider-routing.ts
@@ -20,6 +20,12 @@ const RELAY_HOSTS = new Set<string>([
   `integrate.api.nvidia.com`,
 ])
 
+const BACKEND_CHAT_HOSTS = new Set<string>([
+  // The public relay does not allow this host. In local/desktop builds, route
+  // NVIDIA chat through CatGo's backend OpenAI-compatible proxy instead.
+  `integrate.api.nvidia.com`,
+])
+
 export function needs_relay(url: string): boolean {
   try {
     return RELAY_HOSTS.has(new URL(url).host)
@@ -38,6 +44,16 @@ export function normalize_provider_base_url(base_url: string): string {
     if (base.toLowerCase().endsWith(suffix)) return base.slice(0, -suffix.length).replace(/\/$/, ``)
   }
   return base
+}
+
+export function requires_backend_chat(config: ChatConfig): boolean {
+  const base = normalize_provider_base_url(config.base_url || ``)
+  if (!base) return false
+  try {
+    return BACKEND_CHAT_HOSTS.has(new URL(base).host)
+  } catch {
+    return false
+  }
 }
 
 /** A fetch wrapper that transparently routes CORS-blocked hosts via the relay. */
@@ -62,11 +78,15 @@ export async function relay_fetch(url: string, init?: RequestInit): Promise<Resp
 /** True when the tool-calling loop should run in-browser (no backend proxy). */
 export function is_client_direct(config: ChatConfig): boolean {
   if (SDK_PROVIDERS.has(config.provider)) return false // SDK agents always backend
-  // Non-SDK providers (DeepSeek/Qwen/Kimi/Gemini/Anthropic/custom/ollama) keep
+  if (!STATIC_ONLY && config.provider === `custom` && config.client_direct !== true) return false
+  if (!STATIC_ONLY && requires_backend_chat(config)) return false
+  // Built-in non-SDK providers (DeepSeek/Qwen/Kimi/Gemini/Anthropic/ollama) keep
   // their API key client-side, so default to the in-browser tool-calling loop
   // (not only under static deploys) — otherwise CatBot falls back to a
   // text-only backend proxy and can never call CLIENT_TOOLS (validate_hpc_config,
   // get_skill, structure tools). Explicit client_direct:false opts back into
-  // the text-only path.
+  // the text-only path. Custom providers default to backend in local/desktop
+  // builds because third-party OpenAI-compatible gateways often do not allow
+  // browser CORS even when their /models and backend test calls succeed.
   return STATIC_ONLY || config.client_direct !== false
 }


### PR DESCRIPTION
Author: XCai@JXNU <690857@163.com>

## Summary
- Normalize custom provider base URLs when users paste full endpoint URLs such as `/models` or `/chat/completions`.
- Route NVIDIA and custom OpenAI-compatible providers through the backend in local/desktop builds to avoid browser CORS or relay host restrictions.
- Keep built-in providers such as DeepSeek client-direct by default.
- Fix Ctrl/Cmd+A selection inside the API Key and Base URL settings inputs.

## Verification
- pnpm vitest run src/lib/chat/__tests__/provider-routing.test.ts src/lib/chat/__tests__/client-llm.test.ts

Result: 2 files passed, 20 tests passed.