### PR TITLE
fix(mobile): sticky Ctrl works with the soft keyboard; clear OTP-timeout message

### DIFF
--- a/src-tauri/src/ssh/otp.rs
+++ b/src-tauri/src/ssh/otp.rs
@@ -133,6 +133,19 @@ pub async fn ssh_submit_otp(
             message: "OTP rejected".into(),
             ..Default::default()
         }),
+        // The connection died while the handshake sat waiting for the code —
+        // the server's LoginGraceTime / Duo timeout expired, or (common on
+        // iOS) switching to an authenticator app suspended CatGo long enough
+        // for the socket to drop. The raw russh wording ("Unable to receive
+        // more messages from the channel") reads like a bug; tell the user
+        // what actually happened and what to do.
+        Err(russh::Error::RecvError | russh::Error::SendError | russh::Error::Disconnect) => {
+            Ok(ConnectResult {
+                message: "OTP session expired: the SSH server closed the connection while                           waiting for the code (switching to another app to read it can                           suspend CatGo long enough to time out). Please connect again."
+                    .into(),
+                ..Default::default()
+            })
+        }
         Err(e) => Ok(ConnectResult {
             message: format!("OTP error: {e}"),
             ..Default::default()

--- a/src/lib/mobile/MobileTerminal.svelte
+++ b/src/lib/mobile/MobileTerminal.svelte
@@ -18,6 +18,7 @@
   NEW + standalone: this never touches the desktop terminal / pty.ts.
 -->
 <script lang="ts">
+  import { to_control } from '$lib/mobile/control-chars'
   import { transport } from '$lib/api/transport'
   import Icon from '$lib/Icon.svelte'
   import MobileTerminalKeyBar from '$lib/structure/MobileTerminalKeyBar.svelte'
@@ -80,6 +81,8 @@
   // User toggle: collapse the floating bar to a small pill so the terminal is
   // visible (e.g. in split mode where the pane is short). Re-tap to expand.
   let keybar_open = $state(true)
+  // Sticky-Ctrl from the key bar; folds the next soft-keyboard char in onData.
+  let kb_ctrl_armed = $state(false)
   $effect(() => {
     const vv = window.visualViewport
     if (!vv) return
@@ -247,13 +250,21 @@
         opened_channel = ch
         status = `connected`
 
-        // Stdin: xterm -> PTY.
+        // Stdin: xterm -> PTY. When the key bar's sticky Ctrl is armed, fold
+        // the next single soft-keyboard character into its control char
+        // (Ctrl then `c` -> 0x03 = SIGINT) — letters only exist on the soft
+        // keyboard, so the bar can't produce Ctrl+C by itself.
         term.onData((data: string) => {
-          if (!disposed && channel_id) {
-            transport
-              .ptyWrite(session_id, channel_id, encoder.encode(data))
-              .catch(() => {})
+          if (disposed || !channel_id) return
+          let out = data
+          if (kb_ctrl_armed && data.length === 1) {
+            kb_ctrl_armed = false
+            const ctl = to_control(data)
+            if (ctl !== null) out = ctl
           }
+          transport
+            .ptyWrite(session_id, channel_id, encoder.encode(out))
+            .catch(() => {})
         })
 
         // Resize: keep the remote PTY in sync with xterm's grid.
@@ -389,7 +400,7 @@
     bind:clientHeight={keybar_h}
   >
     {#if keybar_open}
-      <MobileTerminalKeyBar on_key={send_keys} />
+      <MobileTerminalKeyBar on_key={send_keys} bind:ctrl_armed={kb_ctrl_armed} />
     {/if}
     <button
       type="button"

--- a/src/lib/mobile/__tests__/control-chars.test.ts
+++ b/src/lib/mobile/__tests__/control-chars.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { to_control } from '../control-chars'
+
+describe(`to_control`, () => {
+  it(`maps letters to Ctrl-A..Ctrl-Z control chars`, () => {
+    expect(to_control(`c`)).toBe(`\x03`) // SIGINT
+    expect(to_control(`C`)).toBe(`\x03`) // case-insensitive
+    expect(to_control(`a`)).toBe(`\x01`)
+    expect(to_control(`z`)).toBe(`\x1a`) // SIGTSTP
+    expect(to_control(`d`)).toBe(`\x04`) // EOF
+  })
+
+  it(`maps standard non-letter control keys`, () => {
+    expect(to_control(`@`)).toBe(`\x00`)
+    expect(to_control(` `)).toBe(`\x00`)
+    expect(to_control(`[`)).toBe(`\x1b`)
+    expect(to_control(`\\`)).toBe(`\x1c`)
+    expect(to_control(`]`)).toBe(`\x1d`)
+    expect(to_control(`^`)).toBe(`\x1e`)
+    expect(to_control(`_`)).toBe(`\x1f`)
+    expect(to_control(`/`)).toBe(`\x1f`)
+  })
+
+  it(`returns null for unmappable or multi-char input`, () => {
+    expect(to_control(`1`)).toBe(null)
+    expect(to_control(`!`)).toBe(null)
+    expect(to_control(``)).toBe(null)
+    expect(to_control(`ab`)).toBe(null) // autocorrect-style multi-char insert
+  })
+})

--- a/src/lib/mobile/control-chars.ts
+++ b/src/lib/mobile/control-chars.ts
@@ -1,0 +1,30 @@
+/** Map a printable key to its control character (Ctrl+key), or null when the
+ * key has no control mapping. Shared by the terminal key bar (folding its own
+ * buttons) and MobileTerminal (folding the next soft-keyboard char while the
+ * key bar's sticky Ctrl is armed). */
+export function to_control(ch: string): string | null {
+  if (ch.length !== 1) return null
+  const c = ch.toLowerCase()
+  const code = c.charCodeAt(0)
+  // Ctrl-A..Ctrl-Z -> 0x01..0x1a
+  if (code >= 97 && code <= 122) return String.fromCharCode(code - 96)
+  // A handful of standard non-letter control mappings.
+  switch (ch) {
+    case `@`:
+    case ` `:
+      return `\x00`
+    case `[`:
+      return `\x1b`
+    case `\\`:
+      return `\x1c`
+    case `]`:
+      return `\x1d`
+    case `^`:
+      return `\x1e`
+    case `_`:
+    case `/`:
+      return `\x1f`
+    default:
+      return null
+  }
+}

--- a/src/lib/structure/MobileTerminalKeyBar.svelte
+++ b/src/lib/structure/MobileTerminalKeyBar.svelte
@@ -18,45 +18,20 @@
   their normal sequence) to keep behavior predictable.
 -->
 <script lang="ts">
+  import { to_control } from '$lib/mobile/control-chars'
+
   interface Props {
     /** Emitted with the raw byte sequence (as a string) for the pressed key. */
     on_key?: (seq: string) => void
+    /** Sticky Ctrl modifier state. Bindable so the parent terminal can fold the
+     * NEXT soft-keyboard character into a control char too — the bar's own keys
+     * alone can't produce Ctrl+C, since letters come from the soft keyboard. */
+    ctrl_armed?: boolean
   }
 
-  let { on_key }: Props = $props()
+  let { on_key, ctrl_armed = $bindable(false) }: Props = $props()
 
   const ESC = `\x1b`
-
-  // Sticky Ctrl modifier state.
-  let ctrl_armed = $state(false)
-
-  /** Map a printable key to its control char when Ctrl is armed. */
-  function to_control(ch: string): string | null {
-    if (ch.length !== 1) return null
-    const c = ch.toLowerCase()
-    const code = c.charCodeAt(0)
-    // Ctrl-A..Ctrl-Z -> 0x01..0x1a
-    if (code >= 97 && code <= 122) return String.fromCharCode(code - 96)
-    // A handful of standard non-letter control mappings.
-    switch (ch) {
-      case `@`:
-      case ` `:
-        return `\x00`
-      case `[`:
-        return `\x1b`
-      case `\\`:
-        return `\x1c`
-      case `]`:
-        return `\x1d`
-      case `^`:
-        return `\x1e`
-      case `_`:
-      case `/`:
-        return `\x1f`
-      default:
-        return null
-    }
-  }
 
   function emit(seq: string): void {
     on_key?.(seq)


### PR DESCRIPTION
Two bugs reported from iOS TestFlight testing:

## 1. Ctrl+C impossible in the mobile terminal

The key bar's sticky Ctrl only folded keys pressed **on the bar itself** — but the bar has no letter keys. Letters come from the soft keyboard, whose input flows through `term.onData → ptyWrite` untouched, so "tap Ctrl, type c" sent a plain `c`.

Fix: `ctrl_armed` is now a bindable prop; `MobileTerminal` folds the **next single soft-keyboard character** into its control char while armed (Ctrl → c → `0x03` = SIGINT). Multi-char input (autocorrect inserts) is left untouched and disarms safely. `to_control` extracted to `src/lib/mobile/control-chars.ts` with a test suite.

## 2. `OTP error: Unable to receive more messages from the channel`

That string is `russh::Error::RecvError` surfacing raw: the SSH server closed the connection while the keyboard-interactive handshake sat waiting for the code (LoginGraceTime / Duo timeout). On iOS this is easy to hit — switching to an authenticator app to read the code suspends CatGo and stalls the socket. (The reported correlation with renaming a saved connection is timing, not causation: the rename detour outlived the server's grace window. Saved-password keystore keys are `pw:host:port:user`, unaffected by label edits.)

Fix: `RecvError | SendError | Disconnect` during the OTP round now map to an actionable message — "OTP session expired … please connect again" — instead of the raw channel error.

## Validation
- `cargo check` clean; mobile vitest 35/35 (incl. new `to_control` suite); `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)