### PR TITLE
chore(download): bump download page to 1.1.14

### DIFF
--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.1.13";
+  const VERSION = "1.1.14";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;


### PR DESCRIPTION
Points the self-hosted download page at the v1.1.14 Android APK (`CatGo-v1.1.14-android-universal.apk`, attached to the v1.1.14 release). Signed with the catgo-upload key (same as v1.1.13) so it installs over an existing CatGo without uninstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)