### PR TITLE
feat(mobile): tool calling in mobile AI chat (CLIENT_TOOLS agentic loop)

### DIFF
--- a/plan/2026-06-10-mobile-tool-calling-design.md
+++ b/plan/2026-06-10-mobile-tool-calling-design.md
@@ -1,0 +1,87 @@
+# Mobile AI chat: enable tool calling (CLIENT_TOOLS agentic loop)
+
+**Date:** 2026-06-10
+**Status:** approved (design)
+
+## Background
+
+PR #292 shipped mobile AI chat as text-only v1: `chat-state.svelte.ts` passes an
+empty tool list on mobile and routes any hallucinated tool call to an immediate
+error, because `MobileChat.svelte` has no permission UI — a mutating tool call
+would park `request_permission` forever and wedge the chat.
+
+The tool loop itself (`run_tool_loop`, `CLIENT_TOOLS`, `execute_tool`) is
+client-direct and runs in the WebView — the same path the web build uses. All
+slice-level plumbing (`active_tool_blocks`, `active_permission_blocks`,
+`skip_permission`) is UI-agnostic and already works. Only the mobile rendering
+and the gates are missing.
+
+## Decisions
+
+- **Permission UX:** confirmation card per mutating call, with a
+  "don't ask again this session" checkbox wired to the existing
+  `slice.skip_permission` flag (desktop parity, asks at most once if the user
+  opts out).
+- **Tool display:** compact status row per tool call (spinner / ✓ / ✗ + tool
+  name), tap to expand the raw output in a `<pre>`. No reuse of desktop
+  `ToolProgressBlock`/`PermissionCard` (desktop styling + SDK-path coupling).
+- **Tool scope:** full `CLIENT_TOOLS`, no mobile filter. Backend-dependent
+  tools (`get_skill`) fail with a clear error that flows back to the model as a
+  tool result; improve its error message for the no-backend case.
+
+## Changes
+
+### 1. Gates — `src/lib/chat/chat-state.svelte.ts`
+
+- L710: `isMobile() ? [] : CLIENT_TOOLS` → `CLIENT_TOOLS`
+- L718–723: remove the mobile `execute` stub (always `execute_tool`)
+- L724: remove the mobile `kind_of` stub (always `tool_kind`)
+- L683: stop passing `text_only: true` on mobile to
+  `build_sdk_system_prompt` — the system prompt regains tool guidance.
+  Verify the client-direct prompt branch doesn't advertise desktop-only
+  tools (WebSearch/Bash); CLIENT_TOOLS path should already be correct.
+
+### 2. Permission card — `src/lib/mobile/MobileChat.svelte`
+
+Render pending entries of `slice.active_permission_blocks`:
+
+- Tool name + compact JSON input summary
+- Allow / Deny buttons → call the entry's `resolve(ok)`
+- "Don't ask again this session" checkbox → sets `slice.skip_permission`
+- Abort-while-pending already resolves false in chat-state (no wedge)
+
+### 3. Tool status rows — `src/lib/mobile/MobileChat.svelte`
+
+Render `slice.active_tool_blocks`:
+
+- One row per call: status icon (running spinner / complete ✓ / error ✗) +
+  tool name
+- Tap toggles an expanded `<pre>` with the tool output (monospace,
+  horizontal scroll)
+- Placement: above the loading indicator in the message flow (simplified —
+  not interleaved into historical message positions)
+
+### 4. `get_skill` error message — `src/lib/chat/structure-tools.ts`
+
+When the backend fetch fails on mobile, throw a message that tells the model
+the backend is unavailable on mobile rather than a bare HTTP error.
+
+### 5. i18n — `src/lib/i18n/{en,zh}/`
+
+New keys (en/zh parity, enforced by the existing coverage test): allow, deny,
+don't-ask-again, tool running/failed labels.
+
+## Testing
+
+- `chat-state` unit tests: on mobile the tool list is non-empty; permission
+  entry is created for a mutating call and `resolve(true/false)` settles the
+  loop; `skip_permission` bypasses the card.
+- i18n coverage test picks up new keys automatically.
+- Device verification on Android APK (build from this branch): ask CatBot to
+  build a supercell → permission card → tool runs → structure updates.
+
+## Risks
+
+- Tool-calling quality of user-keyed mobile models (DeepSeek/Qwen/Kimi)
+  varies — same exposure as desktop client-direct, no new risk.
+- Desktop behavior unchanged (gates removed are mobile-only branches).

