### PR TITLE
Fix DOS PDOS selection, d-band null handling, and HPC remote listing

### DIFF
--- a/server/catgo/models/dos.py
+++ b/server/catgo/models/dos.py
@@ -85,17 +85,17 @@ class DBandRequest(BaseModel):
 class DBandResponse(BaseModel):
     """D-band analysis results."""
 
-    center_abs: float = Field(description="D-band center absolute (eV)")
-    center_rel: float = Field(description="D-band center relative to Ef (eV)")
-    width: float = Field(description="D-band width / RMS (eV)")
-    variance: float = Field(description="D-band variance (eV^2)")
-    n_d: float = Field(description="Occupied d-electron count")
-    total_d_weight: float = Field(description="Total d-weight")
-    filling_fraction: float = Field(description="D-band filling fraction (0-1)")
-    skewness: float = Field(description="3rd standardised moment")
-    kurtosis: float = Field(description="4th standardised moment")
-    lower_edge: float = Field(description="Lower band edge (eV rel Ef)")
-    upper_edge: float = Field(description="Upper band edge (eV rel Ef)")
+    center_abs: Optional[float] = Field(description="D-band center absolute (eV)")
+    center_rel: Optional[float] = Field(description="D-band center relative to Ef (eV)")
+    width: Optional[float] = Field(description="D-band width / RMS (eV)")
+    variance: Optional[float] = Field(description="D-band variance (eV^2)")
+    n_d: Optional[float] = Field(description="Occupied d-electron count")
+    total_d_weight: Optional[float] = Field(description="Total d-weight")
+    filling_fraction: Optional[float] = Field(description="D-band filling fraction (0-1)")
+    skewness: Optional[float] = Field(description="3rd standardised moment")
+    kurtosis: Optional[float] = Field(description="4th standardised moment")
+    lower_edge: Optional[float] = Field(description="Lower band edge (eV rel Ef)")
+    upper_edge: Optional[float] = Field(description="Upper band edge (eV rel Ef)")
 
 
 class AtomSelectionRequest(BaseModel):

--- a/server/catgo/routers/dos.py
+++ b/server/catgo/routers/dos.py
@@ -497,27 +497,61 @@ def compute_dband(request: DBandRequest) -> DBandResponse:
     )
 
 
+def _select_by_element(elements, requested: list[str]) -> list[int]:
+    wanted = {str(e).strip() for e in requested if str(e).strip()}
+    return [idx for idx, element in enumerate(elements) if str(element).strip() in wanted]
+
+
+def _select_by_index(index_spec: str, nions: int) -> list[int]:
+    atoms: set[int] = set()
+    for raw_part in index_spec.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+
+        if "-" in part:
+            bounds = [p.strip() for p in part.split("-", 1)]
+            if len(bounds) != 2 or not bounds[0].isdigit() or not bounds[1].isdigit():
+                raise HTTPException(status_code=400, detail=f"Invalid atom index range: {part}")
+            start = int(bounds[0])
+            end = int(bounds[1])
+            lo, hi = sorted((start, end))
+            for one_based in range(lo, hi + 1):
+                idx = one_based - 1
+                if 0 <= idx < nions:
+                    atoms.add(idx)
+            continue
+
+        if not part.isdigit():
+            raise HTTPException(status_code=400, detail=f"Invalid atom index: {part}")
+
+        idx = int(part) - 1
+        if 0 <= idx < nions:
+            atoms.add(idx)
+
+    return sorted(atoms)
+
+
 @router.post("/select-atoms")
 def select_atoms(request: AtomSelectionRequest) -> dict:
     """Select atom indices by element symbol or index range (1-based)."""
     session = _get_session(request.session_id)
-    from catgo_dos.selection import combine_selections, select_by_element, select_by_index
 
     data = session.data
     selections = []
 
     if request.elements:
-        indices = select_by_element(data.elements, request.elements)
+        indices = _select_by_element(data.elements, request.elements)
         selections.append(indices)
 
     if request.index_spec:
-        indices = select_by_index(request.index_spec, data.nions, one_based=True)
+        indices = _select_by_index(request.index_spec, data.nions)
         selections.append(indices)
 
     if not selections:
         raise HTTPException(status_code=400, detail="Provide elements or index_spec")
 
-    result = combine_selections(*selections, mode="union")
+    result = sorted({idx for indices in selections for idx in indices})
     return {"atoms": result}
 
 

