### PR TITLE
fix(workflow): drop max-iter fields from ORCA geo-opt and NEB-TS forms

### DIFF
--- a/src/lib/workflow/node-definitions.ts
+++ b/src/lib/workflow/node-definitions.ts
@@ -615,11 +615,6 @@ export const NODE_DEFINITIONS: Record<string, NodeDefinition> = {
           key: `cartesian_opt`, label: `Cartesian Optimization (COpt)`, type: `boolean`, default: false, group: `Optimization`,
           help: `Optimize in Cartesian rather than internal coordinates. Useful for surface/periodic systems.`,
         },
-        {
-          key: `max_iterations`, label: `Max Iterations`, type: `number`, default: 50, group: `Optimization`,
-          min: 10, max: 200,
-          help: `Maximum geometry optimization cycles.`,
-        },
       ]),
       // ── xTB params ──
       ...xtb_only([
@@ -1604,10 +1599,6 @@ Used for ZPE corrections, thermodynamics, and TS verification.
         {
           key: `nimages`, label: `Number of Images`, type: `number`, default: 8, group: `NEB`, min: 4, max: 20,
           help: `NEB images between reactant/product. 8-12 typical; more=smoother path.`,
-        },
-        {
-          key: `neb_cycles`, label: `Max NEB Iterations`, type: `number`, default: 100, group: `NEB`, min: 10, max: 500,
-          help: `Maximum NEB optimization iterations.`,
         },
         {
           key: `uno`, label: `Generate Natural Orbitals (UNO)`, type: `boolean`, default: false, group: `Output`,

--- a/src/lib/workflow/node-defs/calculation/geo-opt.ts
+++ b/src/lib/workflow/node-defs/calculation/geo-opt.ts
@@ -138,11 +138,6 @@ Choose system type first — periodic (crystal/slab) or molecular (cluster/molec
         ],
         help: `MinSteps=geometry opt only, Freq=also run frequency analysis after optimization.`,
       },
-      {
-        key: `max_iterations`, label: `Max Iterations`, type: `number`, default: 50, group: `Optimization`,
-        min: 10, max: 200,
-        help: `Maximum geometry optimization cycles.`,
-      },
     ]),
     // ── xTB params ──
     ...xtb_only([

--- a/src/lib/workflow/node-defs/calculation/ts-search.ts
+++ b/src/lib/workflow/node-defs/calculation/ts-search.ts
@@ -13,7 +13,7 @@ export const TS_SEARCH_NODE: NodeDefinition = {
   description: `Transition state search`,
   inputs: [`structure`, `structure_product`],
   outputs: [`structure`, `energy`, `frequencies`, `trajectory`],
-  default_params: { system_type: `molecular`, software: `sella`, calculator: `xtb`, calculator_method: `GFN2-xTB`, ENCUT: 520, EDIFF: `1e-5`, kpoints: `1×1×1`, fmax: 0.01, max_steps: 500, order: 1, delta: 0.01, gamma: 0.4, method: `r2SCAN-3c`, basis: `6-31G`, nimages: 8, spring_k: 0.1, neb_cycles: 100, charge: 0, multiplicity: 1 },
+  default_params: { system_type: `molecular`, software: `sella`, calculator: `xtb`, calculator_method: `GFN2-xTB`, ENCUT: 520, EDIFF: `1e-5`, kpoints: `1×1×1`, fmax: 0.01, max_steps: 500, order: 1, delta: 0.01, gamma: 0.4, method: `r2SCAN-3c`, basis: `6-31G`, nimages: 8, spring_k: 0.1, charge: 0, multiplicity: 1 },
   help_text: `**Transition State Search** — Find saddle points on the PES.
 
 **Software options:**
@@ -286,10 +286,6 @@ export const TS_SEARCH_NODE: NodeDefinition = {
       {
         key: `nimages`, label: `Number of Images`, type: `number`, default: 8, group: `NEB`, min: 4, max: 20,
         help: `NEB images between reactant/product. 8-12 typical; more=smoother path.`,
-      },
-      {
-        key: `neb_cycles`, label: `Max NEB Iterations`, type: `number`, default: 100, group: `NEB`, min: 10, max: 500,
-        help: `Maximum NEB optimization iterations.`,
       },
       {
         key: `uno`, label: `Generate Natural Orbitals (UNO)`, type: `boolean`, default: false, group: `Output`,


### PR DESCRIPTION
Backends already have sensible defaults for these, so the UI fields were just noise. Removes `max_iterations` from the Geometry Optimization node's ORCA branch and `neb_cycles` from the TS Search ORCA NEB-TS branch (in both the active node-definitions.ts and the parallel node-defs/ copy). Sella and MLP step-limit fields are untouched.