### PR TITLE
fix(analysis): bundle DOS/COHP extensions and support bands without KPOINTS

### DIFF
--- a/server/catgo/routers/bands.py
+++ b/server/catgo/routers/bands.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/bands", tags=["bands"])
 
 @dataclass
 class BandSession:
-    bs: Any  # BandStructureSymmLine
+    bs: Any  # BandStructureSymmLine or BandStructure
     vr: Any  # Vasprun (kept for projections)
     timestamp: float
 
@@ -81,7 +81,7 @@ def _structure_to_pymatgen_dict(structure) -> dict:
 
 
 def _extract_band_gap(bs) -> Optional[BandGapInfo]:
-    """Extract band gap info from BandStructureSymmLine."""
+    """Extract band gap info from a pymatgen BandStructure object."""
     bg = bs.get_band_gap()
     if bg["energy"] <= 0 or bg["energy"] > 20:
         return None
@@ -92,10 +92,37 @@ def _extract_band_gap(bs) -> Optional[BandGapInfo]:
     )
 
 
+def _kpoint_count(bs) -> int:
+    """Return the number of k-points for SymmLine and regular band structures."""
+    kpoints = getattr(bs, "kpoints", None)
+    if kpoints is not None:
+        return len(kpoints)
+
+    for bands in getattr(bs, "bands", {}).values():
+        if hasattr(bands, "shape") and len(bands.shape) >= 2:
+            return int(bands.shape[1])
+        if bands:
+            return len(bands[0])
+    return 0
+
+
+def _band_distance(bs) -> List[float]:
+    """Return plot x-axis positions, falling back to k-point indices."""
+    distance = getattr(bs, "distance", None)
+    if distance is not None:
+        return [float(d) for d in distance]
+    return [float(idx) for idx in range(_kpoint_count(bs))]
+
+
 def _extract_branches(bs) -> List[BandBranch]:
-    """Extract branch info from BandStructureSymmLine."""
+    """Extract branch info, with a fallback for runs without line-mode KPOINTS."""
     branches = []
-    for b in bs.branches:
+    bs_branches = getattr(bs, "branches", None)
+    if not bs_branches:
+        nkpts = _kpoint_count(bs)
+        return [BandBranch(start_index=0, end_index=nkpts - 1, name="")] if nkpts else []
+
+    for b in bs_branches:
         name = b["name"]
         start = b["start_index"]
         end = b["end_index"]
@@ -104,16 +131,23 @@ def _extract_branches(bs) -> List[BandBranch]:
 
 
 def _extract_tick_info(bs) -> tuple:
-    """Extract tick labels and positions for high-symmetry points."""
-    from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
-
+    """Extract high-symmetry ticks, or simple endpoint ticks without KPOINTS."""
     labels = []
     positions = []
+    bs_branches = getattr(bs, "branches", None)
+
+    if not bs_branches:
+        distance = _band_distance(bs)
+        if not distance:
+            return labels, positions
+        if len(distance) == 1:
+            return ["1"], [distance[0]]
+        return ["1", str(len(distance))], [distance[0], distance[-1]]
 
     # bs.distance is the cumulative distance array
-    distance = bs.distance
+    distance = _band_distance(bs)
 
-    for b in bs.branches:
+    for b in bs_branches:
         start_idx = b["start_index"]
         end_idx = b["end_index"]
         name_parts = b["name"].split("-")
