### PR TITLE
fix(structure): MP search results sort by stability (hull) again

### DIFF
--- a/src/lib/api/__tests__/optimade.test.ts
+++ b/src/lib/api/__tests__/optimade.test.ts
@@ -75,3 +75,69 @@ describe(`optimade search static-mode relay substitution`, () => {
     expect(called_url).not.toContain(`catgo-cors-relay`)
   })
 })
+
+// MP moved thermo data into a nested `_mp_stability` dict (keyed by thermo
+// type); the flat `_mp_formation_energy_per_atom` / `_mp_energy_above_hull`
+// fields now return null. Details extraction and stability sorting must read
+// the nested form — and must NOT assign the dict object to numeric fields.
+describe(`MP nested _mp_stability extraction + stability sort`, () => {
+  const mp_stability = {
+    'gga_gga+u': {
+      thermo_id: `mp-1_GGA_GGA+U`,
+      energy_above_hull: 0.27,
+      formation_energy_per_atom: -1.149,
+    },
+    'gga_gga+u_r2scan': {
+      thermo_id: `mp-1_GGA_GGA+U_R2SCAN`,
+      energy_above_hull: 0.28,
+      formation_energy_per_atom: -1.145,
+    },
+  }
+
+  it(`extract_provider_details reads hull + formation energy from _mp_stability (gga_gga+u preferred)`, async () => {
+    const { extract_provider_details } = await import(`../optimade`)
+    const details = extract_provider_details({
+      chemical_formula_reduced: `FeO2`,
+      _mp_stability: mp_stability,
+      _mp_formation_energy_per_atom: null,
+      _mp_energy_above_hull: null,
+    })
+    expect(details.energy_above_hull).toBe(0.27)
+    expect(details.formation_energy).toBe(-1.149)
+  })
+
+  it(`extract_provider_details never assigns the _mp_stability object to a numeric field`, async () => {
+    const { extract_provider_details } = await import(`../optimade`)
+    const details = extract_provider_details({ _mp_stability: mp_stability })
+    expect(typeof details.energy_above_hull).toBe(`number`)
+  })
+
+  it(`falls back to the first thermo entry when gga_gga+u is absent`, async () => {
+    const { extract_provider_details } = await import(`../optimade`)
+    const details = extract_provider_details({
+      _mp_stability: { r2scan: { energy_above_hull: 0.1, formation_energy_per_atom: -2 } },
+    })
+    expect(details.energy_above_hull).toBe(0.1)
+    expect(details.formation_energy).toBe(-2)
+  })
+
+  it(`sort_structures_by_stability orders by energy_above_hull ascending, formation energy as tiebreak`, async () => {
+    const { sort_structures_by_stability } = await import(`../optimade`)
+    const s = (id: string, attrs: Record<string, unknown>) =>
+      ({ id, type: `structures`, attributes: attrs }) as never
+    const sorted = sort_structures_by_stability([
+      s(`high-hull`, { _mp_stability: { 'gga_gga+u': { energy_above_hull: 1.05, formation_energy_per_atom: -0.43 } } }),
+      s(`no-data`, { chemical_formula_reduced: `X` }),
+      s(`stable`, { _mp_stability: { 'gga_gga+u': { energy_above_hull: 0, formation_energy_per_atom: -1.9 } } }),
+      s(`legacy-flat`, { _alexandria_energy_above_hull: 0.1, _alexandria_formation_energy_per_atom: -1.2 }),
+      s(`tie-hull-lower-formation`, { _mp_stability: { 'gga_gga+u': { energy_above_hull: 0, formation_energy_per_atom: -2.5 } } }),
+    ])
+    expect(sorted.map((x: { id: string }) => x.id)).toEqual([
+      `tie-hull-lower-formation`,
+      `stable`,
+      `legacy-flat`,
+      `high-hull`,
+      `no-data`,
+    ])
+  })
+})