--- a/server/catgo/routers/hpc.py
+++ b/server/catgo/routers/hpc.py
@@ -819,11 +819,12 @@ async def list_files(request: FileListRequest) -> FileListResponse:
             timeout=30.0,
         )
         return FileListResponse(success=True, files=files, current_path=resolved)
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         logger.error(f"File listing timed out: {request.path}")
+        message = str(exc) or f"Listing timed out for {request.path}"
         return FileListResponse(
             success=False,
-            message=f"Listing timed out for {request.path}",
+            message=message,
         )
     except Exception as exc:
         logger.error(f"File listing failed: {exc}")

--- a/server/catgo/utils/ssh_file_ops.py
+++ b/server/catgo/utils/ssh_file_ops.py
@@ -77,19 +77,21 @@ class SSHFileOpsMixin:
         # Prefer exec for listing. Many HPC login nodes accept SSH commands but
         # have a slow or unavailable SFTP subsystem; trying SFTP first can spend
         # most of the API timeout before the cheaper command fallback runs.
+        exec_error: Exception
         try:
             return await self._list_dir_subprocess(path)
-        except (asyncio.TimeoutError, TimeoutError):
-            logger.warning("Exec list_dir timed out")
-            raise
+        except (asyncio.TimeoutError, TimeoutError) as e:
+            logger.warning("Exec list_dir timed out, falling back to SFTP")
+            exec_error = e
         except Exception as e:
             if str(e).startswith("Cannot list directory:"):
                 raise
             logger.warning(f"Exec list_dir failed, falling back to SFTP: {e}")
+            exec_error = e
 
         sftp = await self.get_sftp()
         if sftp is None:
-            raise RuntimeError(f"Could not list directory: {path}")
+            raise RuntimeError(f"Could not list directory: {path}") from exec_error
         try:
             return await asyncio.wait_for(self._list_dir_sftp(path), timeout=10)
         except Exception as e:

--- a/server/catgo/utils/ssh_file_ops.py
+++ b/server/catgo/utils/ssh_file_ops.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 class SSHFileOpsMixin:
     """File operation methods for HPCConnection (remote SSH)."""
 
+    _LIST_BEGIN = "__CATGO_LIST_BEGIN__"
+    _LIST_END = "__CATGO_LIST_END__"
+    _LIST_ERROR = "__CATGO_LIST_ERROR__"
+
     async def _run_clean_file_cmd(self, cmd: str, timeout: float = 20):
         """Run file-management commands without login-shell startup noise."""
         clean_cmd = f"bash --noprofile --norc -c {shlex.quote(cmd)}"
@@ -69,18 +73,30 @@ class SSHFileOpsMixin:
         """List files in a remote directory. Returns (resolved_path, files)."""
         if self.is_subprocess_mode:
             return await self._list_dir_subprocess(path)
+
+        # Prefer exec for listing. Many HPC login nodes accept SSH commands but
+        # have a slow or unavailable SFTP subsystem; trying SFTP first can spend
+        # most of the API timeout before the cheaper command fallback runs.
+        try:
+            return await self._list_dir_subprocess(path)
+        except (asyncio.TimeoutError, TimeoutError):
+            logger.warning("Exec list_dir timed out")
+            raise
+        except Exception as e:
+            if str(e).startswith("Cannot list directory:"):
+                raise
+            logger.warning(f"Exec list_dir failed, falling back to SFTP: {e}")
+
         sftp = await self.get_sftp()
         if sftp is None:
-            return await self._list_dir_subprocess(path)
+            raise RuntimeError(f"Could not list directory: {path}")
         try:
-            # Bound the op: realpath/readdir can hang on a DTN-offloaded node
-            # even after the handshake succeeds. Timeout => fall back to exec.
-            return await asyncio.wait_for(self._list_dir_sftp(path), timeout=15)
+            return await asyncio.wait_for(self._list_dir_sftp(path), timeout=10)
         except Exception as e:
-            logger.warning(f"SFTP list_dir failed, falling back to exec: {e}")
+            logger.warning(f"SFTP list_dir failed: {e}")
             self._sftp_failed = True
             self.sftp = None
-            return await self._list_dir_subprocess(path)
+            raise
 
     async def _list_dir_sftp(self, path: str) -> tuple[str, list[FileInfo]]:
         sftp = await self.get_sftp()
