### PR TITLE
chore(release): bump version to 1.1.14

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Bumps `src-tauri/tauri.conf.json` to **1.1.14** to cut the next desktop release.

Tagging `v1.1.14` after merge triggers `tauri-build` (Windows/macOS/Linux installers), `hpc-bundle`, and `build-vscode-sidecars`, which publish a draft GitHub release.

Since v1.1.13:
- feat(workflow): V1→V2 convergence (#224 phases — editable input files, user-in-the-loop review gate, POTCAR/module submit gates, INCAR passthrough)
- fix: custom provider chat routing + settings input shortcuts (#282)
- fix(cli): deterministic `--no-autostart` no-server tests (#283)
- feat(structure): "Upload to HPC" toolbar button + guided dialog (#285)
- feat(md-analysis): XDATCAR support + water-only density selection (#287)

🤖 Generated with [Claude Code](https://claude.com/claude-code)