### PR TITLE
fix(mobile): MP API broken on mobile — relay auth guard fired before native fetch path

### DIFF
--- a/src/lib/chat/__tests__/provider-routing.test.ts
+++ b/src/lib/chat/__tests__/provider-routing.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { is_client_direct, needs_relay, normalize_provider_base_url, relay_fetch, relay_url, RELAY_URL, requires_backend_chat } from '../provider-routing'
 import type { ChatConfig } from '../types'
+
+// Controllable isMobile + native-fetch mocks for the mobile relay_fetch path.
+const mobile_flag = vi.hoisted(() => ({ value: false }))
+const tauri_fetch_mock = vi.hoisted(() => vi.fn())
+vi.mock('$lib/api/transport', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('$lib/api/transport')>()
+  return { ...orig, isMobile: () => mobile_flag.value }
+})
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: tauri_fetch_mock }))
 
 describe(`needs_relay`, () => {
   it(`flags Materials Project OPTIMADE host`, () => {
@@ -89,5 +98,35 @@ describe(`relay_fetch auth-header guard (§8 C)`, () => {
         headers: new Headers({ Authorization: `Bearer secret` }),
       }),
     ).rejects.toThrow(/Refusing to relay/)
+  })
+
+  describe(`mobile native path`, () => {
+    afterEach(() => {
+      mobile_flag.value = false
+      tauri_fetch_mock.mockReset()
+    })
+
+    it(`allows a key-bearing Materials Project request on mobile via native fetch (regression: guard used to fire before the native path and broke MP on mobile)`, async () => {
+      mobile_flag.value = true
+      tauri_fetch_mock.mockResolvedValue(new Response(`{}`, { status: 200 }))
+      const url = `https://api.materialsproject.org/materials/summary/?_limit=1`
+      const resp = await relay_fetch(url, { headers: { 'X-API-KEY': `secret` } })
+      expect(resp.status).toBe(200)
+      // Native fetch got the ORIGINAL url — never the relay.
+      expect(tauri_fetch_mock).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({ headers: { 'X-API-KEY': `secret` } }),
+      )
+    })
+
+    it(`still refuses to relay a key when the native plugin is unavailable on mobile`, async () => {
+      mobile_flag.value = true
+      tauri_fetch_mock.mockRejectedValue(new Error(`plugin missing`))
+      await expect(
+        relay_fetch(`https://api.materialsproject.org/x`, {
+          headers: { 'X-API-KEY': `secret` },
+        }),
+      ).rejects.toThrow(/Refusing to relay/)
+    })
   })
 })

--- a/src/lib/chat/provider-routing.ts
+++ b/src/lib/chat/provider-routing.ts
@@ -77,6 +77,24 @@ function has_auth_header(init?: RequestInit): boolean {
 
 /** A fetch wrapper that transparently routes CORS-blocked hosts via the relay. */
 export async function relay_fetch(url: string, init?: RequestInit): Promise<Response> {
+  // On mobile (Tauri) there is no browser CORS — the native HTTP plugin fetches
+  // from Rust, so CORS-blocked sources (Materials Project, the OPTIMADE provider
+  // list, any provider that omits Access-Control-Allow-Origin) work DIRECTLY
+  // with no relay and no backend. This is why the database showed only PubChem.
+  // Key-bearing requests (e.g. Materials Project X-API-KEY) are safe on this
+  // path: the native fetch goes straight to the target host, never the relay —
+  // which is why this branch must run BEFORE the §8 C guard below (the guard
+  // used to come first and broke MP API access on mobile entirely).
+  if (isMobile()) {
+    try {
+      const { fetch: tauriFetch } = await import(`@tauri-apps/plugin-http`)
+      return await tauriFetch(url, init)
+    } catch (e) {
+      console.warn(`[CatGo] tauri http fetch failed, falling back:`, url, e)
+      // Plugin unavailable (e.g. plain browser) — fall back to the relay path,
+      // which is still protected by the auth-header guard below.
+    }
+  }
   // SECURITY (§8 C): the relay is a third party. NEVER hand it a request that
   // carries the user's API key. Key-bearing chat requests must use llm_fetch
   // (native, no relay) — this guard is defense-in-depth against an accidental
@@ -85,19 +103,6 @@ export async function relay_fetch(url: string, init?: RequestInit): Promise<Resp
     throw new Error(
       `Refusing to relay a request carrying an Authorization/x-api-key header`,
     )
-  }
-  // On mobile (Tauri) there is no browser CORS — the native HTTP plugin fetches
-  // from Rust, so CORS-blocked sources (Materials Project, the OPTIMADE provider
-  // list, any provider that omits Access-Control-Allow-Origin) work DIRECTLY
-  // with no relay and no backend. This is why the database showed only PubChem.
-  if (isMobile()) {
-    try {
-      const { fetch: tauriFetch } = await import(`@tauri-apps/plugin-http`)
-      return await tauriFetch(url, init)
-    } catch (e) {
-      console.warn(`[CatGo] tauri http fetch failed, falling back:`, url, e)
-      // Plugin unavailable (e.g. plain browser) — fall back to the relay path.
-    }
   }
   return fetch(needs_relay(url) ? relay_url(url) : url, init)
 }


### PR DESCRIPTION
## Problem

Since #292, the mobile app cannot reach the Materials Project API at all: key validation and property fetches throw `Refusing to relay a request carrying an Authorization/x-api-key header`.

#292 added a (correct in intent) security guard to `relay_fetch`: never hand a key-bearing request to the third-party CORS relay. But the guard was placed **before** the mobile native-HTTP branch. On mobile (`VITE_STATIC_ONLY=1` builds), MP requests carry `X-API-KEY` and target `api.materialsproject.org` (a relay-listed host) — so the guard threw even though the Tauri native fetch goes directly to MP and never touches the relay.

## Fix

Reorder `relay_fetch`: the mobile native path runs first (key goes only to the target host — safe); the §8 C guard still protects the relay fallback when the native plugin is unavailable.

## Tests

- 2 new regression tests: key-bearing MP request on mobile succeeds via native fetch with the ORIGINAL url; plugin-unavailable fallback still refuses to relay the key.
- `src/lib/chat` + `src/lib/api` suites: 97/97 pass.

## Note

The STATIC_ONLY **web** build's MP-key path (relay forwards X-API-KEY by design, #147) is still blocked by the same guard — intentionally not touched here; needs a separate decision (allowlist MP host through the user-owned relay vs drop web MP key support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)