@@ -106,37 +122,68 @@ class SSHFileOpsMixin:
         return resolved, files
 
     async def _list_dir_subprocess(self, path: str) -> tuple[str, list[FileInfo]]:
-        if path == "~" or path.startswith("~/"):
-            home = (await self._run_marked_file_cmd("printf %s \"$HOME\"", timeout=10)).strip()
-            path = path.replace("~", home, 1)
-        resolved = (
-            await self._run_marked_file_cmd(
-                f"readlink -f -- {shlex.quote(path)} 2>/dev/null || printf %s {shlex.quote(path)}",
-                timeout=10,
-            )
-        ).strip() or path
-        # find format: type|size|mtime|name. Use maxdepth instead of shell globs
-        # so huge directories and dotfiles do not expand inside the shell.
-        cmd = (
-            f"cd {shlex.quote(resolved)} && "
-            "find . -mindepth 1 -maxdepth 1 "
-            "-printf '%y|%s|%T@|%f\\n' 2>/dev/null | head -n 5000"
+        error_marker = shlex.quote(self._LIST_ERROR + "%s\\n")
+        begin_marker = shlex.quote(self._LIST_BEGIN + "%s\\n")
+        end_marker = shlex.quote(self._LIST_END + "\\n")
+        script = f"""
+p={shlex.quote(path)}
+case "$p" in
+  '~') p=$HOME ;;
+  '~/'*) p=$HOME/${{p#'~/'}} ;;
+esac
+if ! cd -- "$p" 2>/dev/null; then
+  printf {error_marker} "$p"
+  exit 2
+fi
+resolved=$(pwd -P 2>/dev/null || printf '%s' "$p")
+printf {begin_marker} "$resolved"
+if command -v find >/dev/null 2>&1; then
+  find . -mindepth 1 -maxdepth 1 -printf '%y|%s|%T@|%f\\n' 2>/dev/null | head -n 5000
+else
+  for f in ./* ./.[!.]* ./..?*; do
+    [ -e "$f" ] || continue
+    name=${{f#./}}
+    if [ -d "$f" ]; then kind=d; else kind=f; fi
+    size=$(wc -c < "$f" 2>/dev/null || printf 0)
+    mtime=$(date -r "$f" +%s 2>/dev/null || printf 0)
+    printf '%s|%s|%s|%s\\n' "$kind" "$size" "$mtime" "$name"
+  done
+fi
+printf {end_marker}
+"""
+        result = await self._run_clean_file_cmd(script, timeout=20)
+        stdout = result.stdout or ""
+        error_line = next(
+            (line for line in stdout.splitlines() if line.startswith(self._LIST_ERROR)),
+            "",
         )
-        output = await self._run_marked_file_cmd(cmd, timeout=20)
+        if result.exit_status != 0 or error_line:
+            target = error_line[len(self._LIST_ERROR):] if error_line else path
+            detail = (result.stderr or "").strip()
+            raise RuntimeError(f"Cannot list directory: {target}{': ' + detail if detail else ''}")
+
+        begin = stdout.find(self._LIST_BEGIN)
+        end = stdout.find(self._LIST_END, begin)
+        if begin < 0 or end < 0:
+            raise RuntimeError("Could not parse remote directory listing")
+
+        payload = stdout[begin + len(self._LIST_BEGIN):end].strip("\r\n")
+        lines = payload.splitlines()
+        resolved = lines[0].strip() if lines else path
         files: list[FileInfo] = []
-        for line in output.strip().split("\n"):
+        for line in lines[1:]:
             if not line.strip():
                 continue
             parts = line.split("|", 3)
             if len(parts) < 4:
                 continue
-            ftype, size_str, mtime_str, name = parts
+            kind, size_str, mtime_str, name = parts
             if name in (".", ".."):
                 continue
             files.append(FileInfo(
                 name=name,
                 path=f"{resolved}/{name}",
-                is_dir=ftype == "d",
+                is_dir=kind == "d" or "directory" in kind.lower(),
                 size_bytes=int(size_str) if size_str.isdigit() else 0,
                 modified_time=str(int(float(mtime_str))) if mtime_str else "",
             ))

--- a/server/tests/test_ssh_file_ops.py
+++ b/server/tests/test_ssh_file_ops.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from catgo.utils.ssh_file_ops import SSHFileOpsMixin
@@ -67,3 +68,35 @@ async def test_remote_listing_surfaces_cd_failure() -> None:
 
     with pytest.raises(RuntimeError, match="Cannot list directory: /missing"):
         await ops.list_remote_dir("/missing")
+
+
+class _TimeoutThenSftpOps(SSHFileOpsMixin):
+    def __init__(self) -> None:
+        self.sftp = object()
+        self._sftp_failed = False
+        self.sftp_called = False
+
+    @property
+    def is_subprocess_mode(self) -> bool:
+        return False
+
+    async def get_sftp(self):
+        return self.sftp
+
+    async def _list_dir_subprocess(self, path: str):
+        raise asyncio.TimeoutError()
+
+    async def _list_dir_sftp(self, path: str):
+        self.sftp_called = True
+        return "/resolved", []
+
+
+@pytest.mark.asyncio
+async def test_exec_timeout_falls_back_to_sftp() -> None:
+    ops = _TimeoutThenSftpOps()
+
+    resolved, files = await ops.list_remote_dir("/data")
+
+    assert ops.sftp_called is True
+    assert resolved == "/resolved"
+    assert files == []

--- a/server/tests/test_ssh_file_ops.py
+++ b/server/tests/test_ssh_file_ops.py
@@ -1,0 +1,69 @@
+import pytest
+
+from catgo.utils.ssh_file_ops import SSHFileOpsMixin
+
+
+class _CompletedProcess:
+    def __init__(self, exit_status: int, stdout: str, stderr: str) -> None:
+        self.exit_status = exit_status
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeRunner:
+    def __init__(self, stdout: str, exit_status: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.exit_status = exit_status
+        self.stderr = stderr
+        self.commands: list[str] = []
+
+    async def run(self, cmd: str, check: bool = False, timeout: float = 60) -> _CompletedProcess:
+        self.commands.append(cmd)
+        return _CompletedProcess(self.exit_status, self.stdout, self.stderr)
+
+
+class _ListingOps(SSHFileOpsMixin):
+    def __init__(self, runner: _FakeRunner) -> None:
+        self.conn = runner
+        self.sftp = None
+        self._sftp_failed = False
+
+    @property
+    def is_subprocess_mode(self) -> bool:
+        return True
+
+    async def get_sftp(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_remote_listing_ignores_login_shell_noise() -> None:
+    stdout = "\n".join(
+        [
+            "Last login: Wed Jun 10 12:00:00 from 10.0.0.2",
+            "__CATGO_LIST_BEGIN__/home/user",
+            "d|4096|1718000000.0|project",
+            "f|12|1718000001.0|README.md",
+            "__CATGO_LIST_END__",
+            "",
+        ]
+    )
+    runner = _FakeRunner(stdout)
+    ops = _ListingOps(runner)
+
+    resolved, files = await ops.list_remote_dir("~")
+
+    assert resolved == "/home/user"
+    assert [f.name for f in files] == ["project", "README.md"]
+    assert files[0].is_dir is True
+    assert files[1].path == "/home/user/README.md"
+    assert "find . -mindepth 1 -maxdepth 1" in runner.commands[0]
+
+
+@pytest.mark.asyncio
+async def test_remote_listing_surfaces_cd_failure() -> None:
+    runner = _FakeRunner("__CATGO_LIST_ERROR__/missing\n", exit_status=2)
+    ops = _ListingOps(runner)
+
+    with pytest.raises(RuntimeError, match="Cannot list directory: /missing"):
+        await ops.list_remote_dir("/missing")

--- a/src/lib/electronic/DosAnalysisPane.svelte
+++ b/src/lib/electronic/DosAnalysisPane.svelte
@@ -132,6 +132,86 @@
     return new_orbital === `custom` ? new_orbital_custom : new_orbital
   }
 
+  function parse_index_spec(spec: string, nions: number): number[] {
+    const atoms = new Set<number>()
+    for (const raw_part of spec.split(`,`)) {
+      const part = raw_part.trim()
+      if (!part) continue
+
+      const range = part.match(/^(\d+)\s*-\s*(\d+)$/)
+      if (range) {
+        const start = Number.parseInt(range[1], 10)
+        const end = Number.parseInt(range[2], 10)
+        const lo = Math.min(start, end)
+        const hi = Math.max(start, end)
+        for (let one_based = lo; one_based <= hi; one_based += 1) {
+          const idx = one_based - 1
+          if (idx >= 0 && idx < nions) atoms.add(idx)
+        }
+        continue
+      }
+
+      if (/^\d+$/.test(part)) {
+        const idx = Number.parseInt(part, 10) - 1
+        if (idx >= 0 && idx < nions) atoms.add(idx)
+      }
+    }
+    return [...atoms].sort((a, b) => a - b)
+  }
+
+  function select_atoms_locally(opts: { elements?: string[]; index_spec?: string }): number[] {
+    if (!session) return []
+
+    const selections: number[] = []
+    if (opts.elements?.length) {
+      const wanted = new Set(opts.elements.map((el) => el.trim()).filter(Boolean))
+      session.elements.forEach((el, idx) => {
+        if (wanted.has(String(el).trim())) selections.push(idx)
+      })
+    }
+
+    if (opts.index_spec?.trim()) {
+      selections.push(...parse_index_spec(opts.index_spec, session.nions))
+    }
+
+    return [...new Set(selections)].sort((a, b) => a - b)
+  }
+
+  async function resolve_atoms(opts: { elements?: string[]; index_spec?: string }): Promise<number[]> {
+    if (!session) return []
+    try {
+      const atoms = await select_atoms(session.session_id, opts)
+      if (atoms.length > 0) return atoms
+    } catch (e) {
+      console.warn(`DOS atom selection endpoint failed; falling back to local selection`, e)
+    }
+    return select_atoms_locally(opts)
+  }
+
+  function format_num(value: number | null | undefined, digits: number, suffix = ``): string {
+    return typeof value === `number` && Number.isFinite(value)
+      ? `${value.toFixed(digits)}${suffix}`
+      : `—`
+  }
+
+  function format_percent(value: number | null | undefined, digits: number): string {
+    return typeof value === `number` && Number.isFinite(value)
+      ? `${(value * 100).toFixed(digits)}%`
+      : `—`
+  }
+
+  function format_range(
+    lower: number | null | undefined,
+    upper: number | null | undefined,
+    digits: number,
+    suffix = ``,
+  ): string {
+    return typeof lower === `number` && Number.isFinite(lower) &&
+      typeof upper === `number` && Number.isFinite(upper)
+      ? `${lower.toFixed(digits)} ~ ${upper.toFixed(digits)}${suffix}`
+      : `—`
+  }
+
   function is_procar(f: File): boolean {
     return f.name.toUpperCase().startsWith(`PROCAR`)
   }
@@ -259,35 +339,42 @@
     poscar_file = null
   }
 
+  async function build_current_group(): Promise<DOSGroup | null> {
+    if (!session) return null
+    let atoms: number[]
+    if (selection_mode === `element`) {
+      if (!new_element) return null
+      atoms = await resolve_atoms({ elements: [new_element] })
+    } else {
+      if (!new_index_spec.trim()) return null
+      atoms = await resolve_atoms({ index_spec: new_index_spec.trim() })
+    }
+
+    if (atoms.length === 0) {
+      error_msg = t('structure.dos_no_atoms_selection')
+      return null
+    }
+
+    const orb = get_orbital_value()
+    const sel_label = selection_mode === `element` ? new_element : `[${new_index_spec}]`
+    const label = new_label || `${sel_label}-${orb}`
+
+    return {
+      atoms,
+      channels: orb,
+      label,
+      normalize: new_normalize,
+    }
+  }
+
   async function add_group() {
-    if (!session) return
     error_msg = ``
 
     try {
-      let atoms: number[]
-      if (selection_mode === `element`) {
-        if (!new_element) return
-        atoms = await select_atoms(session.session_id, { elements: [new_element] })
-      } else {
-        if (!new_index_spec.trim()) return
-        atoms = await select_atoms(session.session_id, { index_spec: new_index_spec.trim() })
-      }
+      const group = await build_current_group()
+      if (!group) return
 
-      if (atoms.length === 0) {
-        error_msg = t('structure.dos_no_atoms_selection')
-        return
-      }
-
-      const orb = get_orbital_value()
-      const sel_label = selection_mode === `element` ? new_element : `[${new_index_spec}]`
-      const label = new_label || `${sel_label}-${orb}`
-
-      groups = [...groups, {
-        atoms,
-        channels: orb,
-        label,
-        normalize: new_normalize,
-      }]
+      groups = [...groups, group]
       new_label = ``
       error_msg = ``
     } catch (e: any) {
@@ -300,12 +387,21 @@
   }
 
   async function run_compute() {
-    if (!session || groups.length === 0) return
+    if (!session) return
     computing = true
     error_msg = ``
     try {
+      let compute_groups = groups
+      if (compute_groups.length === 0) {
+        const group = await build_current_group()
+        if (!group) return
+        compute_groups = [group]
+        groups = [group]
+        new_label = ``
+      }
+
       const params = { sigma, emin, emax, ngrid }
-      const pdos = await compute_pdos(session.session_id, groups, params)
+      const pdos = await compute_pdos(session.session_id, compute_groups, params)
 
       if (include_total) {
         const total = await compute_total_dos(session.session_id, params)
@@ -328,10 +424,10 @@
       let atoms: number[]
       if (dband_sel_mode === `element`) {
         if (!dband_element) return
-        atoms = await select_atoms(session.session_id, { elements: [dband_element] })
+        atoms = await resolve_atoms({ elements: [dband_element] })
       } else {
         if (!dband_index_spec.trim()) return
-        atoms = await select_atoms(session.session_id, { index_spec: dband_index_spec.trim() })
+        atoms = await resolve_atoms({ index_spec: dband_index_spec.trim() })
       }
 
       if (atoms.length === 0) {
@@ -679,7 +775,7 @@
     <button
       class="btn-compute"
       onclick={run_compute}
-      disabled={computing || groups.length === 0}
+      disabled={computing || (groups.length === 0 && (selection_mode === `element` ? !new_element : !new_index_spec.trim()))}
     >
       {#if computing}
         <Spinner /> {t('structure.computing')}
@@ -740,18 +836,18 @@
       {#if dos_state.dband_result}
         <table class="dband-table">
           <tbody>
-            <tr><td>{t('structure.dos_center_abs')}</td><td>{dos_state.dband_result.center_abs.toFixed(4)} eV</td></tr>
-            <tr><td>{t('structure.dos_center_rel_ef')}</td><td>{dos_state.dband_result.center_rel.toFixed(4)} eV</td></tr>
-            <tr><td>{t('structure.dos_width_rms')}</td><td>{dos_state.dband_result.width.toFixed(4)} eV</td></tr>
-            <tr><td>{t('structure.dos_variance')}</td><td>{dos_state.dband_result.variance.toFixed(4)} eV&sup2;</td></tr>
-            <tr><td>n<sub>d</sub></td><td>{dos_state.dband_result.n_d.toFixed(3)}</td></tr>
-            <tr><td>{t('structure.dos_total_d_weight')}</td><td>{dos_state.dband_result.total_d_weight.toFixed(3)}</td></tr>
-            <tr><td>{t('structure.dos_filling')}</td><td>{(dos_state.dband_result.filling_fraction * 100).toFixed(1)}%</td></tr>
-            <tr><td>{t('structure.dos_skewness')}</td><td>{dos_state.dband_result.skewness.toFixed(4)}</td></tr>
-            <tr><td>{t('structure.dos_kurtosis')}</td><td>{dos_state.dband_result.kurtosis.toFixed(4)}</td></tr>
+            <tr><td>{t('structure.dos_center_abs')}</td><td>{format_num(dos_state.dband_result.center_abs, 4, ` eV`)}</td></tr>
+            <tr><td>{t('structure.dos_center_rel_ef')}</td><td>{format_num(dos_state.dband_result.center_rel, 4, ` eV`)}</td></tr>
+            <tr><td>{t('structure.dos_width_rms')}</td><td>{format_num(dos_state.dband_result.width, 4, ` eV`)}</td></tr>
+            <tr><td>{t('structure.dos_variance')}</td><td>{format_num(dos_state.dband_result.variance, 4, ` eV²`)}</td></tr>
+            <tr><td>n<sub>d</sub></td><td>{format_num(dos_state.dband_result.n_d, 3)}</td></tr>
+            <tr><td>{t('structure.dos_total_d_weight')}</td><td>{format_num(dos_state.dband_result.total_d_weight, 3)}</td></tr>
+            <tr><td>{t('structure.dos_filling')}</td><td>{format_percent(dos_state.dband_result.filling_fraction, 1)}</td></tr>
+            <tr><td>{t('structure.dos_skewness')}</td><td>{format_num(dos_state.dband_result.skewness, 4)}</td></tr>
+            <tr><td>{t('structure.dos_kurtosis')}</td><td>{format_num(dos_state.dband_result.kurtosis, 4)}</td></tr>
             <tr>
               <td>{t('structure.dos_band_edges')}</td>
-              <td>{dos_state.dband_result.lower_edge.toFixed(2)} ~ {dos_state.dband_result.upper_edge.toFixed(2)} eV</td>
+              <td>{format_range(dos_state.dband_result.lower_edge, dos_state.dband_result.upper_edge, 2, ` eV`)}</td>
             </tr>
           </tbody>
         </table>

--- a/src/lib/electronic/DosPlotWindow.svelte
+++ b/src/lib/electronic/DosPlotWindow.svelte
@@ -35,7 +35,10 @@
   let dos_plot: DosPlot | undefined = $state()
 
   let dband_center_val = $derived(
-    show_dband_line && dband_result ? dband_result.center_rel : null
+    show_dband_line && typeof dband_result?.center_rel === `number` &&
+      Number.isFinite(dband_result.center_rel)
+      ? dband_result.center_rel
+      : null
   )
 
   function download_blob(content: string, filename: string, mime: string) {

--- a/src/lib/electronic/types.ts
+++ b/src/lib/electronic/types.ts
@@ -36,17 +36,17 @@ export interface PDOSResult {
 }
 
 export interface DBandResult {
-  center_abs: number
-  center_rel: number
-  width: number
-  variance: number
-  n_d: number
-  total_d_weight: number
-  filling_fraction: number
-  skewness: number
-  kurtosis: number
-  lower_edge: number
-  upper_edge: number
+  center_abs: number | null
+  center_rel: number | null
+  width: number | null
+  variance: number | null
+  n_d: number | null
+  total_d_weight: number | null
+  filling_fraction: number | null
+  skewness: number | null
+  kurtosis: number | null
+  lower_edge: number | null
+  upper_edge: number | null
 }
 
 export interface DOSPlotConfig {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1357,7 +1357,10 @@
   let dos_plot_ref: DosPlot | undefined = $state()
   let show_dos_panel = $derived(dos_state.dos_result !== null)
   let dband_center_for_plot = $derived(
-    dos_state.show_dband_line && dos_state.dband_result ? dos_state.dband_result.center_rel : null
+    dos_state.show_dband_line && typeof dos_state.dband_result?.center_rel === `number` &&
+      Number.isFinite(dos_state.dband_result.center_rel)
+      ? dos_state.dband_result.center_rel
+      : null
   )
 
   // Band structure state

--- a/src/lib/structure/controllers/tool-controller.svelte.ts
+++ b/src/lib/structure/controllers/tool-controller.svelte.ts
@@ -108,7 +108,10 @@ export function create_tool_controller(deps: ToolDeps) {
   let dos_plot_ref: DosPlot | undefined = $state()
   let show_dos_panel = $derived(dos_state.dos_result !== null)
   let dband_center_for_plot = $derived(
-    dos_state.show_dband_line && dos_state.dband_result ? dos_state.dband_result.center_rel : null
+    dos_state.show_dband_line && typeof dos_state.dband_result?.center_rel === 'number' &&
+      Number.isFinite(dos_state.dband_result.center_rel)
+      ? dos_state.dband_result.center_rel
+      : null
   )
 
   let band_state: BandViewState = $state({


### PR DESCRIPTION
## Summary

This PR contains bug fixes made after the UI viewport PR.

### DOS / PDOS / d-band fixes

- Fixed PDOS calculation button staying disabled when no PDOS group had been added yet.
- Allows `Compute PDOS` to automatically create a group from the current element/index selection.
- Added frontend fallback atom selection from session metadata when `/api/dos/select-atoms` fails or returns empty.
- Made backend atom selection independent from `catgo_dos.selection` by implementing element and index-range selection directly.
- Fixed d-band result rendering when backend returns null/invalid values, avoiding `.toFixed()` crashes.
- Safely hides d-band center plot lines when the center value is null or non-finite.

### HPC listing fixes

- Prefer command-based remote directory listing before SFTP to avoid SFTP subsystem timeout on some HPC login nodes.
- Added robust marker parsing so login-shell banners/noise do not break directory listing.
- Improved timeout/error messages for `Listing timed out`.
- Added tests for noisy remote listing output and listing failure handling.

## Validation

- `py_compile` passed for modified backend files.
- `git diff --cached --check` passed.
- `svelte-check` still reports the existing baseline `11 errors / 303 warnings`; no new DOS-specific errors were introduced.
- `pytest server/tests/test_ssh_file_ops.py` was not run locally because the current Python environment does not have `pytest` installed.
