### PR TITLE
fix(app): route external links through shell.open in Tauri shells (GitHub links dead on iOS)

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -2,12 +2,18 @@ import '../src/lib/app.css'
 import App from './App.svelte'
 import { mount } from 'svelte'
 import { init_backend_url } from '../src/lib/api/backend-url.svelte'
+import { install_external_link_handler } from '../src/lib/io/external-links'
 
 // Model C: a hosted frontend can target a user-chosen backend. Apply the saved
 // backend URL (localStorage 'catgo-backend-url') to ALL API consumers BEFORE the
 // app mounts and any HPC/MP/chat/compute module makes its first call. No-op when
 // nothing is saved, so the default (http://localhost:8000) is preserved.
 init_backend_url()
+
+// In the Tauri shells (desktop + mobile), plain external <a> links are blocked
+// by the WebView; route them through shell.open so they reach the system
+// browser. No-op in regular browser builds.
+install_external_link_handler()
 
 const target = document.getElementById(`app`)!
 

--- a/src/lib/io/external-links.ts
+++ b/src/lib/io/external-links.ts
@@ -1,0 +1,52 @@
+// Global external-link interception for the Tauri shells.
+//
+// Inside a Tauri WebView a plain `<a href="https://..." target="_blank">` is
+// dead: iOS/Android WKWebView ignores it entirely, and the desktop WebView2 /
+// WebKitGTK popup policy blocks `window.open`. Only code that explicitly calls
+// the shell plugin (e.g. MobileWorkspace's GitHub button) worked — every other
+// anchor (editor "Star on GitHub", chat markdown links, static-mode banner,
+// release-notes links) silently did nothing on mobile.
+//
+// This installs ONE capture-phase click listener that routes any cross-origin
+// http(s) anchor through `shell.open` (system browser). In a regular browser
+// build it is a no-op. Same-origin links and non-http schemes are untouched.
+import { check_tauri } from './tauri'
+
+let installed = false
+
+export function install_external_link_handler(): void {
+  if (typeof document === `undefined` || installed) return
+  installed = true
+
+  document.addEventListener(
+    `click`,
+    (event) => {
+      // Checked per-click (not at install) so a plain browser build stays a
+      // strict no-op even if the handler was installed before Tauri detection.
+      if (!check_tauri()) return
+      if (event.defaultPrevented) return
+      // Respect modified clicks (open-in-new-tab gestures in a real browser).
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+
+      const anchor = (event.target as HTMLElement | null)?.closest?.(`a[href]`)
+      if (!anchor) return
+      const href = anchor.getAttribute(`href`)
+      if (!href || !/^https?:\/\//i.test(href)) return
+
+      let url: URL
+      try {
+        url = new URL(href, globalThis.location?.href)
+      } catch {
+        return
+      }
+      if (url.origin === globalThis.location?.origin) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      void import(`@tauri-apps/plugin-shell`)
+        .then(({ open }) => open(url.toString()))
+        .catch((err) => console.warn(`[external-links] shell.open failed:`, err))
+    },
+    true,
+  )
+}

--- a/tests/vitest/external-links.test.ts
+++ b/tests/vitest/external-links.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const open_mock = vi.fn(() => Promise.resolve())
+let tauri_present = true
+
+vi.mock(`$lib/io/tauri`, () => ({ check_tauri: () => tauri_present }))
+vi.mock(`@tauri-apps/plugin-shell`, () => ({ open: open_mock }))
+
+import { install_external_link_handler } from '$lib/io/external-links'
+
+function click_anchor(href: string): MouseEvent {
+  const anchor = document.createElement(`a`)
+  anchor.href = href
+  anchor.textContent = `link`
+  document.body.appendChild(anchor)
+  const event = new MouseEvent(`click`, { bubbles: true, cancelable: true })
+  anchor.dispatchEvent(event)
+  anchor.remove()
+  return event
+}
+
+describe(`install_external_link_handler`, () => {
+  beforeEach(() => {
+    open_mock.mockClear()
+    tauri_present = true
+    document.body.replaceChildren()
+  })
+
+  it(`routes cross-origin http(s) anchors through shell.open`, async () => {
+    install_external_link_handler()
+    const event = click_anchor(`https://github.com/Hello-QM/catgo-LRG`)
+    expect(event.defaultPrevented).toBe(true)
+    await vi.waitFor(() => expect(open_mock).toHaveBeenCalledWith(`https://github.com/Hello-QM/catgo-LRG`))
+  })
+
+  it(`leaves same-origin links alone`, () => {
+    install_external_link_handler()
+    const event = click_anchor(`${globalThis.location.origin}/some/page`)
+    expect(event.defaultPrevented).toBe(false)
+    expect(open_mock).not.toHaveBeenCalled()
+  })
+
+  it(`leaves non-http schemes alone`, () => {
+    install_external_link_handler()
+    const event = click_anchor(`mailto:someone@example.com`)
+    expect(event.defaultPrevented).toBe(false)
+    expect(open_mock).not.toHaveBeenCalled()
+  })
+
+  it(`does nothing outside Tauri`, () => {
+    tauri_present = false
+    install_external_link_handler()
+    const event = click_anchor(`https://github.com/Hello-QM/catgo-LRG`)
+    expect(event.defaultPrevented).toBe(false)
+    expect(open_mock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Reported: GitHub links don't open in the iOS app.

## Root cause

Inside a Tauri WebView a plain `<a href="https://..." target="_blank">` is dead: iOS/Android WKWebView ignores it entirely, and the desktop WebView2 / WebKitGTK popup policy blocks `window.open`. Only code that explicitly called the shell plugin worked — MobileWorkspace's GitHub button — while every other anchor (the editor's Star-on-GitHub link, chat markdown links, the static-mode banner's release/marketplace links) silently did nothing.

## Fix

`src/lib/io/external-links.ts`: one capture-phase document click listener installed at boot (`desktop/main.ts`) that routes any cross-origin http(s) anchor through `shell.open` → system browser (Safari on iOS). Untouched: same-origin links, non-http schemes (mailto: etc.), modified clicks (cmd/ctrl/shift/alt), and plain browser builds (Tauri detection is per-click; install is idempotent).

The shell plugin already has the native iOS implementation (`UIApplication.shared.open`) and `shell:allow-open` is in the default capability, so no Rust/capability changes needed.

## Validation

- New vitest suite (4 tests): external → shell.open + preventDefault; same-origin untouched; mailto untouched; non-Tauri untouched.
- `svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)