### PR TITLE
feat(mobile): multi-cluster sessions — connect several clusters, per-cluster terminal tabs

### DIFF
--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -124,6 +124,11 @@ const mobile: Record<string, string> = {
   term_panel:             `Terminals`,
   term_label:             `Terminal {n}`,
   term_new:               `New terminal`,
+  term_add_where:         `New terminal on…`,
+  term_add_new_cluster:   `Connect a new cluster…`,
+  connected_label:        `Connected clusters`,
+  connected_current:      `current`,
+  connected_eject:        `Disconnect this cluster`,
   term_close:             `Close terminal`,
   term_edit:              `Edit terminals`,
 

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -124,6 +124,11 @@ const mobile: Record<string, string> = {
   term_panel:             `终端`,
   term_label:             `终端 {n}`,
   term_new:               `新建终端`,
+  term_add_where:         `在哪个集群新建终端…`,
+  term_add_new_cluster:   `连接新集群…`,
+  connected_label:        `已连接集群`,
+  connected_current:      `当前`,
+  connected_eject:        `断开此集群`,
   term_close:             `关闭终端`,
   term_edit:              `编辑终端`,
 

--- a/src/lib/mobile/MobileConnect.svelte
+++ b/src/lib/mobile/MobileConnect.svelte
@@ -26,14 +26,36 @@
     type SavedConnection,
   } from './connections'
   import { endpointKey, reuseSession, rememberSession } from './sessions'
+  import { clusters } from './clusters.svelte'
   import { t } from '$lib/i18n/index.svelte'
+
+  export interface ConnectedMeta {
+    host: string
+    port: number
+    username: string
+    /** Saved nickname if set, else `user@host`. */
+    label: string
+  }
 
   interface Props {
     /** Emitted with the live session id once authentication completes. */
-    on_connected?: (session_id: string) => void
+    on_connected?: (session_id: string, meta: ConnectedMeta) => void
+    /** Disconnect one live cluster (endpoint key) — owned by the workspace. */
+    on_eject?: (key: string) => void
   }
 
-  let { on_connected }: Props = $props()
+  let { on_connected, on_eject }: Props = $props()
+
+  function connected_meta(): ConnectedMeta {
+    const h = host.trim()
+    const u = username.trim()
+    return {
+      host: h,
+      port,
+      username: u,
+      label: label.trim() || (port === 22 ? `${u}@${h}` : `${u}@${h}:${port}`),
+    }
+  }
 
   // ─── Saved (non-secret) connections ───
   let saved = $state<SavedConnection[]>([])
@@ -249,7 +271,7 @@
         save_prompt_visible = true
         return
       }
-      on_connected?.(r.sessionId)
+      on_connected?.(r.sessionId, connected_meta())
       return
     }
     // Not connected and no OTP round => authentication failed / refused.
@@ -283,7 +305,7 @@
       if (reused) {
         persist_non_secrets()
         connecting = false
-        on_connected?.(reused)
+        on_connected?.(reused, connected_meta())
         return
       }
     } catch {
@@ -383,7 +405,7 @@
     const id = pending_session
     pending_session = ``
     pending_pw = ``
-    on_connected?.(id)
+    on_connected?.(id, connected_meta())
   }
 
   /** Save the password (encrypted) for OTP-only reconnect, then continue. */
@@ -411,6 +433,45 @@
 <div class="connect-wrap">
   <div class="connect-card">
     <div class="connect-title">{t(`mobile.connect_title`)}</div>
