### PR TITLE
fix(mobile): SSH connection password + terminal keyboard UX

### DIFF
--- a/deploy/ios/LOCAL-TESTING-PROGRESS.md
+++ b/deploy/ios/LOCAL-TESTING-PROGRESS.md
@@ -207,5 +207,58 @@ Connect dialog: host = Mac LAN IP, user = Mac username, port 22, Mac login
 password. (iPad must be on the same LAN — it already is, since it loads the UI
 from that IP.)
 
+## 2026-06-09 — connection + terminal/keyboard polish (device-tested)
+
+Found while a colleague + we tested SSH connections and the terminal on iPhone/iPad.
+
+### SSH connection password (`MobileConnect.svelte`, `OtpDialog.svelte`)
+
+- **Saved password never applied → "Password authentication rejected".** The
+  `password = pw` copy lived INSIDE `if (!auto_password)`, but tapping a saved
+  connection (`pick_saved`) pre-loads `auto_password`, so the block was skipped
+  and an empty password was sent. Fixed: apply the saved password whenever it's
+  the password method (any load path); mark `used_saved_pw` when sending the
+  unchanged saved password so we don't re-offer to save it.
+- **No masked feedback on tap.** `pick_saved` now fills the (masked) password
+  field from the store for the password method, so the user sees `••••` and can
+  just tap Connect.
+- **2FA clusters.** Reconnect now pre-fills the password prompt(s) from the saved
+  password even in a MIXED password+OTP round (new `prefill` prop on
+  `OtpDialog`); submits silently only when the whole round is password prompts.
+  Generalized from the old "exactly one prompt" rule.
+- **Key-trim consistency.** `persist_non_secrets` trims host/username so the saved
+  descriptor matches the (trimmed) password key.
+
+### iPhone top-bar overflow (`MobileWorkspace.svelte`)
+
+- Save (and Disconnect) were scrolling off the right edge. Wrapped the secondary
+  actions in a `.mw-actions-scroll` flexbox scroller; Save/Disconnect stay OUTSIDE
+  it (`flex-shrink:0`) so they're always pinned/visible on a narrow screen.
+
+### Terminal soft-keyboard (`MobileTerminal.svelte`, `MobileWorkspace.svelte`)
+
+- **Key bar hidden under the keyboard.** It floats `position:fixed` just above
+  the keyboard (height tracked via `visualViewport`; no transformed ancestors so
+  fixed tracks the viewport). CSS transition + debounced re-fit keep it smooth.
+- **Split mode auto-expand.** When the keyboard opens in split layout, the
+  workspace switches to full-terminal (keep-warm `visibility:hidden`, NOT
+  display:none) and restores the split on close — so the terminal is usable.
+- **Collapse toggle.** A toggle on the bar hides it to a corner pill (terminal
+  visible) and back; `preventDefault` + refocus keep the keyboard up. Styled to
+  fill the strip (`align-self:stretch`, strip bg) so there's no dark box.
+
+### Visualizer (`MobileWorkspace.svelte`)
+
+- Touch-drag to rotate the 3D viewer triggered WKWebView text selection
+  ("selects the whole thing"). Added `-webkit-user-select:none` +
+  `-webkit-touch-callout:none` to `.mw-struct`.
+
+### Known benign noise
+
+- Xcode: ~390 *"Object file … built for newer 'iOS' version (17.0) than being
+  linked (14.0)"* warnings — the Rust `libapp.a` targets iOS 17 but `project.yml`
+  links iOS 14. Cosmetic; align `IPHONEOS_DEPLOYMENT_TARGET` / `project.yml`
+  `deploymentTarget` to silence.
+
 ---
 *Session notes — a resume guide for building and testing CatGo on iOS.*

--- a/deploy/ios/LOCAL-TESTING-PROGRESS.md
+++ b/deploy/ios/LOCAL-TESTING-PROGRESS.md
@@ -253,12 +253,39 @@ Found while a colleague + we tested SSH connections and the terminal on iPhone/i
   ("selects the whole thing"). Added `-webkit-user-select:none` +
   `-webkit-touch-callout:none` to `.mw-struct`.
 
-### Known benign noise
+### Review follow-ups (post code-review)
 