--- a/src/lib/api/optimade.ts
+++ b/src/lib/api/optimade.ts
@@ -389,6 +389,7 @@ const PROVIDER_EXTRA_FIELDS: Record<string, string[]> = {
     `_mp_spacegroup_number`,
     `_mp_chemical_system`,
     `_mp_chemsys`,
+    `_mp_stability`,
   ],
   alexandria: [
     `_alexandria_formation_energy_per_atom`,
@@ -457,17 +458,27 @@ function default_sort_for_provider(provider: string): string | undefined {
   return field ? field : undefined
 }
 
-/** Local fallback: re-sort already-fetched structures by formation energy ascending. */
-function sort_by_formation_energy(structures: OptimadeStructure[]): OptimadeStructure[] {
-  const get_e = (s: OptimadeStructure): number => {
-    const attrs = s.attributes as Record<string, unknown>
-    for (const [k, v] of Object.entries(attrs)) {
-      if (typeof v !== `number`) continue
-      if (/^_\w+_(formation|enthalpy_formation|delta_e)/.test(k)) return v
-    }
-    return Number.POSITIVE_INFINITY
+/** Local fallback sort: most stable first — energy_above_hull ascending
+ *  (0 = on the hull), formation energy per atom as the tiebreak, entries
+ *  without any thermo data last. Reads both flat `_provider_*` fields and
+ *  MP's nested `_mp_stability` via extract_provider_details. Providers'
+ *  server-side `sort` support is spotty (MP OPTIMADE 400s on it), so the
+ *  client always re-sorts. */
+export function sort_structures_by_stability(
+  structures: OptimadeStructure[],
+): OptimadeStructure[] {
+  const rank = (s: OptimadeStructure): [number, number] => {
+    const d = extract_provider_details(s.attributes as Record<string, unknown>)
+    return [
+      typeof d.energy_above_hull === `number` ? d.energy_above_hull : Number.POSITIVE_INFINITY,
+      typeof d.formation_energy === `number` ? d.formation_energy : Number.POSITIVE_INFINITY,
+    ]
   }
-  return [...structures].sort((a, b) => get_e(a) - get_e(b))
+  return [...structures].sort((a, b) => {
+    const [ha, fa] = rank(a)
+    const [hb, fb] = rank(b)
+    return ha !== hb ? ha - hb : fa - fb
+  })
 }
 
 export interface OptimadeSearchResult {
@@ -590,7 +601,7 @@ export async function search_optimade_structures(
         sort,
       }
       const result = await post_to_extension_optimade_search(provider, extension_options)
-      result.structures = sort_by_formation_energy(result.structures)
+      result.structures = sort_structures_by_stability(result.structures)
       return result
     }
 
@@ -624,7 +635,7 @@ export async function search_optimade_structures(
       }
       if (!response.ok) throw new Error(`OPTIMADE API error (${response.status})`)
       const data = await response.json() as { data?: OptimadeStructure[]; meta?: { data_returned?: number; data_available?: number } }
-      const structures = sort_by_formation_energy(data.data || [])
+      const structures = sort_structures_by_stability(data.data || [])
       return {
         structures,
         total_count: data.meta?.data_returned ?? data.meta?.data_available,
@@ -663,7 +674,7 @@ export async function search_optimade_structures(
         })
         if (retry.ok) {
           const retry_data = await retry.json() as { data?: OptimadeStructure[]; meta?: { data_returned?: number; data_available?: number } }
-          const retry_structs = sort_by_formation_energy(retry_data.data || [])
+          const retry_structs = sort_structures_by_stability(retry_data.data || [])
           return {
             structures: retry_structs,
             total_count: retry_data.meta?.data_returned ?? retry_data.meta?.data_available,
@@ -676,7 +687,7 @@ export async function search_optimade_structures(
 
     const data = await response.json() as { data?: OptimadeStructure[]; meta?: { data_returned?: number; data_available?: number } }
 
-    const structures = sort_by_formation_energy(data.data || [])
+    const structures = sort_structures_by_stability(data.data || [])
     const total_count = data.meta?.data_returned ?? data.meta?.data_available
 
     return {
@@ -737,9 +748,37 @@ export function extract_provider_details(
     // Skip standard OPTIMADE fields
     if (!attr_key.startsWith(`_`)) continue
 
+    // MP moved thermo data into a nested `_mp_stability` dict keyed by thermo
+    // type ({'gga_gga+u': {energy_above_hull, formation_energy_per_atom}, ...});
+    // the flat _mp_energy_above_hull / _mp_formation_energy_per_atom fields now
+    // return null. Prefer gga_gga+u (MP's default mixed thermo — matches the
+    // REST summary numbers), falling back to the first entry.
+    if (attr_key === `_mp_stability` && typeof attr_val === `object`) {
+      const thermos = attr_val as Record<string, Record<string, unknown>>
+      const entry = thermos[`gga_gga+u`] ?? Object.values(thermos)[0]
+      if (entry && typeof entry === `object`) {
+        if (typeof entry.energy_above_hull === `number` && details.energy_above_hull === undefined) {
+          details.energy_above_hull = entry.energy_above_hull
+        }
+        if (typeof entry.formation_energy_per_atom === `number` && details.formation_energy === undefined) {
+          details.formation_energy = entry.formation_energy_per_atom
+        }
+      }
+      continue
+    }
+
     let matched = false
     for (const { key, regex } of DETAIL_PATTERNS) {
       if (regex.test(attr_key) && details[key] === undefined) {
+        // Numeric detail fields must only accept numbers — e.g. a provider's
+        // `_*_stability` OBJECT must not land in energy_above_hull.
+        const numeric_keys: (keyof ProviderDetails)[] = [
+          `band_gap`,
+          `energy_above_hull`,
+          `formation_energy`,
+          `spacegroup_number`,
+        ]
+        if (numeric_keys.includes(key) && typeof attr_val !== `number`) continue
         ;(details as unknown as Record<string, unknown>)[key] = attr_val
         matched = true
         break

--- a/src/lib/structure/OptimadeSearchModal.svelte
+++ b/src/lib/structure/OptimadeSearchModal.svelte
@@ -276,15 +276,24 @@
 
       mp_summaries = new_map
 
-      // Re-sort current results by MP formation energy (lowest first) now that
-      // we have authoritative numbers; structures without a value go to the end.
+      // Re-sort current results by stability now that we have authoritative
+      // numbers: energy_above_hull ascending (0 = on the hull), formation
+      // energy per atom as the tiebreak; structures without data go last.
       if (search_results?.structures?.length) {
+        const rank = (id: string): [number, number] => {
+          const s = new_map.get(id)
+          const hull = typeof s?.energy_above_hull === `number`
+            ? s.energy_above_hull
+            : Number.POSITIVE_INFINITY
+          const form = typeof s?.formation_energy_per_atom === `number`
+            ? s.formation_energy_per_atom
+            : Number.POSITIVE_INFINITY
+          return [hull, form]
+        }
         const sorted = [...search_results.structures].sort((a, b) => {
-          const ea = new_map.get(a.id)?.formation_energy_per_atom
-          const eb = new_map.get(b.id)?.formation_energy_per_atom
-          const va = typeof ea === `number` ? ea : Number.POSITIVE_INFINITY
-          const vb = typeof eb === `number` ? eb : Number.POSITIVE_INFINITY
-          return va - vb
+          const [ha, fa] = rank(a.id)
+          const [hb, fb] = rank(b.id)
+          return ha !== hb ? ha - hb : fa - fb
         })
         search_results = { ...search_results, structures: sorted }
       }


### PR DESCRIPTION
## Problem

MP database search results display in server order — not by stability. Reported on mobile after #306 made the MP key work; affects all platforms.

Three stacked causes (curl-verified against live MP OPTIMADE):
1. `optimade.materialsproject.org` **400s on the `sort` param** ("Unable to sort on unknown field '_mp_formation_energy_per_atom'") — existing fallback re-queries without sort, so ordering is client-side.
2. **MP schema change**: flat `_mp_formation_energy_per_atom` / `_mp_energy_above_hull` now return `null`; real numbers live in nested `_mp_stability.<thermo_type>.{energy_above_hull, formation_energy_per_atom}`. The local sort compared nothing but +Infinity (no-op).
3. The post-enrichment re-sort used **formation energy**, but stability order is **energy_above_hull ascending**.

Bonus latent bug fixed: the `_*_stability` OBJECT matched the `energy_above_hull` regex in `extract_provider_details` and could be assigned into a numeric field.

## Fix

- Parse nested `_mp_stability` (prefer `gga_gga+u`, MP's default mixed thermo — matches REST summary numbers; fallback first entry); numeric-type guards on detail fields
- `sort_structures_by_stability` replaces `sort_by_formation_energy`: hull asc → formation asc → no-data last; handles flat (other providers) + nested (MP) forms
- Modal post-enrichment re-sort uses the same rank from MP REST data
- `_mp_stability` added to requested response_fields

## Tests

4 new cases (nested extraction, gga_gga+u preference + fallback, object-assignment guard, full sort order incl. legacy flat fields + tiebreak). api+structure suites 59/59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)