--- a/plan/2026-06-10-mobile-tool-calling-plan.md
+++ b/plan/2026-06-10-mobile-tool-calling-plan.md
@@ -1,0 +1,493 @@
+# Mobile Tool Calling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable the CLIENT_TOOLS agentic tool-calling loop in mobile AI chat (currently text-only), with a mobile permission card and compact tool-status rows.
+
+**Architecture:** All tool-loop plumbing already exists and is UI-agnostic (`slice.active_tool_blocks`, `slice.active_permission_blocks`, `slice.skip_permission` in `chat-state.svelte.ts`). The work is: (1) remove the three `isMobile()` text-only gates in chat-state, (2) keep the mobile Unicode-formula rendering instruction by adding a `unicode_math` param to the tooled system prompt, (3) render permission cards + tool rows in `MobileChat.svelte`, (4) friendlier `get_skill` error when no backend, (5) i18n keys (en/zh parity enforced by existing coverage test).
+
+**Tech Stack:** Svelte 5 runes, vitest, existing chat-state slice plumbing. Formatting: repo pre-commit hook runs `deno fmt` (single quotes, no semicolons) — let it format, re-stage, commit again if it rewrites files. `.svelte` files are NOT deno-formatted.
+
+**Branch:** `feat/mobile-tool-calling` (spec already committed: `plan/2026-06-10-mobile-tool-calling-design.md`).
+
+---
+
+### Task 1: `unicode_math` param on the tooled system prompt
+
+Mobile loses the text-only prompt (which carried the "write formulas in Unicode, no LaTeX" instruction). The tooled prompt needs an opt-in version of that note, because the mobile markdown renderer is plain-text (no KaTeX/HTML).
+
+**Files:**
+- Modify: `src/lib/chat/llm-client.ts` (function `build_sdk_system_prompt`, starts ~line 21)
+- Create: `src/lib/chat/__tests__/llm-client.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/chat/__tests__/llm-client.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { build_sdk_system_prompt } from '../llm-client'
+
+describe(`build_sdk_system_prompt unicode_math`, () => {
+  it(`appends the Unicode-formula note to the TOOLED prompt when unicode_math is set`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, false, true)
+    expect(prompt).toMatch(/UNICODE characters/)
+    expect(prompt).toMatch(/never use \$\.\.\.\$/)
+    // Still the tooled prompt, not the text-only one
+    expect(prompt).toMatch(/catgo_/)
+  })
+
+  it(`omits the note by default (desktop)`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, false)
+    expect(prompt).not.toMatch(/does NOT render LaTeX/)
+    expect(prompt).toMatch(/catgo_/)
+  })
+
+  it(`text_only branch is unchanged and already carries the note`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, true)
+    expect(prompt).toMatch(/TEXT-ONLY/)
+    expect(prompt).toMatch(/UNICODE characters/)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/chat/__tests__/llm-client.test.ts`
+Expected: FAIL — first test fails (5th argument ignored, no Unicode note in tooled prompt).
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/chat/llm-client.ts`, add the param and the append. Signature change:
+
+```ts
+export function build_sdk_system_prompt(
+  provider: LLMProvider,
+  structure_context?: string,
+  has_session: boolean = false,
+  text_only: boolean = false,
+  unicode_math: boolean = false,
+): string {
+```
+
+At the END of the tooled branch (after the existing `msg` assembly, right before the
+final `return` of the non-text-only path — keep the existing `has_session` /
+`structure_context` appends in the same order they are today), add:
+
+```ts
+  if (unicode_math) {
+    msg += `\n\nRendering: this chat does NOT render LaTeX or HTML. Write ` +
+      `chemical formulas and math with UNICODE characters (e.g. TiO₂, H₂O, ` +
+      `α-Fe₂O₃, x², E=mc²) — never use $...$, \\(...\\), <sub>, or <sup>.`
+  }
+```
+
+Also update the doc comment above the function: `text_only` = no tools at all;
+`unicode_math` = tooled, but the host UI has a plain-text renderer (mobile).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/chat/__tests__/llm-client.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat/llm-client.ts src/lib/chat/__tests__/llm-client.test.ts
+git commit -m "feat(chat): unicode_math note for tooled system prompt (mobile renderer)"
+```
+
+---
+
+### Task 2: Remove the mobile text-only gates in chat-state
+
+**Files:**
+- Modify: `src/lib/chat/chat-state.svelte.ts` (client-direct branch, ~lines 676–724)
+
+- [ ] **Step 1: Flip the system-prompt call**
+
+At ~line 677 (`const system = build_sdk_system_prompt(`), the current code is:
+
+```ts
+      const system = build_sdk_system_prompt(
+        chat_config.provider,
+        combined_context,
+        false,
+        // Mobile/client-direct runs tool-free (isMobile() ? [] : CLIENT_TOOLS
+        // below) — use the tool-free prompt so the model answers from the inline
+        // structure context instead of promising tool actions it can't perform.
+        isMobile(),
+      )
+```
+
+Replace with:
+
+```ts
+      const system = build_sdk_system_prompt(
+        chat_config.provider,
+        combined_context,
+        false,
+        false,
+        // Mobile renders chat with a plain-text markdown renderer (no KaTeX/
+        // HTML) — keep the Unicode-formula instruction in the tooled prompt.
+        isMobile(),
+      )
+```
+
+- [ ] **Step 2: Flip the tool list, execute, and kind_of**
+
+At ~lines 705–724, the current code is:
+
+```ts
+            // Text-only on mobile (§4): run the loop with an EMPTY tool list so the
+            // model never attempts a tool call. Combined with Phase A's
+            // omit-tools-when-empty body fix this makes mobile chat pure text.
+            // Desktop keeps the full CLIENT_TOOLS agentic loop.
+            isMobile() ? [] : CLIENT_TOOLS,
+            slice.abort_controller?.signal,
+          ),
+        // Mobile is text-only and offers no tools, but a model can still
+        // hallucinate a tool_call. There is no PermissionCard on mobile, so a
+        // `mutate` call would park request_permission forever and wedge the chat
+        // (loading never clears). Route any such call to an immediate error with
+        // read-kind (skips the permission gate) so the loop unwinds cleanly.
+        execute: isMobile()
+          ? () =>
+            Promise.resolve(
+              `{"error":"tools are not available in mobile chat"}`,
+            )
+          : execute_tool,
+        kind_of: isMobile() ? () => `read` as const : tool_kind,
+```
+
+Replace with:
+
+```ts
+            // Desktop AND mobile run the full CLIENT_TOOLS agentic loop; the
+            // mobile permission card in MobileChat.svelte renders
+            // active_permission_blocks, so mutating calls no longer wedge.
+            CLIENT_TOOLS,
+            slice.abort_controller?.signal,
+          ),
+        execute: execute_tool,
+        kind_of: tool_kind,
+```
+
+If `isMobile` is now unused in this file, remove the import (check with
+`grep -n isMobile src/lib/chat/chat-state.svelte.ts` — there is another use at
+~line 110, so likely keep it).
+
+- [ ] **Step 3: Run the chat suites**
+
+Run: `pnpm vitest run src/lib/chat`
+Expected: all pass (tool-loop, client-llm, structure-tools, etc. unaffected — they don't mock isMobile to true).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/chat/chat-state.svelte.ts
+git commit -m "feat(mobile): run the full CLIENT_TOOLS tool loop in mobile chat"
+```
+
+---
+
+### Task 3: Friendlier `get_skill` error when the backend is absent
+
+**Files:**
+- Modify: `src/lib/chat/structure-tools.ts` (~line 186, the `get_skill` executor)
+
+- [ ] **Step 1: Wrap the backend fetch**
+
+Current executor body:
+
+```ts
+  async (input) => {
+    const path = String((input.skill_path as string) ?? ``).trim().replace(/^\/+|\/+$/g, ``)
+    const url = path ? `${API_BASE}/skills/${path}` : `${API_BASE}/skills/`
+    const res = await fetch(url)
+    if (!res.ok) {
+      throw new Error(`Skill fetch failed (HTTP ${res.status}). Call get_skill with no argument to list available skills.`)
+    }
+    const data = await res.json()
+    return path ? (data.content ?? data) : (data.skills ?? data)
+  },
+```
+
+Replace the fetch + error handling (keep the rest):
+
+```ts
+  async (input) => {
+    const path = String((input.skill_path as string) ?? ``).trim().replace(/^\/+|\/+$/g, ``)
+    const url = path ? `${API_BASE}/skills/${path}` : `${API_BASE}/skills/`
+    let res: Response
+    try {
+      res = await fetch(url)
+    } catch {
+      // Mobile / static builds have no Python backend at API_BASE.
+      throw new Error(
+        `Skill guides require the CatGo backend, which is not available in this build (mobile/static). Proceed with your own domain knowledge instead of retrying.`,
+      )
+    }
+    if (!res.ok) {
+      throw new Error(`Skill fetch failed (HTTP ${res.status}). Call get_skill with no argument to list available skills.`)
+    }
+    const data = await res.json()
+    return path ? (data.content ?? data) : (data.skills ?? data)
+  },
+```
+
+(No new unit test: the change is an error-message rewording on a network-level
+failure; the existing structure-tools tests cover the registry wiring.)
+
+- [ ] **Step 2: Run the suite**
+
+Run: `pnpm vitest run src/lib/chat/__tests__/structure-tools.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/chat/structure-tools.ts
+git commit -m "fix(chat): clear get_skill error when the backend is unavailable (mobile/static)"
+```
+
+---
+
+### Task 4: i18n keys (en + zh, parity enforced by coverage test)
+
+**Files:**
+- Modify: `src/lib/i18n/en/mobile.ts`
+- Modify: `src/lib/i18n/zh/mobile.ts`
+
+- [ ] **Step 1: Add the keys**
+
+In `src/lib/i18n/en/mobile.ts`, next to the existing `ai_*` keys (~line 135):
+
+```ts
+  ai_tool_permission:     `CatBot wants to run a tool`,
+  ai_allow:               `Allow`,
+  ai_deny:                `Deny`,
+  ai_dont_ask_again:      `Don't ask again this session`,
+  ai_tool_failed:         `failed`,
+```
+
+In `src/lib/i18n/zh/mobile.ts`, same keys:
+
+```ts
+  ai_tool_permission:     `CatBot 请求执行工具`,
+  ai_allow:               `允许`,
+  ai_deny:                `拒绝`,
+  ai_dont_ask_again:      `本会话内不再询问`,
+  ai_tool_failed:         `失败`,
+```
+
+(Match the literal style of the surrounding lines — backtick strings, aligned
+colons if the file aligns them.)
+
+- [ ] **Step 2: Run the i18n coverage test**
+
+Run: `pnpm vitest run src/lib/i18n`
+Expected: PASS — en/zh key sets in parity.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/i18n/en/mobile.ts src/lib/i18n/zh/mobile.ts
+git commit -m "feat(i18n): mobile tool-permission strings (en/zh)"
+```
+
+---
+
+### Task 5: Permission card + tool status rows in MobileChat
+
+**Files:**
+- Modify: `src/lib/mobile/MobileChat.svelte` (script ~line 21+, markup ~line 310, styles at the bottom)
+
+- [ ] **Step 1: Script additions**
+
+In the `<script>` block (near the other `$state` declarations, ~line 105):
+
+```ts
+  import { SvelteSet } from 'svelte/reactivity'
+  import type { PermissionEntry } from '$lib/chat/chat-state.svelte'
+
+  // Tool rows the user has tapped open (cleared per-send is unnecessary —
+  // entries are replaced wholesale at the start of each client-direct run).
+  const expanded_tools = new SvelteSet<string>()
+  function toggle_tool(id: string): void {
+    if (expanded_tools.has(id)) expanded_tools.delete(id)
+    else expanded_tools.add(id)
+  }
+
+  // "Don't ask again this session" checkbox state for the permission card.
+  let skip_session = $state(false)
+
+  function decide_permission(entry: PermissionEntry, ok: boolean): void {
+    entry.status = ok ? `approved` : `denied`
+    if (ok && skip_session) slice.skip_permission.value = true
+    entry.resolve?.(ok)
+  }
+```
+
+(`SvelteSet` import goes with the other imports at the top; the rest after the
+existing state declarations. `PermissionEntry` is exported from
+`$lib/chat/chat-state.svelte` — verify with `grep -n 'export interface PermissionEntry' src/lib/chat/chat-state.svelte.ts`.)
+
+- [ ] **Step 2: Markup**
+
+In the `ai-body` block, AFTER the `{#each slice.messages.list …}` loop closes and
+BEFORE the `{#if slice.loading.value}` thinking indicator (~line 311), insert:
+
+```svelte
+      <!-- Tool calls of the current run: compact status rows, tap to expand -->
+      {#each Object.entries(slice.active_tool_blocks.entries) as [id, tb] (id)}
+        <div class="ai-tool" class:error={tb.status === `error`}>
+          <button type="button" class="ai-tool-row" onclick={() => toggle_tool(id)}>
+            {#if tb.status === `running`}
+              <span class="ai-dots" aria-hidden="true"></span>
+            {:else if tb.status === `error`}
+              <span class="ai-tool-mark err">✗</span>
+            {:else}
+              <span class="ai-tool-mark ok">✓</span>
+            {/if}
+            <span class="ai-tool-name">{tb.toolName}</span>
+            {#if tb.status === `error`}<span class="ai-tool-sub">{t(`mobile.ai_tool_failed`)}</span>{/if}
+          </button>
+          {#if expanded_tools.has(id)}
+            <pre class="ai-tool-out">{tb.output || JSON.stringify(tb.input, null, 1)}</pre>
+          {/if}
+        </div>
+      {/each}
+
+      <!-- Pending mutating-tool permission cards (client-direct loop) -->
+      {#each Object.entries(slice.active_permission_blocks.entries) as [id, pb] (id)}
+        {#if pb.status === `pending` && pb.resolve}
+          <div class="ai-perm" role="alertdialog" aria-label={t(`mobile.ai_tool_permission`)}>
+            <div class="ai-perm-title">{t(`mobile.ai_tool_permission`)}</div>
+            <div class="ai-perm-tool">{pb.toolName}</div>
+            <pre class="ai-perm-input">{JSON.stringify(pb.input, null, 1)}</pre>
+            <label class="ai-perm-skip">
+              <input type="checkbox" bind:checked={skip_session} />
+              {t(`mobile.ai_dont_ask_again`)}
+            </label>
+            <div class="ai-perm-actions">
+              <button type="button" class="ai-perm-deny" onclick={() => decide_permission(pb, false)}>{t(`mobile.ai_deny`)}</button>
+              <button type="button" class="ai-perm-allow" onclick={() => decide_permission(pb, true)}>{t(`mobile.ai_allow`)}</button>
+            </div>
+          </div>
+        {/if}
+      {/each}
+```
+
+- [ ] **Step 3: Styles**
+
+Append to the `<style>` block (follow existing `.ai-*` class conventions and CSS
+custom properties used in the file):
+
+```css
+  .ai-tool {
+    margin: 2px 0;
+    border-radius: 8px;
+    background: var(--surface-2, rgba(148, 163, 184, 0.08));
+    overflow: hidden;
+  }
+  .ai-tool-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    background: transparent;
+    border: none;
+    color: var(--text-color-muted, #94a3b8);
+    font-size: 13px;
+    text-align: left;
+  }
+  .ai-tool-mark.ok { color: var(--success-color, #4ade80); }
+  .ai-tool-mark.err { color: var(--error-color, #f87171); }
+  .ai-tool-name { font-family: monospace; }
+  .ai-tool-sub { margin-left: auto; font-size: 12px; opacity: 0.8; }
+  .ai-tool-out,
+  .ai-perm-input {
+    margin: 0;
+    padding: 8px 10px;
+    font-size: 12px;
+    font-family: monospace;
+    overflow-x: auto;
+    white-space: pre;
+    color: var(--text-color-muted, #94a3b8);
+    background: rgba(0, 0, 0, 0.15);
+  }
+  .ai-tool-out { max-height: 40vh; overflow-y: auto; }
+  .ai-perm {
+    margin: 6px 0;
+    padding: 10px;
+    border: 1px solid var(--warning-color, #facc15);
+    border-radius: 10px;
+    display: grid;
+    gap: 8px;
+  }
+  .ai-perm-title { font-weight: 600; font-size: 14px; }
+  .ai-perm-tool { font-family: monospace; font-size: 13px; }
+  .ai-perm-skip { display: flex; align-items: center; gap: 6px; font-size: 13px; }
+  .ai-perm-actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .ai-perm-actions button {
+    min-height: 40px;
+    padding: 0 16px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    font-size: 14px;
+  }
+  .ai-perm-allow { background: var(--accent-color, #3b82f6); color: white; }
+  .ai-perm-deny { background: transparent; border-color: var(--border-color, #334155) !important; color: var(--text-color-muted, #94a3b8); }
+```
+
+(Adjust custom-property names to whatever the file already uses — check the
+existing `.ai-error` / `.ai-msg` rules and reuse their variables.)
+
+- [ ] **Step 4: Type-check + full test suite**
+
+Run: `pnpm check 2>&1 | tail -20` — no new errors in MobileChat.svelte.
+Run: `pnpm vitest run src/lib/chat src/lib/mobile src/lib/i18n`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mobile/MobileChat.svelte
+git commit -m "feat(mobile): permission card + tool status rows in AI chat"
+```
+
+---
+
+### Task 6: Full-suite regression + device verification notes
+
+- [ ] **Step 1: Full unit suite**
+
+Run: `pnpm vitest run`
+Expected: same pass count as main (1 known flaky: RdfPlot under full suite — rerun in isolation if it fails).
+
+- [ ] **Step 2: Desktop smoke (no regression)**
+
+Run `pnpm desktop:serve`, open chat, ask "make a 2x2x2 supercell" → desktop
+PermissionCard appears as before, tool runs. (Desktop path untouched, but the
+system-prompt call changed — verify a normal tooled conversation still works.)
+
+- [ ] **Step 3: Device verification (Android)**
+
+Build APK from this branch (conda env with openjdk=17, `pnpm tauri android build --apk true`, debug-sign, `adb install`). On device:
+1. Open a structure → AI chat → ask "build a 2x2x2 supercell".
+2. Expect: permission card → Allow → tool row ✓ → structure updates in the viewer.
+3. Ask again with "don't ask again" checked → second mutating call runs without a card.
+4. Ask something needing `get_skill` → tool row ✗, model continues with its own knowledge (no wedge).
+5. Stop button mid-permission → card resolves, loading clears (abort path).
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+git push -u origin feat/mobile-tool-calling
+gh pr create --title "feat(mobile): tool calling in mobile AI chat" --body "..."
+```
+
+PR body: link `plan/2026-06-10-mobile-tool-calling-design.md`, note desktop
+behavior unchanged, list device-verified steps from Step 3.

--- a/src/lib/chat/__tests__/llm-client.test.ts
+++ b/src/lib/chat/__tests__/llm-client.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { build_sdk_system_prompt } from '../llm-client'
+
+describe(`build_sdk_system_prompt unicode_math`, () => {
+  it(`appends the Unicode-formula note to the TOOLED prompt when unicode_math is set`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, false, true)
+    expect(prompt).toMatch(/UNICODE characters/)
+    expect(prompt).toMatch(/never use \$\.\.\.\$/)
+    // Still the tooled prompt, not the text-only one
+    expect(prompt).toMatch(/catgo_/)
+  })
+
+  it(`omits the note by default (desktop)`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, false)
+    expect(prompt).not.toMatch(/does NOT render LaTeX/)
+    expect(prompt).toMatch(/catgo_/)
+  })
+
+  it(`text_only branch is unchanged and already carries the note`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, true)
+    expect(prompt).toMatch(/TEXT-ONLY/)
+    expect(prompt).toMatch(/UNICODE characters/)
+  })
+})

