### PR TITLE
fix(ui): keep desktop overlays within viewport

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -2294,8 +2294,10 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: min(80vw, 900px);
-    height: min(80vh, 700px);
+    width: min(900px, calc(100vw - 32px));
+    height: min(700px, calc(100vh - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     z-index: 100;
     border-radius: 8px;
     overflow: hidden;
@@ -2309,6 +2311,8 @@
     inset: 0;
     z-index: 99;
     background: rgba(0, 0, 0, 0.4);
+    padding: 16px;
+    overflow: auto;
   }
 
   :global(*) {
@@ -2626,9 +2630,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
     background: rgba(0, 0, 0, 0.5);
     z-index: 100000050;
     animation: fade-in 0.15s ease-out;
+    overflow: auto;
   }
 
   .modal-dialog {
@@ -2636,9 +2642,11 @@
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
     border-radius: 12px;
     padding: 24px;
-    min-width: 320px;
-    max-width: 420px;
+    min-width: min(320px, calc(100vw - 32px));
+    max-width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+    overflow: auto;
   }
 
   .modal-dialog h3 {
@@ -2657,6 +2665,7 @@
   .modal-actions {
     display: flex;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
   }
 

--- a/desktop/Sidebar.svelte
+++ b/desktop/Sidebar.svelte
@@ -207,6 +207,30 @@
   let drag_data = $state<{ type: 'project' | 'result' | 'workflow'; id: string | number } | null>(null)
   let drop_target_id = $state<string | null>(null)
 
+  function clamp_context_position(x: number, y: number, width = 220, height = 280) {
+    if (typeof window === `undefined`) return { x, y }
+    const margin = 8
+    const max_x = Math.max(margin, window.innerWidth - width - margin)
+    const max_y = Math.max(margin, window.innerHeight - height - margin)
+    return {
+      x: Math.min(Math.max(x, margin), max_x),
+      y: Math.min(Math.max(y, margin), max_y),
+    }
+  }
+
+  function open_catgo_context_menu(e: MouseEvent, file: LocalFile) {
+    if (!on_open_editor) return
+    e.preventDefault()
+    e.stopPropagation()
+    catgo_ctx = { ...clamp_context_position(e.clientX, e.clientY, 180, 96), file }
+  }
+
+  function open_fs_context_menu(e: MouseEvent, item: FileBrowseItem) {
+    e.preventDefault()
+    e.stopPropagation()
+    fsb.fs_ctx = { ...clamp_context_position(e.clientX, e.clientY, 220, 260), item }
+  }
+
   // [2025-02] Database management state
   let current_db = $state<DbInfo | null>(null)
   const is_tauri = typeof window !== `undefined` && (`__TAURI__` in window || `__TAURI_INTERNALS__` in window)
@@ -559,13 +583,15 @@
 
   function handle_project_contextmenu(e: MouseEvent, project_id: string) {
     const target = make_project_target(project_id)
-    ctx_menu = open_context_menu(e, target)
+    const menu = open_context_menu(e, target)
+    ctx_menu = { ...menu, ...clamp_context_position(menu.x, menu.y, 240, 320) }
     ctx_target_snapshot = target
   }
 
   function handle_result_contextmenu(e: MouseEvent, result: DbResult, parent_id: string) {
     const target = make_result_target(result, parent_id)
-    ctx_menu = open_context_menu(e, target)
+    const menu = open_context_menu(e, target)
+    ctx_menu = { ...menu, ...clamp_context_position(menu.x, menu.y, 240, 360) }
     ctx_target_snapshot = target
   }
 
@@ -854,7 +880,7 @@
     ondragend={() => { drag_data = null; drop_target_id = null }}
     onclick={() => toggle_workflow(wf.id)}
     ondblclick={() => on_open_workflow?.(wf.id)}
-    oncontextmenu={(e) => { const target = make_workflow_target(wf); ctx_menu = open_context_menu(e, target); ctx_target_snapshot = target }}
+    oncontextmenu={(e) => { const target = make_workflow_target(wf); const menu = open_context_menu(e, target); ctx_menu = { ...menu, ...clamp_context_position(menu.x, menu.y, 240, 320) }; ctx_target_snapshot = target }}
   >
     <svg class="chevron small" class:open={db_expanded_workflows.has(wf.id)} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
       <path d="M9 18l6-6-6-6" />
@@ -1036,7 +1062,7 @@
         {#if sections_open.structures}
           <div class="section-files" transition:slide={{ duration: 150 }}>
             {#each structure_list as file}
-              <button class="file-item" onclick={() => handle_local_click(file)} oncontextmenu={(e) => { if (!on_open_editor) return; e.preventDefault(); e.stopPropagation(); catgo_ctx = { x: e.clientX, y: e.clientY, file } }} title={file.name}>
+              <button class="file-item" onclick={() => handle_local_click(file)} oncontextmenu={(e) => open_catgo_context_menu(e, file)} title={file.name}>
                 <svg class="file-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d={get_file_icon(file.name)} />
                 </svg>
@@ -1057,7 +1083,7 @@
         {#if sections_open.molecules}
           <div class="section-files" transition:slide={{ duration: 150 }}>
             {#each molecule_list as file}
-              <button class="file-item" onclick={() => handle_local_click(file)} oncontextmenu={(e) => { if (!on_open_editor) return; e.preventDefault(); e.stopPropagation(); catgo_ctx = { x: e.clientX, y: e.clientY, file } }} title={file.name}>
+              <button class="file-item" onclick={() => handle_local_click(file)} oncontextmenu={(e) => open_catgo_context_menu(e, file)} title={file.name}>
                 <svg class="file-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d={get_file_icon(file.name)} />
                 </svg>
@@ -1078,7 +1104,7 @@
         {#if sections_open.trajectories}
           <div class="section-files" transition:slide={{ duration: 150 }}>
             {#each trajectory_list as file}
-              <button class="file-item" onclick={() => handle_local_click(file)} oncontextmenu={(e) => { if (!on_open_editor) return; e.preventDefault(); e.stopPropagation(); catgo_ctx = { x: e.clientX, y: e.clientY, file } }} title={file.name}>
+              <button class="file-item" onclick={() => handle_local_click(file)} oncontextmenu={(e) => open_catgo_context_menu(e, file)} title={file.name}>
                 <svg class="file-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d={get_file_icon(file.name)} />
                 </svg>
@@ -1237,7 +1263,7 @@
                   <button
                     class="fs-file-item {fs_file_icon_class(item)}"
                     onclick={() => fsb.fs_handle_click(item)}
-                    oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); fsb.fs_ctx = { x: e.clientX, y: e.clientY, item } }}
+                    oncontextmenu={(e) => open_fs_context_menu(e, item)}
                     title={item.path}
                     draggable={item.type === `file`}
                     ondragstart={(e) => {
@@ -2547,18 +2573,21 @@
   .ctx-menu {
     position: fixed;
     z-index: 9999;
-    min-width: 140px;
+    min-width: min(140px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
     background: var(--page-bg, #1e293b);
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
     border-radius: 6px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
     padding: 4px;
-    overflow: hidden;
+    overflow: auto;
   }
 
   .ctx-item {
     display: block;
     width: 100%;
+    max-width: 100%;
     padding: 5px 10px;
     font-size: 11px;
     background: transparent;
@@ -2568,6 +2597,9 @@
     text-align: left;
     border-radius: 3px;
     transition: background 0.1s;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .ctx-item:hover {
@@ -2648,16 +2680,23 @@
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
     border-radius: 8px;
     padding: 4px 0;
-    min-width: 120px;
+    min-width: min(120px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
     z-index: 100000061;
+    overflow: auto;
   }
   .fs-ctx-item {
     display: block;
     width: 100%;
+    max-width: 100%;
     padding: 4px 12px;
     font-size: 12px;
     color: var(--text-color, #e5e7eb);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     background: none;
     border: none;
     cursor: pointer;
@@ -2742,13 +2781,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
+    overflow: auto;
   }
   .diagnostics-overlay-content {
     background: var(--bg-secondary, #1e1e2e);
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
     border-radius: 10px;
-    width: min(600px, 90vw);
-    max-height: 80vh;
+    width: min(600px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     overflow-y: auto;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
   }

--- a/desktop/TabBar.svelte
+++ b/desktop/TabBar.svelte
@@ -386,13 +386,16 @@
     top: 100%;
     right: 0;
     margin-top: 4px;
-    min-width: 160px;
+    min-width: min(160px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 48px);
     background: var(--dialog-bg, var(--surface-bg, #1c1c2e));
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
     border-radius: 8px;
     padding: 4px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
     z-index: 100000030;
+    overflow: auto;
   }
 
   .layout-menu-item {
@@ -408,6 +411,13 @@
     font-size: 12px;
     cursor: pointer;
     transition: background 0.15s, color 0.15s;
+    min-width: 0;
+  }
+
+  .layout-menu-item span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .layout-menu-item:hover {

--- a/desktop/WorkflowView.svelte
+++ b/desktop/WorkflowView.svelte
@@ -365,9 +365,9 @@
       chat_open={show_chat}
     />
   {:else if view === `v2_dag`}
-    <div style="display:flex; flex:1; overflow:hidden;">
-      <div style="flex:1; position:relative;">
-        <div style="position:absolute; top:8px; left:8px; z-index:10;">
+    <div class="v2-dag-layout">
+      <div class="v2-dag-main">
+        <div class="v2-dag-back">
           <button class="back-btn" onclick={() => { view = `list`; load_list() }}>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>
             {t('common.workflows')}
@@ -375,7 +375,7 @@
         </div>
         <WorkflowDAGViewer workflow_id={v2_workflow_id} onselect_task={(id) => { v2_selected_task = id }} />
       </div>
-      <div style="width:420px;border-left:1px solid var(--border-color,#333);background:var(--surface-bg,#111);flex-shrink:0;overflow:hidden;">
+      <div class="v2-task-panel">
         <EngineTaskEditor
           task_id={v2_selected_task}
           workflow_id={v2_workflow_id}
@@ -623,6 +623,46 @@
     z-index: 9999;
   }
 
+  .v2-dag-layout {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .v2-dag-main {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    position: relative;
+  }
+
+  .v2-dag-back {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 10;
+    max-width: calc(100% - 16px);
+  }
+
+  .v2-task-panel {
+    width: min(420px, 38vw);
+    min-width: 280px;
+    border-left: 1px solid var(--border-color, #333);
+    background: var(--surface-bg, #111);
+    flex-shrink: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .v2-task-panel > :global(*) {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+  }
+
   .workflow-dashboard {
     flex: 1;
     overflow-y: auto;
@@ -630,6 +670,21 @@
     max-width: 900px;
     margin: 0 auto;
     width: 100%;
+  }
+
+  @media (max-width: 900px) {
+    .v2-dag-layout {
+      flex-direction: column;
+    }
+
+    .v2-task-panel {
+      width: 100%;
+      min-width: 0;
+      min-height: 220px;
+      max-height: 42%;
+      border-left: none;
+      border-top: 1px solid var(--border-color, #333);
+    }
   }
 
   .dashboard-header {

--- a/desktop/components/CloseAllModal.svelte
+++ b/desktop/components/CloseAllModal.svelte
@@ -65,9 +65,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
     background: rgba(0, 0, 0, 0.5);
     z-index: 100000050;
     animation: fade-in 0.15s ease-out;
+    overflow: auto;
   }
 
   .modal-dialog {
@@ -75,13 +77,15 @@
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
     border-radius: 12px;
     padding: 24px;
-    min-width: 320px;
-    max-width: 420px;
+    min-width: min(320px, calc(100vw - 32px));
+    max-width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+    overflow: auto;
   }
 
   .close-all-dialog {
-    max-width: 480px;
+    max-width: min(480px, calc(100vw - 32px));
   }
 
   .modal-dialog h3 {
@@ -100,6 +104,7 @@
   .modal-actions {
     display: flex;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
   }
 
@@ -160,6 +165,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
     padding: 6px 8px;
     border-radius: 4px;
     cursor: pointer;
@@ -178,10 +184,16 @@
   .close-all-formula {
     font-weight: 600;
     color: var(--text-color, #e0e0e0);
-    min-width: 80px;
+    min-width: 0;
+    max-width: 110px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .close-all-target {
+    min-width: 0;
+    flex: 1;
     color: var(--text-color-muted, #9ca3af);
     font-size: 11px;
     overflow: hidden;

--- a/desktop/components/ExportSaveDialog.svelte
+++ b/desktop/components/ExportSaveDialog.svelte
@@ -150,9 +150,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
     background: rgba(0, 0, 0, 0.5);
     z-index: 100000050;
     animation: fade-in 0.15s ease-out;
+    overflow: auto;
   }
 
   .modal-dialog {
@@ -160,9 +162,11 @@
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
     border-radius: 12px;
     padding: 24px;
-    min-width: 320px;
-    max-width: 420px;
+    min-width: min(320px, calc(100vw - 32px));
+    max-width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+    overflow: auto;
   }
 
   .modal-dialog h3 {
@@ -181,6 +185,7 @@
   .modal-actions {
     display: flex;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
   }
 
@@ -232,6 +237,7 @@
     align-items: center;
     gap: 6px;
     width: 100%;
+    min-width: 0;
     padding: 6px 8px;
     font-size: 12px;
     background: transparent;
@@ -240,6 +246,9 @@
     cursor: pointer;
     text-align: left;
     transition: background 0.1s;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .save-tree-item:hover {
@@ -272,6 +281,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    min-width: 0;
     font-size: 12px;
     color: var(--text-color-muted, #6b7280);
   }
@@ -295,6 +305,8 @@
     border-radius: 4px;
     word-break: break-all;
     font-family: monospace;
+    max-height: 120px;
+    overflow: auto;
   }
 
   .export-fs-browser {
@@ -304,11 +316,13 @@
   .export-fs-pathbar {
     display: flex;
     gap: 4px;
+    min-width: 0;
     margin-bottom: 4px;
   }
 
   .export-fs-path-input {
     flex: 1;
+    min-width: 0;
     padding: 4px 8px;
     font-size: 12px;
     font-family: monospace;
@@ -358,6 +372,7 @@
     align-items: center;
     gap: 6px;
     width: 100%;
+    min-width: 0;
     padding: 5px 8px;
     font-size: 12px;
     background: transparent;
@@ -365,6 +380,9 @@
     color: var(--text-color, #e2e8f0);
     cursor: pointer;
     text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .export-fs-item:hover {
@@ -385,6 +403,7 @@
   }
 
   .export-input, .export-select {
+    min-width: 0;
     padding: 6px 8px;
     font-size: 13px;
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));

--- a/desktop/components/FilePickerModal.svelte
+++ b/desktop/components/FilePickerModal.svelte
@@ -118,15 +118,17 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
     z-index: 1000;
+    overflow: auto;
   }
 
   .fp-dialog {
     background: var(--page-bg, #1a1f2e);
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
     border-radius: 8px;
-    width: 480px;
-    max-height: 70vh;
+    width: min(480px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
@@ -215,6 +217,7 @@
     align-items: center;
     gap: 8px;
     width: 100%;
+    min-width: 0;
     padding: 5px 14px;
     font-size: 12px;
     background: transparent;
@@ -222,6 +225,13 @@
     color: var(--text-color, #e2e8f0);
     cursor: pointer;
     text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .fp-item svg {
+    flex-shrink: 0;
   }
 
   .fp-item:hover { background: rgba(128, 128, 128, 0.1); }
@@ -245,6 +255,7 @@
 
   .fp-filename-input {
     flex: 1;
+    min-width: 0;
     padding: 4px 8px;
     font-size: 12px;
     background: var(--btn-bg, rgba(128, 128, 128, 0.1));
@@ -261,6 +272,7 @@
   .fp-actions {
     display: flex;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
     padding: 10px 14px;
     border-top: 1px solid var(--border-color, rgba(128, 128, 128, 0.15));

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -176,6 +176,24 @@
     on_drag_start()
   }
 
+  // Containment bounds: normally the viewport, but when the toggle lives
+  // inside a modal dialog the pane must stay within IT — fixed positioning
+  // otherwise reasons in viewport coords and happily parks the pane outside
+  // the dialog, over unrelated UI (e.g. the structure controls escaping
+  // StructureEditModal onto the workflow side panels). `min_width` guards
+  // against modals too small to host the pane at all (fall back to viewport).
+  function containment_bounds(min_width: number): { left: number; top: number; right: number; bottom: number } {
+    const anchor = toggle_pane_btn ?? pane_div
+    const modal_el = anchor?.closest(
+      `dialog, [role="dialog"], .struct-edit3d-modal`,
+    ) as HTMLElement | null
+    const rect = modal_el?.getBoundingClientRect()
+    if (rect && rect.width > min_width && rect.height > 200) {
+      return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }
+    }
+    return { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight }
+  }
+
   // Position calculation — returns viewport-relative coordinates. Panes are
   // portaled to <body>, so fixed positioning is the safest way to avoid
   // clipping/overflow from toolbar wrappers, transformed parents, or split panes.
@@ -215,18 +233,7 @@
     const pane_width = Math.min((pane_rect && pane_rect.width >= 100) ? pane_rect.width : 450, safe_w)
     const pane_height = Math.min((pane_rect && pane_rect.height >= 50) ? pane_rect.height : 400, safe_h)
 
-    // Containment bounds: normally the viewport, but when the toggle lives
-    // inside a modal dialog the pane must stay within IT — fixed positioning
-    // otherwise reasons in viewport coords and happily parks the pane outside
-    // the dialog, over unrelated UI (e.g. the structure controls escaping
-    // StructureEditModal onto the workflow side panels).
-    const modal_el = toggle_pane_btn.closest(
-      `dialog, [role="dialog"], .struct-edit3d-modal`,
-    ) as HTMLElement | null
-    const modal_rect = modal_el?.getBoundingClientRect()
-    const bounds = (modal_rect && modal_rect.width > pane_width + margin && modal_rect.height > 200)
-      ? { left: modal_rect.left, top: modal_rect.top, right: modal_rect.right, bottom: modal_rect.bottom }
-      : { left: 0, top: 0, right: vw, bottom: vh }
+    const bounds = containment_bounds(pane_width + margin)
 
     const right_open = toggle_rect.right + (offset.x ?? 5)
     const left_open = toggle_rect.left - pane_width - (offset.x ?? 5)
@@ -315,23 +322,25 @@
     }
   })
 
-  // Clamp pane geometry so it remains inside the visible viewport.
+  // Clamp pane geometry so it remains inside the visible bounds (viewport,
+  // or the enclosing modal — see containment_bounds).
   // Re-runs on show, resize, and content changes via ResizeObserver.
   function clamp_to_viewport() {
     if (!pane_div || !show) return
     const rect = pane_div.getBoundingClientRect()
     const margin = 16
-    const max_left = Math.max(margin, window.innerWidth - rect.width - margin)
-    const max_top = Math.max(margin, window.innerHeight - Math.min(rect.height, window.innerHeight - margin * 2) - margin)
-    const next_left = Math.max(margin, Math.min(rect.left, max_left))
-    const next_top = Math.max(margin, Math.min(rect.top, max_top))
-    const available = window.innerHeight - next_top - margin
+    const b = containment_bounds(rect.width + margin)
+    const max_left = Math.max(b.left + margin, b.right - rect.width - margin)
+    const max_top = Math.max(b.top + margin, b.bottom - Math.min(rect.height, b.bottom - b.top - margin * 2) - margin)
+    const next_left = Math.max(b.left + margin, Math.min(rect.left, max_left))
+    const next_top = Math.max(b.top + margin, Math.min(rect.top, max_top))
+    const available = b.bottom - next_top - margin
     const clamped = available > 100
       ? (max_height ? `min(${max_height}, ${available}px)` : `${available}px`)
       : initial_position.maxHeight
 
-    const is_outside_viewport = rect.left < margin || rect.top < margin ||
-      rect.right > window.innerWidth - margin || rect.bottom > window.innerHeight - margin
+    const is_outside_viewport = rect.left < b.left + margin || rect.top < b.top + margin ||
+      rect.right > b.right - margin || rect.bottom > b.bottom - margin
     if ((is_outside_viewport || !has_been_dragged) && (
       Math.abs(next_left - rect.left) > 1 ||
       Math.abs(next_top - rect.top) > 1 ||

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -33,21 +33,6 @@
         const initial_top = node.offsetTop
         let dragging = false
 
-        // Walk up to find a reasonably-sized container for clamping bounds.
-        // node.offsetParent can be a tiny <SECTION> (30px) which makes dragging impossible.
-        // Use the closest ancestor with substantial height, or fall back to viewport.
-        function find_clamp_bounds(): { w: number; h: number } {
-          let el = node.parentElement
-          while (el) {
-            if (el.clientHeight >= 200 && el.clientWidth >= 200) {
-              return { w: el.clientWidth, h: el.clientHeight }
-            }
-            el = el.parentElement
-          }
-          return { w: window.innerWidth, h: window.innerHeight }
-        }
-        const bounds = find_clamp_bounds()
-
         function on_mousemove(e: MouseEvent) {
           const dx = e.clientX - start_x
           const dy = e.clientY - start_y
@@ -58,9 +43,10 @@
             node.style.userSelect = `none`
             document.body.style.cursor = `grabbing`
           }
-          const min_visible = 60
-          const new_left = Math.max(-node.offsetWidth + min_visible, Math.min(initial_left + dx, bounds.w - min_visible))
-          const new_top = Math.max(0, Math.min(initial_top + dy, bounds.h - min_visible))
+          const margin = 16
+          const min_visible = Math.min(80, Math.max(40, node.offsetWidth / 4))
+          const new_left = Math.max(margin - node.offsetWidth + min_visible, Math.min(initial_left + dx, window.innerWidth - min_visible))
+          const new_top = Math.max(margin, Math.min(initial_top + dy, window.innerHeight - min_visible))
           node.style.left = `${new_left}px`
           node.style.top = `${new_top}px`
           node.style.right = `auto`
@@ -139,6 +125,12 @@
   let initial_position = $state({ left: `50px`, top: `50px`, maxHeight: `` })
   let show_control_buttons = $state(false)
 
+  function viewport_max_width() {
+    if (typeof window === `undefined`) return max_width
+    if (!max_width || max_width === `none`) return `calc(100vw - 32px)`
+    return `min(${max_width}, calc(100vw - 32px))`
+  }
+
   function toggle_pane() {
     show = !show
     if (!show) {
@@ -184,135 +176,86 @@
     on_drag_start()
   }
 
-  // Position calculation — returns { left, top, maxHeight } relative to positioned ancestor.
-  // Clamps vertically so the pane never extends below the ancestor container.
-  // Combines caller's max_height constraint with available-space clamping via CSS min().
+  // Position calculation — returns viewport-relative coordinates. Panes are
+  // portaled to <body>, so fixed positioning is the safest way to avoid
+  // clipping/overflow from toolbar wrappers, transformed parents, or split panes.
   function calculate_position() {
-    const margin = 20
+    const margin = 16
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    const safe_w = Math.max(220, vw - margin * 2)
+    const safe_h = Math.max(160, vh - margin * 2)
 
     if (!toggle_pane_btn) {
       console.debug(`[DraggablePane] no toggle_pane_btn, using fallback position`)
-      return { left: `50px`, top: `50px`, maxHeight: max_height || `` }
+      return {
+        left: `${Math.max(margin, Math.round((vw - Math.min(450, safe_w)) / 2))}px`,
+        top: `${Math.max(margin, Math.round((vh - Math.min(400, safe_h)) / 2))}px`,
+        maxHeight: max_height ? `min(${max_height}, ${safe_h}px)` : `${safe_h}px`,
+      }
     }
 
     const toggle_rect = toggle_pane_btn.getBoundingClientRect()
     if (toggle_rect.width === 0 && toggle_rect.height === 0) {
       console.debug(`[DraggablePane] toggle button is hidden (0x0), deferring`)
-      return { left: `50px`, top: `50px`, maxHeight: max_height || `` }
+      return {
+        left: `${Math.max(margin, Math.round((vw - Math.min(450, safe_w)) / 2))}px`,
+        top: `${Math.max(margin, Math.round((vh - Math.min(400, safe_h)) / 2))}px`,
+        maxHeight: max_height ? `min(${max_height}, ${safe_h}px)` : `${safe_h}px`,
+      }
     }
 
     const pane_rect = pane_div?.getBoundingClientRect()
     // `||` would only catch width === 0; getBoundingClientRect can return a
     // tiny non-zero width during the same tick that show=true (race with
     // content layout). Treat anything below 100px as an unreliable
-    // measurement and use the conservative fallback instead, so calc_left
+    // measurement and use the conservative fallback instead, so the left
     // doesn't pick a right-anchored position the actual (wider) pane will
     // overflow when it finishes laying out.
-    const pane_width = (pane_rect && pane_rect.width >= 100) ? pane_rect.width : 450
-    const pane_height = (pane_rect && pane_rect.height >= 50) ? pane_rect.height : 400
-    const positioned_ancestor = toggle_pane_btn.offsetParent as HTMLElement
-    const ancestor_rect = positioned_ancestor?.getBoundingClientRect()
+    const pane_width = Math.min((pane_rect && pane_rect.width >= 100) ? pane_rect.width : 450, safe_w)
+    const pane_height = Math.min((pane_rect && pane_rect.height >= 50) ? pane_rect.height : 400, safe_h)
 
     // Containment bounds: normally the viewport, but when the toggle lives
-    // inside a modal dialog the pane must stay within IT — the fixed-position
-    // fallback below otherwise reasons in viewport coords and happily parks
-    // the pane outside the dialog, over unrelated UI (e.g. the structure
-    // controls escaping StructureEditModal onto the workflow side panels).
+    // inside a modal dialog the pane must stay within IT — fixed positioning
+    // otherwise reasons in viewport coords and happily parks the pane outside
+    // the dialog, over unrelated UI (e.g. the structure controls escaping
+    // StructureEditModal onto the workflow side panels).
     const modal_el = toggle_pane_btn.closest(
       `dialog, [role="dialog"], .struct-edit3d-modal`,
     ) as HTMLElement | null
     const modal_rect = modal_el?.getBoundingClientRect()
     const bounds = (modal_rect && modal_rect.width > pane_width + margin && modal_rect.height > 200)
       ? { left: modal_rect.left, top: modal_rect.top, right: modal_rect.right, bottom: modal_rect.bottom }
-      : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight }
+      : { left: 0, top: 0, right: vw, bottom: vh }
 
-    // Decide pane left position. Reasons in VIEWPORT coords because the
-    // positioned ancestor (toggle_pane_btn.offsetParent) is only a
-    // coordinate origin, not a fits-here constraint. When offsetParent
-    // resolves to a small wrapper (e.g., a button-sized flex item near
-    // the viewport's right edge — exactly what the trajectory info
-    // toggle hits) using ancestor.width as the constraint makes both
-    // right_open and left_open fail in the old algorithm; it then clamps
-    // to ancestor-left = 0, and the pane lands AT the ancestor's left
-    // edge — sitting near the viewport's right side, with the pane
-    // overflowing past it. Viewport bounds are what users actually see.
-    //
-    // container_w is kept in the signature for callers but unused; if a
-    // smaller logical containment is ever needed, gate behind a prop.
-    function calc_left(btn_right: number, btn_left: number, origin_left: number, _container_w: number): number {
-      const right_open_vp = btn_right + (offset.x ?? 5)
-      const left_open_vp = btn_left - pane_width - (offset.x ?? 5)
-      // Prefer right of the button if the pane fits within the containment
-      // bounds (viewport, or the enclosing modal); otherwise flip left.
-      const target_vp = right_open_vp + pane_width <= bounds.right - margin
-        ? right_open_vp
-        : left_open_vp
-      // Clamp: pane's right edge ≤ bounds.right − margin,
-      // pane's left edge ≥ bounds.left + margin.
-      const clamped_vp = Math.max(bounds.left + margin, Math.min(target_vp, bounds.right - pane_width - margin))
-      // Convert back to ancestor-relative for the inline `left:` style.
-      // May be negative when the ancestor sits near the viewport's right
-      // edge — that's correct; the pane extends leftward past the ancestor.
-      return clamped_vp - origin_left
-    }
+    const right_open = toggle_rect.right + (offset.x ?? 5)
+    const left_open = toggle_rect.left - pane_width - (offset.x ?? 5)
+    // Prefer right of the button if the pane fits within the containment
+    // bounds (viewport, or the enclosing modal); otherwise flip left.
+    let left_val = right_open + pane_width <= bounds.right - margin ? right_open : left_open
+    left_val = Math.max(bounds.left + margin, Math.min(left_val, bounds.right - pane_width - margin))
 
-    // Also fall back to viewport when the ancestor is too small to contain the pane.
-    // Trajectory/split-pane layouts can resolve `offsetParent` to a small toolbar SECTION
-    // whose height is much less than the pane needs, which collapses available_h to 0.
-    if (!ancestor_rect || ancestor_rect.height === 0 || ancestor_rect.height < pane_height + margin * 2) {
-      const vw = bounds.right
-      const vh = bounds.bottom
-      let top_px = toggle_rect.bottom + (offset.y ?? 5)
-      // When the pane is too tall to fit at its natural anchored position, prefer
-      // shrinking its `maxHeight` (the pane scrolls internally) over yanking it up
-      // to the viewport edge, which would land it on top of OS title bars or
-      // Tauri drag regions and prevent the user from grabbing the pane's drag
-      // handle. Only pull `top_px` up when there isn't enough room below for a
-      // minimally usable pane (200px), and never above a safe minimum (50px).
-      const TOP_MIN = 50 // safety from OS chrome / Tauri drag regions
-      const MIN_PANE_HEIGHT = 200
-      if (top_px + MIN_PANE_HEIGHT > vh - margin) {
-        top_px = Math.max(TOP_MIN, vh - MIN_PANE_HEIGHT - margin)
-      }
-      const left_px = calc_left(toggle_rect.right, toggle_rect.left, 0, vw)
-      // Clamp max-height so the pane never extends below the viewport
-      const available_h = `${vh - top_px - margin}px`
-      const effective_max_h = max_height ? `min(${max_height}, ${available_h})` : available_h
-      const result = { left: `${left_px}px`, top: `${top_px}px`, maxHeight: effective_max_h }
-      // Switch to fixed positioning so coords are viewport-relative AND we escape
-      // any `overflow: hidden` on the small ancestor that would otherwise clip the pane.
-      // Raise z-index above modal overlays (e.g. .struct-preview-overlay is 9999):
-      // the pane's default z (10) paints UNDER the dialog, leaving it visible but
-      // unclickable — "the pane is below the structure window".
-      if (pane_div) {
-        pane_div.style.position = `fixed`
-        pane_div.style.zIndex = `10000`
-      }
-      console.debug(`[DraggablePane] viewport fallback:`, { toggle_rect: { bottom: toggle_rect.bottom, right: toggle_rect.right }, vh, pane_height, result })
-      return result
+    let top_val = toggle_rect.bottom + (offset.y ?? 5)
+    if (top_val + pane_height > bounds.bottom - margin) {
+      const above = toggle_rect.top - pane_height - (offset.y ?? 5)
+      top_val = above >= bounds.top + margin
+        ? above
+        : Math.max(bounds.top + margin, Math.round((bounds.top + bounds.bottom - pane_height) / 2))
     }
-    // Restore default positioning (CSS rule sets position: absolute) when the ancestor is adequate.
-    if (pane_div && pane_div.style.position === `fixed`) {
-      pane_div.style.position = ``
-      pane_div.style.zIndex = ``
-    }
+    top_val = Math.max(bounds.top + margin, Math.min(top_val, bounds.bottom - pane_height - margin))
 
-    const ancestor_h = ancestor_rect.height
-    let top_val = toggle_rect.bottom - ancestor_rect.top + (offset.y ?? 5)
-    if (top_val + pane_height > ancestor_h - margin) {
-      top_val = Math.max(margin, ancestor_h - pane_height - margin)
-    }
-    const left_val = calc_left(toggle_rect.right, toggle_rect.left, ancestor_rect.left, ancestor_rect.width)
-    // Clamp max-height so the pane never extends below the ancestor container
-    const available_h = `${ancestor_h - top_val - margin}px`
+    const available_h = `${Math.max(120, bounds.bottom - top_val - margin)}px`
     const effective_max_h = max_height ? `min(${max_height}, ${available_h})` : available_h
     const result = { left: `${left_val}px`, top: `${top_val}px`, maxHeight: effective_max_h }
-    console.debug(`[DraggablePane] positioned:`, {
-      toggle: { bottom: toggle_rect.bottom, right: toggle_rect.right },
-      ancestor: { top: ancestor_rect.top, height: ancestor_h, tag: positioned_ancestor?.tagName },
-      pane: { width: pane_width, height: pane_height },
-      result,
-    })
+    // Fixed positioning escapes overflow clipping; the z-index raise keeps the
+    // pane above modal overlays (e.g. .struct-preview-overlay is z 9999 —
+    // the pane's default z of 10 would paint under the dialog, leaving it
+    // visible but unclickable).
+    if (pane_div) {
+      pane_div.style.position = `fixed`
+      pane_div.style.zIndex = `10000`
+    }
+    console.debug(`[DraggablePane] positioned:`, { toggle: { bottom: toggle_rect.bottom, right: toggle_rect.right }, pane: { width: pane_width, height: pane_height }, bounds, result })
     return result
   }
 
@@ -332,18 +275,23 @@
   // Debounced resize handler for better performance
   let resize_timeout: ReturnType<typeof setTimeout> | undefined = $state(undefined)
 
-  function handle_resize() { // Only reposition if pane is visible and hasn't been manually dragged
-    if (!show || has_been_dragged || currently_dragging) return
+  function handle_resize() {
+    if (!show || currently_dragging) return
 
     if (resize_timeout) clearTimeout(resize_timeout)
     const current_timeout = setTimeout(() => {
       if (resize_timeout !== current_timeout) return
-      if (show && toggle_pane_btn && !has_been_dragged && pane_div) {
-        const pos = calculate_position()
-        initial_position = pos
-        pane_div.style.left = pos.left
-        pane_div.style.top = pos.top
-        if (pos.maxHeight) pane_div.style.maxHeight = pos.maxHeight
+      if (show && pane_div) {
+        if (toggle_pane_btn && !has_been_dragged) {
+          const pos = calculate_position()
+          initial_position = pos
+          pane_div.style.left = pos.left
+          pane_div.style.top = pos.top
+          if (pos.maxHeight) pane_div.style.maxHeight = pos.maxHeight
+        } else {
+          // Even manually moved panes must remain reachable after viewport changes.
+          clamp_to_viewport()
+        }
       }
     }, 50) // Debounce resize events
     resize_timeout = current_timeout
@@ -362,31 +310,41 @@
         pane_div.style.width = ``
         pane_div.style.height = ``
         pane_div.style.maxHeight = pos.maxHeight || ``
-        pane_div.style.maxWidth = ``
+        pane_div.style.maxWidth = viewport_max_width()
       }
     }
   })
 
-  // Clamp pane max-height so it never extends below its containing boundary.
-  // Uses the closest overflow-clipping ancestor (modal, .structure, etc.) or viewport.
+  // Clamp pane geometry so it remains inside the visible viewport.
   // Re-runs on show, resize, and content changes via ResizeObserver.
-  function clamp_max_height() {
+  function clamp_to_viewport() {
     if (!pane_div || !show) return
     const rect = pane_div.getBoundingClientRect()
-    // Walk up to find the nearest overflow-clipping ancestor
-    let bottom = window.innerHeight
-    let el: HTMLElement | null = pane_div.offsetParent as HTMLElement | null
-    while (el) {
-      const style = getComputedStyle(el)
-      if (style.overflowY === `hidden` || style.overflowY === `clip`) {
-        bottom = el.getBoundingClientRect().bottom
-        break
+    const margin = 16
+    const max_left = Math.max(margin, window.innerWidth - rect.width - margin)
+    const max_top = Math.max(margin, window.innerHeight - Math.min(rect.height, window.innerHeight - margin * 2) - margin)
+    const next_left = Math.max(margin, Math.min(rect.left, max_left))
+    const next_top = Math.max(margin, Math.min(rect.top, max_top))
+    const available = window.innerHeight - next_top - margin
+    const clamped = available > 100
+      ? (max_height ? `min(${max_height}, ${available}px)` : `${available}px`)
+      : initial_position.maxHeight
+
+    const is_outside_viewport = rect.left < margin || rect.top < margin ||
+      rect.right > window.innerWidth - margin || rect.bottom > window.innerHeight - margin
+    if ((is_outside_viewport || !has_been_dragged) && (
+      Math.abs(next_left - rect.left) > 1 ||
+      Math.abs(next_top - rect.top) > 1 ||
+      initial_position.maxHeight !== clamped
+    )) {
+      initial_position = {
+        left: `${next_left}px`,
+        top: `${next_top}px`,
+        maxHeight: clamped,
       }
-      el = el.offsetParent as HTMLElement | null
     }
-    const available = bottom - rect.top - 20
+
     if (available > 100) {
-      const clamped = max_height ? `min(${max_height}, ${available}px)` : `${available}px`
       if (initial_position.maxHeight !== clamped) {
         initial_position = { ...initial_position, maxHeight: clamped }
       }
@@ -396,8 +354,8 @@
   $effect(() => {
     if (!show || !pane_div) return
     // Clamp on show and whenever the pane or its container resizes
-    requestAnimationFrame(clamp_max_height)
-    const ro = new ResizeObserver(() => clamp_max_height())
+    requestAnimationFrame(clamp_to_viewport)
+    const ro = new ResizeObserver(() => clamp_to_viewport())
     ro.observe(pane_div)
     // Also observe the offsetParent (container) for modal resize
     if (pane_div.offsetParent instanceof HTMLElement) {
@@ -586,7 +544,7 @@
     role="dialog"
     aria-label="Draggable pane"
     aria-modal="false"
-    style:max-width={max_width}
+    style:max-width={viewport_max_width()}
     style:max-height={initial_position.maxHeight || null}
     style:top={initial_position.top}
     style:left={initial_position.left}
@@ -702,7 +660,7 @@
     background-color: color-mix(in srgb, var(--accent-color, #007acc) 15%, transparent);
   }
   div.draggable-pane {
-    position: absolute; /* Use absolute so pane scrolls with page content */
+    position: fixed;
     background: var(--pane-bg, var(--page-bg, light-dark(white, black)));
     border: var(--pane-border, 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)));
     border-radius: var(--pane-border-radius, 10px);
@@ -719,7 +677,7 @@
     width: 28em;
     min-width: 200px;
     min-height: 120px;
-    max-width: var(--pane-max-width, 80cqw);
+    max-width: min(var(--pane-max-width, 80cqw), calc(100vw - 32px));
     resize: both;
     overflow-x: var(--pane-overflow-x, hidden);
     overflow-y: var(--pane-overflow-y, auto);

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -357,6 +357,8 @@
     left: 0;
     margin: var(--nav-dropdown-margin, 3pt 0 0 0);
     min-width: max-content;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 96px);
     background-color: var(--nav-dropdown-bg, var(--surface-bg, var(--bg-color, #ffffff)));
     border: 1px solid
       var(--nav-dropdown-border-color, var(--border-color, rgba(128, 128, 128, 0.25)));
@@ -367,6 +369,8 @@
     flex-direction: column;
     gap: var(--nav-dropdown-gap, 5pt);
     z-index: var(--nav-dropdown-z-index, 100);
+    overflow: auto;
+    box-sizing: border-box;
   }
   .dropdown-menu.visible {
     display: flex;
@@ -377,6 +381,8 @@
     text-decoration: none;
     color: inherit;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     transition: background-color 0.2s;
   }
   .dropdown-menu a:hover {
@@ -467,6 +473,8 @@
     }
     .dropdown-menu {
       position: static;
+      max-width: 100%;
+      max-height: none;
       border: none;
       box-shadow: none;
       margin-top: 0.25em;

--- a/src/lib/dialog-shared.css
+++ b/src/lib/dialog-shared.css
@@ -9,7 +9,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 16px;
+  overflow: auto;
   backdrop-filter: blur(4px);
+  box-sizing: border-box;
 }
 
 .dialog-modal {
@@ -20,10 +23,12 @@
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
   font-family: 'SF Mono', 'Cascadia Code', 'JetBrains Mono', 'Fira Code', monospace;
   font-size: 13px;
-  max-height: 90vh;
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 32px);
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
 }
 
 /* Modal header/title */
@@ -31,8 +36,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
+  min-width: 0;
   padding: 16px 20px;
   border-bottom: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
+  flex-shrink: 0;
 }
 
 .dialog-modal .modal-title {
@@ -40,6 +48,10 @@
   font-weight: 600;
   color: var(--text-color, light-dark(#1f2937, #eee));
   margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Close button */
@@ -53,6 +65,7 @@
   border-radius: 4px;
   transition: all 0.15s;
   line-height: 1;
+  flex-shrink: 0;
 }
 
 .dialog-modal .close-btn:hover {
@@ -66,6 +79,10 @@
   border-bottom: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
   padding: 0 16px;
   gap: 4px;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex-shrink: 0;
 }
 
 .dialog-modal .tab-bar button,
@@ -79,6 +96,8 @@
   font-size: 12px;
   padding: 8px 12px;
   transition: all 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .dialog-modal .tab-bar button:hover,
@@ -117,6 +136,7 @@
   padding: 8px 10px;
   transition: border-color 0.15s, box-shadow 0.15s;
   width: 100%;
+  min-width: 0;
   box-sizing: border-box;
   font-family: inherit;
 }
@@ -246,6 +266,18 @@
   overflow-y: auto;
   flex: 1;
   min-height: 0;
+  min-width: 0;
+}
+
+.dialog-modal .modal-footer,
+.dialog-modal .dialog-footer,
+.dialog-modal .footer,
+.dialog-modal .actions,
+.dialog-modal .button-row,
+.dialog-modal .btn-row {
+  flex-wrap: wrap;
+  min-width: 0;
+  flex-shrink: 0;
 }
 
 /* List items / rows */

--- a/src/lib/electronic/DosAnalysisPane.svelte
+++ b/src/lib/electronic/DosAnalysisPane.svelte
@@ -972,25 +972,39 @@
     position: fixed; inset: 0; z-index: 1000;
     background: rgba(0, 0, 0, 0.5); backdrop-filter: blur(2px);
     display: flex; align-items: center; justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .procar-modal {
     background: light-dark(#fff, #1e1e2e); border-radius: 10px;
-    width: min(420px, 90vw); box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    box-sizing: border-box;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
     border: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
   }
   .procar-header {
     display: flex; align-items: center; justify-content: space-between;
+    gap: 8px;
     padding: 10px 14px; border-bottom: 1px solid light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.08));
+    min-width: 0;
+    flex-shrink: 0;
   }
-  .procar-header h3 { margin: 0; font-size: 0.95em; color: var(--text-color, #fff); }
-  .close-btn { background: none; border: none; color: var(--text-color-muted, rgba(255, 255, 255, 0.5)); font-size: 1.3em; cursor: pointer; padding: 0 4px; }
+  .procar-header h3 { margin: 0; font-size: 0.95em; color: var(--text-color, #fff); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .close-btn { background: none; border: none; color: var(--text-color-muted, rgba(255, 255, 255, 0.5)); font-size: 1.3em; cursor: pointer; padding: 0 4px; flex-shrink: 0; }
   .close-btn:hover { color: var(--text-color, #fff); }
-  .procar-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; }
+  .procar-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; overflow-y: auto; min-height: 0; min-width: 0; }
   .file-slot {
     padding: 8px 10px; border-radius: 6px;
     background: light-dark(rgba(0, 0, 0, 0.03), rgba(255, 255, 255, 0.04));
     border: 1px dashed light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15));
     display: flex; flex-direction: column; gap: 4px;
+    min-width: 0;
   }
   .file-slot.done {
     border-style: solid;
@@ -998,7 +1012,7 @@
     background: light-dark(rgba(34, 197, 94, 0.05), rgba(34, 197, 94, 0.06));
   }
   .slot-label { font-size: 0.8em; font-weight: 600; color: var(--text-color-muted, rgba(255, 255, 255, 0.6)); }
-  .slot-file { font-size: 0.85em; color: var(--text-color, #fff); display: flex; align-items: center; gap: 6px; }
+  .slot-file { font-size: 0.85em; color: var(--text-color, #fff); display: flex; align-items: center; gap: 6px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .slot-browse {
     font-size: 0.82em; color: var(--accent-color, #007acc); cursor: pointer;
     text-decoration: underline; text-underline-offset: 2px;
@@ -1010,6 +1024,8 @@
   .procar-footer {
     display: flex; justify-content: flex-end; gap: 8px;
     padding: 10px 14px; border-top: 1px solid light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.08));
+    flex-wrap: wrap;
+    flex-shrink: 0;
   }
   .btn-cancel {
     padding: 5px 12px; border-radius: 4px; cursor: pointer; font-size: 0.85em;

--- a/src/lib/electronic/FileSourceDialog.svelte
+++ b/src/lib/electronic/FileSourceDialog.svelte
@@ -580,9 +580,10 @@
   /* .backdrop - layout handled by dialog-shared.css via .dialog-backdrop */
 
   .modal {
-    max-width: 520px;
-    width: 95%;
-    max-height: 85vh;
+    width: min(520px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
+    min-width: 0;
   }
 
   .modal-header {
@@ -608,6 +609,7 @@
     font-size: 12px;
     color: var(--text-color-muted, light-dark(#6b7280, #9ca3af));
     line-height: 1.5;
+    overflow-wrap: anywhere;
   }
 
   /* ─── Tab bar ─── */
@@ -627,6 +629,7 @@
   /* ─── Modal body ─── */
   .modal-body {
     padding: 16px 20px 20px;
+    min-width: 0;
   }
 
   /* ─── Drop zone (Tab 1) ─── */

--- a/src/lib/gesture/GestureSettingsPane.svelte
+++ b/src/lib/gesture/GestureSettingsPane.svelte
@@ -306,12 +306,13 @@
 
 <style>
   .gesture-settings {
-    position: absolute;
-    top: 40px;
-    right: 8px;
+    position: fixed;
+    top: max(40px, env(safe-area-inset-top, 0px) + 12px);
+    right: max(8px, env(safe-area-inset-right, 0px) + 12px);
     z-index: 100000;
     width: 300px;
-    max-height: calc(100% - 56px);
+    max-width: calc(100vw - 24px);
+    max-height: calc(100vh - 56px);
     overflow-y: auto;
     border: 1px solid rgba(0, 255, 247, 0.2);
     border-radius: 8px;

--- a/src/lib/plugins/components/PermissionDialog.svelte
+++ b/src/lib/plugins/components/PermissionDialog.svelte
@@ -106,15 +106,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
     z-index: 1000;
+    overflow: auto;
   }
 
   .dialog {
     background: var(--bg-color, #fff);
     border-radius: 8px;
-    max-width: 450px;
-    width: 90%;
+    width: min(450px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    overflow: auto;
   }
 
   header {

--- a/src/lib/structure/FileTree.svelte
+++ b/src/lib/structure/FileTree.svelte
@@ -75,10 +75,21 @@
   function open_ctx_menu(e: MouseEvent, node: TreeNode) {
     e.preventDefault()
     e.stopPropagation()
-    ctx_menu = { x: e.clientX, y: e.clientY, node }
+    ctx_menu = { ...clamp_menu_position(e.clientX, e.clientY, 240, 320), node }
   }
 
   function close_ctx_menu() { ctx_menu = null }
+
+  function clamp_menu_position(x: number, y: number, width = 220, height = 280) {
+    if (typeof window === `undefined`) return { x, y }
+    const margin = 8
+    const max_x = Math.max(margin, window.innerWidth - width - margin)
+    const max_y = Math.max(margin, window.innerHeight - height - margin)
+    return {
+      x: Math.min(Math.max(x, margin), max_x),
+      y: Math.min(Math.max(y, margin), max_y),
+    }
+  }
 
   async function do_new_folder(parent_path: string) {
     if (!on_mkdir || !new_folder_name.trim()) return
@@ -1401,6 +1412,7 @@
   /* Context menu */
   .ft-ctx-overlay {
     position: fixed; inset: 0; z-index: 100000060;
+    overflow: auto;
   }
   .ft-ctx-menu {
     position: fixed;
@@ -1408,13 +1420,17 @@
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
     border-radius: 8px;
     padding: 4px 0;
-    min-width: 140px;
+    min-width: min(140px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
     z-index: 100000061;
+    overflow: auto;
   }
   .ft-ctx-item {
     display: block;
     width: 100%;
+    max-width: 100%;
     padding: 5px 12px;
     font-size: 12px;
     color: var(--text-color, #e5e7eb);
@@ -1422,6 +1438,9 @@
     border: none;
     cursor: pointer;
     text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .ft-ctx-item:hover {
     background: rgba(99, 102, 241, 0.15);
@@ -1448,9 +1467,12 @@
     border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
     border-radius: 10px;
     padding: 16px 20px;
-    min-width: 280px;
+    min-width: min(280px, calc(100vw - 32px));
+    max-width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
     z-index: 100000062;
+    overflow: auto;
   }
   .ft-delete-dialog p {
     margin: 0 0 8px;
@@ -1466,6 +1488,7 @@
   .ft-delete-actions {
     display: flex;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
     margin-top: 12px;
   }

--- a/src/lib/structure/HpcUploadDialog.svelte
+++ b/src/lib/structure/HpcUploadDialog.svelte
@@ -248,39 +248,66 @@
     position: fixed; inset: 0; z-index: 2000;
     background: rgba(0, 0, 0, 0.45);
     display: flex; align-items: center; justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .hpc-upload-dialog {
-    width: 460px; max-width: 92vw; max-height: 86vh; overflow: auto;
+    width: min(460px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
+    overflow: auto;
     background: var(--surface-bg, #1e1e1e); color: var(--text-color, #ddd);
     border: 1px solid var(--border-color, #444); border-radius: 8px;
     padding: 14px 16px; box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
     display: flex; flex-direction: column; gap: 10px;
+    min-width: 0;
+    box-sizing: border-box;
   }
-  header { display: flex; align-items: center; justify-content: space-between; }
-  header h3 { margin: 0; font-size: 1.05em; }
-  .close-x { background: none; border: none; color: inherit; cursor: pointer; font-size: 1.1em; }
+  header { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
+  header h3 { margin: 0; font-size: 1.05em; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .close-x { background: none; border: none; color: inherit; cursor: pointer; font-size: 1.1em; flex-shrink: 0; }
   .hint, .muted { color: var(--text-color-dim, #888); }
-  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
   .field > span { font-size: 0.85em; color: var(--text-color-dim, #999); }
-  .field.row { flex-direction: row; gap: 10px; align-items: flex-end; }
-  .field.row .grow { flex: 1; }
-  .field.row label { display: flex; flex-direction: column; gap: 4px; }
+  .field.row { flex-direction: row; gap: 10px; align-items: flex-end; min-width: 0; }
+  .field.row .grow { flex: 1; min-width: 0; }
+  .field.row label { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
   select, input[type='text'] {
     padding: 5px 7px; background: var(--input-bg, #2a2a2a);
     color: inherit; border: 1px solid var(--border-color, #444); border-radius: 4px;
+    min-width: 0;
+    box-sizing: border-box;
   }
-  .path-bar { display: flex; gap: 6px; align-items: center; }
-  .path-bar button { padding: 3px 8px; border: 1px solid var(--border-color, #444); background: var(--input-bg, #2a2a2a); color: inherit; border-radius: 4px; cursor: pointer; }
+  .path-bar { display: flex; gap: 6px; align-items: center; min-width: 0; }
+  .path-bar button { padding: 3px 8px; border: 1px solid var(--border-color, #444); background: var(--input-bg, #2a2a2a); color: inherit; border-radius: 4px; cursor: pointer; flex-shrink: 0; }
   .cur-path { flex: 1; min-width: 0; font-size: 0.85em; font-family: monospace; background: var(--input-bg, #2a2a2a); padding: 4px 6px; border-radius: 4px; }
   .dir-list { max-height: 180px; overflow: auto; border: 1px solid var(--border-color, #444); border-radius: 4px; }
-  .dir-row { display: block; width: 100%; text-align: left; padding: 5px 8px; background: none; border: none; color: inherit; cursor: pointer; font-size: 0.88em; }
+  .dir-row { display: block; width: 100%; text-align: left; padding: 5px 8px; background: none; border: none; color: inherit; cursor: pointer; font-size: 0.88em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .dir-row:hover { background: var(--hover-bg, rgba(255, 255, 255, 0.06)); }
   .dir-row.error { color: #e57373; cursor: default; }
   .upload-err { color: #e57373; font-size: 0.85em; background: rgba(229, 115, 115, 0.1); padding: 6px 8px; border-radius: 4px; word-break: break-word; }
   .progress { height: 6px; background: var(--input-bg, #2a2a2a); border-radius: 3px; overflow: hidden; }
   .progress-fill { height: 100%; background: var(--accent-color, #2196f3); transition: width 0.15s; }
-  footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
+  footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; flex-wrap: wrap; }
   footer .primary { background: var(--accent-color, #2196f3); color: #fff; border: none; padding: 6px 14px; border-radius: 4px; cursor: pointer; }
   footer .primary:disabled { opacity: 0.5; cursor: not-allowed; }
   footer .ghost { background: none; border: 1px solid var(--border-color, #444); color: inherit; padding: 6px 12px; border-radius: 4px; cursor: pointer; }
+
+  @media (max-width: 520px) {
+    .hpc-upload-overlay {
+      padding: 8px;
+    }
+
+    .hpc-upload-dialog {
+      width: calc(100vw - 16px);
+      max-width: calc(100vw - 16px);
+      max-height: calc(100vh - 16px);
+    }
+
+    .field.row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
 </style>

--- a/src/lib/structure/OptimadePreviewModal.svelte
+++ b/src/lib/structure/OptimadePreviewModal.svelte
@@ -243,31 +243,42 @@
     align-items: center;
     justify-content: center;
     z-index: 100000010;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
 
   .modal-content {
     background: var(--surface-bg, #1e1e1e);
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
-    width: 90vw;
-    max-width: 1000px;
-    max-height: 85vh;
+    width: min(1000px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
+    box-sizing: border-box;
   }
 
   .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 12px 16px;
     border-bottom: 1px solid var(--border-color, #444);
+    min-width: 0;
   }
 
   .modal-header h2 {
     margin: 0;
     font-size: 1.1rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .close-btn {
@@ -279,6 +290,7 @@
     font-size: 20px;
     cursor: pointer;
     border-radius: 4px;
+    flex-shrink: 0;
   }
 
   .close-btn:hover {
@@ -293,6 +305,8 @@
     display: flex;
     align-items: stretch;
     justify-content: stretch;
+    min-height: 0;
+    min-width: 0;
   }
 
   .preview-container {
@@ -302,6 +316,7 @@
     width: 100%;
     height: 100%;
     max-height: 500px;
+    min-width: 0;
   }
 
   .structure-preview-column {
@@ -309,6 +324,7 @@
     flex-direction: column;
     height: 100%;
     min-height: 300px;
+    min-width: 0;
     border: 1px solid var(--border-color, #444);
     border-radius: 4px;
     overflow: hidden;
@@ -320,6 +336,7 @@
     gap: 12px;
     overflow-y: auto;
     padding-right: 8px;
+    min-width: 0;
   }
 
   .info-section {
@@ -430,6 +447,7 @@
     padding: 12px 16px;
     border-top: 1px solid var(--border-color, #444);
     background: var(--surface-bg-hover, #333);
+    flex-wrap: wrap;
   }
 
   .cancel-btn,
@@ -465,6 +483,10 @@
   }
 
   @media (max-width: 800px) {
+    .modal-overlay {
+      padding: 8px;
+    }
+
     .preview-container {
       grid-template-columns: 1fr;
       gap: 16px;
@@ -476,7 +498,9 @@
     }
 
     .modal-content {
-      max-width: 95vw;
+      width: calc(100vw - 16px);
+      max-width: calc(100vw - 16px);
+      max-height: calc(100vh - 16px);
     }
   }
 </style>

--- a/src/lib/structure/OptimadeSearchModal.svelte
+++ b/src/lib/structure/OptimadeSearchModal.svelte
@@ -1037,30 +1037,41 @@
     align-items: center;
     justify-content: center;
     z-index: 100000010;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .modal-content {
     background: var(--surface-bg, #1e1e1e);
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
-    width: 90vw;
-    max-width: 900px;
-    max-height: 85vh;
+    width: min(900px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
+    box-sizing: border-box;
   }
   .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 12px 16px;
     border-bottom: 1px solid var(--border-color, #444);
     position: relative;
     z-index: 10;
+    min-width: 0;
   }
   .modal-header h2 {
     margin: 0;
     font-size: 1.1rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .close-btn {
     width: 28px;
@@ -1071,6 +1082,7 @@
     font-size: 20px;
     cursor: pointer;
     border-radius: 4px;
+    flex-shrink: 0;
   }
   .close-btn:hover {
     background: var(--surface-bg-hover, #333);
@@ -1079,6 +1091,8 @@
     padding: 16px;
     overflow-y: auto;
     flex: 1;
+    min-height: 0;
+    min-width: 0;
   }
   .mode-tabs {
     display: flex;
@@ -1089,6 +1103,9 @@
     border-radius: 999px;
     border: 1px solid var(--border-color, #444);
     width: fit-content;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
   }
   .mode-tab {
     padding: 6px 16px;
@@ -1099,6 +1116,8 @@
     font-size: 0.85rem;
     cursor: pointer;
     transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .mode-tab:hover:not(.active) {
     color: inherit;
@@ -1143,6 +1162,7 @@
   .provider-section select {
     flex: 1;
     max-width: 300px;
+    min-width: 0;
     padding: 6px 10px;
     border: 1px solid var(--border-color, #444);
     border-radius: 4px;
@@ -1184,9 +1204,11 @@
     display: flex;
     gap: 8px;
     width: 100%;
+    min-width: 0;
   }
   .api-key-input-row input {
     flex: 1;
+    min-width: 0;
     padding: 6px 10px;
     border: 1px solid var(--border-color, #444);
     border-radius: 4px;
@@ -1248,11 +1270,13 @@
     gap: 12px;
     margin-bottom: 16px;
     flex-wrap: wrap;
+    min-width: 0;
   }
   .search-field {
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
   }
   .search-field label {
     font-size: 0.9rem;
@@ -1265,6 +1289,7 @@
     background: var(--surface-bg, #1e1e1e);
     color: inherit;
     width: 150px;
+    min-width: 0;
   }
   .search-btn {
     display: flex;
@@ -1290,6 +1315,7 @@
   }
   .results-section {
     min-height: 300px;
+    min-width: 0;
   }
   .results-section h3 {
     margin: 0 0 10px;

--- a/src/lib/structure/PasteContentModal.svelte
+++ b/src/lib/structure/PasteContentModal.svelte
@@ -174,28 +174,39 @@ Direct
     align-items: center;
     justify-content: center;
     z-index: 100000010;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .modal-content {
     background: var(--surface-bg, #1e1e1e);
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
-    width: 90vw;
-    max-width: 700px;
-    max-height: 85vh;
+    width: min(700px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
+    box-sizing: border-box;
   }
   .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 12px 16px;
     border-bottom: 1px solid var(--border-color, #444);
+    min-width: 0;
   }
   .modal-header h2 {
     margin: 0;
     font-size: 1.1rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .close-btn {
     width: 28px;
@@ -206,6 +217,7 @@ Direct
     font-size: 20px;
     cursor: pointer;
     border-radius: 4px;
+    flex-shrink: 0;
   }
   .close-btn:hover {
     background: var(--surface-bg-hover, #333);
@@ -217,6 +229,8 @@ Direct
     display: flex;
     flex-direction: column;
     gap: 16px;
+    min-height: 0;
+    min-width: 0;
   }
   .format-section {
     display: flex;
@@ -254,6 +268,7 @@ Direct
     align-items: center;
     gap: 8px;
     margin-top: 4px;
+    min-width: 0;
   }
   .filename-input label {
     font-size: 0.85rem;
@@ -269,6 +284,7 @@ Direct
     color: inherit;
     font-size: 0.85rem;
     max-width: 200px;
+    min-width: 0;
   }
   .content-section {
     display: flex;
@@ -276,6 +292,7 @@ Direct
     gap: 8px;
     flex: 1;
     min-height: 0;
+    min-width: 0;
   }
   .content-section > label {
     font-size: 0.9rem;
@@ -293,6 +310,8 @@ Direct
     font-size: 0.85rem;
     line-height: 1.4;
     resize: vertical;
+    min-width: 0;
+    box-sizing: border-box;
   }
   .content-section textarea::placeholder {
     color: var(--text-color-muted, #666);
@@ -321,6 +340,7 @@ Direct
     gap: 12px;
     padding-top: 8px;
     border-top: 1px solid var(--border-color, #444);
+    flex-wrap: wrap;
   }
   .cancel-btn {
     padding: 8px 16px;
@@ -352,5 +372,26 @@ Direct
   .import-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  @media (max-width: 520px) {
+    .modal-overlay {
+      padding: 8px;
+    }
+
+    .modal-content {
+      width: calc(100vw - 16px);
+      max-width: calc(100vw - 16px);
+      max-height: calc(100vh - 16px);
+    }
+
+    .filename-input {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .filename-input input {
+      max-width: none;
+    }
   }
 </style>

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -174,6 +174,17 @@
   let center_camera_trigger = $state(0) // Increment to trigger camera centering on new structure
   let reset_camera_up_trigger = $state(0) // Increment to reset camera.up to [0,1,0] after slab cut
 
+  function clamp_floating_position(x: number, y: number, width: number, height: number) {
+    if (typeof window === `undefined`) return { x, y }
+    const margin = 8
+    const max_x = Math.max(margin, window.innerWidth - width - margin)
+    const max_y = Math.max(margin, window.innerHeight - height - margin)
+    return {
+      x: Math.min(Math.max(x, margin), max_x),
+      y: Math.min(Math.max(y, margin), max_y),
+    }
+  }
+
   // Phase X5: atom-delete fast-path, bound from <StructureScene>. StructureScene
   // owns atom_manager + bond_state + bond_manager and publishes this hook; we
   // call it in `delete_selected()` (below) BEFORE mutating `structure` so the
@@ -4327,8 +4338,9 @@
 
     <!-- Element selector for add/replace operations -->
     {#if context_menu_visible}
-      {@const selector_top = `${context_menu_position.y}px`}
-      {@const selector_left = `${context_menu_position.x + 180}px`}
+      {@const selector_position = clamp_floating_position(context_menu_position.x + 180, context_menu_position.y, 300, 400)}
+      {@const selector_top = `${selector_position.y}px`}
+      {@const selector_left = `${selector_position.x}px`}
       <div class="element-selector" style:top={selector_top} style:left={selector_left}>
         <div class="element-selector-header">{t('structure.select_element')}</div>
         <div class="element-grid">
@@ -4508,13 +4520,14 @@
   {/if}
   <!-- Charge label color picker popup (right-click on a charge label) -->
   {#if charge_state.charge_color_menu}
+    {@const charge_color_position = clamp_floating_position(charge_state.charge_color_menu.x, charge_state.charge_color_menu.y, 180, 170)}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class="charge-color-overlay" onclick={() => charge_state.charge_color_menu = null}>
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="charge-color-popup"
-        style:left="{charge_state.charge_color_menu.x}px"
-        style:top="{charge_state.charge_color_menu.y}px"
+        style:left="{charge_color_position.x}px"
+        style:top="{charge_color_position.y}px"
         onclick={(e) => e.stopPropagation()}
       >
         <div class="charge-color-row">
@@ -5772,6 +5785,9 @@
     color: var(--text-color, #e2e8f0);
     z-index: 201;
     min-width: 130px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow: auto;
   }
   .charge-color-row {
     display: flex;
@@ -5825,15 +5841,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
     z-index: 100000002;
+    overflow: auto;
   }
   .periodic-table-modal {
     background: var(--surface-bg, #1e1e1e);
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
-    max-width: 95vw;
-    max-height: 90vh;
+    width: min-content;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     overflow: auto;
   }
   .periodic-table-modal-header {
@@ -5864,7 +5883,8 @@
   }
   .periodic-table-modal-content {
     padding: 16px;
-    min-width: 700px;
+    min-width: 0;
+    overflow: auto;
   }
   .periodic-table-modal-content :global(.periodic-table) {
     font-size: 0.75em;
@@ -5960,9 +5980,9 @@
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     padding: 8px;
     z-index: 100000002;
-    max-width: 300px;
-    max-height: 400px;
-    overflow-y: auto;
+    max-width: min(300px, calc(100vw - 16px));
+    max-height: min(400px, calc(100vh - 16px));
+    overflow: auto;
   }
   .element-selector-header {
     font-size: 0.65rem;

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -898,6 +898,8 @@
     position: absolute;
     top: 115%;
     right: 0;
+    max-width: calc(100vw - 24px);
+    overflow-x: auto;
     background: var(--surface-bg);
     border-radius: 4px;
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
@@ -1102,8 +1104,10 @@
     border-radius: var(--border-radius, 6px);
     padding: 4px;
     width: max-content;
-    max-width: calc(100cqw - 20px);
+    max-width: min(420px, calc(100vw - 24px));
+    max-height: calc(100vh - 96px);
     overflow-x: auto;
+    overflow-y: auto;
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     font-size: 0.9rem;
   }
@@ -1145,7 +1149,7 @@
 
   /* === 片段选择器 === */
   .fragment-selector {
-    max-width: 400px;
+    max-width: min(400px, calc(100vw - 36px));
   }
   .fragment-categories {
     display: flex;
@@ -1183,5 +1187,19 @@
     background: var(--accent-color, #007acc);
     color: white;
     border-color: var(--accent-color, #007acc);
+  }
+
+  @media (max-width: 560px) {
+    .pencil-mode-selector,
+    .view-mode-dropdown {
+      position: fixed;
+      left: 50%;
+      right: auto;
+      top: 72px;
+      transform: translateX(-50%);
+      width: max-content;
+      max-width: calc(100vw - 24px);
+      z-index: 100000020;
+    }
   }
 </style>

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -544,15 +544,17 @@
     top: 100%;
     right: 0;
     z-index: 100;
-    min-width: 260px;
-    max-width: 400px;
+    min-width: min(260px, calc(100vw - 16px));
     width: max-content;
+    max-width: min(400px, calc(100vw - 16px));
+    max-height: calc(100vh - 72px);
     background: var(--surface-bg);
     border: 1px solid var(--border-color);
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
     padding: 4px 0;
     margin-top: 2px;
+    overflow: auto;
   }
   .tw-dropdown-header {
     padding: 6px 10px 3px;
@@ -586,6 +588,9 @@
     text-align: left;
     transition: background 0.1s;
     white-space: nowrap;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .tw-dropdown-item:hover {
     background: var(--surface-bg-hover);

--- a/src/lib/structure/VacuumBoxModal.svelte
+++ b/src/lib/structure/VacuumBoxModal.svelte
@@ -98,28 +98,39 @@
     align-items: center;
     justify-content: center;
     z-index: 100000010;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .modal-content {
     background: var(--surface-bg, #1e1e1e);
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
-    width: 90vw;
-    max-width: 400px;
-    max-height: 85vh;
+    width: min(400px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
+    box-sizing: border-box;
   }
   .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 12px 16px;
     border-bottom: 1px solid var(--border-color, #444);
+    min-width: 0;
   }
   .modal-header h2 {
     margin: 0;
     font-size: 1.1em;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .close-btn {
     width: 28px;
@@ -130,6 +141,7 @@
     font-size: 20px;
     cursor: pointer;
     border-radius: 4px;
+    flex-shrink: 0;
   }
   .close-btn:hover {
     background: light-dark(rgba(0, 0, 0, 0.08), rgba(255, 255, 255, 0.1));
@@ -138,6 +150,8 @@
     padding: 16px;
     overflow-y: auto;
     flex: 1;
+    min-height: 0;
+    min-width: 0;
   }
   .param-row {
     display: flex;
@@ -145,15 +159,18 @@
     align-items: center;
     gap: 8pt;
     padding: 3pt 2pt;
+    min-width: 0;
   }
   .param-row input[type="number"] {
     width: 70px;
     text-align: right;
+    min-width: 0;
   }
   .padding-presets {
     display: flex;
     gap: 4px;
     padding: 2pt 2pt;
+    flex-wrap: wrap;
   }
   .preset-chip {
     flex: 1;
@@ -164,6 +181,7 @@
     cursor: pointer;
     font-size: 0.85em;
     color: inherit;
+    min-width: 0;
   }
   .preset-chip:hover {
     background: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.15));
@@ -198,5 +216,26 @@
     font-size: 0.8em;
     color: var(--text-color-muted);
     margin-top: 0.6em;
+  }
+
+  @media (max-width: 420px) {
+    .modal-overlay {
+      padding: 8px;
+    }
+
+    .modal-content {
+      width: calc(100vw - 16px);
+      max-width: calc(100vw - 16px);
+      max-height: calc(100vh - 16px);
+    }
+
+    .param-row {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .param-row input[type="number"] {
+      width: 100%;
+    }
   }
 </style>

--- a/src/lib/workflow/AdsorbatePlacePanel.svelte
+++ b/src/lib/workflow/AdsorbatePlacePanel.svelte
@@ -1641,19 +1641,28 @@
     position: fixed; inset: 0; z-index: 9999;
     background: rgba(0,0,0,0.35);
     display: flex; align-items: center; justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .sd-prompt {
     background: var(--dialog-bg, light-dark(#fff, #1e2028));
     border: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
-    border-radius: 8px; padding: 16px 20px; min-width: 280px;
+    border-radius: 8px; padding: 16px 20px;
+    width: min(360px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    overflow: auto;
+    min-width: 0;
+    box-sizing: border-box;
     box-shadow: 0 8px 24px rgba(0,0,0,0.25);
   }
   .sd-prompt-title {
     font-size: 13px; font-weight: 600; margin-bottom: 12px;
     color: var(--text-color, light-dark(#1f2937, #eee));
+    overflow-wrap: anywhere;
   }
   .sd-prompt-buttons {
-    display: flex; gap: 8px; justify-content: flex-end;
+    display: flex; gap: 8px; justify-content: flex-end; flex-wrap: wrap;
   }
   .pubchem-results {
     max-height: 120px; overflow-y: auto; display: flex; flex-direction: column;

--- a/src/lib/workflow/BatchStatusSection.svelte
+++ b/src/lib/workflow/BatchStatusSection.svelte
@@ -353,9 +353,10 @@
   .bs-file-item { font-size: 10px; font-family: monospace; padding: 2px 8px; border: 1px solid var(--dialog-border, rgba(0,0,0,0.1)); border-radius: 3px; background: var(--input-bg, #f5f5f5); color: var(--text-color, #333); cursor: pointer; }
   .bs-file-item:hover { background: var(--dialog-border, rgba(0,0,0,0.06)); color: var(--accent-color, #3b82f6); }
 
-  .bs-file-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; }
-  .bs-file-modal { background: var(--pane-bg, #1a1a2e); border: 1px solid var(--dialog-border, #404040); border-radius: 8px; width: 80vw; max-width: 700px; max-height: 80vh; display: flex; flex-direction: column; overflow: hidden; }
-  .bs-file-modal-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; border-bottom: 1px solid var(--dialog-border, #404040); font-size: 12px; font-weight: 600; color: var(--text-color, #eee); }
+  .bs-file-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; padding: 16px; overflow: auto; }
+  .bs-file-modal { background: var(--pane-bg, #1a1a2e); border: 1px solid var(--dialog-border, #404040); border-radius: 8px; width: min(700px, calc(100vw - 32px)); max-height: calc(100vh - 32px); display: flex; flex-direction: column; overflow: hidden; }
+  .bs-file-modal-header { display: flex; justify-content: space-between; align-items: center; gap: 8px; min-width: 0; padding: 8px 12px; border-bottom: 1px solid var(--dialog-border, #404040); font-size: 12px; font-weight: 600; color: var(--text-color, #eee); }
+  .bs-file-modal-header span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
   .bs-file-modal-header button { background: none; border: none; color: var(--text-color-dim, #999); cursor: pointer; font-size: 14px; padding: 2px 6px; }
   .bs-file-modal-header button:hover { color: var(--text-color, #eee); }
   .bs-file-modal-content { padding: 12px; overflow: auto; font-size: 11px; font-family: monospace; color: var(--text-color, #ccc); white-space: pre-wrap; word-break: break-all; margin: 0; flex: 1; }

--- a/src/lib/workflow/EnergyDiagramModal.svelte
+++ b/src/lib/workflow/EnergyDiagramModal.svelte
@@ -61,10 +61,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
+    overflow: auto;
   }
   .ed-modal {
-    width: min(900px, 92vw);
-    height: min(85vh, 800px);
+    width: min(900px, calc(100vw - 32px));
+    height: min(800px, calc(100vh - 32px));
     background: var(--surface-bg);
     border: 1px solid light-dark(rgba(0,0,0,0.15), rgba(255,255,255,0.15));
     border-radius: 10px;
@@ -78,6 +80,7 @@
     align-items: center;
     padding: 12px 16px;
     gap: 12px;
+    min-width: 0;
     border-bottom: 1px solid light-dark(rgba(0,0,0,0.08), rgba(255,255,255,0.08));
   }
   .ed-title {
@@ -85,12 +88,18 @@
     font-size: 15px;
     font-weight: 600;
     color: var(--text-color, #eee);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .ed-actions {
     display: flex;
     align-items: center;
     gap: 6px;
     margin-left: auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
   .ed-save-btn {
     padding: 5px 14px;

--- a/src/lib/workflow/JobScriptWorkplace.svelte
+++ b/src/lib/workflow/JobScriptWorkplace.svelte
@@ -256,8 +256,10 @@
 
 <style>
   .jsw-modal {
-    width: min(900px, 95vw);
-    height: min(650px, 85vh);
+    width: min(900px, calc(100vw - 32px));
+    height: min(650px, calc(100vh - 32px));
+    min-width: 0;
+    min-height: 0;
   }
 
   .jsw-body {
@@ -265,6 +267,7 @@
     grid-template-columns: 200px 1fr;
     flex: 1;
     min-height: 0;
+    min-width: 0;
     overflow: hidden;
   }
 
@@ -274,6 +277,7 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
   }
 
   .jsw-new-btn {
@@ -360,6 +364,8 @@
     padding: 12px 16px;
     gap: 8px;
     overflow-y: auto;
+    min-width: 0;
+    min-height: 0;
   }
 
   .jsw-editor-fields {
@@ -371,6 +377,7 @@
   .jsw-field-row {
     display: flex;
     gap: 10px;
+    min-width: 0;
   }
 
   .jsw-field {
@@ -378,6 +385,7 @@
     display: flex;
     flex-direction: column;
     gap: 3px;
+    min-width: 0;
   }
 
   .jsw-label {
@@ -423,6 +431,7 @@
     flex-direction: column;
     gap: 3px;
     min-height: 0;
+    min-width: 0;
   }
 
   .jsw-textarea {
@@ -439,6 +448,7 @@
     resize: none;
     outline: none;
     box-sizing: border-box;
+    min-width: 0;
   }
   .jsw-textarea:focus {
     border-color: var(--accent-color, light-dark(#4f46e5, #3b82f6));
@@ -468,6 +478,7 @@
     gap: 8px;
     align-items: center;
     padding-top: 4px;
+    flex-wrap: wrap;
   }
 
   .jsw-btn {
@@ -517,5 +528,22 @@
     height: 100%;
     color: var(--text-color-muted);
     font-size: 12px;
+  }
+
+  @media (max-width: 700px) {
+    .jsw-body {
+      grid-template-columns: 1fr;
+      grid-template-rows: minmax(120px, 34%) 1fr;
+    }
+
+    .jsw-sidebar {
+      border-right: none;
+      border-bottom: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
+    }
+
+    .jsw-field-row {
+      flex-direction: column;
+      gap: 8px;
+    }
   }
 </style>

--- a/src/lib/workflow/PauseDialog.svelte
+++ b/src/lib/workflow/PauseDialog.svelte
@@ -117,14 +117,16 @@
 
 <style>
   .pause-dialog {
-    width: 480px;
-    max-width: 90vw;
+    width: min(480px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    min-width: 0;
   }
 
   .pd-body {
     padding: 16px 20px;
     overflow-y: auto;
-    max-height: 60vh;
+    max-height: none;
+    min-height: 0;
   }
 
   .pd-empty {
@@ -145,6 +147,8 @@
     gap: 6px;
     margin-bottom: 10px;
     font-size: 11px;
+    flex-wrap: wrap;
+    min-width: 0;
   }
 
   .pd-link {
@@ -168,6 +172,7 @@
   .pd-count {
     margin-left: auto;
     color: var(--text-color-dim, light-dark(#9ca3af, #6b7280));
+    min-width: 0;
   }
 
   .pd-list {
@@ -185,6 +190,7 @@
     cursor: pointer;
     border: 1px solid var(--dialog-border, light-dark(#e5e7eb, #333));
     transition: background 0.15s;
+    min-width: 0;
   }
 
   .pd-job:hover {
@@ -214,12 +220,17 @@
     font-size: 13px;
     font-weight: 500;
     color: var(--text-color, light-dark(#1f2937, #eee));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .pd-job-meta {
     display: flex;
     gap: 8px;
     font-size: 11px;
+    min-width: 0;
+    flex-wrap: wrap;
   }
 
   .pd-status {
@@ -243,6 +254,7 @@
     gap: 8px;
     padding: 12px 20px;
     border-top: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
+    flex-wrap: wrap;
   }
 
   .pd-btn {

--- a/src/lib/workflow/RunConfigDialog.svelte
+++ b/src/lib/workflow/RunConfigDialog.svelte
@@ -875,30 +875,37 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
+    overflow: auto;
     backdrop-filter: blur(4px);
+    box-sizing: border-box;
   }
 
   .modal {
     background: var(--dialog-bg, light-dark(#fff, #1c1d21));
     border: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
     border-radius: 12px;
-    max-width: 600px;
-    width: 95%;
-    max-height: 85vh;
+    width: min(600px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
     font-family: 'SF Mono', 'Cascadia Code', 'JetBrains Mono', monospace;
     font-size: 13px;
     color: var(--text-color, light-dark(#374151, #eee));
+    min-width: 0;
+    box-sizing: border-box;
   }
 
   .modal-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
     padding: 16px 20px 12px;
     flex-shrink: 0;
+    min-width: 0;
   }
 
   .modal-title {
@@ -907,6 +914,10 @@
     font-weight: 600;
     color: var(--text-color, light-dark(#1f2937, #eee));
     letter-spacing: 0.3px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .close-btn {
@@ -919,6 +930,7 @@
     border-radius: 4px;
     font-family: inherit;
     line-height: 1;
+    flex-shrink: 0;
   }
   .close-btn:hover {
     color: var(--text-color, light-dark(#374151, #eee));
@@ -932,6 +944,9 @@
     padding: 0 20px;
     border-bottom: 1px solid var(--dialog-border, light-dark(#d1d5db, #3a3a3a));
     flex-shrink: 0;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
   }
 
   /* ─── Calc mode toggle ─── */
@@ -957,6 +972,8 @@
     text-transform: uppercase;
     letter-spacing: 0.8px;
     transition: all 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .tab:hover {
     color: var(--text-color, light-dark(#374151, #eee));
@@ -970,6 +987,8 @@
     padding: 16px 20px;
     overflow-y: auto;
     flex: 1;
+    min-height: 0;
+    min-width: 0;
   }
 
   .section {
@@ -1220,6 +1239,7 @@
     padding: 14px 20px;
     border-top: 1px solid var(--dialog-border, light-dark(#d1d5db, #3a3a3a));
     flex-shrink: 0;
+    flex-wrap: wrap;
   }
 
   .btn {

--- a/src/lib/workflow/StructureInputDialog.svelte
+++ b/src/lib/workflow/StructureInputDialog.svelte
@@ -976,7 +976,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 16px;
+    overflow: auto;
     backdrop-filter: blur(4px);
+    box-sizing: border-box;
   }
 
   /* ─── Modal ─── */
@@ -984,15 +987,17 @@
     background: var(--dialog-bg, light-dark(#fff, #1c1d21));
     border: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
     border-radius: 12px;
-    max-width: 500px;
-    width: 95%;
-    max-height: 85vh;
+    width: min(500px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px);
     display: flex;
     flex-direction: column;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
     font-family: 'SF Mono', 'Cascadia Code', 'JetBrains Mono', monospace;
     font-size: 13px;
     color: var(--text-color, light-dark(#374151, #eee));
+    min-width: 0;
+    box-sizing: border-box;
   }
 
   /* ─── Header ─── */
@@ -1000,9 +1005,11 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
     padding: 16px 20px;
     border-bottom: 1px solid var(--dialog-border, light-dark(#d1d5db, #3a3a3a));
     flex-shrink: 0;
+    min-width: 0;
   }
 
   .modal-title {
@@ -1011,6 +1018,10 @@
     font-weight: 600;
     color: var(--text-color, light-dark(#1f2937, #eee));
     letter-spacing: 0.3px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .close-btn {
@@ -1023,6 +1034,7 @@
     border-radius: 4px;
     font-family: inherit;
     line-height: 1;
+    flex-shrink: 0;
   }
   .close-btn:hover {
     color: var(--text-color, light-dark(#374151, #eee));
@@ -1068,6 +1080,9 @@
     padding: 0 20px;
     flex-shrink: 0;
     background: var(--dialog-bg, light-dark(#fff, #1c1d21));
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
   }
 
   .tab-btn {
@@ -1082,6 +1097,8 @@
     cursor: pointer;
     transition: all 0.15s;
     letter-spacing: 0.3px;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .tab-btn:hover {
     color: var(--text-color, light-dark(#374151, #eee));
@@ -1096,6 +1113,8 @@
     padding: 16px 20px;
     overflow-y: auto;
     flex: 1;
+    min-height: 0;
+    min-width: 0;
   }
 
   /* ─── Sections ─── */
@@ -1401,6 +1420,7 @@
     padding: 14px 20px;
     border-top: 1px solid var(--dialog-border, light-dark(#d1d5db, #3a3a3a));
     flex-shrink: 0;
+    flex-wrap: wrap;
   }
 
   /* ─── Buttons ─── */

--- a/src/lib/workflow/WorkflowEditor.svelte
+++ b/src/lib/workflow/WorkflowEditor.svelte
@@ -3576,7 +3576,9 @@
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
     font-size: 10px;
     line-height: 1.25;
-    white-space: nowrap;
+    max-width: min(260px, calc(100vw - 32px));
+    white-space: normal;
+    overflow-wrap: anywhere;
     pointer-events: none;
     opacity: 0;
     visibility: hidden;
@@ -3646,6 +3648,9 @@
     position: absolute; top: 44px; left: 50%; transform: translateX(-50%);
     background: color-mix(in srgb, var(--error-color) 85%, var(--surface-bg)); color: light-dark(#dc2626, #fca5a5); padding: 6px 16px; border-radius: 6px;
     font-size: 11px; z-index: 20; pointer-events: none;
+    max-width: calc(100% - 24px);
+    text-align: center;
+    overflow-wrap: anywhere;
     animation: wf-fade-in 0.2s ease;
   }
   .load-error-bar {
@@ -3660,7 +3665,9 @@
     position: absolute; top: 44px; left: 50%; transform: translateX(-50%);
     background: color-mix(in srgb, var(--error-color) 85%, var(--surface-bg)); color: light-dark(#dc2626, #fca5a5); padding: 6px 16px; border-radius: 6px;
     font-size: 11px; z-index: 20; display: flex; align-items: center; gap: 10px;
-    max-width: 80%; animation: wf-fade-in 0.2s ease;
+    max-width: calc(100% - 24px); animation: wf-fade-in 0.2s ease;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
   .error-dismiss {
     background: none; border: none; color: light-dark(#dc2626, #fca5a5); cursor: pointer;
@@ -3673,6 +3680,9 @@
     padding: 6px 16px; border-radius: 6px; font-size: 11px; z-index: 20;
     display: flex; align-items: center; gap: 8px; animation: wf-fade-in 0.2s ease;
     border: 1px solid color-mix(in srgb, #2563eb 30%, transparent);
+    max-width: calc(100% - 24px);
+    min-width: 0;
+    flex-wrap: wrap;
   }
   .external-change-bar button {
     background: color-mix(in srgb, #2563eb 20%, transparent); border: 1px solid color-mix(in srgb, #2563eb 40%, transparent);
@@ -3685,7 +3695,9 @@
     padding: 6px 16px; border-radius: 6px; font-size: 11px; z-index: 20;
     display: flex; align-items: center; gap: 8px; animation: wf-fade-in 0.2s ease;
     border: 1px solid color-mix(in srgb, #f59e0b 30%, transparent);
-    max-width: 90%;
+    max-width: calc(100% - 24px);
+    min-width: 0;
+    flex-wrap: wrap;
   }
   .hpc-banner strong { color: light-dark(#78350f, #fde68a); }
   .hpc-banner-connect {
@@ -3704,8 +3716,13 @@
   .tmpl-overlay {
     position: absolute; left: 10px; top: 50px; z-index: 30;
     background: var(--surface-bg); border: 1px solid var(--border-color); border-radius: 8px;
-    padding: 12px; width: 300px; backdrop-filter: blur(8px);
-    max-height: calc(100vh - 120px); overflow-y: auto;
+    padding: 12px;
+    width: min(300px, calc(100% - 20px));
+    max-width: calc(100vw - 32px);
+    backdrop-filter: blur(8px);
+    max-height: calc(100vh - 120px);
+    overflow: auto;
+    box-sizing: border-box;
   }
   .tmpl-title { font-size: 10px; font-weight: 700; color: var(--text-color-muted); text-transform: uppercase; letter-spacing: 1.2px; margin-bottom: 8px; }
   .tmpl-group-header { font-size: 9px; font-weight: 700; color: var(--text-color-muted); text-transform: uppercase; letter-spacing: 1px; margin: 10px 0 4px; padding-top: 6px; border-top: 1px solid var(--border-color); }
@@ -3716,9 +3733,9 @@
     cursor: pointer; color: inherit; font-family: inherit; transition: all 0.12s;
   }
   .tmpl-card:hover { background: var(--surface-bg-hover); border-color: var(--text-color-muted); }
-  .tmpl-name { font-size: 12px; font-weight: 600; color: var(--text-color-muted); }
-  .tmpl-desc { font-size: 10px; color: var(--text-color-muted); margin-top: 2px; }
-  .tmpl-meta { font-size: 9px; color: var(--text-color-muted); margin-top: 2px; }
+  .tmpl-name { font-size: 12px; font-weight: 600; color: var(--text-color-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tmpl-desc { font-size: 10px; color: var(--text-color-muted); margin-top: 2px; overflow-wrap: anywhere; }
+  .tmpl-meta { font-size: 9px; color: var(--text-color-muted); margin-top: 2px; overflow-wrap: anywhere; }
   .tmpl-quick-strip {
     display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 4px;
   }
@@ -3747,6 +3764,8 @@
   .help {
     position: absolute; bottom: 10px; right: 290px; font-size: 9px;
     color: var(--border-color); z-index: 5; text-align: right; line-height: 1.6;
+    max-width: min(260px, calc(100% - 320px));
+    overflow-wrap: anywhere;
   }
   .rpanel {
     width: 280px; background: var(--surface-bg); border-left: 1px solid var(--border-color);
@@ -3788,6 +3807,26 @@
      the rpanel's .pcontent handles scrolling, not the individual panels */
   .pcontent :global(.config-panel.dialog-modal),
   .pcontent :global(.config-panel) { max-height: none !important; height: auto !important; overflow: visible !important; }
+
+  @media (max-width: 820px) {
+    .tmpl-overlay {
+      left: 8px;
+      right: 8px;
+      width: auto;
+      max-width: none;
+    }
+
+    .minimap,
+    .help {
+      display: none;
+    }
+
+    .execution-error,
+    .external-change-bar,
+    .hpc-banner {
+      align-items: flex-start;
+    }
+  }
   .props { display: flex; flex-direction: column; }
   .prop-lbl { font-size: 13px; font-weight: 600; color: var(--text-color); }
   .sec-label {

--- a/src/lib/workflow/components/CustomCommandWizard.svelte
+++ b/src/lib/workflow/components/CustomCommandWizard.svelte
@@ -269,10 +269,11 @@
   .ccw-overlay {
     position: fixed; inset: 0; background: rgba(0,0,0,0.65); z-index: 9999;
     display: flex; align-items: center; justify-content: center;
+    padding: 16px; overflow: auto;
   }
   .ccw-modal {
-    width: min(640px, 94vw);
-    max-height: 90vh;
+    width: min(640px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
     background: var(--surface-bg, #1e2330);
     border: 1px solid var(--border-color, rgba(255,255,255,0.1));
     border-radius: 10px;
@@ -285,11 +286,12 @@
   /* Header */
   .ccw-header {
     display: flex; align-items: center; justify-content: space-between;
+    gap: 8px; min-width: 0;
     padding: 12px 16px;
     border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.08));
     flex-shrink: 0;
   }
-  .ccw-title { margin: 0; font-size: 14px; font-weight: 700; }
+  .ccw-title { margin: 0; font-size: 14px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
   .ccw-close-btn {
     width: 28px; height: 28px; border-radius: 5px; border: none;
     background: transparent; color: var(--text-color-muted, #94a3b8);

--- a/src/lib/workflow/components/DopingWorkflowModal.svelte
+++ b/src/lib/workflow/components/DopingWorkflowModal.svelte
@@ -447,9 +447,13 @@
   .dw-overlay {
     position: fixed; inset: 0; background: rgba(0,0,0,0.75); z-index: 9999;
     display: flex; align-items: center; justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .dw-modal {
-    width: 96vw; height: 94vh;
+    width: min(96vw, calc(100vw - 32px));
+    height: min(94vh, calc(100vh - 32px));
     background: var(--dialog-bg, var(--surface-bg, #fff));
     border: 1px solid var(--dialog-border, rgba(0,0,0,0.12));
     border-radius: 10px;
@@ -457,17 +461,23 @@
     overflow: hidden;
     box-shadow: 0 20px 60px rgba(0,0,0,0.2);
     color: var(--text-color, #1a1a1a);
+    min-width: 0;
+    min-height: 0;
+    box-sizing: border-box;
   }
   .dw-header {
     display: flex; align-items: center; justify-content: space-between;
+    gap: 8px;
     padding: 10px 16px;
     border-bottom: 1px solid var(--dialog-border, rgba(0,0,0,0.08));
     flex-shrink: 0;
+    min-width: 0;
   }
   .dw-title {
     margin: 0; font-size: 15px; font-weight: 600; color: #e2e8f0;
+    min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
-  .dw-header-actions { display: flex; gap: 8px; align-items: center; }
+  .dw-header-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
   .dw-gen-btn {
     padding: 6px 16px; border-radius: 6px; font-size: 12px; font-weight: 600;
     background: rgba(59,130,246,0.15); border: 1px solid rgba(59,130,246,0.3);
@@ -491,12 +501,13 @@
 
   /* Side-by-side body */
   .dw-body {
-    flex: 1; display: flex; min-height: 0;
+    flex: 1; display: flex; min-height: 0; min-width: 0;
   }
 
   /* Left panel */
   .dw-left {
-    width: 420px; flex-shrink: 0;
+    width: min(420px, 38vw); flex-shrink: 0;
+    min-width: 280px;
     display: flex; flex-direction: column;
     border-right: 1px solid var(--dialog-border, rgba(0,0,0,0.08));
     overflow-y: auto; overflow-x: hidden;
@@ -617,7 +628,7 @@
 
   /* Right panel */
   .dw-right {
-    flex: 1; position: relative; min-width: 0;
+    flex: 1; position: relative; min-width: 0; min-height: 0;
     --struct-height: 100%;
     --struct-width: 100%;
   }
@@ -706,5 +717,49 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     flex: 1;
+  }
+
+  @media (max-width: 900px) {
+    .dw-modal {
+      width: calc(100vw - 32px);
+      height: calc(100vh - 32px);
+    }
+
+    .dw-body {
+      flex-direction: column;
+    }
+
+    .dw-left {
+      width: 100%;
+      min-width: 0;
+      max-height: 42%;
+      border-right: none;
+      border-bottom: 1px solid var(--dialog-border, rgba(0,0,0,0.08));
+    }
+
+    .dw-right {
+      min-height: 260px;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .dw-overlay {
+      padding: 8px;
+    }
+
+    .dw-modal {
+      width: calc(100vw - 16px);
+      height: calc(100vh - 16px);
+    }
+
+    .dw-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .dw-header-actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
   }
 </style>

--- a/src/lib/workflow/components/FileBrowserModal.svelte
+++ b/src/lib/workflow/components/FileBrowserModal.svelte
@@ -96,23 +96,24 @@
   .vasp-modal-overlay {
     position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999;
     display: flex; align-items: center; justify-content: center;
+    padding: 16px; overflow: auto;
   }
   .vasp-modal {
-    width: min(900px, 90vw); height: min(700px, 85vh);
+    width: min(900px, calc(100vw - 32px)); height: min(700px, calc(100vh - 32px));
     background: var(--surface-bg); border: 1px solid var(--border-color); border-radius: 10px;
     display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 20px 60px rgba(0,0,0,0.5);
   }
   .vasp-modal-header {
-    display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+    display: flex; align-items: center; gap: 12px; padding: 10px 16px; min-width: 0;
     border-bottom: 1px solid light-dark(rgba(0,0,0,0.08), rgba(255,255,255,0.08)); flex-shrink: 0;
   }
-  .vasp-modal-title { font-size: 14px; font-weight: 700; color: var(--text-color, #eee); margin: 0; white-space: nowrap; }
+  .vasp-modal-title { font-size: 14px; font-weight: 700; color: var(--text-color, #eee); margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
   .vasp-tab {
     padding: 6px 16px; background: none; border: none; border-bottom: 2px solid transparent;
     color: var(--text-color-muted); font-size: 12px; font-weight: 600; cursor: pointer;
   }
   .vasp-tab:hover { color: var(--text-color-muted, #94a3b8); }
-  .vasp-modal-actions { display: flex; gap: 6px; }
+  .vasp-modal-actions { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; margin-left: auto; }
   .vasp-close-btn {
     padding: 3px 8px; background: none; border: 1px solid var(--border-color);
     border-radius: 5px; color: var(--text-color-muted, #94a3b8); font-size: 16px; cursor: pointer; line-height: 1;

--- a/src/lib/workflow/components/InputEditorModal.svelte
+++ b/src/lib/workflow/components/InputEditorModal.svelte
@@ -64,18 +64,19 @@
   .modal-overlay {
     position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999;
     display: flex; align-items: center; justify-content: center;
+    padding: 16px; overflow: auto;
   }
   .modal {
-    width: min(900px, 90vw); height: min(700px, 85vh);
+    width: min(900px, calc(100vw - 32px)); height: min(700px, calc(100vh - 32px));
     background: var(--surface-bg); border: 1px solid var(--border-color); border-radius: 10px;
     display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 20px 60px rgba(0,0,0,0.5);
   }
   .modal-header {
-    display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+    display: flex; align-items: center; gap: 12px; padding: 10px 16px; min-width: 0;
     border-bottom: 1px solid light-dark(rgba(0,0,0,0.08), rgba(255,255,255,0.08)); flex-shrink: 0;
   }
-  .modal-title { font-size: 14px; font-weight: 700; color: var(--text-color, #eee); margin: 0; white-space: nowrap; }
-  .modal-actions { display: flex; gap: 6px; margin-left: auto; }
+  .modal-title { font-size: 14px; font-weight: 700; color: var(--text-color, #eee); margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+  .modal-actions { display: flex; gap: 6px; margin-left: auto; flex-wrap: wrap; justify-content: flex-end; }
   .save-btn {
     padding: 5px 14px; background: var(--accent-color, #3b82f6); border: none; border-radius: 5px;
     color: white; font-size: 12px; font-weight: 600; cursor: pointer;

--- a/src/lib/workflow/components/ResultTablePanel.svelte
+++ b/src/lib/workflow/components/ResultTablePanel.svelte
@@ -454,14 +454,17 @@
 
 <style>
   .result-panel {
-    width: 900px;
-    max-width: 95vw;
+    width: min(900px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    min-width: 0;
   }
 
   /* Summary section */
   .summary-section {
     padding: 12px 20px;
     border-bottom: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
+    min-width: 0;
+    flex-shrink: 0;
   }
 
   .summary-line {
@@ -470,6 +473,8 @@
     gap: 8px;
     font-size: 14px;
     margin-bottom: 10px;
+    min-width: 0;
+    flex-wrap: wrap;
   }
 
   .summary-total {
@@ -488,6 +493,10 @@
   .summary-expr {
     color: var(--text-color-muted, light-dark(#6b7280, #9ca3af));
     font-size: 12px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .controls-row {
@@ -554,6 +563,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
   }
 
   .filter-label {
@@ -567,12 +577,18 @@
 
   .filter-input {
     flex: 1;
+    min-width: 0;
     font-size: 12px;
+  }
+
+  .modal-body {
+    overflow: auto;
   }
 
   /* Data table */
   .result-table {
     width: 100%;
+    min-width: max-content;
     border-collapse: collapse;
     font-size: 12px;
   }
@@ -738,6 +754,7 @@
     gap: 16px;
     font-size: 11px;
     color: var(--text-color-muted, light-dark(#6b7280, #9ca3af));
+    flex-wrap: wrap;
   }
 
   /* Footer */
@@ -747,6 +764,8 @@
     padding: 12px 20px;
     border-top: 1px solid var(--dialog-border, light-dark(#d1d5db, #404040));
     justify-content: flex-end;
+    flex-wrap: wrap;
+    flex-shrink: 0;
   }
 
   .btn-action {

--- a/src/lib/workflow/components/StructureEditModal.svelte
+++ b/src/lib/workflow/components/StructureEditModal.svelte
@@ -176,18 +176,27 @@
   .struct-preview-overlay {
     position: fixed; inset: 0; background: rgba(0,0,0,0.7); z-index: 9999;
     display: flex; align-items: center; justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    box-sizing: border-box;
   }
   .struct-preview-header {
     display: flex; align-items: center; padding: 12px 16px; gap: 12px;
     border-bottom: 1px solid light-dark(rgba(0,0,0,0.08), rgba(255,255,255,0.08));
+    min-width: 0;
+    flex-shrink: 0;
   }
   .struct-preview-title {
     margin: 0; font-size: 15px; font-weight: 600; color: var(--text-color, #eee);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    min-width: 0;
   }
   .edit3d-tabs {
     display: flex; gap: 2px; background: light-dark(rgba(0,0,0,0.06), rgba(255,255,255,0.06));
     border-radius: 6px; padding: 2px; flex-shrink: 0;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
   }
   .edit3d-tab {
     padding: 4px 12px; border: none; border-radius: 4px; font-size: 12px; font-weight: 500;
@@ -202,16 +211,20 @@
     color: var(--text-color, #eee);
   }
   .struct-preview-close {
-    background: none; border: none; color: var(--text-color-muted, #94a3b8); font-size: 20px; cursor: pointer; padding: 4px 8px;
+    background: none; border: none; color: var(--text-color-muted, #94a3b8); font-size: 20px; cursor: pointer; padding: 4px 8px; flex-shrink: 0;
   }
   .struct-preview-close:hover { color: var(--text-color, #fff); }
   .struct-edit3d-modal {
-    width: min(1100px, 92vw); height: min(800px, 90vh);
+    width: min(1100px, calc(100vw - 32px));
+    height: min(800px, calc(100vh - 32px));
     background: var(--surface-bg); border: 1px solid light-dark(rgba(0,0,0,0.15), rgba(255,255,255,0.15)); border-radius: 10px;
     display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+    min-width: 0;
+    min-height: 0;
+    box-sizing: border-box;
   }
   .struct-edit3d-actions {
-    display: flex; align-items: center; gap: 6px; margin-left: auto;
+    display: flex; align-items: center; gap: 6px; margin-left: auto; flex-wrap: wrap; justify-content: flex-end;
   }
   .struct-edit3d-save {
     padding: 5px 14px; border-radius: 5px; font-size: 12px; font-weight: 600; cursor: pointer;
@@ -226,6 +239,7 @@
     color: #f59e0b; background: #f59e0b12;
     border-bottom: 1px solid #f59e0b30;
     text-align: center;
+    flex-shrink: 0;
   }
   .struct-edit3d-body {
     flex: 1; position: relative; min-height: 0; overflow: hidden;
@@ -240,6 +254,8 @@
     display: flex; align-items: center; gap: 8px; padding: 6px 16px;
     background: light-dark(rgba(59,130,246,0.06), rgba(59,130,246,0.1));
     border-bottom: 1px solid light-dark(rgba(59,130,246,0.15), rgba(59,130,246,0.2));
+    flex-wrap: wrap;
+    flex-shrink: 0;
   }
   .freeze-toolbar-stat {
     font-size: 11px; color: var(--text-color, #eee); margin-right: auto;
@@ -255,4 +271,26 @@
     background: light-dark(rgba(59,130,246,0.2), rgba(59,130,246,0.3));
   }
   .freeze-tb-btn:disabled { opacity: 0.4; cursor: default; }
+
+  @media (max-width: 720px) {
+    .struct-preview-overlay {
+      padding: 8px;
+    }
+
+    .struct-edit3d-modal {
+      width: calc(100vw - 16px);
+      height: calc(100vh - 16px);
+    }
+
+    .struct-preview-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .struct-edit3d-actions {
+      width: 100%;
+      justify-content: flex-start;
+      margin-left: 0;
+    }
+  }
 </style>

--- a/src/lib/workflow/components/VaspEditorModal.svelte
+++ b/src/lib/workflow/components/VaspEditorModal.svelte
@@ -85,25 +85,26 @@
   .vasp-modal-overlay {
     position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999;
     display: flex; align-items: center; justify-content: center;
+    padding: 16px; overflow: auto;
   }
   .vasp-modal {
-    width: min(900px, 90vw); height: min(700px, 85vh);
+    width: min(900px, calc(100vw - 32px)); height: min(700px, calc(100vh - 32px));
     background: var(--surface-bg); border: 1px solid var(--border-color); border-radius: 10px;
     display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 20px 60px rgba(0,0,0,0.5);
   }
   .vasp-modal-header {
-    display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+    display: flex; align-items: center; gap: 12px; padding: 10px 16px; min-width: 0;
     border-bottom: 1px solid light-dark(rgba(0,0,0,0.08), rgba(255,255,255,0.08)); flex-shrink: 0;
   }
-  .vasp-modal-title { font-size: 14px; font-weight: 700; color: var(--text-color, #eee); margin: 0; white-space: nowrap; }
-  .vasp-tabs { display: flex; gap: 0; flex: 1; }
+  .vasp-modal-title { font-size: 14px; font-weight: 700; color: var(--text-color, #eee); margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+  .vasp-tabs { display: flex; gap: 0; flex: 1; min-width: 0; overflow-x: auto; }
   .vasp-tab {
     padding: 6px 16px; background: none; border: none; border-bottom: 2px solid transparent;
     color: var(--text-color-muted); font-size: 12px; font-weight: 600; cursor: pointer;
   }
   .vasp-tab:hover { color: var(--text-color-muted, #94a3b8); }
   .vasp-tab.active { color: light-dark(#7c3aed, #a78bfa); border-bottom-color: light-dark(#7c3aed, #a78bfa); }
-  .vasp-modal-actions { display: flex; gap: 6px; }
+  .vasp-modal-actions { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
   .vasp-save-btn {
     padding: 5px 14px; background: var(--accent-color, #3b82f6); border: none; border-radius: 5px;
     color: white; font-size: 12px; font-weight: 600; cursor: pointer;

--- a/tests/vitest/DraggablePane.modal-bounds.test.ts
+++ b/tests/vitest/DraggablePane.modal-bounds.test.ts
@@ -35,28 +35,28 @@ describe(`DraggablePane modal containment`, () => {
       props: { children: () => `Pane Content`, show: true, show_pane: true },
     })
 
-    const modal_rect = {
-      left: 110, top: 50, right: 1512, bottom: 1050,
-      width: 1402, height: 1000, x: 110, y: 50,
+    const make_rect = (left: number, top: number, right: number, bottom: number) => ({
+      left, top, right, bottom,
+      width: right - left, height: bottom - top, x: left, y: top,
       toJSON: () => ({}),
-    } as DOMRect
-    // Toggle near the modal's right edge; pane measures 450x400.
-    const toggle_rect = {
-      left: 1450, top: 140, right: 1482, bottom: 172,
-      width: 32, height: 32, x: 1450, y: 140,
-      toJSON: () => ({}),
-    } as DOMRect
-    const pane_rect = {
-      left: 0, top: 0, right: 450, bottom: 400,
-      width: 450, height: 400, x: 0, y: 0,
-      toJSON: () => ({}),
-    } as DOMRect
+    }) as DOMRect
 
-    vi.spyOn(modal, `getBoundingClientRect`).mockReturnValue(modal_rect)
+    const modal_rect = make_rect(110, 50, 1512, 1050)
+    // Toggle near the modal's right edge; pane measures 450x400.
+    const toggle_rect = make_rect(1450, 140, 1482, 172)
+    const pane_rect = make_rect(0, 0, 450, 400)
+
+    // Prototype-level mock: per-element spies break if the component
+    // re-creates the toggle/pane elements between clicks.
+    void modal
+    vi.spyOn(Element.prototype, `getBoundingClientRect`).mockImplementation(function(this: Element) {
+      if (this.classList?.contains(`struct-edit3d-modal`)) return modal_rect
+      if (this.classList?.contains(`pane-toggle`)) return toggle_rect
+      if (this.classList?.contains(`draggable-pane`)) return pane_rect
+      return make_rect(0, 0, 0, 0)
+    })
     const toggle = document.querySelector(`.pane-toggle`) as HTMLElement
     const pane = document.querySelector(`.draggable-pane`) as HTMLElement
-    vi.spyOn(toggle, `getBoundingClientRect`).mockReturnValue(toggle_rect)
-    vi.spyOn(pane, `getBoundingClientRect`).mockReturnValue(pane_rect)
 
     // Two clicks: first computes position (positioning side-effect), second opens.
     await click(toggle)

--- a/tests/vitest/DraggablePane.test.ts
+++ b/tests/vitest/DraggablePane.test.ts
@@ -158,7 +158,9 @@ describe(`DraggablePane`, () => {
       props: { ...default_props, show: true, max_width: `600px` },
     })
     const pane = doc_query(`.draggable-pane`)
-    expect(pane.style.maxWidth).toBe(`600px`)
+    // PR #298: max_width is clamped to the viewport so wide panes can't
+    // overflow small windows.
+    expect(pane.style.maxWidth).toBe(`min(600px, calc(100vw - 32px))`)
   })
 
   test(`ARIA defaults`, () => {


### PR DESCRIPTION
## Summary

This PR improves desktop/browser UI responsiveness by keeping overlays, dialogs, dropdowns, context menus, and floating panels within the visible viewport.

## Fixed

- Clamp draggable/floating panes to the viewport and re-clamp them after window resize.
- Prevent desktop modals and shared dialog components from overflowing the screen.
- Add safe viewport padding, max-width/max-height limits, internal scrolling, text ellipsis, and button wrapping.
- Improve responsive behavior for workflow dialogs, structure import/preview dialogs, file browser dialogs, HPC upload dialogs, DOS helper dialogs, and navigation dropdowns.
- Make narrow browser layouts fall back to stacked layouts where fixed side panels could previously squeeze or overflow content.

## Validation

- `git diff --check` passed.
- Local frontend/backend were reachable:
  - `http://127.0.0.1:3100/`
  - `http://127.0.0.1:8000/`
- Browser smoke test was performed with Chrome headless screenshots for the workflow page at:
  - `480x720`
  - `1280x800`
- `pnpm check` was run and still reports the existing baseline result: `14 errors and 303 warnings`. No additional errors were introduced by this UI-only change.

## Author

XCai@JXNU  
690857@163.com