### PR TITLE
fix(ci): monotonic CFBundleVersion for TestFlight re-uploads

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -175,7 +175,14 @@ jobs:
           # terminal/files (russh over Tauri invoke, not HTTP). Backend-only UI
           # (chat/workflow/plugin_hub) is already hidden on mobile.
           VITE_STATIC_ONLY: '1'
-        run: pnpm tauri ios build --export-method app-store-connect --config '{"identifier":"org.catgo.app"}'
+        # bundleVersion (CFBundleVersion) must be STRICTLY INCREASING per upload
+        # for App Store Connect — a fixed value (previously the marketing
+        # version) makes every re-upload of the same app version fail with
+        # ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE. github.run_number is
+        # monotonic per workflow, so every run is uploadable.
+        run: >
+          pnpm tauri ios build --export-method app-store-connect
+          --config '{"identifier":"org.catgo.app","bundle":{"iOS":{"bundleVersion":"${{ github.run_number }}"}}}'
 
       # ---- Upload the signed IPA to App Store Connect (TestFlight) ----
       # Needs an App Store Connect API key (App Store Connect → Users and Access →


### PR DESCRIPTION
The iOS rebuild for the external-links fix failed at upload:

```
The bundle version must be higher than the previously uploaded version: '1.1.15'
ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE
```

CFBundleVersion inherited the marketing version from tauri.conf, so any second upload of the same app version is rejected by App Store Connect. Pass `github.run_number` as `bundle.iOS.bundleVersion` (tauri-utils ≥2.8 maps it straight to CFBundleVersion) in the signed-build `--config` override. CFBundleShortVersionString (what testers see) stays the marketing version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)