--- a/src/lib/chat/__tests__/llm-client.test.ts
+++ b/src/lib/chat/__tests__/llm-client.test.ts
@@ -16,9 +16,22 @@ describe(`build_sdk_system_prompt unicode_math`, () => {
     expect(prompt).toMatch(/catgo_/)
   })
 
-  it(`text_only branch is unchanged and already carries the note`, () => {
+  it(`text_only prompt is unaffected (has its own Unicode note; unicode_math param is a no-op)`, () => {
     const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, true)
     expect(prompt).toMatch(/TEXT-ONLY/)
     expect(prompt).toMatch(/UNICODE characters/)
+  })
+
+  it(`unicode_math is a no-op when text_only is also true (no duplication)`, () => {
+    const prompt = build_sdk_system_prompt(`deepseek`, undefined, false, true, true)
+    expect(prompt).toMatch(/TEXT-ONLY/)
+    const count = (prompt.match(/does NOT render LaTeX/g) ?? []).length
+    expect(count).toBe(1)
+  })
+
+  it(`sdk-gemini with unicode_math drops the LaTeX instruction`, () => {
+    const prompt = build_sdk_system_prompt(`sdk-gemini`, undefined, false, false, true)
+    expect(prompt).toMatch(/UNICODE characters/)
+    expect(prompt).not.toMatch(/Use LaTeX/)
   })
 })

