### PR TITLE
chore(vscode): sync root package.json to 1.1.14 for marketplace publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.6",
+  "version": "1.1.14",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",


### PR DESCRIPTION
The VS Code extension in the **Marketplace** (`Hello-QM.catgo-vscode`, linked from the in-app StaticModeBanner) is stuck at **1.1.6**.

`vsix-publish.yml` derives the extension version from root `package.json` at publish time (single source of truth). Root `package.json` was still `1.1.6`, so every tagged publish synced to 1.1.6 and `vsce publish` no-opped on "already published" — the Marketplace never advanced.

Bumping root `package.json` 1.1.6 → 1.1.14. After merge, dispatching `vsix-publish` (or the next tag) ships the current extension to the Marketplace and names the release asset `catgo-1.1.14.vsix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)