-- Xcode: ~390 *"Object file … built for newer 'iOS' version (17.0) than being
-  linked (14.0)"* warnings — the Rust `libapp.a` targets iOS 17 but `project.yml`
-  links iOS 14. Cosmetic; align `IPHONEOS_DEPLOYMENT_TARGET` / `project.yml`
-  `deploymentTarget` to silence.
+- **Per-tab stream cancel.** `MobileChat`'s unmount-cancel `$effect` read the
+  reactive `active_id`, so switching tabs cancelled the LEFT tab's stream. Now
+  reads it via `untrack` → cancels only on real unmount.
+- **Silent password-save failure.** `save_password_yes` swallowed a `keyStore`
+  error. Now surfaces it in the save dialog with a Retry (`save_pw_failed` /
+  `save_pw_retry`).
+- **Stale saved password.** If a saved password is rejected on reconnect (changed
+  server-side), clear it in-memory AND from the store (overwrite empty — no
+  delete command; empty reads back as "none") and prompt to re-enter
+  (`saved_pw_rejected`). Mainly matters for the keyboard-interactive auto-answer
+  path, which the user couldn't otherwise interrupt.
+
+### Fixed: Xcode deployment-target warnings
+
+- The ~390 *"object file built for newer iOS (17.0) than being linked (14.0)"*
+  warnings: added `export IPHONEOS_DEPLOYMENT_TARGET="${...:-14.0}"` to the
+  `gen/apple/project.yml` "Build Rust Code" preBuildScript (next to the PATH
+  export) so cargo builds the Rust lib for iOS 14 to match the project's link
+  target. **Machine-local (gen/apple is gitignored) — re-apply after
+  `tauri ios init`, then `xcodegen generate` + rebuild.**
+
+### Not changed — by design / platform
+
+- **No SSE streaming on iOS** — the Tauri HTTP plugin buffers the whole body;
+  fixing needs native plugin work. The single-read fallback + idle-timeout make
+  it correct, just one-shot. Out of scope.
+- **Conservative password-prompt capture** — only offers to save when the prompt
+  is recognized as a password (excludes passcode/OTP/duo) so we never persist a
+  one-time code. Intentional; broadening it is unsafe.
+- **One abort-listener per send** in `stream_client_llm` — bounded and GC'd with
+  the per-send AbortController; not a real leak.
 
 ---
 *Session notes — a resume guide for building and testing CatGo on iOS.*