+
+    {#if clusters.list.length > 0}
+      <!-- Clusters the user is logged into RIGHT NOW. Tap = make it the active
+           one (instant — the session is already authenticated); ⏏ = disconnect
+           just that cluster. Connecting a new cluster below does NOT drop these. -->
+      <div class="live-list">
+        <div class="saved-head">
+          <span class="saved-label">{t(`mobile.connected_label`)}</span>
+        </div>
+        {#each clusters.list as c (c.key)}
+          <div class="live-row" class:active={c.key === clusters.active_key}>
+            <button
+              type="button"
+              class="live-pick"
+              onclick={() =>
+                on_connected?.(c.session_id, {
+                  host: c.host,
+                  port: c.port,
+                  username: c.username,
+                  label: c.label,
+                })}
+            >
+              <span class="live-dot" aria-hidden="true"></span>
+              <span class="live-name">{c.label}</span>
+              {#if c.key === clusters.active_key}
+                <span class="live-current">{t(`mobile.connected_current`)}</span>
+              {/if}
+            </button>
+            <button
+              type="button"
+              class="live-eject"
+              title={t(`mobile.connected_eject`)}
+              aria-label={t(`mobile.connected_eject`)}
+              onclick={() => on_eject?.(c.key)}
+            >⏏</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
 
     {#if saved.length > 0}
       <div class="saved-list">
@@ -730,6 +791,61 @@
     font-weight: 600;
     color: var(--text-color, #e0e0e0);
     margin-bottom: 16px;
+  }
+  .live-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 12px;
+  }
+  .live-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid var(--border-color, #4443);
+    border-radius: 8px;
+    padding: 2px 6px 2px 2px;
+  }
+  .live-row.active {
+    border-color: var(--accent-color, #1976d2);
+  }
+  .live-pick {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    background: none;
+    border: none;
+    padding: 8px;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+  }
+  .live-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #2e7d32;
+    flex-shrink: 0;
+  }
+  .live-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .live-current {
+    font-size: 11px;
+    opacity: 0.65;
+    flex-shrink: 0;
+  }
+  .live-eject {
+    background: none;
+    border: none;
+    font-size: 16px;
+    padding: 6px 8px;
+    color: inherit;
+    opacity: 0.8;
   }
   .saved-list {
     display: flex;

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -34,16 +34,25 @@
   import {
     active_cwd,
     add_tab,
-    clear_tabs,
     close_tab,
+    close_tabs_for_session,
+    ensure_tab,
     MAX_TABS,
     path_basename,
-    reset_for_session,
     set_tab_cwd,
     switch_tab,
     term_tabs,
     toggle_edit_mode,
   } from './terminal-tabs.svelte'
+  import {
+    clusters,
+    get_active_cluster,
+    register_cluster,
+    remove_cluster,
+    set_active_cluster,
+  } from './clusters.svelte'
+  import type { ConnectedMeta } from './MobileConnect.svelte'
+  import { endpointKey } from './sessions'
   import { check_tauri } from '$lib/io/tauri'
   import LocaleSwitch from '$lib/i18n/LocaleSwitch.svelte'
   import Icon from '$lib/Icon.svelte'
@@ -167,6 +176,13 @@
   // stays up), then refit after the DOM shows the now-active tab.
   async function select_tab(id: string): Promise<void> {
     switch_tab(id)
+    // Activating a tab also activates its cluster: Files/Jobs/chat follow.
+    const tab = term_tabs.tabs.find((t) => t.id === id)
+    if (tab && tab.session_id !== session_id) {
+      session_id = tab.session_id
+      const c = clusters.list.find((x) => x.session_id === tab.session_id)
+      if (c) set_active_cluster(c.key)
+    }
     term_refs[id]?.focus?.()
     await tick()
     term_refs[id]?.refit?.()
@@ -202,6 +218,9 @@
     if (sheet_tab) remove_tab(sheet_tab)
   }
   const has_content = $derived(structure != null || trajectory != null)
+  const multi_cluster_tabs = $derived(
+    new Set(term_tabs.tabs.map((t) => t.session_id)).size > 1,
+  )
 
   // Auto-dismiss the save/notice banner so it never sticks permanently; a ✕ also
   // clears it immediately.
@@ -330,19 +349,61 @@
     }
   }
 
-  // Drop the session → the terminal pane shows the connect form again (saved
-  // connections + OTP-only reconnect still apply). The structure stays loaded.
-  function disconnect(): void {
+  // Eject ONE cluster from the workspace (its russh session stays alive on the
+  // Rust side for silent ControlMaster-style reuse — see sessions.ts). Other
+  // connected clusters keep their tabs; the next one becomes active. With no
+  // clusters left the terminal pane shows the connect form again.
+  function eject_cluster(key: string): void {
+    const c = clusters.list.find((x) => x.key === key)
+    if (c) close_tabs_for_session(c.session_id)
+    const next = remove_cluster(key)
+    if (next) {
+      session_id = next.session_id
+      ensure_tab(next.session_id, next.label)
+      return
+    }
     session_id = null
-    clear_tabs()
     ks_visible = false
     files_open = false
     if (!has_content) mode = is_web ? `choose` : `terminal`
   }
 
-  function on_connected(id: string): void {
+  function disconnect(): void {
+    const active = get_active_cluster()
+    if (active) eject_cluster(active.key)
+    else session_id = null
+  }
+
+  // "+" on the tab strip: with one cluster it's ambiguous what the user wants
+  // (another shell here, or a different cluster?) — ask. Selecting a connected
+  // cluster opens a tab on it without re-auth; "new cluster" shows the connect
+  // form WITHOUT dropping any live session.
+  let add_sheet_visible = $state(false)
+  function add_tab_on(cluster_session: string, cluster_label: string): void {
+    add_sheet_visible = false
+    add_tab(cluster_session, cluster_label)
+    const c = clusters.list.find((x) => x.session_id === cluster_session)
+    if (c) {
+      set_active_cluster(c.key)
+      session_id = c.session_id
+    }
+  }
+  function add_new_cluster(): void {
+    add_sheet_visible = false
+    session_id = null // shows MobileConnect; live clusters stay registered
+  }
+
+  function on_connected(id: string, meta: ConnectedMeta): void {
     session_id = id
-    reset_for_session(id) // seed a single terminal tab for this session
+    register_cluster({
+      key: endpointKey(meta.host, meta.port, meta.username),
+      session_id: id,
+      host: meta.host,
+      port: meta.port,
+      username: meta.username,
+      label: meta.label,
+    })
+    ensure_tab(id, meta.label) // seed (or refocus) this cluster's terminal tab
     if (mode === `choose`) mode = `terminal`
 
     // Offer SSH-key passwordless setup once per endpoint (skip if already keyed
@@ -563,7 +624,8 @@
                   >
                     <Icon icon="Terminal" />
                     <span class="mw-tabchip-label"
-                      >{path_basename(tab.cwd) || t(`mobile.term_label`, { n: tab.seq })}</span
+                      >{multi_cluster_tabs ? `${tab.cluster} · ` : ``}{path_basename(tab.cwd) ||
+                        t(`mobile.term_label`, { n: tab.seq })}</span
                     >
                   </button>
                   {#if term_tabs.edit_mode && term_tabs.tabs.length > 1}
@@ -582,7 +644,7 @@
                   class="mw-tab-add"
                   title={t(`mobile.term_new`)}
                   aria-label={t(`mobile.term_new`)}
-                  onclick={() => add_tab()}
+                  onclick={() => (add_sheet_visible = true)}
                 ><Icon icon="Plus" /></button>
               {/if}
               {#if term_tabs.tabs.length > 1}
@@ -604,16 +666,47 @@
                 <div class="mw-termtab" class:inactive={tab.id !== term_tabs.active_id}>
                   <MobileTerminal
                     bind:this={term_refs[tab.id]}
-                    {session_id}
+                    session_id={tab.session_id}
                     on_cwd={(p) => set_tab_cwd(tab.id, p)}
                   />
                 </div>
               {/each}
             </div>
+
+            {#if add_sheet_visible}
+              <!-- "+" chooser: a shell on a connected cluster, or a new cluster. -->
+              <div
+                class="mw-addsheet-backdrop"
+                role="presentation"
+                onclick={() => (add_sheet_visible = false)}
+              >
+                <div
+                  class="mw-addsheet"
+                  role="dialog"
+                  aria-label={t(`mobile.term_new`)}
+                  onclick={(e) => e.stopPropagation()}
+                >
+                  <div class="mw-addsheet-title">{t(`mobile.term_add_where`)}</div>
+                  {#each clusters.list as c (c.key)}
+                    <button type="button" class="mw-addsheet-opt" onclick={() => add_tab_on(c.session_id, c.label)}>
+                      <Icon icon="Terminal" />
+                      <span>{c.label}</span>
+                      {#if c.key === clusters.active_key}
+                        <span class="mw-addsheet-cur">{t(`mobile.connected_current`)}</span>
+                      {/if}
+                    </button>
+                  {/each}
+                  <button type="button" class="mw-addsheet-opt new" onclick={add_new_cluster}>
+                    <Icon icon="Plus" />
+                    <span>{t(`mobile.term_add_new_cluster`)}</span>
+                  </button>
+                </div>
+              </div>
+            {/if}
           </div>
         {:else}
           <div class="mw-connect">
-            <MobileConnect {on_connected} />
+            <MobileConnect {on_connected} on_eject={eject_cluster} />
           </div>
         {/if}
       </div>
@@ -1021,6 +1114,51 @@
   }
   .mw-tabbar::-webkit-scrollbar {
     display: none;
+  }
+  .mw-addsheet-backdrop {
+    position: absolute;
+    inset: 0;
+    background: #0006;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    z-index: 30;
+  }
+  .mw-addsheet {
+    width: 100%;
+    max-width: 420px;
+    background: var(--surface-bg, var(--page-bg, #fff));
+    border-radius: 12px 12px 0 0;
+    padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .mw-addsheet-title {
+    font-size: 13px;
+    opacity: 0.7;
+    padding: 4px 6px 8px;
+  }
+  .mw-addsheet-opt {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: 1px solid var(--border-color, #4443);
+    border-radius: 8px;
+    padding: 12px;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+  }
+  .mw-addsheet-opt.new {
+    border-style: dashed;
+  }
+  .mw-addsheet-cur {
+    margin-left: auto;
+    font-size: 11px;
+    opacity: 0.65;
   }
   .mw-tabchip {
     position: relative;

--- a/src/lib/mobile/__tests__/terminal-tabs.test.ts
+++ b/src/lib/mobile/__tests__/terminal-tabs.test.ts
@@ -4,13 +4,13 @@ import {
   add_tab,
   clear_tabs,
   close_tab,
+  close_tabs_for_session,
+  ensure_tab,
   MAX_TABS,
   path_basename,
-  reset_for_session,
   set_tab_cwd,
   switch_tab,
   term_tabs,
-  toggle_edit_mode,
 } from '../terminal-tabs.svelte'
 
 // Module-level state persists between tests — reset it each time.
@@ -29,45 +29,49 @@ describe(`path_basename`, () => {
   it(`returns empty for empty input`, () => {
     expect(path_basename(``)).toBe(``)
   })
+  it(`returns a no-slash relative path unchanged`, () => {
+    expect(path_basename(`proj`)).toBe(`proj`)
+  })
 })
 
 describe(`terminal-tabs registry`, () => {
-  it(`reset_for_session seeds exactly one active tab`, () => {
-    reset_for_session(`s1`)
+  it(`ensure_tab seeds exactly one active tab for a new session`, () => {
+    ensure_tab(`s1`, `me@a`)
     expect(term_tabs.tabs.length).toBe(1)
     expect(term_tabs.active_id).toBe(term_tabs.tabs[0].id)
-    expect(term_tabs.session_id).toBe(`s1`)
+    expect(term_tabs.tabs[0].session_id).toBe(`s1`)
+    expect(term_tabs.tabs[0].cluster).toBe(`me@a`)
   })
 
-  it(`reset_for_session is idempotent for the same session`, () => {
-    reset_for_session(`s1`)
-    add_tab()
-    const n = term_tabs.tabs.length
-    reset_for_session(`s1`) // same session, has tabs → no wipe
-    expect(term_tabs.tabs.length).toBe(n)
+  it(`ensure_tab refocuses (not duplicates) a session that already has tabs`, () => {
+    ensure_tab(`s1`, `me@a`)
+    const first = term_tabs.tabs[0].id
+    add_tab(`s1`, `me@a`)
+    ensure_tab(`s1`, `me@a`)
+    expect(term_tabs.tabs.length).toBe(2)
+    expect(term_tabs.active_id).toBe(first)
   })
 
-  it(`reset_for_session wipes when the session changes`, () => {
-    reset_for_session(`s1`)
-    add_tab()
-    reset_for_session(`s2`)
-    expect(term_tabs.tabs.length).toBe(1)
-    expect(term_tabs.session_id).toBe(`s2`)
+  it(`tabs from several sessions coexist — connecting B keeps A's tabs`, () => {
+    ensure_tab(`s1`, `me@a`)
+    ensure_tab(`s2`, `me@b`)
+    expect(term_tabs.tabs.length).toBe(2)
+    expect(term_tabs.tabs.map((t) => t.session_id)).toEqual([`s1`, `s2`])
   })
 
   it(`add_tab appends, activates, and caps at MAX_TABS`, () => {
-    reset_for_session(`s1`) // 1 tab
-    for (let i = 0; i < 10; i++) add_tab()
+    ensure_tab(`s1`, `me@a`) // 1 tab
+    for (let i = 0; i < 10; i++) add_tab(`s1`, `me@a`)
     expect(term_tabs.tabs.length).toBe(MAX_TABS)
-    expect(add_tab()).toBeNull()
+    expect(add_tab(`s1`, `me@a`)).toBeNull()
     const last = term_tabs.tabs[term_tabs.tabs.length - 1]
     expect(term_tabs.active_id).toBe(last.id)
   })
 
   it(`switch_tab changes the active tab and ignores unknown ids`, () => {
-    reset_for_session(`s1`)
+    ensure_tab(`s1`, `me@a`)
     const first = term_tabs.tabs[0].id
-    add_tab()
+    add_tab(`s1`, `me@a`)
     switch_tab(first)
     expect(term_tabs.active_id).toBe(first)
     switch_tab(`nope`)
@@ -75,44 +79,27 @@ describe(`terminal-tabs registry`, () => {
   })
 
   it(`close_tab removes the tab and reassigns the active selection`, () => {
-    reset_for_session(`s1`)
+    ensure_tab(`s1`, `me@a`)
     const a = term_tabs.tabs[0].id
-    add_tab()
+    add_tab(`s1`, `me@a`)
     const b = term_tabs.active_id as string
     close_tab(b)
     expect(term_tabs.tabs.some((t) => t.id === b)).toBe(false)
     expect(term_tabs.active_id).toBe(a)
   })
 
-  it(`closing the last tab respawns a fresh one`, () => {
-    reset_for_session(`s1`)
+  it(`closing the last tab respawns a fresh one on the SAME cluster`, () => {
+    ensure_tab(`s1`, `me@a`)
     const only = term_tabs.tabs[0].id
     close_tab(only)
     expect(term_tabs.tabs.length).toBe(1)
     expect(term_tabs.tabs[0].id).not.toBe(only)
-  })
-
-  it(`set_tab_cwd updates cwd; active_cwd follows the active tab`, () => {
-    reset_for_session(`s1`)
-    const a = term_tabs.tabs[0].id
-    add_tab()
-    const b = term_tabs.active_id as string
-    set_tab_cwd(a, `/home/u/alpha`)
-    set_tab_cwd(b, `/home/u/beta`)
-    expect(active_cwd()).toBe(`/home/u/beta`) // b is active
-    switch_tab(a)
-    expect(active_cwd()).toBe(`/home/u/alpha`)
-  })
-})
-
-describe(`terminal-tabs registry — edge cases`, () => {
-  it(`path_basename returns a no-slash relative path unchanged`, () => {
-    expect(path_basename(`proj`)).toBe(`proj`)
+    expect(term_tabs.tabs[0].session_id).toBe(`s1`)
   })
 
   it(`close_tab is a no-op for an unknown id`, () => {
-    reset_for_session(`s1`)
-    add_tab()
+    ensure_tab(`s1`, `me@a`)
+    add_tab(`s1`, `me@a`)
     const before = term_tabs.tabs.length
     const active = term_tabs.active_id
     close_tab(`nope`)
@@ -121,50 +108,78 @@ describe(`terminal-tabs registry — edge cases`, () => {
   })
 
   it(`closing a NON-active tab leaves the active selection unchanged`, () => {
-    reset_for_session(`s1`)
+    ensure_tab(`s1`, `me@a`)
     const a = term_tabs.tabs[0].id
-    add_tab() // b, now active
+    add_tab(`s1`, `me@a`) // b, now active
     const b = term_tabs.active_id as string
-    close_tab(a) // close the inactive one
+    close_tab(a)
     expect(term_tabs.active_id).toBe(b)
     expect(term_tabs.tabs.some((t) => t.id === a)).toBe(false)
   })
 
-  it(`switch_tab ignores an id that was closed`, () => {
-    reset_for_session(`s1`)
+  it(`set_tab_cwd updates cwd; active_cwd follows the active tab`, () => {
+    ensure_tab(`s1`, `me@a`)
     const a = term_tabs.tabs[0].id
-    add_tab()
+    add_tab(`s1`, `me@a`)
     const b = term_tabs.active_id as string
-    close_tab(a)
-    switch_tab(a) // a no longer exists
-    expect(term_tabs.active_id).toBe(b)
+    set_tab_cwd(a, `/home/u/alpha`)
+    set_tab_cwd(b, `/home/u/beta`)
+    expect(active_cwd()).toBe(`/home/u/beta`) // b is active
+    switch_tab(a)
+    expect(active_cwd()).toBe(`/home/u/alpha`)
   })
 
-  it(`active_cwd is empty when there is no active tab`, () => {
-    clear_tabs()
-    expect(active_cwd()).toBe(``)
+  it(`close_tabs_for_session removes only that cluster's tabs (no respawn)`, () => {
+    ensure_tab(`s1`, `me@a`)
+    add_tab(`s1`, `me@a`)
+    ensure_tab(`s2`, `me@b`)
+    close_tabs_for_session(`s1`)
+    expect(term_tabs.tabs.length).toBe(1)
+    expect(term_tabs.tabs[0].session_id).toBe(`s2`)
+    expect(term_tabs.active_id).toBe(term_tabs.tabs[0].id)
   })
 
-  it(`set_tab_cwd is a no-op for an unknown id`, () => {
-    reset_for_session(`s1`)
-    expect(() => set_tab_cwd(`nope`, `/x`)).not.toThrow()
-    expect(active_cwd()).toBe(``)
+  it(`close_tabs_for_session of the LAST cluster leaves an empty strip`, () => {
+    ensure_tab(`s1`, `me@a`)
+    close_tabs_for_session(`s1`)
+    expect(term_tabs.tabs.length).toBe(0)
+    expect(term_tabs.active_id).toBe(null)
+  })
+})
+
+describe(`clusters registry`, () => {
+  it(`register / switch / remove round-trip`, async () => {
+    const { clusters, get_active_cluster, register_cluster, remove_cluster, set_active_cluster } =
+      await import(`../clusters.svelte`)
+    clusters.list.length = 0
+    clusters.active_key = null
+
+    register_cluster({ key: `a:22:u`, session_id: `s1`, host: `a`, port: 22, username: `u`, label: `u@a` })
+    register_cluster({ key: `b:22:u`, session_id: `s2`, host: `b`, port: 22, username: `u`, label: `u@b` })
+    expect(clusters.list.length).toBe(2)
+    expect(clusters.active_key).toBe(`b:22:u`) // newest connect becomes active
+
+    set_active_cluster(`a:22:u`)
+    expect(get_active_cluster()?.session_id).toBe(`s1`)
+
+    // Removing the active cluster activates the remaining one.
+    const next = remove_cluster(`a:22:u`)
+    expect(next?.key).toBe(`b:22:u`)
+    expect(clusters.active_key).toBe(`b:22:u`)
+
+    // Removing the last leaves none.
+    expect(remove_cluster(`b:22:u`)).toBe(null)
+    expect(clusters.active_key).toBe(null)
   })
 
-  it(`edit_mode toggles, and drops back off once only one tab remains`, () => {
-    reset_for_session(`s1`)
-    add_tab() // 2 tabs
-    toggle_edit_mode()
-    expect(term_tabs.edit_mode).toBe(true)
-    close_tab(term_tabs.active_id as string) // back to 1 tab
-    expect(term_tabs.edit_mode).toBe(false)
-  })
-
-  it(`reset_for_session clears a lingering edit_mode`, () => {
-    reset_for_session(`s1`)
-    add_tab()
-    toggle_edit_mode()
-    reset_for_session(`s2`) // different session → fresh state
-    expect(term_tabs.edit_mode).toBe(false)
+  it(`re-registering the same endpoint refreshes instead of duplicating`, async () => {
+    const { clusters, register_cluster } = await import(`../clusters.svelte`)
+    clusters.list.length = 0
+    clusters.active_key = null
+    register_cluster({ key: `a:22:u`, session_id: `s1`, host: `a`, port: 22, username: `u`, label: `u@a` })
+    register_cluster({ key: `a:22:u`, session_id: `s9`, host: `a`, port: 22, username: `u`, label: `nick` })
+    expect(clusters.list.length).toBe(1)
+    expect(clusters.list[0].session_id).toBe(`s9`)
+    expect(clusters.list[0].label).toBe(`nick`)
   })
 })

--- a/src/lib/mobile/clusters.svelte.ts
+++ b/src/lib/mobile/clusters.svelte.ts
@@ -1,0 +1,65 @@
+/**
+ * Live multi-cluster registry — which clusters the user is logged into RIGHT
+ * NOW, and which one is "active" (drives the Files / Jobs / chat panels).
+ *
+ * Complements `sessions.ts` (endpoint→session_id reuse cache): sessions.ts
+ * remembers connections that can be silently reattached; this registry holds
+ * the user-visible list of clusters that are currently attached to the
+ * workspace UI. Module-level `$state` so it survives component remounts —
+ * same lifetime model as sessions.ts / terminal-tabs (a fresh app launch
+ * starts empty, which is correct: SSH sessions cannot outlive the process).
+ */
+
+export type LiveCluster = {
+  /** Endpoint key, `host:port:user` (see sessions.endpointKey). */
+  key: string
+  /** The live russh session id on the Rust side. */
+  session_id: string
+  host: string
+  port: number
+  username: string
+  /** Display label: the saved connection's nickname, else `user@host`. */
+  label: string
+}
+
+export const clusters = $state({
+  list: [] as LiveCluster[],
+  /** Endpoint key of the cluster the workspace panels operate on. */
+  active_key: null as string | null,
+})
+
+/** Add (or refresh) a cluster and make it the active one. */
+export function register_cluster(c: LiveCluster): void {
+  const idx = clusters.list.findIndex((x) => x.key === c.key)
+  if (idx >= 0) clusters.list[idx] = c
+  else clusters.list.push(c)
+  clusters.active_key = c.key
+}
+
+/** Remove a cluster (on eject). Returns the next cluster to activate, if any. */
+export function remove_cluster(key: string): LiveCluster | null {
+  const idx = clusters.list.findIndex((x) => x.key === key)
+  if (idx >= 0) clusters.list.splice(idx, 1)
+  if (clusters.active_key === key) {
+    const next = clusters.list[Math.min(idx, clusters.list.length - 1)] ?? null
+    clusters.active_key = next?.key ?? null
+    return next
+  }
+  return get_active_cluster()
+}
+
+export function set_active_cluster(key: string): LiveCluster | null {
+  const c = clusters.list.find((x) => x.key === key) ?? null
+  if (c) clusters.active_key = c.key
+  return c
+}
+
+export function get_active_cluster(): LiveCluster | null {
+  return clusters.list.find((x) => x.key === clusters.active_key) ?? null
+}
+
+/** Drop a cluster whose session turned out dead (without touching the rest). */
+export function drop_dead_cluster(session_id: string): void {
+  const c = clusters.list.find((x) => x.session_id === session_id)
+  if (c) remove_cluster(c.key)
+}

--- a/src/lib/mobile/terminal-tabs.svelte.ts
+++ b/src/lib/mobile/terminal-tabs.svelte.ts
@@ -8,10 +8,11 @@
  * component (the `$effect` closure), NOT here — storing DOM-tied objects in
  * module state would leak and block GC after a tab closes.
  *
- * Single-host (v1): the list belongs to the currently-connected session. Call
- * `reset_for_session(id)` on (re)connect to seed a fresh single tab, and
- * `clear_tabs()` on disconnect. Multi-host (a `Map<endpointKey, TermTab[]>`) is
- * a future extension — see docs/developer/mobile-terminal-tabs-design.md.
+ * Multi-host: each tab carries the `session_id` (and a cluster label) it is
+ * bound to, so tabs for several clusters coexist in one strip. `ensure_tab()`
+ * seeds a first tab per session on connect; `close_tabs_for_session()` removes
+ * a cluster's tabs on eject. (Supersedes the single-host v1 noted in
+ * docs/developer/mobile-terminal-tabs-design.md §6.1.)
  */
 
 export type TermTab = {
@@ -21,6 +22,11 @@ export type TermTab = {
   cwd: string
   /** 1-based creation ordinal, used for the `Terminal N` fallback label. */
   seq: number
+  /** The live SSH session this tab's PTY runs on. */
+  session_id: string
+  /** Short cluster label (saved-connection nickname or `user@host`) shown on
+   * the chip when tabs from several clusters coexist. */
+  cluster: string
 }
 
 /** Hard cap on simultaneous terminals (N live PTYs + xterm instances on a
@@ -32,8 +38,6 @@ export const term_tabs = $state({
   active_id: null as string | null,
   /** Edit mode reveals a ✕ on each tab for closing several quickly. */
   edit_mode: false,
-  /** The session these tabs belong to (single-host v1). */
-  session_id: null as string | null,
 })
 
 // Monotonic across the whole app life so ids never collide, even after a
@@ -56,11 +60,11 @@ export function path_basename(path: string): string {
   return idx >= 0 ? trimmed.slice(idx + 1) : trimmed
 }
 
-/** Add a terminal and make it active. No-op (returns null) past MAX_TABS. */
-export function add_tab(): string | null {
+/** Add a terminal on `session_id` and make it active. No-op past MAX_TABS. */
+export function add_tab(session_id: string, cluster: string): string | null {
   if (term_tabs.tabs.length >= MAX_TABS) return null
   seq_counter += 1
-  const tab: TermTab = { id: next_id(), cwd: ``, seq: seq_counter }
+  const tab: TermTab = { id: next_id(), cwd: ``, seq: seq_counter, session_id, cluster }
   term_tabs.tabs.push(tab)
   term_tabs.active_id = tab.id
   return tab.id
@@ -76,12 +80,14 @@ export function switch_tab(id: string): void {
 export function close_tab(id: string): void {
   const idx = term_tabs.tabs.findIndex((t) => t.id === id)
   if (idx === -1) return
+  const closed = term_tabs.tabs[idx]
   term_tabs.tabs.splice(idx, 1)
   // The ✕ affordance only shows with >1 tab, so don't leave edit mode "on"
   // (and re-appearing) once we're back down to a single terminal.
   if (term_tabs.tabs.length <= 1) term_tabs.edit_mode = false
   if (term_tabs.tabs.length === 0) {
-    add_tab() // last-tab respawn — always ≥ 1 terminal
+    // last-tab respawn on the same cluster — always ≥ 1 terminal
+    add_tab(closed.session_id, closed.cluster)
     return
   }
   if (term_tabs.active_id === id) {
@@ -106,23 +112,33 @@ export function active_cwd(): string {
   return tab?.cwd ?? ``
 }
 
-/** Seed a fresh single-tab registry for a (new) session. Idempotent for the
- *  same session id that already has tabs, so re-renders don't wipe state. */
-export function reset_for_session(session_id: string): void {
-  if (term_tabs.session_id === session_id && term_tabs.tabs.length > 0) return
-  term_tabs.tabs = []
-  term_tabs.active_id = null
-  term_tabs.edit_mode = false
-  term_tabs.session_id = session_id
-  seq_counter = 0
-  add_tab()
+/** Make sure `session_id` has at least one tab; activate its first tab.
+ *  Idempotent — reconnecting/switching to a cluster that already has tabs
+ *  just focuses them instead of wiping anything. */
+export function ensure_tab(session_id: string, cluster: string): void {
+  const existing = term_tabs.tabs.find((t) => t.session_id === session_id)
+  if (existing) {
+    term_tabs.active_id = existing.id
+    return
+  }
+  add_tab(session_id, cluster)
 }
 
-/** Wipe everything (on disconnect). */
+/** Close all tabs bound to one session (cluster eject). Unlike close_tab,
+ *  closing the last tab overall does NOT respawn — an empty strip is correct
+ *  when no cluster is connected. */
+export function close_tabs_for_session(session_id: string): void {
+  term_tabs.tabs = term_tabs.tabs.filter((t) => t.session_id !== session_id)
+  if (term_tabs.tabs.length <= 1) term_tabs.edit_mode = false
+  if (!term_tabs.tabs.some((t) => t.id === term_tabs.active_id)) {
+    term_tabs.active_id = term_tabs.tabs[0]?.id ?? null
+  }
+}
+
+/** Wipe everything (full reset, e.g. all clusters gone). */
 export function clear_tabs(): void {
   term_tabs.tabs = []
   term_tabs.active_id = null
   term_tabs.edit_mode = false
-  term_tabs.session_id = null
   seq_counter = 0
 }


### PR DESCRIPTION
Requested: the phone app forces one cluster at a time — to use a second cluster you must eject the first. Now the login page keeps several clusters connected, and the terminal “+” asks whether the new tab goes on the current cluster or a new one.

The Rust `SshState` and `sessions.ts` (ControlMaster-style reuse) were already multi-session — only the UI was single-host.

## What changed

- **`clusters.svelte.ts` (new):** reactive registry of live clusters `{endpoint, session_id, label}` + the active one (drives Files / Jobs / chat).
- **Terminal tabs are per-cluster:** each tab carries its `session_id` + cluster label; tabs from several clusters coexist in one strip (supersedes the single-host v1 in `docs/developer/mobile-terminal-tabs-design.md` §6.1). Chip labels show a `cluster ·` prefix when tabs span clusters. Last-tab respawn stays on the same cluster; ejecting a cluster closes only its tabs.
- **“+” chooser sheet:** pick any connected cluster (no re-auth) or *Connect a new cluster…* — which shows the connect form **without dropping live sessions**.
- **Connect page:** new *Connected clusters* section — tap to switch the active cluster instantly, ⏏ to disconnect one. The eject keeps the russh session alive on the Rust side for silent reuse (existing sessions.ts semantics).
- **Tab activation = cluster activation:** tapping a tab on cluster B makes B active, so Files/Jobs/chat follow the terminal you're looking at.
- i18n en/zh parity.

## Validation

- terminal-tabs suite rewritten for the multi-host model + clusters-registry tests (34 mobile tests pass).
- Full vitest: 3975 passed (1 known RdfPlot parallel-load flake, passes in isolation).
- `svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)