### PR TITLE
fix(cli): deterministic --no-autostart 'no server' tests (CATGO_API discovery override)

### DIFF
--- a/server/catgo/cli/server_link.py
+++ b/server/catgo/cli/server_link.py
@@ -42,6 +42,18 @@ class ServerLink:
 
     @classmethod
     def discover(cls) -> "ServerLink | None":
+        # Honor CATGO_API (the var `catgo setup` writes): when set, target ONLY
+        # that endpoint and do NOT fall back to the local-port scan. This lets a
+        # user point catgo at a specific server (remote tunnel / custom port) and
+        # lets tests force a deterministic "no server" by pointing it at a dead
+        # port — otherwise discovery depends on whatever happens to run on :8000.
+        import os
+        api = os.environ.get("CATGO_API")
+        if api:
+            base = api.rstrip("/")
+            if base.endswith("/api"):
+                base = base[: -len("/api")]
+            return cls(base_url=base) if _ping(f"{base}/health") else None
         for port in (8000, 33413):
             url = f"http://localhost:{port}"
             if _ping(f"{url}/health"):

--- a/server/tests/cli/test_argparse.py
+++ b/server/tests/cli/test_argparse.py
@@ -51,12 +51,21 @@ def _cu_poscar(tmp_path):
     return src
 
 
-def _run_catgo(*cli_args):
+def _run_catgo(*cli_args, env=None):
+    import os
     import subprocess, sys
+    run_env = {**os.environ, **(env or {})}
     return subprocess.run(
         [sys.executable, "-m", "catgo", *cli_args],
-        cwd=str(SERVER_DIR), capture_output=True, text=True,
+        cwd=str(SERVER_DIR), capture_output=True, text=True, env=run_env,
     )
+
+
+# A guaranteed-unreachable server endpoint: forces ServerLink.discover() to
+# return None regardless of whether a dev CatGO server is running on :8000.
+# (Without this, the --no-autostart "no server" tests are environment-dependent:
+# they pass in CI but fail on a workstation with `catgo serve` up.)
+_NO_SERVER_ENV = {"CATGO_API": "http://127.0.0.1:59999"}
 
 
 def test_convert_without_out_clean_error(tmp_path):
@@ -132,7 +141,8 @@ def test_no_autostart_global_flag_listed():
 
 def test_push_without_server_with_no_autostart_clean_exit(tmp_path):
     # No CatGO server running in CI; --no-autostart must NOT spawn one.
-    r = _run_catgo("--no-autostart", "push", "--panel", "default")
+    r = _run_catgo("--no-autostart", "push", "--panel", "default",
+                   env=_NO_SERVER_ENV)
     assert r.returncode == 2
     assert "--no-autostart" in r.stderr
     assert "unreachable" in r.stderr.lower() or "server" in r.stderr.lower()
@@ -156,7 +166,8 @@ def test_viewer_subcommands_in_help():
 
 def test_no_autostart_after_subcommand_also_works(tmp_path):
     # Users will type the flag in either position; both must work.
-    r = _run_catgo("push", "--no-autostart", "--panel", "default")
+    r = _run_catgo("push", "--no-autostart", "--panel", "default",
+                   env=_NO_SERVER_ENV)
     assert r.returncode == 2, r.stderr
     assert "unrecognized" not in r.stderr  # not an argparse rejection
     assert "--no-autostart" in r.stderr or "server" in r.stderr.lower()

--- a/server/tests/cli/test_shell.py
+++ b/server/tests/cli/test_shell.py
@@ -148,10 +148,14 @@ def test_shell_freq_analyze_via_menu(tmp_path):
     assert "imaginary=0" in text
 
 
-def test_shell_no_autostart_blocks_push():
+def test_shell_no_autostart_blocks_push(monkeypatch):
     # Without a real server and with no_autostart=True, choosing `push`
     # in the menu must NOT spawn a daemon; the shell surfaces a clean
     # OpError-format line and returns to the menu.
+    # Point discovery at a dead endpoint so the test is deterministic even on a
+    # workstation with `catgo serve` running on :8000 (CATGO_API short-circuits
+    # ServerLink.discover to that one endpoint).
+    monkeypatch.setenv("CATGO_API", "http://127.0.0.1:59999")
     out = []
     script = iter(["push", "", "q"])   # op name, panel (empty), quit
     sh = InteractiveShell(session=Session(),


### PR DESCRIPTION
## What
3 CLI tests — `test_push_without_server_with_no_autostart_clean_exit`,
`test_no_autostart_after_subcommand_also_works` (in `test_argparse.py`), and
`test_shell_no_autostart_blocks_push` (in `test_shell.py`) — were
**environment-dependent**: green in CI (no server) but RED on a workstation
running `catgo serve` on :8000.

## Root cause
`ServerLink.discover()` scans `:8000`/`:33413`. A live dev server made
`discover()` return a link, so `_run_op` skipped the `--no-autostart → exit 2`
branch and `push` instead hit input validation (`exit 1`, "push requires
<input>"). The assertions (`returncode == 2`, "unreachable"/"--no-autostart" in
stderr) only hold when no server is found.

## Fix
- `ServerLink.discover()` now honors **`CATGO_API`** (the var `catgo setup`
  already writes): when set, it targets ONLY that endpoint and skips the
  local-port scan.
- The 3 tests point `CATGO_API` at a dead port (`http://127.0.0.1:59999`) so
  discovery deterministically finds no server — exercising the real
  `--no-autostart` path regardless of any ambient `catgo serve`.
- Bonus: `CATGO_API` now also lets a user aim `catgo` at a specific server
  (remote tunnel / custom port), not just the hardcoded local ports.

## Test
`tests/cli/`: **195 passed, 3 skipped** (the 3 formerly-failing now pass).
No product behavior change unless `CATGO_API` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
