### PR TITLE
fix(ci): e2e lane — run real-app smoke suite, surface failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,8 @@ jobs:
         run: pnpm run build:doc-chunks
 
       # Browsers are preinstalled in the container image, so no download step.
+      # No step-level continue-on-error: the job-level one already keeps e2e
+      # non-gating, and the step must show a real X when tests fail (#310 —
+      # the double continue-on-error painted a failing suite green).
       - name: Run e2e tests
-        continue-on-error: true
         run: npx playwright test

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,19 +4,27 @@ const CI = !!process.env.CI
 
 export default {
   webServer: {
-    command: `vite dev --port 3005`,
+    // Serve the real app: the desktop config is what users run. A bare
+    // `vite dev` (no config) was a plain static server — every page 404'd and
+    // the whole legacy suite died on its first visibility assert (#310).
+    command: `PORT=3005 pnpm desktop:dev`,
     port: 3005,
     // In CI always start a fresh server (never silently attach to a stale one);
     // locally reuse an already-running dev server for fast iteration.
     reuseExistingServer: !CI,
     // Bound startup so a server that never becomes ready fails fast instead of
-    // stalling (paired with the job-level timeout-minutes in CI).
-    timeout: 120_000,
+    // stalling (paired with the job-level timeout-minutes in CI). predev may
+    // build doc chunks on a cold checkout, so allow extra headroom.
+    timeout: 180_000,
   },
   workers: CI ? 4 : 8,
-  timeout: 15_000, // Global timeout per test
+  timeout: 30_000, // Global timeout per test
   // Cap whole-run wall time so a hung navigation can't run to the job ceiling.
   globalTimeout: CI ? 15 * 60_000 : undefined,
-  testDir: `tests/playwright`,
-  maxFailures: 1,
+  // tests/playwright is the legacy matterviz demo-site suite — it targets
+  // routes (/test/*, /periodic-table, ...) that do not exist in this repo and
+  // can never pass. Only the smoke suite against the real app runs (#310).
+  testDir: `tests/e2e`,
+  // One flaky test must not zero out the rest of the run's coverage.
+  maxFailures: CI ? 10 : 1,
 } satisfies PlaywrightTestConfig

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -1,0 +1,58 @@
+// Smoke tests for the real CatGo app (served by vite.desktop.config.ts).
+//
+// The legacy tests/playwright suite came from upstream matterviz and targets
+// demo-site routes (/test/*, /periodic-table, ...) that do not exist in this
+// repo — it cannot pass and is excluded from CI (see playwright.config.ts and
+// issue #310). This suite drives the actual app at `/` instead: launcher,
+// editor mount, WebGL canvas, and the layout round-trip that previously
+// scrambled the viewer (#309).
+import { expect, test } from '@playwright/test'
+
+// No backend runs in CI: /api requests fail and the app must still render.
+// Avoid `networkidle` (HMR websocket keeps the connection pool busy).
+
+test(`launcher renders the sample structure preview`, async ({ page }) => {
+  await page.goto(`/`, { waitUntil: `load` })
+  await expect(page.getByText(`Water`, { exact: true })).toBeVisible({ timeout: 20_000 })
+  const canvas = page.locator(`canvas`).first()
+  await expect(canvas).toBeVisible({ timeout: 20_000 })
+})
+
+test(`opening the sample structure mounts the editor with a live canvas`, async ({ page }) => {
+  await page.goto(`/`, { waitUntil: `load` })
+  const card = page.getByRole(`button`, { name: /^Structure viewer/ })
+  await card.click({ timeout: 20_000 })
+
+  // A workspace tab appears and the editor's WebGL canvas has real dimensions.
+  await expect(page.getByRole(`tab`).first()).toBeVisible({ timeout: 20_000 })
+  const canvas = page.locator(`canvas`).first()
+  await expect(canvas).toBeVisible({ timeout: 20_000 })
+  const size = await canvas.evaluate((el) => ({
+    w: (el as HTMLCanvasElement).clientWidth,
+    h: (el as HTMLCanvasElement).clientHeight,
+  }))
+  expect(size.w).toBeGreaterThan(100)
+  expect(size.h).toBeGreaterThan(100)
+})
+
+test(`layout round-trip keeps the viewer canvas alive`, async ({ page }) => {
+  await page.goto(`/`, { waitUntil: `load` })
+  await page.getByRole(`button`, { name: /^Structure viewer/ }).click({ timeout: 20_000 })
+  await expect(page.locator(`canvas`).first()).toBeVisible({ timeout: 20_000 })
+
+  // Single -> Side by Side -> Single. Each step the canvas must stay mounted
+  // and visible (this round-trip used to rescale/crop the view, #309/#310).
+  const layout_menu = page.getByRole(`button`, { name: `Single`, exact: true })
+  await layout_menu.click()
+  await page.getByRole(`button`, { name: `Side by Side` }).last().click()
+  await expect(page.locator(`canvas`).first()).toBeVisible({ timeout: 20_000 })
+
+  await page.getByRole(`button`, { name: `Side by Side`, exact: true }).first().click()
+  await page.getByRole(`button`, { name: `Single` }).last().click()
+  // Dropping back to one pane may warn about removing loaded structures.
+  const confirm = page.getByRole(`button`, { name: `Continue` })
+  if (await confirm.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await confirm.click()
+  }
+  await expect(page.locator(`canvas`).first()).toBeVisible({ timeout: 20_000 })
+})


### PR DESCRIPTION
Closes #310.

## What was actually wrong (three layers deep)

1. `continue-on-error: true` at **both** the job and step level — any failure still rendered a green check.
2. The playwright `webServer` command was a bare `vite dev` with **no config file** (the repo has no `vite.config.ts`, only `vite.desktop.config.ts`) — a plain static file server, so every `page.goto` 404'd.
3. `tests/playwright/` is the upstream **matterviz demo-site suite**: it targets routes (`/test/*`, `/periodic-table`, `/phase-diagram`, …) that do not exist in this repo. It can never pass here. With `maxFailures: 1`, the first assert killed the remaining 560+ tests on every run.

So the lane wasn't "flaky" — it had **zero working coverage** and the double continue-on-error hid it.

## Changes

- **New `tests/e2e/smoke.test.ts`** driving the real app served by `vite.desktop.config.ts`: launcher renders, editor mounts with a live WebGL canvas (real dimensions asserted), and the Single → Side by Side → Single layout round-trip stays alive — the exact flow that scrambled the viewer in #309.
- **`playwright.config.ts`**: `webServer` runs `pnpm desktop:dev`; `testDir` → `tests/e2e` (legacy suite left on disk but documented and excluded); `maxFailures: 10` in CI so one flake can't zero the run.
- **`test.yml`**: step-level `continue-on-error` removed — failures now show a real ❌. The job-level one stays for now; once the lane proves stable it should be removed so e2e becomes a real gate (follow-up).

## Validation

- Local: 3/3 pass against a fresh `pnpm desktop:dev` (~22 s).
- Local with `SERVER_PORT` pointed at a dead port (mirrors CI's no-backend environment): 3/3 pass.

## Follow-ups (out of scope)

- Decide the fate of `tests/playwright/` — port the relevant viewer tests to real-app flows, or delete the suite.
- Promote the e2e job to a required check once it has a green streak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)