--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -69,6 +69,7 @@ const mobile: Record<string, string> = {
   connecting:             `Connecting…`,
   connect_action:         `Connect`,
   connection_failed:      `Connection failed.`,
+  saved_pw_rejected:      `Saved password was rejected — it may have changed. Enter it again to reconnect.`,
   auth_cancelled:         `Authentication cancelled.`,
 
   // ── Save-password prompt (MobileConnect) ─────────────────────────────

--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -76,6 +76,8 @@ const mobile: Record<string, string> = {
   save_pw_body:           `Next time you connect to {user} you'll only need the one-time passcode (OTP). The password is encrypted on this device.`,
   save_pw_not_now:        `Not now`,
   save_pw_save:           `Save password`,
+  save_pw_retry:          `Retry`,
+  save_pw_failed:         `Couldn't save the password — it wasn't stored. Retry, or continue and enter it next time.`,
 
   // ── OTP dialog (OtpDialog) ───────────────────────────────────────────
   otp_title:              `Verification required`,

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -69,6 +69,7 @@ const mobile: Record<string, string> = {
   connecting:             `连接中…`,
   connect_action:         `连接`,
   connection_failed:      `连接失败。`,
+  saved_pw_rejected:      `已保存的密码被拒绝 — 可能已更改。请重新输入以连接。`,
   auth_cancelled:         `认证已取消。`,
 
   // ── 保存密码提示 (MobileConnect) ─────────────────────────────────────

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -76,6 +76,8 @@ const mobile: Record<string, string> = {
   save_pw_body:           `下次连接到 {user} 时，你只需输入一次性验证码（OTP）。密码会加密保存在本设备上。`,
   save_pw_not_now:        `暂不`,
   save_pw_save:           `保存密码`,
+  save_pw_retry:          `重试`,
+  save_pw_failed:         `无法保存密码 — 未能存储。请重试，或继续并下次手动输入。`,
 
   // ── OTP 对话框 (OtpDialog) ───────────────────────────────────────────
   otp_title:              `需要验证`,

--- a/src/lib/mobile/MobileChat.svelte
+++ b/src/lib/mobile/MobileChat.svelte
@@ -19,6 +19,7 @@
   renderer only when a fenced code block is detected.
 -->
 <script lang="ts">
+  import { untrack } from 'svelte'
   import Icon from '$lib/Icon.svelte'
   import { get_display_text } from '$lib/chat/types'
   import {
@@ -130,7 +131,12 @@
   })
 
   // Abort the active chat's in-flight stream when the overlay unmounts (§6).
-  $effect(() => () => cancel_generation(active_id))
+  // Read active_id via `untrack` so the effect takes NO reactive dependency on
+  // it — otherwise switching tabs would re-run the effect and its teardown would
+  // cancel the stream of the tab you just LEFT (breaking per-tab background
+  // streaming). With untrack, the teardown runs only on real unmount and cancels
+  // whatever tab is active at that moment.
+  $effect(() => () => cancel_generation(untrack(() => active_id)))
 
   const has_key = $derived(local_key.trim().length > 0)
   const show_setup = $derived(setup_open || (key_checked && !has_key))

--- a/src/lib/mobile/MobileConnect.svelte
+++ b/src/lib/mobile/MobileConnect.svelte
@@ -87,6 +87,8 @@
   // Post-success "save password?" prompt, parked until the user decides so we
   // stay mounted (calling on_connected swaps us out).
   let save_prompt_visible = $state(false)
+  // Shown inside the save-password dialog when the encrypted store write fails,
+  // so a failed save isn't silently swallowed (the dialog offers Retry).
   let save_error = $state(``)
   let pending_session = ``
   let pending_pw = ``
@@ -254,6 +256,18 @@
     otp_visible = false
     otp_busy = false
     error_msg = r.message || t(`mobile.connection_failed`)
+    // If THIS attempt used a saved password and it was rejected, it's probably
+    // stale (changed on the server). Clear it — in-memory AND from the encrypted
+    // store (overwrite empty; there's no delete command, and an empty value
+    // reads back as "no saved password") — so the next attempt prompts fresh
+    // instead of silently re-submitting the wrong one (esp. the keyboard-
+    // interactive auto-answer path, which the user can't otherwise interrupt).
+    if (used_saved_pw) {
+      auto_password = ``
+      used_saved_pw = false
+      transport.keyStore(endpoint_pw_key(), ``).catch(() => {/* best-effort */})
+      error_msg = t(`mobile.saved_pw_rejected`)
+    }
   }
 
   async function connect(): Promise<void> {

--- a/src/lib/mobile/MobileConnect.svelte
+++ b/src/lib/mobile/MobileConnect.svelte
@@ -87,6 +87,7 @@
   // Post-success "save password?" prompt, parked until the user decides so we
   // stay mounted (calling on_connected swaps us out).
   let save_prompt_visible = $state(false)
+  let save_error = $state(``)
   let pending_session = ``
   let pending_pw = ``
 
@@ -242,6 +243,7 @@
         pending_session = r.sessionId
         pending_pw = captured_password
         captured_password = ``
+        save_error = ``
         save_prompt_visible = true
         return
       }
@@ -363,6 +365,7 @@
 
   function finish_connect(): void {
     save_prompt_visible = false
+    save_error = ``
     const id = pending_session
     pending_session = ``
     pending_pw = ``
@@ -371,10 +374,15 @@
 
   /** Save the password (encrypted) for OTP-only reconnect, then continue. */
   async function save_password_yes(): Promise<void> {
+    save_error = ``
     try {
       await transport.keyStore(endpoint_pw_key(), pending_pw)
     } catch {
-      /* store unavailable — proceed without saving */
+      // The user explicitly chose to save — don't pretend it worked (that would
+      // silently re-create the "empty password on reconnect → rejected" bug).
+      // Surface it and keep the dialog so they can retry or continue without it.
+      save_error = t(`mobile.save_pw_failed`)
+      return
     }
     finish_connect()
   }
@@ -609,9 +617,14 @@
       <div class="sp-body">
         {t(`mobile.save_pw_body`, { user: `${username}@${host}` })}
       </div>
+      {#if save_error}
+        <div class="sp-error" role="alert">{save_error}</div>
+      {/if}
       <div class="sp-actions">
         <button type="button" class="sp-no" onclick={finish_connect}>{t(`mobile.save_pw_not_now`)}</button>
-        <button type="button" class="sp-yes" onclick={save_password_yes}>{t(`mobile.save_pw_save`)}</button>
+        <button type="button" class="sp-yes" onclick={save_password_yes}>
+          {save_error ? t(`mobile.save_pw_retry`) : t(`mobile.save_pw_save`)}
+        </button>
       </div>
     </div>
   </div>
@@ -647,6 +660,12 @@
     line-height: 1.5;
     color: var(--text-color-muted, #cbd5e1);
     margin-bottom: 18px;
+  }
+  .sp-error {
+    font-size: 0.85em;
+    line-height: 1.4;
+    color: #ff6b6b;
+    margin-bottom: 14px;
   }
   .sp-actions {
     display: flex;

--- a/src/lib/mobile/MobileConnect.svelte
+++ b/src/lib/mobile/MobileConnect.svelte
@@ -70,6 +70,10 @@
   let otp_pending_id = $state(``)
   let otp_prompts = $state<OtpPrompt[]>([])
   let otp_instructions = $state(``)
+  // Pre-filled answers for the current OTP round (index-aligned with
+  // otp_prompts) — used to seed password prompt(s) from a saved password in a
+  // mixed password+2FA round, so the user only types the OTP.
+  let otp_prefill = $state<string[]>([])
 
   // ─── Saved-password / OTP-only reconnect ───
   // A password loaded from the encrypted store for the picked connection; when a
@@ -132,12 +136,19 @@
     username = c.username
     method = c.method
     key_path = c.keyPath ?? ``
+    password = `` // reset; filled (masked) from the store below for password auth
     error_msg = ``
     auto_password = ``
     transport
       .keyLoad(`pw:${c.host}:${c.port}:${c.username}`)
       .then((pw) => {
-        if (pw) auto_password = pw
+        if (pw) {
+          auto_password = pw
+          // Show the saved password (masked ••••) so the user sees it's stored
+          // and can just tap Connect. keyboard-interactive has no password field
+          // — it uses auto_password to answer the prompt round instead.
+          if (c.method === `password`) password = pw
+        }
       })
       .catch(() => {
         /* no stored password / desktop transport — type it manually */
@@ -166,8 +177,18 @@
   }
 
   function persist_non_secrets(): void {
+    // Trim host/username so the saved descriptor matches the password key
+    // (endpoint_pw_key also trims) — otherwise a stray space means pick_saved's
+    // keyLoad looks under a different key than the password was stored at.
     saved = upsertConnection(
-      { host, port, username, method, keyPath: key_path, label },
+      {
+        host: host.trim(),
+        port,
+        username: username.trim(),
+        method,
+        keyPath: key_path,
+        label,
+      },
       Date.now(),
     )
   }
@@ -186,15 +207,24 @@
       otp_pending_id = r.pendingId
       otp_prompts = r.prompts
       otp_instructions = r.instructions
-      // OTP-only reconnect: if this round is just the account-password prompt and
-      // we have a saved password, answer it silently and only surface later
-      // rounds (the Duo passcode) to the user.
-      if (auto_password && r.prompts.length === 1 && is_password_prompt(r.prompts[0])) {
+      otp_prefill = []
+      // Saved-password reconnect: answer the account-password prompt(s) from the
+      // stored password. If the WHOLE round is password prompts, submit silently
+      // (OTP-only reconnect). If it's MIXED (password + a Duo/OTP passcode),
+      // surface the dialog with the password field(s) pre-filled so the user
+      // only types the 2FA code — works regardless of how many prompts the
+      // server bundles together.
+      if (auto_password && r.prompts.some(is_password_prompt)) {
         used_saved_pw = true
         const pw = auto_password
-        auto_password = ``
-        void submit_otp([pw])
-        return
+        if (r.prompts.every(is_password_prompt)) {
+          auto_password = `` // consumed
+          void submit_otp(r.prompts.map(() => pw))
+          return
+        }
+        // Mixed round: seed password prompts, leave OTP prompts blank. Keep
+        // auto_password in case a later round re-prompts for the password.
+        otp_prefill = r.prompts.map((p) => (is_password_prompt(p) ? pw : ``))
       }
       otp_visible = true
       otp_busy = false
@@ -243,20 +273,32 @@
     } catch {
       /* fall through to a fresh connect */
     }
-    // Robustly load a saved password for THIS endpoint (so OTP-only reconnect
-    // works even when the form was filled manually, not via a saved-list tap).
+    // Load a saved password for THIS endpoint if we don't already have one (so a
+    // manually-filled form benefits too, not just a saved-list tap).
     if (!auto_password) {
       try {
         const pw = await transport.keyLoad(endpoint_pw_key())
-        if (pw) {
-          auto_password = pw
-          // password method: fill the form value directly; keyboard-interactive
-          // uses auto_password to answer the password prompt round.
-          if (method === `password` && !password) password = pw
-        }
+        if (pw) auto_password = pw
       } catch {
         /* no stored password / desktop transport */
       }
+    }
+    // password method: apply the saved password to the form value that connect()
+    // sends below. This MUST run whether auto_password came from a saved-list tap
+    // (pick_saved pre-loads it) or the keyLoad just above. The old code only set
+    // `password` INSIDE the `if (!auto_password)` block, so tapping a saved
+    // connection (which pre-loads auto_password) skipped it → an empty password
+    // was sent → "Password authentication rejected". keyboard-interactive instead
+    // uses auto_password to answer the prompt round (see apply_result).
+    if (method === `password` && !password && auto_password) {
+      password = auto_password
+    }
+    // If we're about to send EXACTLY the saved password (the user didn't edit the
+    // pre-filled field), mark it so apply_result doesn't redundantly re-offer to
+    // save it. If they edited it to a new value, this stays false → we offer to
+    // save the new one.
+    if (method === `password` && auto_password && password === auto_password) {
+      used_saved_pw = true
     }
     try {
       const r = await transport.connect({
@@ -554,6 +596,7 @@
     prompts={otp_prompts}
     instructions={otp_instructions}
     busy={otp_busy}
+    prefill={otp_prefill}
     on_submit={submit_otp}
     on_cancel={cancel_otp}
   />

--- a/src/lib/mobile/MobileTerminal.svelte
+++ b/src/lib/mobile/MobileTerminal.svelte
@@ -19,6 +19,7 @@
 -->
 <script lang="ts">
   import { transport } from '$lib/api/transport'
+  import Icon from '$lib/Icon.svelte'
   import MobileTerminalKeyBar from '$lib/structure/MobileTerminalKeyBar.svelte'
 
   interface Props {
@@ -63,6 +64,46 @@
       }
     })
   }
+
+  // iOS: the soft keyboard OVERLAYS the WKWebView (the layout viewport doesn't
+  // shrink), so the bottom key bar (Esc/Tab/Ctrl/arrows) would hide behind it.
+  // Track the keyboard height via visualViewport and pad the terminal up by that
+  // much, so the key bar sits right above the keyboard and the grid re-fits to
+  // the smaller area. Self-correcting cross-platform: where the webview already
+  // resizes for the keyboard (Android native insets), innerHeight shrinks too,
+  // so the computed inset is ~0 (no double-pad); on desktop there's no soft
+  // keyboard so it stays 0.
+  let kb_inset = $state(0)
+  // Measured height of the key bar, so we can reserve exactly that much space
+  // above the keyboard when the bar floats (see template / styles).
+  let keybar_h = $state(48)
+  // User toggle: collapse the floating bar to a small pill so the terminal is
+  // visible (e.g. in split mode where the pane is short). Re-tap to expand.
+  let keybar_open = $state(true)
+  $effect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    let last = -1
+    let refit_timer: ReturnType<typeof setTimeout> | null = null
+    const update = () => {
+      const next = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop))
+      if (next === last) return
+      last = next
+      kb_inset = next // padding glides via the CSS transition (see styles)
+      // Re-fit the grid ONCE after the keyboard settles — running it on every
+      // animation frame is what makes the bar look jumpy.
+      if (refit_timer) clearTimeout(refit_timer)
+      refit_timer = setTimeout(() => refit(), 140)
+    }
+    update()
+    vv.addEventListener(`resize`, update)
+    vv.addEventListener(`scroll`, update)
+    return () => {
+      if (refit_timer) clearTimeout(refit_timer)
+      vv.removeEventListener(`resize`, update)
+      vv.removeEventListener(`scroll`, update)
+    }
+  })
 
   /** Focus the hidden xterm textarea (raises the soft keyboard). The parent
    *  calls this from a tab tap handler — a trusted gesture, which WKWebView
@@ -325,7 +366,10 @@
   })
 </script>
 
-<div class="mobile-terminal">
+<div
+  class="mobile-terminal"
+  style="padding-bottom: {kb_inset > 0 ? kb_inset + keybar_h : 0}px"
+>
   <div class="mt-body" bind:this={container_el}>
     {#if status === `init`}
       <div class="mt-status">Opening shell…</div>
@@ -333,7 +377,34 @@
       <div class="mt-error">{error_msg}</div>
     {/if}
   </div>
-  <MobileTerminalKeyBar on_key={send_keys} />
+  <!-- When the keyboard is up, the bar floats fixed just above it (so it's
+       reachable even in split mode where the pane is too short to hold it in
+       flow). When the keyboard is down it sits in normal flow at the bottom.
+       The toggle collapses it to a small pill so the terminal stays visible. -->
+  <div
+    class="mt-keybar"
+    class:floating={kb_inset > 0}
+    class:closed={!keybar_open}
+    style:bottom="{kb_inset}px"
+    bind:clientHeight={keybar_h}
+  >
+    {#if keybar_open}
+      <MobileTerminalKeyBar on_key={send_keys} />
+    {/if}
+    <button
+      type="button"
+      class="mt-keybar-toggle"
+      onpointerdown={(e) => e.preventDefault()}
+      onclick={() => {
+        keybar_open = !keybar_open
+        // Keep the soft keyboard up: tapping a button blurs the hidden xterm
+        // textarea (which dismisses the keyboard), so refocus it like the keys do.
+        term_ref?.focus()
+      }}
+      aria-label={keybar_open ? `Hide terminal keys` : `Show terminal keys`}
+      title={keybar_open ? `Hide keys` : `Show keys`}
+    ><Icon icon={keybar_open ? `Collapse` : `Expand`} /></button>
+  </div>
 </div>
 
 <style>
@@ -343,6 +414,12 @@
     width: 100%;
     height: 100%;
     min-height: 0;
+    /* border-box so the dynamic padding-bottom (soft-keyboard inset) shrinks the
+       content within height:100% rather than overflowing it. */
+    box-sizing: border-box;
+    /* Glide the key bar with the keyboard instead of stepping through the few
+       discrete heights visualViewport reports during the open/close animation. */
+    transition: padding-bottom 0.18s ease-out;
     background: var(--page-bg, #0e1117);
   }
   .mt-body {
@@ -360,6 +437,60 @@
   .mt-body :global(.xterm-screen) {
     height: 100%;
     width: 100%;
+  }
+  .mt-keybar {
+    display: flex;
+    align-items: stretch;
+    flex-shrink: 0;
+    /* Match the key strip so there's no black gap behind the toggle. */
+    background: var(--keybar-bg, #1e1e1e);
+  }
+  .mt-keybar :global(.keybar) {
+    flex: 1;
+    min-width: 0;
+  }
+  /* Keyboard up: float the key bar fixed just above it (left/right:0, bottom set
+     inline to the keyboard inset) so it's reachable regardless of how short the
+     terminal pane is in split mode. No transformed ancestors, so fixed tracks
+     the viewport. The transition glides it with the keyboard. */
+  .mt-keybar.floating {
+    position: fixed;
+    left: 0;
+    right: 0;
+    z-index: 50;
+    transition: bottom 0.18s ease-out;
+  }
+  /* Collapsed while floating: shrink to just the toggle pill, pinned to the
+     right, so the terminal underneath stays visible. */
+  .mt-keybar.floating.closed {
+    left: auto;
+    background: var(--keybar-bg, #1e1e1e);
+    border-top: 1px solid var(--keybar-border, #333);
+    border-left: 1px solid var(--keybar-border, #333);
+    border-top-left-radius: 10px;
+  }
+  .mt-keybar-toggle {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 52px;
+    align-self: stretch; /* fill the full strip height — no margin gaps */
+    font-size: 14px;
+    /* Same surface as the strip so it can't contrast as a "box"; the blue icon
+       and a thin left divider are what mark it as the toggle control. */
+    color: #0a84ff;
+    background: var(--keybar-bg, #1e1e1e);
+    border: none;
+    border-left: 1px solid var(--keybar-border, #333);
+    cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .mt-keybar-toggle:active {
+    background: var(--key-bg, #2d2d2d);
   }
   .mt-status {
     padding: 12px;

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -80,6 +80,40 @@
   let db_visible = $state(false)
   let save_msg = $state(``)
 
+  // Auto-expand the terminal while typing: in a split layout the soft keyboard
+  // leaves almost no room for the terminal, so when it opens we switch to the
+  // full-terminal view and restore the split when it closes. Gated on no overlay
+  // (the chat/files own their own keyboard) so we only react to the terminal.
+  let kb_open = $state(false)
+  let mode_before_kb: Mode | null = null
+  $effect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const update = () => {
+      // >120px of inset = a real soft keyboard, not the URL bar / safe area.
+      const open = window.innerHeight - vv.height - vv.offsetTop > 120
+      if (open !== kb_open) kb_open = open
+    }
+    update()
+    vv.addEventListener(`resize`, update)
+    vv.addEventListener(`scroll`, update)
+    return () => {
+      vv.removeEventListener(`resize`, update)
+      vv.removeEventListener(`scroll`, update)
+    }
+  })
+  $effect(() => {
+    const split = mode === `split-h` || mode === `split-v`
+    if (kb_open && split && !ai_open && !files_open && !db_visible) {
+      mode_before_kb = mode
+      mode = `terminal`
+    } else if (!kb_open && mode_before_kb) {
+      // Restore the split only if the user didn't manually pick another view.
+      if (mode === `terminal`) mode = mode_before_kb
+      mode_before_kb = null
+    }
+  })
+
   // Hide the editor toolbar items that don't apply on mobile: server/HPC +
   // terminal are owned by MobileWorkspace (russh); workflow, plugin_hub and chat
   // are Python-backend-only (chat streams via /api/agent/stream) so they can't
@@ -403,6 +437,7 @@
         {/if}
       </div>
       <div class="mw-actions">
+        <div class="mw-actions-scroll">
         <LocaleSwitch compact />
         <button type="button" class="mw-act ai" onclick={() => (ai_open = true)} title={t(`mobile.action_ai`)} aria-label={t(`mobile.action_ai`)}>
           <Icon icon="Chat" />
@@ -438,6 +473,7 @@
           <Icon icon="Database" />
           <span class="mw-act-label">{t(`mobile.action_import_database_short`)}</span>
         </button>
+        </div>
         {#if can_save}
           <button type="button" class="mw-act save" onclick={save} title={t(`mobile.action_save_structure`)}>
             <Icon icon="Download" />
@@ -765,10 +801,21 @@
     gap: 2px;
     flex-shrink: 1;
     min-width: 0;
+    align-items: center;
+  }
+  /* Inner scroller holds the SECONDARY actions (locale, AI, undo/redo, files,
+     open, database). Save + Disconnect sit OUTSIDE it as direct .mw-actions
+     children (flex-shrink:0), so on a narrow iPhone they stay pinned/visible on
+     the right instead of scrolling off the edge. */
+  .mw-actions-scroll {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 1;
+    min-width: 0;
     overflow-x: auto;
     scrollbar-width: none;
   }
-  .mw-actions::-webkit-scrollbar {
+  .mw-actions-scroll::-webkit-scrollbar {
     display: none;
   }
   .mw-tabs button,
@@ -897,6 +944,13 @@
     --struct-height: 100%;
     --struct-width: 100%;
     overflow: hidden;
+    /* iOS: a touch-drag to rotate the 3D viewer otherwise triggers WKWebView's
+       native text selection (it grabs the toolbar labels and "selects the whole
+       thing"). Suppress selection + the callout on the whole structure pane —
+       there's no user-selectable text here, only the canvas + tool buttons. */
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   .mw-struct :global(.structure-main) {
     height: 100%;

--- a/src/lib/mobile/OtpDialog.svelte
+++ b/src/lib/mobile/OtpDialog.svelte
@@ -25,17 +25,31 @@
     on_submit?: (responses: string[]) => void
     /** Emitted when the user cancels this OTP round. */
     on_cancel?: () => void
+    /** Optional initial answers (index-aligned with `prompts`) — used to
+     *  pre-fill the account-password field from a saved password so the user
+     *  only types the remaining (2FA / OTP) prompts. */
+    prefill?: string[]
   }
 
-  let { prompts, instructions = ``, busy = false, on_submit, on_cancel }: Props =
-    $props()
+  let {
+    prompts,
+    instructions = ``,
+    busy = false,
+    on_submit,
+    on_cancel,
+    prefill = [],
+  }: Props = $props()
 
   // One answer slot per prompt. Re-derived whenever the prompts array identity
   // changes (i.e. a new multi-round step), so stale answers never leak forward.
+  // Seed from `prefill` (e.g. a saved password) where provided.
+  // Not a writable $derived: `responses[i]` is two-way bound to the inputs
+  // (user-edited), so it must be reset-from-props $state, not a pure derived.
+  // eslint-disable-next-line svelte/prefer-writable-derived
   let responses = $state<string[]>([])
   $effect(() => {
     // Track prompts length/identity; reset the answer buffer for a new round.
-    responses = prompts.map(() => ``)
+    responses = prompts.map((_, i) => prefill[i] ?? ``)
   })
 
   function submit(): void {


### PR DESCRIPTION
## Mobile SSH connection password + terminal keyboard UX

Device-tested fixes (iPhone + iPad) found after #292 merged, while a colleague
and I tested SSH connections and the terminal. Supersedes the reverted #288/#293
"HPC password saving" attempt with a working version.

iOS-specific behavior is gated on mobile (`isMobile()` / WKWebView), so desktop
and production are unchanged. Full per-change notes: `deploy/ios/LOCAL-TESTING-PROGRESS.md`.

### Connection password (`MobileConnect.svelte`, `OtpDialog.svelte`)
- **Saved password not applied on reconnect → "Password authentication rejected".**
  The apply lived inside an `if (!auto_password)` block that a saved-list tap
  skips, so an empty password was sent. Now applied on any load path.
- **Masked feedback** — tapping a saved login fills the password field (`••••`)
  so you can just tap Connect; no re-prompt to save the unchanged password.
- **2FA clusters** — the saved password pre-fills the password prompt even in a
  mixed password+OTP round (new `prefill` prop on `OtpDialog`); silent submit
  only when the whole round is password prompts.
- **Failed save is surfaced** (not silently swallowed) with a Retry.
- **Stale saved password** — if rejected on reconnect (changed server-side),
  it's cleared (memory + store) and you're prompted to re-enter.
- Host/username trimmed for key parity.

### Terminal soft-keyboard (`MobileTerminal.svelte`, `MobileWorkspace.svelte`)
- Key bar (Esc/Tab/Ctrl/arrows) **floats above the keyboard** (`visualViewport`)
  instead of hiding behind it; smooth (CSS transition + debounced re-fit).
- **Split-mode auto-expand** — the terminal goes full-screen while typing and
  restores the split on keyboard close (keep-warm `visibility:hidden`).
- **Collapse toggle** for the bar (keeps the keyboard up).

### Layout / visualizer (`MobileWorkspace.svelte`)
- iPhone: Save/Disconnect pinned outside the scrollable action row so they can't
  slide off the narrow top bar.
- 3D viewer: suppress WKWebView text-selection on touch-drag-to-rotate.

### Chat (`MobileChat.svelte`)
- Cancel-on-unmount effect reads `active_id` via `untrack` so switching chat tabs
  no longer cancels the stream of the tab you left.

### Testing
- `vitest` unaffected (changes are `.svelte` + i18n; no touched `.ts` logic has
  tests). i18n en/zh parity holds for the 3 new keys.
- Manually verified on device: saved-password reconnect, 2FA pre-fill, the
  keyboard bar + auto-expand + toggle, iPhone Save button, visualizer rotate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