--- a/src/lib/chat/chat-state.svelte.ts
+++ b/src/lib/chat/chat-state.svelte.ts
@@ -677,9 +677,9 @@ export async function send_message(
         chat_config.provider,
         combined_context,
         false,
-        // Mobile/client-direct runs tool-free (isMobile() ? [] : CLIENT_TOOLS
-        // below) — use the tool-free prompt so the model answers from the inline
-        // structure context instead of promising tool actions it can't perform.
+        false,
+        // Mobile renders chat with a plain-text markdown renderer (no KaTeX/
+        // HTML) — keep the Unicode-formula instruction in the tooled prompt.
         isMobile(),
       )
 
@@ -703,25 +703,14 @@ export async function send_message(
             history,
             chat_config,
             system,
-            // Text-only on mobile (§4): run the loop with an EMPTY tool list so the
-            // model never attempts a tool call. Combined with Phase A's
-            // omit-tools-when-empty body fix this makes mobile chat pure text.
-            // Desktop keeps the full CLIENT_TOOLS agentic loop.
-            isMobile() ? [] : CLIENT_TOOLS,
+            // Desktop AND mobile run the full CLIENT_TOOLS agentic loop; the
+            // mobile permission card in MobileChat.svelte renders
+            // active_permission_blocks, so mutating calls no longer wedge.
+            CLIENT_TOOLS,
             slice.abort_controller?.signal,
           ),
