### PR TITLE
fix(mobile): MP API still broken on local mobile builds — gates missed isMobile()

### DIFF
--- a/src/lib/api/__tests__/materials-project.test.ts
+++ b/src/lib/api/__tests__/materials-project.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { search_mp_structures, set_mp_api_key, validate_mp_api_key } from '../materials-project'
+
+// Controllable isMobile + native-fetch mocks (same pattern as provider-routing tests).
+const mobile_flag = vi.hoisted(() => ({ value: false }))
+const tauri_fetch_mock = vi.hoisted(() => vi.fn())
+vi.mock('$lib/api/transport', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('$lib/api/transport')>()
+  return { ...orig, isMobile: () => mobile_flag.value }
+})
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: tauri_fetch_mock }))
+
+describe(`materials-project mobile gating`, () => {
+  afterEach(() => {
+    mobile_flag.value = false
+    tauri_fetch_mock.mockReset()
+    set_mp_api_key(``)
+    vi.unstubAllGlobals()
+  })
+
+  // Regression: local Android/iOS dev builds run with STATIC_ONLY=false, so the
+  // old `vscode_api || STATIC_ONLY` gate sent mobile down the backend-proxy
+  // branch (localhost:8000 — unreachable on a phone). Mobile must take the
+  // direct-API branch like optimade.ts does (STATIC_ONLY || isMobile()).
+  it(`validate_mp_api_key on mobile hits the MP API directly, not the backend proxy`, async () => {
+    mobile_flag.value = true
+    tauri_fetch_mock.mockResolvedValue(new Response(`{"data":[]}`, { status: 200 }))
+    const ok = await validate_mp_api_key(`test-key`)
+    expect(ok).toBe(true)
+    const url = String(tauri_fetch_mock.mock.calls[0]?.[0] ?? ``)
+    expect(url).toMatch(/^https:\/\/api\.materialsproject\.org\//)
+  })
+
+  it(`validate_mp_api_key on mobile returns false when MP rejects the key`, async () => {
+    mobile_flag.value = true
+    tauri_fetch_mock.mockResolvedValue(new Response(`{}`, { status: 401, statusText: `Unauthorized` }))
+    const ok = await validate_mp_api_key(`bad-key`)
+    expect(ok).toBe(false)
+  })
+
+  it(`search_mp_structures on mobile queries the MP API directly`, async () => {
+    mobile_flag.value = true
+    set_mp_api_key(`test-key`)
+    tauri_fetch_mock.mockResolvedValue(
+      new Response(`{"data":[{"material_id":"mp-1"}]}`, { status: 200 }),
+    )
+    const results = await search_mp_structures([`Fe`, `O`], undefined, 5)
+    expect(results).toHaveLength(1)
+    const url = String(tauri_fetch_mock.mock.calls[0]?.[0] ?? ``)
+    expect(url).toMatch(/^https:\/\/api\.materialsproject\.org\/materials\/summary/)
+    expect(url).toContain(`elements=Fe%2CO`)
+  })
+
+  it(`desktop (non-mobile, non-static) still uses the backend proxy`, async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(
+      new Response(`{"valid":true}`, { status: 200 }),
+    )
+    vi.stubGlobal(`fetch`, fetch_mock)
+    const ok = await validate_mp_api_key(`test-key`)
+    expect(ok).toBe(true)
+    const url = String(fetch_mock.mock.calls[0]?.[0] ?? ``)
+    expect(url).toContain(`/mp/validate-key`)
+    expect(tauri_fetch_mock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/api/materials-project.ts
+++ b/src/lib/api/materials-project.ts
@@ -5,7 +5,14 @@
 // sends no Access-Control-Allow-Origin, so direct browser fetches are blocked.
 
 import { API_BASE as _DEFAULT_API, STATIC_ONLY } from './config'
+import { isMobile } from '$lib/api/transport'
 import { relay_fetch } from '$lib/chat/provider-routing'
+
+// Mobile has no Python backend regardless of STATIC_ONLY (local dev builds run
+// with STATIC_ONLY=false), so it must take the direct-API branch — same rule
+// optimade.ts applies to every gate. relay_fetch then uses the native Tauri
+// HTTP plugin (no browser CORS, key goes straight to MP).
+const direct_api = (): boolean => STATIC_ONLY || isMobile()
 
 // API base URL - same as other API modules
 let API_BASE = _DEFAULT_API
@@ -162,7 +169,7 @@ export async function search_mp_structures(
   let url: string
   let data: { data?: MPSummaryData[] }
 
-  if (vscode_api || STATIC_ONLY) {
+  if (vscode_api || direct_api()) {
     // Direct Materials Project API call (relay-routed in the web build)
     const params = new URLSearchParams({
       _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal`,
@@ -223,7 +230,7 @@ export async function get_mp_structure_summary(material_id: string): Promise<MPS
     let url: string
     let data: { data?: MPSummaryData }
 
-    if (vscode_api || STATIC_ONLY) {
+    if (vscode_api || direct_api()) {
       // Direct API call (relay-routed in the web build)
       const params = new URLSearchParams({
         _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal`,
@@ -268,7 +275,7 @@ export async function validate_mp_api_key(key: string): Promise<boolean> {
       url = `https://api.materialsproject.org/materials/summary/?_limit=1`
       await fetch_json_smart(url, key)
       return true // If we got here without error, key is valid
-    } else if (STATIC_ONLY) {
+    } else if (direct_api()) {
       // Web build: validate via the new MP API summary endpoint through the relay
       // (the www.materialsproject.org api_check host is not relay-allowlisted).
       // fetch_json_smart throws on a non-2xx (e.g. 401 invalid key) → caught below.


### PR DESCRIPTION
## Problem

After #301, the Android APK (built locally via `desktop:build`, which does NOT set `VITE_STATIC_ONLY`) still reported "Invalid API key". Root cause: `materials-project.ts` gates on `vscode_api || STATIC_ONLY` only — with `STATIC_ONLY=false` mobile takes the **backend-proxy branch**, fetching `localhost:8000/api/mp/...` on a phone with no backend. `validate_mp_api_key` catches the failure and returns false.

#301's relay-guard fix was correct for STATIC_ONLY builds (iOS CI) but this code path never reaches `relay_fetch`.

This is the missing half of 3b0d554 (Jun 2), which applied `is_static || isMobile()` to every gate in `optimade.ts` but missed `materials-project.ts` — OPTIMADE search worked, key-bearing MP features never did on local mobile builds.

## Fix

`direct_api() = STATIC_ONLY || isMobile()` replaces all three gates (search / summary / validate). On mobile the direct branch goes through `relay_fetch` → native Tauri HTTP → straight to MP (key never relayed, #301 ordering).

## Tests

New `materials-project.test.ts` (4): mobile validate + search hit `api.materialsproject.org` directly via native fetch; MP 401 → false; desktop non-static still uses the backend proxy. api+chat suites 111/111.

## Verification

Pending on-device re-test after this lands (Android, 8XEUV4YHX49XXCIV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)