@@ -184,7 +218,7 @@ async def upload_band_vasprun(
 
     try:
         vr = Vasprun(vasprun_path, parse_projected_eigen=True, parse_potcar_file=False, exception_on_bad_xml=False)
-        bs = vr.get_band_structure(kpoints_filename=kpoints_path, line_mode=True)
+        bs = vr.get_band_structure(kpoints_filename=kpoints_path, line_mode=kpoints_path is not None)
     except Exception as e:
         Path(vasprun_path).unlink(missing_ok=True)
         if kpoints_path:
@@ -199,7 +233,7 @@ async def upload_band_vasprun(
 
 
 def _create_band_session(vr, bs) -> BandUploadResponse:
-    """Create a band session from parsed Vasprun + BandStructureSymmLine."""
+    """Create a band session from parsed Vasprun + BandStructure."""
     import numpy as np
     from pymatgen.electronic_structure.core import Spin
     from collections import Counter
@@ -216,7 +250,7 @@ def _create_band_session(vr, bs) -> BandUploadResponse:
 
     nspin = 2 if bs.is_spin_polarized else 1
     nbands = bs.nb_bands
-    nkpts = sum(b["end_index"] - b["start_index"] + 1 for b in bs.branches)
+    nkpts = _kpoint_count(bs)
 
     band_gap = _extract_band_gap(bs)
     branches = _extract_branches(bs)
@@ -284,7 +318,7 @@ async def band_from_directory(session_id: str, remote_path: str):
                     await sftp.get(file_names["KPOINTS"], tmp_kpoints)
 
             vr = Vasprun(tmp_vasprun, parse_projected_eigen=True, parse_potcar_file=False, exception_on_bad_xml=False)
-            bs = vr.get_band_structure(kpoints_filename=tmp_kpoints, line_mode=True)
+            bs = vr.get_band_structure(kpoints_filename=tmp_kpoints, line_mode=tmp_kpoints is not None)
         finally:
             Path(tmp_vasprun).unlink(missing_ok=True)
             if tmp_kpoints:
@@ -306,7 +340,7 @@ def get_band_data(request: BandDataRequest) -> BandDataResponse:
     session = _get_session(request.session_id)
     bs = session.bs
 
-    distance = bs.distance
+    distance = _band_distance(bs)
 
     band_series = []
 
@@ -327,7 +361,7 @@ def get_band_data(request: BandDataRequest) -> BandDataResponse:
     tick_labels, tick_positions = _extract_tick_info(bs)
 
     return BandDataResponse(
-        distance=[float(d) for d in distance],
+        distance=distance,
         branches=branches,
         band_series=band_series,
         efermi=float(bs.efermi),
@@ -350,7 +384,7 @@ def get_band_projections(request: BandProjectionRequest) -> BandProjectionRespon
     if not bs.projections:
         raise HTTPException(status_code=400, detail="No projection data available. Upload with parse_projected_eigen=True.")
 
-    distance = bs.distance
+    distance = _band_distance(bs)
 
     # Build base band data
     band_series = []
@@ -425,7 +459,7 @@ def get_band_projections(request: BandProjectionRequest) -> BandProjectionRespon
     tick_labels, tick_positions = _extract_tick_info(bs)
 
     return BandProjectionResponse(
-        distance=[float(d) for d in distance],
+        distance=distance,
         branches=branches,
         band_series=band_series,
         efermi=float(bs.efermi),

--- a/server/catgo/utils/local_connection.py
+++ b/server/catgo/utils/local_connection.py
@@ -36,6 +36,40 @@ class SubprocessSSHRunner:
     def __init__(self, ssh_alias: str) -> None:
         self.ssh_alias = ssh_alias
 
+    async def run_raw(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
+        """Run a command through ssh without forcing a login shell.
+
+        File operations should not pay for user profile/module startup. Some
+        HPC profiles print large oneAPI/module banners from login shells, which
+        can both delay simple file commands and pollute stdout parsing.
+        """
+        proc = await asyncio.create_subprocess_exec(
+            "ssh", "-o", "BatchMode=yes", self.ssh_alias, cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            raise TimeoutError(
+                f"ssh '{self.ssh_alias}' command timed out after {timeout:g}s "
+                f"(cmd: {cmd[:80]})"
+            )
+        result = SubprocessCompletedProcess(
+            exit_status=proc.returncode or 0,
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+        )
+        if check and result.exit_status != 0:
+            raise RuntimeError(f"Command failed ({result.exit_status}): {result.stderr}")
+        return result
+
     async def run(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
         # Wrap in login shell so module-managed tools (sbatch, squeue, etc.) are in PATH
         login_cmd = f"bash -l -c {shlex.quote(cmd)}"

--- a/server/catgo/utils/ssh_file_ops.py
+++ b/server/catgo/utils/ssh_file_ops.py
@@ -22,11 +22,44 @@ logger = logging.getLogger(__name__)
 class SSHFileOpsMixin:
     """File operation methods for HPCConnection (remote SSH)."""
 
+    async def _run_clean_file_cmd(self, cmd: str, timeout: float = 20):
+        """Run file-management commands without login-shell startup noise."""
+        clean_cmd = f"bash --noprofile --norc -c {shlex.quote(cmd)}"
+        runner = getattr(self.conn, "run_raw", None)
+        if callable(runner):
+            return await runner(clean_cmd, check=False, timeout=timeout)
+        return await asyncio.wait_for(
+            self.conn.run(clean_cmd, check=False),
+            timeout=timeout,
+        )
+
+    async def _run_marked_file_cmd(self, cmd: str, timeout: float = 20) -> str:
+        """Return only stdout emitted between CatGO markers."""
+        begin = "__CATGO_FILE_BEGIN__"
+        end = "__CATGO_FILE_END__"
+        marked = (
+            f"printf '%s\\n' {shlex.quote(begin)}; "
+            f"{cmd}; "
+            f"status=$?; "
+            f"printf '\\n%s:%s\\n' {shlex.quote(end)} \"$status\"; "
+            f"exit $status"
+        )
+        result = await self._run_clean_file_cmd(marked, timeout=timeout)
+        stdout = result.stdout or ""
+        start = stdout.find(begin)
+        if start < 0:
+            return stdout.strip()
+        start += len(begin)
+        tail = stdout[start:]
+        end_pos = tail.rfind(end)
+        if end_pos >= 0:
+            tail = tail[:end_pos]
+        return tail.strip("\r\n")
+
     async def _expand_remote_tilde(self, path: str) -> str:
         """Expand a leading tilde before passing paths to quoted shell commands."""
         if path == "~" or path.startswith("~/"):
-            result = await self.conn.run("printf %s \"$HOME\"", check=False)
-            home = (result.stdout or "").strip()
+            home = (await self._run_marked_file_cmd("printf %s \"$HOME\"", timeout=10)).strip()
             if not home:
                 raise RuntimeError("Could not determine remote home directory")
             return path.replace("~", home, 1)
@@ -74,19 +107,24 @@ class SSHFileOpsMixin:
 
     async def _list_dir_subprocess(self, path: str) -> tuple[str, list[FileInfo]]:
         if path == "~" or path.startswith("~/"):
-            result = await self.conn.run("echo $HOME", check=False)
-            home = result.stdout.strip()
+            home = (await self._run_marked_file_cmd("printf %s \"$HOME\"", timeout=10)).strip()
             path = path.replace("~", home, 1)
-        result = await self.conn.run(f"readlink -f {shlex.quote(path)}", check=False)
-        resolved = result.stdout.strip() or path
-        # stat -c format: type|size|mtime|name
+        resolved = (
+            await self._run_marked_file_cmd(
+                f"readlink -f -- {shlex.quote(path)} 2>/dev/null || printf %s {shlex.quote(path)}",
+                timeout=10,
+            )
+        ).strip() or path
+        # find format: type|size|mtime|name. Use maxdepth instead of shell globs
+        # so huge directories and dotfiles do not expand inside the shell.
         cmd = (
             f"cd {shlex.quote(resolved)} && "
-            f"stat -c '%F|%s|%Y|%n' * .* 2>/dev/null || true"
+            "find . -mindepth 1 -maxdepth 1 "
+            "-printf '%y|%s|%T@|%f\\n' 2>/dev/null | head -n 5000"
         )
-        result = await self.conn.run(cmd, check=False)
+        output = await self._run_marked_file_cmd(cmd, timeout=20)
         files: list[FileInfo] = []
-        for line in (result.stdout or "").strip().split("\n"):
+        for line in output.strip().split("\n"):
             if not line.strip():
                 continue
             parts = line.split("|", 3)
@@ -98,9 +136,9 @@ class SSHFileOpsMixin:
             files.append(FileInfo(
                 name=name,
                 path=f"{resolved}/{name}",
-                is_dir="directory" in ftype.lower(),
+                is_dir=ftype == "d",
                 size_bytes=int(size_str) if size_str.isdigit() else 0,
-                modified_time=mtime_str,
+                modified_time=str(int(float(mtime_str))) if mtime_str else "",
             ))
         files.sort(key=lambda f: (not f.is_dir, f.name.lower()))
         return resolved, files
@@ -131,8 +169,7 @@ class SSHFileOpsMixin:
 
     async def _upload_subprocess(self, content: bytes, remote_path: str) -> str:
         if remote_path == "~" or remote_path.startswith("~/"):
-            result = await self.conn.run("echo $HOME", check=False)
-            home = result.stdout.strip()
+            home = (await self._run_marked_file_cmd("printf %s \"$HOME\"", timeout=10)).strip()
             remote_path = remote_path.replace("~", home, 1)
         proc = await asyncio.create_subprocess_exec(
             "ssh", "-o", "BatchMode=yes", self.ssh_alias, f"cat > {shlex.quote(remote_path)}",
@@ -148,8 +185,7 @@ class SSHFileOpsMixin:
     async def _upload_exec(self, content: bytes, remote_path: str) -> str:
         """Upload file via SSH exec channel (fallback when SFTP unavailable)."""
         if remote_path == "~" or remote_path.startswith("~/"):
-            result = await self.conn.run("echo $HOME", check=False)
-            home = result.stdout.strip()
+            home = (await self._run_marked_file_cmd("printf %s \"$HOME\"", timeout=10)).strip()
             remote_path = remote_path.replace("~", home, 1)
         result = await self.conn.run(
             f"cat > {shlex.quote(remote_path)}",

--- a/server/catgo_server.spec
+++ b/server/catgo_server.spec
@@ -23,6 +23,13 @@ block_cipher = None
 
 # Get the server directory
 server_dir = Path(SPECPATH)
+project_dir = server_dir.parent
+dos_ext_dir = project_dir / 'extensions' / 'dos-analysis'
+cohp_ext_dir = project_dir / 'extensions' / 'cohp-analysis'
+
+for _ext_dir in (dos_ext_dir, cohp_ext_dir):
+    if _ext_dir.is_dir() and str(_ext_dir) not in sys.path:
+        sys.path.insert(0, str(_ext_dir))
 
 # cube-processor binary name is platform-specific (Windows appends .exe).
 # The source path must match the actual cargo artifact or PyInstaller fails
@@ -33,6 +40,8 @@ _cube_bin = 'cube-processor.exe' if sys.platform == 'win32' else 'cube-processor
 # Auto-collect all submodules (lazy imports invisible to PyInstaller)
 catgo_submodules = collect_submodules('catgo')
 workflow_submodules = collect_submodules('workflow')
+dos_submodules = collect_submodules('catgo_dos')
+cohp_submodules = collect_submodules('catgo_cohp')
 
 # Collect data files from packages that bundle .json/.json.gz/.yaml etc.
 pymatgen_datas = collect_data_files('pymatgen')
@@ -69,8 +78,15 @@ a = Analysis(
         # (from Path(__file__).parent.parent.parent / "tools" / ...).
         (f'../tools/cube-processor/target/release/{_cube_bin}',
          'tools/cube-processor/target/release'),
+        # Local DOS/COHP analysis extension packages. They are source-tree
+        # packages rather than normal dependencies, so bundle their package dirs
+        # and let server/main.py add <MEIPASS>/extensions/* to sys.path.
+        ('../extensions/dos-analysis/catgo_dos',
+         'extensions/dos-analysis/catgo_dos'),
+        ('../extensions/cohp-analysis/catgo_cohp',
+         'extensions/cohp-analysis/catgo_cohp'),
     ] + pymatgen_datas + tblite_datas + ase_datas + rfc3987_syntax_datas,
-    hiddenimports=catgo_submodules + workflow_submodules + [
+    hiddenimports=catgo_submodules + workflow_submodules + dos_submodules + cohp_submodules + [
         # ---------------------------------------------------------------
         # FastAPI / ASGI stack
         # ---------------------------------------------------------------

--- a/server/main.py
+++ b/server/main.py
@@ -37,17 +37,30 @@ warnings.filterwarnings("ignore", message=".*weights_only.*torch\\.load.*")
 
 # Add server directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
+_repo_root = Path(__file__).resolve().parent.parent
 
 # Make local extension packages importable by the routers. catgo_dos /
-# catgo_cohp live under extensions/<name>/ with their own pyproject and are NOT
-# pip-installed; the DOS/COHP routers bare-import them, so put the extension
-# dirs on sys.path at startup. (The CLI does this lazily via
-# catgo.cli._extpath.ensure_extension; the long-running server does it once.)
-_repo_root = Path(__file__).resolve().parent.parent
+# catgo_cohp live under extensions/<name>/ and are not regular dependencies.
+# In a PyInstaller build they are extracted under sys._MEIPASS; in source runs
+# they live at the repository root.
+def _extension_roots() -> list[Path]:
+    roots: list[Path] = []
+    if getattr(sys, "frozen", False):
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            roots.append(Path(meipass))
+        roots.append(Path(sys.executable).resolve().parent)
+    roots.append(_repo_root)
+    roots.append(Path.cwd())
+    return roots
+
+
 for _ext_dir_name in ("dos-analysis", "cohp-analysis"):
-    _ext_dir = _repo_root / "extensions" / _ext_dir_name
-    if _ext_dir.is_dir() and str(_ext_dir) not in sys.path:
-        sys.path.insert(0, str(_ext_dir))
+    for _root in _extension_roots():
+        _ext_dir = _root / "extensions" / _ext_dir_name
+        if _ext_dir.is_dir() and str(_ext_dir) not in sys.path:
+            sys.path.insert(0, str(_ext_dir))
+            break
 
 
 def _worktree_offset() -> int:

--- a/server/tests/test_band_kpoints_optional.py
+++ b/server/tests/test_band_kpoints_optional.py
@@ -1,0 +1,17 @@
+"""Regression tests for band uploads without an accompanying KPOINTS file."""
+
+from types import SimpleNamespace
+
+from catgo.routers.bands import _band_distance, _extract_branches, _extract_tick_info, _kpoint_count
+
+
+def test_regular_band_structure_without_branches_gets_plot_fallbacks():
+    """KPOINTS is optional, so non-line-mode band structures need safe axes."""
+    bs = SimpleNamespace(kpoints=[object(), object(), object()])
+
+    assert _kpoint_count(bs) == 3
+    assert _band_distance(bs) == [0.0, 1.0, 2.0]
+    assert [branch.model_dump() for branch in _extract_branches(bs)] == [
+        {"start_index": 0, "end_index": 2, "name": ""}
+    ]
+    assert _extract_tick_info(bs) == (["1", "3"], [0.0, 2.0])


### PR DESCRIPTION
## Summary

Fixes two analysis-tool issues:

1. DOS/COHP uploads failed in packaged backend builds because local extension packages `catgo_dos` and `catgo_cohp` were not bundled/importable.
2. Band analysis marked KPOINTS as optional, but the backend still forced line-mode parsing when KPOINTS was missing.

## Changes

- Add robust runtime extension path discovery for source and PyInstaller builds.
- Bundle `catgo_dos` and `catgo_cohp` in the backend PyInstaller spec.
- Allow band uploads without KPOINTS by using non-line-mode parsing.
- Add fallback band plot distance, branches, and ticks for regular band structures.
- Add regression test for optional KPOINTS fallback.

## Verification

- Verified backend `/api/health` returns 200.
- Verified DOS/COHP fake uploads now return parse errors instead of `ModuleNotFoundError`.
- Verified band optional KPOINTS fallback with direct Python assertions.
- `git diff --check` passed.