-        // Mobile is text-only and offers no tools, but a model can still
-        // hallucinate a tool_call. There is no PermissionCard on mobile, so a
-        // `mutate` call would park request_permission forever and wedge the chat
-        // (loading never clears). Route any such call to an immediate error with
-        // read-kind (skips the permission gate) so the loop unwinds cleanly.
-        execute: isMobile()
-          ? () =>
-            Promise.resolve(
-              `{"error":"tools are not available in mobile chat"}`,
-            )
-          : execute_tool,
-        kind_of: isMobile() ? () => `read` as const : tool_kind,
+        execute: execute_tool,
+        kind_of: tool_kind,
         request_permission: (call) =>
           new Promise<boolean>((resolve) => {
             // Session-scoped bypass: approve immediately, no card.

--- a/src/lib/chat/client-llm.ts
+++ b/src/lib/chat/client-llm.ts
@@ -210,7 +210,8 @@ export async function* stream_client_llm(
   // makes providers (e.g. DeepSeek) stop emitting structured tool_calls and leak
   // raw tool-call markup into content. (Verified against the live DeepSeek API,
   // 2026-05-26.) BUT: an empty `"tools": []` 400s on Anthropic, so OMIT the
-  // field entirely when the tool list is empty (text-only mobile chat path).
+  // field entirely when the tool list is empty (defensive — all current
+  // callers pass the full CLIENT_TOOLS list).
   const openai_tools = tools.map((t) => ({
     type: `function`,
     function: {

--- a/src/lib/chat/llm-client.ts
+++ b/src/lib/chat/llm-client.ts
@@ -80,7 +80,11 @@ Rules: Act first, explain after. Use standard defaults (slab: 10 Å thickness, 1
         has_session
           ? ``
           : `When greeting, briefly describe the loaded structure in one sentence.`
-      } Use LaTeX for math and chemical formulas ($H_2O$, $E = mc^2$, $\\alpha$-Fe₂O₃) with $...$ for inline and $$...$$ for display math. Never use HTML tags (<sub>, <sup>).`
+      } ${
+        !unicode_math
+          ? `Use LaTeX for math and chemical formulas ($H_2O$, $E = mc^2$, $\\alpha$-Fe₂O₃) with $...$ for inline and $$...$$ for display math. `
+          : ``
+      }Never use HTML tags (<sub>, <sup>).`
   }
 
   if (unicode_math) {

--- a/src/lib/chat/llm-client.ts
+++ b/src/lib/chat/llm-client.ts
@@ -17,12 +17,15 @@ Answer questions based on the documentation and structure context provided. Be c
  *  prompt advertises tools (catgo_, WebSearch, Bash, ...) and says "call tools
  *  directly"; with no tools wired up the model promises actions it can't perform
  *  and burns turns hallucinating tool calls (then stalls). The text-only branch
- *  drops all tool talk and points the model at the inline structure context. */
+ *  drops all tool talk and points the model at the inline structure context.
+ *  `unicode_math` = when true and not in text_only mode, appends a note that the
+ *  host UI renders plain text (not LaTeX/HTML), so use Unicode for formulas instead. */
 export function build_sdk_system_prompt(
   provider: LLMProvider,
   structure_context?: string,
   has_session: boolean = false,
   text_only: boolean = false,
+  unicode_math: boolean = false,
 ): string {
   if (text_only) {
     let msg = `You are CatBot, a materials science assistant in CatGO ` +
@@ -78,6 +81,12 @@ Rules: Act first, explain after. Use standard defaults (slab: 10 Å thickness, 1
           ? ``
           : `When greeting, briefly describe the loaded structure in one sentence.`
       } Use LaTeX for math and chemical formulas ($H_2O$, $E = mc^2$, $\\alpha$-Fe₂O₃) with $...$ for inline and $$...$$ for display math. Never use HTML tags (<sub>, <sup>).`
+  }
+
+  if (unicode_math) {
+    msg += `\n\nRendering: this chat does NOT render LaTeX or HTML. Write ` +
+      `chemical formulas and math with UNICODE characters (e.g. TiO₂, H₂O, ` +
+      `α-Fe₂O₃, x², E=mc²) — never use $...$, \\(...\\), <sub>, or <sup>.`
   }
 
   if (structure_context) {

--- a/src/lib/chat/llm-client.ts
+++ b/src/lib/chat/llm-client.ts
@@ -13,7 +13,8 @@ const SYSTEM_PROMPT =
 Answer questions based on the documentation and structure context provided. Be concise and helpful. When the user asks about their current structure, reference the structure context below. If the documentation doesn't cover the topic, say so honestly.`
 
 /** System message for SDK agents with agent-specific guidance. Exported for chat-state SDK path.
- *  `text_only` = the caller runs with NO tools (mobile/client-direct). The default
+ *  `text_only` = the caller runs with NO tools (no current caller sets this; kept
+ *  for the tool-free prompt variant). The default
  *  prompt advertises tools (catgo_, WebSearch, Bash, ...) and says "call tools
  *  directly"; with no tools wired up the model promises actions it can't perform
  *  and burns turns hallucinating tool calls (then stalls). The text-only branch

--- a/src/lib/chat/structure-tools.ts
+++ b/src/lib/chat/structure-tools.ts
@@ -185,7 +185,15 @@ register(
   async (input) => {
     const path = String((input.skill_path as string) ?? ``).trim().replace(/^\/+|\/+$/g, ``)
     const url = path ? `${API_BASE}/skills/${path}` : `${API_BASE}/skills/`
-    const res = await fetch(url)
+    let res: Response
+    try {
+      res = await fetch(url)
+    } catch {
+      // Mobile / static builds have no Python backend at API_BASE.
+      throw new Error(
+        `Skill guides require the CatGo backend, which is not available in this build (mobile/static). Proceed with your own domain knowledge instead of retrying.`,
+      )
+    }
     if (!res.ok) {
       throw new Error(`Skill fetch failed (HTTP ${res.status}). Call get_skill with no argument to list available skills.`)
     }

--- a/src/lib/chat/structure-tools.ts
+++ b/src/lib/chat/structure-tools.ts
@@ -189,9 +189,10 @@ register(
     try {
       res = await fetch(url)
     } catch {
-      // Mobile / static builds have no Python backend at API_BASE.
+      // fetch() rejects only on network-level failure: mobile/static builds
+      // have no Python backend at API_BASE, and desktop may not have it running.
       throw new Error(
-        `Skill guides require the CatGo backend, which is not available in this build (mobile/static). Proceed with your own domain knowledge instead of retrying.`,
+        `Skill guides require the CatGo backend, which is unreachable (mobile/static build, or backend not running). Proceed with your own domain knowledge instead of retrying.`,
       )
     }
     if (!res.ok) {

--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -152,6 +152,11 @@ const mobile: Record<string, string> = {
   ai_rate_limited:        `Rate limit reached — the free tier allows only a few messages per minute. Wait a few seconds and resend, or pick a higher-limit model in settings.`,
   ai_model_busy:          `The model is busy right now (high demand) — usually temporary. Wait a moment and resend, or try a different model in settings.`,
   ai_message_placeholder: `Type a message…`,
+  ai_tool_permission:    `CatBot wants to run a tool`,
+  ai_allow:              `Allow`,
+  ai_deny:               `Deny`,
+  ai_dont_ask_again:     `Don't ask again this session`,
+  ai_tool_failed:        `failed`,
 }
 
 export default mobile

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -152,6 +152,11 @@ const mobile: Record<string, string> = {
   ai_rate_limited:        `已达到速率限制 — 免费层每分钟只能发送少量消息。请等待几秒后重试，或在设置中选择额度更高的模型。`,
   ai_model_busy:          `模型当前繁忙（需求高峰）— 通常是暂时的。请稍候重试，或在设置中尝试其他模型。`,
   ai_message_placeholder: `输入消息…`,
+  ai_tool_permission:    `CatBot 请求执行工具`,
+  ai_allow:              `允许`,
+  ai_deny:               `拒绝`,
+  ai_dont_ask_again:     `本会话内不再询问`,
+  ai_tool_failed:        `失败`,
 }
 
 export default mobile

--- a/src/lib/mobile/MobileChat.svelte
+++ b/src/lib/mobile/MobileChat.svelte
@@ -20,6 +20,7 @@
 -->
 <script lang="ts">
   import { untrack } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
   import Icon from '$lib/Icon.svelte'
   import { get_display_text } from '$lib/chat/types'
   import {
@@ -29,6 +30,7 @@
     send_message,
     set_session_api_key,
   } from '$lib/chat/chat-state.svelte'
+  import type { PermissionEntry } from '$lib/chat/chat-state.svelte'
   import { loadApiKey, redact } from './ai-keys'
   import MobileChatSetup from './MobileChatSetup.svelte'
   import { build_structure_context } from '$lib/chat/context'
@@ -107,6 +109,23 @@
   let setup_open = $state(false)
 
   let input = $state(``)
+
+  // Tool rows the user has tapped open (entries are replaced wholesale at the
+  // start of each client-direct run, so no per-send cleanup is needed).
+  const expanded_tools = new SvelteSet<string>()
+  function toggle_tool(id: string): void {
+    if (expanded_tools.has(id)) expanded_tools.delete(id)
+    else expanded_tools.add(id)
+  }
+
+  // "Don't ask again this session" checkbox state for the permission card.
+  let skip_session = $state(false)
+
+  function decide_permission(entry: PermissionEntry, ok: boolean): void {
+    entry.status = ok ? `approved` : `denied`
+    if (ok && skip_session) slice.skip_permission.value = true
+    entry.resolve?.(ok)
+  }
 
   // Load the stored key for the current provider whenever it changes. Async-race
   // guard (§5): capture the provider; only apply if it's still selected on
@@ -308,6 +327,45 @@
           {/if}
         {/each}
       {/if}
+
+      <!-- Tool calls of the current run: compact status rows, tap to expand -->
+      {#each Object.entries(slice.active_tool_blocks.entries) as [id, tb] (id)}
+        <div class="ai-tool" class:error={tb.status === `error`}>
+          <button type="button" class="ai-tool-row" onclick={() => toggle_tool(id)}>
+            {#if tb.status === `running`}
+              <span class="ai-dots" aria-hidden="true"></span>
+            {:else if tb.status === `error`}
+              <span class="ai-tool-mark err">✗</span>
+            {:else}
+              <span class="ai-tool-mark ok">✓</span>
+            {/if}
+            <span class="ai-tool-name">{tb.toolName}</span>
+            {#if tb.status === `error`}<span class="ai-tool-sub">{t(`mobile.ai_tool_failed`)}</span>{/if}
+          </button>
+          {#if expanded_tools.has(id)}
+            <pre class="ai-tool-out">{tb.output || JSON.stringify(tb.input, null, 1)}</pre>
+          {/if}
+        </div>
+      {/each}
+
+      <!-- Pending mutating-tool permission cards (client-direct loop) -->
+      {#each Object.entries(slice.active_permission_blocks.entries) as [id, pb] (id)}
+        {#if pb.status === `pending` && pb.resolve}
+          <div class="ai-perm" role="alertdialog" aria-label={t(`mobile.ai_tool_permission`)}>
+            <div class="ai-perm-title">{t(`mobile.ai_tool_permission`)}</div>
+            <div class="ai-perm-tool">{pb.toolName}</div>
+            <pre class="ai-perm-input">{JSON.stringify(pb.input, null, 1)}</pre>
+            <label class="ai-perm-skip">
+              <input type="checkbox" bind:checked={skip_session} />
+              {t(`mobile.ai_dont_ask_again`)}
+            </label>
+            <div class="ai-perm-actions">
+              <button type="button" class="ai-perm-deny" onclick={() => decide_permission(pb, false)}>{t(`mobile.ai_deny`)}</button>
+              <button type="button" class="ai-perm-allow" onclick={() => decide_permission(pb, true)}>{t(`mobile.ai_allow`)}</button>
+            </div>
+          </div>
+        {/if}
+      {/each}
 
       {#if slice.loading.value}
         <div class="ai-thinking" aria-live="polite">
@@ -681,5 +739,66 @@
   }
   .ai-send.stop {
     background: #ff6b6b;
+  }
+  .ai-tool {
+    margin: 2px 0;
+    border-radius: 8px;
+    background: var(--surface-2, rgba(148, 163, 184, 0.08));
+    overflow: hidden;
+  }
+  .ai-tool-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    background: transparent;
+    border: none;
+    color: var(--text-color-muted, #94a3b8);
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .ai-tool-mark.ok { color: var(--success-color, #4ade80); }
+  .ai-tool-mark.err { color: #ff6b6b; }
+  .ai-tool-name { font-family: monospace; }
+  .ai-tool-sub { margin-left: auto; font-size: 12px; opacity: 0.8; }
+  .ai-tool-out,
+  .ai-perm-input {
+    margin: 0;
+    padding: 8px 10px;
+    font-size: 12px;
+    font-family: monospace;
+    overflow-x: auto;
+    white-space: pre;
+    color: var(--text-color-muted, #94a3b8);
+    background: rgba(0, 0, 0, 0.15);
+  }
+  .ai-tool-out { max-height: 40vh; overflow-y: auto; }
+  .ai-perm {
+    margin: 6px 0;
+    padding: 10px;
+    border: 1px solid rgba(250, 204, 21, 0.6);
+    border-radius: 10px;
+    display: grid;
+    gap: 8px;
+  }
+  .ai-perm-title { font-weight: 600; font-size: 14px; color: var(--text-color, #e0e0e0); }
+  .ai-perm-tool { font-family: monospace; font-size: 13px; color: var(--text-color-muted, #94a3b8); }
+  .ai-perm-skip { display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-color-muted, #94a3b8); }
+  .ai-perm-actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .ai-perm-actions button {
+    min-height: 40px;
+    padding: 0 16px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  .ai-perm-allow { background: var(--accent-color, #3b82f6); color: white; }
+  .ai-perm-deny {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.12) !important;
+    color: var(--text-color-muted, #94a3b8);
   }
 </style>

--- a/src/lib/mobile/MobileChat.svelte
+++ b/src/lib/mobile/MobileChat.svelte
@@ -4,8 +4,10 @@
   Mirrors the .mw-files-overlay pattern. Reuses the existing chat lifecycle
   (get_chat_slice / send_message / cancel_generation) under tab id 'mobile', so
   history, the loading indicator, abort, and the pending-send queue all come for
-  free (§4). Text-only: chat-state runs the client-direct loop with an EMPTY
-  tool list on mobile.
+  free (§4). Tool calling: chat-state runs the full CLIENT_TOOLS client-direct
+  loop on mobile; this overlay renders the tool status rows and the
+  permission card (active_tool_blocks / active_permission_blocks) so mutating
+  calls are gated rather than wedging the chat.
 
   Key handling (§5/§8): the API key is loaded from the native encrypted store
   into a LOCAL $state and pushed into chat_config in-memory via

--- a/src/lib/mobile/MobileChat.svelte
+++ b/src/lib/mobile/MobileChat.svelte
@@ -19,7 +19,7 @@
   renderer only when a fenced code block is detected.
 -->
 <script lang="ts">
-  import { untrack } from 'svelte'
+  import { tick, untrack } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
   import Icon from '$lib/Icon.svelte'
   import { get_display_text } from '$lib/chat/types'
@@ -121,6 +121,19 @@
   // "Don't ask again this session" checkbox state for the permission card.
   let skip_session = $state(false)
 
+  // The checkbox is per-card UI state; the effective bypass lives per-slice in
+  // slice.skip_permission. Reset the checkbox when switching chat tabs.
+  $effect(() => {
+    void active_id
+    skip_session = false
+  })
+
+  // Cap the permission-card input preview (structure params can be huge).
+  function truncate_input(input: Record<string, unknown>): string {
+    const text = JSON.stringify(input, null, 1)
+    return text.length > 400 ? `${text.slice(0, 400)}…` : text
+  }
+
   function decide_permission(entry: PermissionEntry, ok: boolean): void {
     entry.status = ok ? `approved` : `denied`
     if (ok && skip_session) slice.skip_permission.value = true
@@ -147,6 +160,27 @@
       .catch(() => {
         if (p === chat_config.provider) key_checked = true
       })
+  })
+
+  // Scroll container bound in the template — used for auto-scroll below.
+  let body_el = $state<HTMLElement | null>(null)
+
+  // Auto-scroll to bottom on new content (messages, tool rows, permission
+  // cards) — a pending permission card below the fold would otherwise look
+  // like a hang while the tool loop blocks awaiting the decision.
+  $effect(() => {
+    // Touch the reactive sources so the effect re-runs on any of them.
+    void slice.messages.list.length
+    void get_display_text(
+      slice.messages.list[slice.messages.list.length - 1]?.content ?? ``,
+    ).length
+    void Object.values(slice.active_tool_blocks.entries)
+      .map((tb) => tb.status)
+      .join()
+    void Object.keys(slice.active_permission_blocks.entries).length
+    const el = body_el
+    if (!el) return
+    tick().then(() => el.scrollTo({ top: el.scrollHeight }))
   })
 
   // Abort the active chat's in-flight stream when the overlay unmounts (§6).
@@ -308,7 +342,7 @@
       <MobileChatSetup on_done={on_setup_done} />
     </div>
   {:else}
-    <div class="ai-body">
+    <div class="ai-body" bind:this={body_el}>
       {#if slice.messages.list.length === 0}
         <div class="ai-empty">
           <Icon icon="Chat" />
@@ -354,7 +388,7 @@
           <div class="ai-perm" role="alertdialog" aria-label={t(`mobile.ai_tool_permission`)}>
             <div class="ai-perm-title">{t(`mobile.ai_tool_permission`)}</div>
             <div class="ai-perm-tool">{pb.toolName}</div>
-            <pre class="ai-perm-input">{JSON.stringify(pb.input, null, 1)}</pre>
+            <pre class="ai-perm-input">{truncate_input(pb.input)}</pre>
             <label class="ai-perm-skip">
               <input type="checkbox" bind:checked={skip_session} />
               {t(`mobile.ai_dont_ask_again`)}
@@ -775,6 +809,12 @@
     background: rgba(0, 0, 0, 0.15);
   }
   .ai-tool-out { max-height: 40vh; overflow-y: auto; }
+  .ai-perm-input {
+    max-height: 120px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
   .ai-perm {
     margin: 6px 0;
     padding: 10px;


### PR DESCRIPTION
## Summary

Mobile AI chat was text-only v1 (#292): an empty tool list on mobile because `MobileChat.svelte` had no permission UI — a mutating tool call would park `request_permission` forever. This PR enables the full `CLIENT_TOOLS` agentic loop on mobile (same client-direct path the web build uses) and adds the missing UI.

Design: `plan/2026-06-10-mobile-tool-calling-design.md` · Plan: `plan/2026-06-10-mobile-tool-calling-plan.md`

## Changes

- **chat-state**: remove the 3 mobile gates — tool list `CLIENT_TOOLS` unconditionally, `execute_tool`/`tool_kind` unconditional; system prompt switches from `text_only` to the tooled prompt
- **llm-client**: new `unicode_math` param appends the Unicode-formula note (TiO₂ not $TiO_2$) to the tooled prompt — mobile's lite markdown renderer has no KaTeX/HTML; sdk-gemini's LaTeX instruction is suppressed under this flag to avoid contradiction
- **MobileChat**: permission card for pending `active_permission_blocks` (Allow/Deny + per-session "don't ask again" → `skip_permission`), compact tool-status rows for `active_tool_blocks` (tap to expand output), input preview capped at 400 chars / 120px (desktop PermissionCard parity), auto-scroll so a pending card can't sit invisibly below the fold, checkbox resets per chat tab
- **structure-tools**: `get_skill` throws a clear "backend unreachable" message (mobile/static or backend not running) so the model proceeds instead of retrying
- **i18n**: 5 new keys, en/zh parity

## Desktop impact

None. Removed branches were mobile-only; both `build_sdk_system_prompt` call sites verified (SDK path untouched; desktop client-direct passes `unicode_math=false` → byte-identical prompt, covered by test).

## Tests

- New: `llm-client.test.ts` (5 tests — unicode_math matrix incl. text_only interaction + gemini suppression)
- Full suite: **3951 passed / 51 skipped / 0 failed**
- `pnpm check`: 0 errors in touched files

## Device verification (pending — needs new APK/IPA build)

1. Open structure → AI chat → "build a 2x2x2 supercell" → permission card → Allow → tool row ✓ → structure updates
2. "Don't ask again" → next mutating call runs card-free
3. `get_skill`-needing question → tool row ✗, model continues
4. Stop mid-permission → card resolves, loading clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)