### PR TITLE
fix(viewer): cap bond length on PBC-straddling molecules + fix collapsed periodic-table modal

### DIFF
--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -5927,8 +5927,13 @@
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
-    width: min-content;
-    max-width: calc(100vw - 32px);
+    /* A DEFINITE width is required: the periodic table inside uses
+       `container-type: inline-size` with `cqw` units, so without a resolved
+       container width its tiles collapse to ~0. `width: min-content` doesn't
+       break that circular dependency (cqw is treated as 0 during intrinsic
+       sizing); a concrete width does. Capped to the viewport (minus a margin)
+       so it never overflows a narrow pane. */
+    width: min(720px, calc(100vw - 32px));
     max-height: calc(100vh - 32px);
     overflow: auto;
   }
@@ -5960,7 +5965,11 @@
   }
   .periodic-table-modal-content {
     padding: 16px;
+    /* Fill the modal's definite width (set on .periodic-table-modal) so the
+       periodic table's container-query units resolve against a real width. */
     min-width: 0;
+    box-sizing: border-box;
+    width: 100%;
     overflow: auto;
   }
   .periodic-table-modal-content :global(.periodic-table) {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -245,6 +245,13 @@
   // atom count change (args change). ensure_instance_capacity() handles growth.
   const INITIAL_MESH_CAPACITY = 64
 
+  // Maximum rendered covalent bond length (Å). The longest real single bonds
+  // (e.g. heavy-metal–metal) are ~3.5 Å; 4 Å leaves headroom while still
+  // discarding bonds stretched across the cell by a PBC/image rendering
+  // artifact (the minimum-image distance is short, but a raw straight-line
+  // draw spans the whole cell).
+  const MAX_BOND_LENGTH = 4.0
+
   // Shared empty positions buffer for BondManagerInstances when the new bond
   // system is disabled or the structure has no sites.
   const EMPTY_POSITIONS = new Float32Array(0)
@@ -2820,6 +2827,10 @@
     // Start with auto-detected bonds, filter out deleted, hidden, and invalid transforms
     let result = bond_pairs.filter((bond) => {
       if (!bond.transform_matrix || bond.transform_matrix.some((v) => !Number.isFinite(v))) return false
+      // Hard cap on rendered bond length. No real covalent bond exceeds this;
+      // anything longer is a PBC/image rendering artifact (e.g. a bond drawn
+      // straight across the cell instead of via the minimum image), so drop it.
+      if (bond.bond_length > MAX_BOND_LENGTH) return false
       const key = get_bond_key(bond.site_idx_1, bond.site_idx_2)
       if (_deleted_bond_keys.has(key)) return false
       if (!is_site_visible(bond.site_idx_1) || !is_site_visible(bond.site_idx_2)) return false


### PR DESCRIPTION
Closes #322. Two independent structure-viewer display fixes.

### 1. Cap rendered bond length (`StructureScene.svelte`)
A structure with molecules straddling the periodic boundary (e.g. Au slab + water, where a water O and its H wrap to opposite cell faces) could render an O–H bond straight across the cell (~18 Å) instead of via the minimum image. The bond detector already emits the correct cross-cell jimage + minimum-image length (~1 Å), but the long artifact still appeared in the viewer. A hard cap (`MAX_BOND_LENGTH = 4.0 Å`) in `filtered_bond_pairs` drops any rendered covalent bond longer than 4 Å — no real bond exceeds ~3.5 Å, correct cross-cell bonds are ~1 Å (unaffected), and manual bonds / hydrogen bonds bypass the cap.

### 2. Periodic-table modal collapse (`Structure.svelte`)
The pencil-mode *Select Element → periodic table* modal collapsed to a tiny block. `PeriodicTable` uses `container-type: inline-size` with `cqw` units, so it needs a resolved container width; the modal only had `max-width` (and `width: min-content` doesn't break the circular dependency — `cqw` is treated as 0 during intrinsic sizing). Gave the modal a concrete `width: min(720px, calc(100vw - 32px))` and made the content fill it, so the table renders at full readable size and scales down responsively on narrow panes.

### Test plan
- [x] `svelte-check` clean on both files.
- [x] Bond cap: verified against the reported Au/water CIF — the ~18 Å cross-cell bond is dropped while the legitimate short bonds (incl. correct minimum-image cross-cell bonds) remain.
- [x] Modal: rebuilt; the periodic table renders at full size instead of collapsing.
- Note: resolves a merge with upstream's recent edits to the same modal CSS (kept the viewport-margin caps, replaced `width: min-content` with a concrete width that actually resolves the container-query units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
