### PR TITLE
fix(viewer): ortho zoom — fit whole structure, stop clobbering user zoom on pane resize

### DIFF
--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -1746,10 +1746,46 @@
   let computed_zoom = $state<number>(untrack(() => initial_zoom))
   $effect(() => {
     if (!(width > 0) || !(height > 0)) return
+    // Once the user zooms (TrackballControls writes camera.zoom directly, so it
+    // drifts from the last computed_zoom we applied), stop auto-recomputing:
+    // re-running on a pane resize (layout switch, sidebar toggle) would clobber
+    // their zoom level and visibly rescale the view. Read untracked — camera
+    // mutations must not re-trigger this effect.
+    const user_zoomed = untrack(() => {
+      const cam = camera as any
+      return cam?.isOrthographicCamera && Math.abs(cam.zoom - computed_zoom) > 1e-3
+    })
+    if (user_zoomed) return
     const structure_max_dim = Math.max(1, structure_size)
     const viewer_min_dim = Math.min(width, height)
-    const scale_factor = viewer_min_dim / (structure_max_dim * 30) // 30px per unit — fills more of the viewport
-    let new_zoom = initial_zoom * scale_factor
+    // Size the view from the atom bounding box when it is tighter than the cell
+    // average — molecules have no lattice and would otherwise fall back to the
+    // 10 A placeholder and render tiny.
+    let fit_size = structure_max_dim
+    if (structure?.sites?.length) {
+      let min_x = Infinity, max_x = -Infinity
+      let min_y = Infinity, max_y = -Infinity
+      let min_z = Infinity, max_z = -Infinity
+      for (const s of structure.sites) {
+        const [x, y, z] = s.xyz
+        if (x < min_x) min_x = x; if (x > max_x) max_x = x
+        if (y < min_y) min_y = y; if (y > max_y) max_y = y
+        if (z < min_z) min_z = z; if (z > max_z) max_z = z
+      }
+      // +2 A: atom centers ignore the rendered sphere radii (~1 A per side),
+      // which dominate the visual extent of small molecules.
+      const extent = Math.max(max_x - min_x, max_y - min_y, max_z - min_z, 1) + 2
+      fit_size = Math.min(structure_max_dim, extent * 1.2)
+    }
+    // Fit the whole structure into the viewport's short axis with a 25% margin
+    // (the margin absorbs the longest cell axis exceeding the average, atom
+    // radii, and boundary image atoms).
+    // initial_zoom acts as a relative knob: at its default the structure just
+    // fits; larger values zoom in proportionally. (The previous fixed 30 px/Å
+    // density cropped any structure wider than viewer_min_dim/30 Å — e.g.
+    // LiFePO4's 10.3 Å axis in a half-width side-by-side pane.)
+    const fit_zoom = viewer_min_dim / (Math.max(1, fit_size) * 1.25)
+    let new_zoom = fit_zoom * (initial_zoom / DEFAULTS.structure.initial_zoom)
     if (min_zoom && min_zoom > 0) new_zoom = Math.max(min_zoom, new_zoom)
     if (max_zoom && max_zoom > 0) new_zoom = Math.min(max_zoom, new_zoom)
     computed_zoom = new_zoom


### PR DESCRIPTION
## Problem (reported while testing PR #303, but reproduces identically on main)

Switching layout Single → Side by Side → Single "messes up" the 3D view:

1. **Wide cells render cropped with giant atoms.** `computed_zoom` used a fixed 30 px/Å density, so any structure wider than `viewer_min_dim / 30` Å overflowed the pane (LiFePO4's 10.3 Å axis in a half-width pane needs ~660 px but only has ~585).
2. **Every pane resize clobbered the user's zoom.** The effect re-ran on width/height changes (layout switch, sidebar toggle) and overwrote `camera.zoom`, visibly rescaling the view on each layout round-trip.

Verified pre-existing on main via side-by-side reproduction on two dev instances (main vs PR #303 — pixel-identical failure), so this is independent of #303.

## Fix

In the `computed_zoom` effect (`StructureScene.svelte`):

- **Fit semantics**: zoom now fits the whole structure into the viewport's short axis with a 25% margin. Uses the atom bounding box (plus ~2 Å sphere-radius padding) when tighter than the average cell axis — molecules have no lattice and previously fell back to a 10 Å placeholder.
- **`initial_zoom` becomes a relative knob**: at its default the structure just fits; larger values zoom in proportionally.
- **Respect user zoom**: skip recomputing once `camera.zoom` drifts from the last applied computed value (TrackballControls writes `camera.zoom` directly on wheel zoom). Read untracked so camera mutations don't re-trigger the effect.

## Validation

- Browser-verified on a dev instance: LiFePO4 fully framed in a half-width side-by-side pane; Single → Side by Side → Single round-trip no longer rescales or crops; molecules unaffected.
- `tests/vitest/structure/`: 1187 passed.
- Full vitest: 3960 passed; 6 failures under parallel load (HDF5 parse, XRD labels, symmetry pane) all pass in isolation — load flakes, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)