### PR TITLE
feat(hpc): support selecting private key files

### DIFF
--- a/server/catgo/models/hpc.py
+++ b/server/catgo/models/hpc.py
@@ -43,6 +43,7 @@ class HPCConnectionConfig(BaseModel):
     password: Optional[SecretStr] = None  # For password/password_otp methods
     auth_method: AuthMethod = AuthMethod.PASSWORD
     key_file: Optional[str] = None  # For key/key_otp methods (e.g. ~/.ssh/id_rsa_kaust)
+    key_content: Optional[SecretStr] = None  # In-memory private key material; never persisted
     jump_host: Optional[str] = None
     jump_port: int = 22
     jump_username: Optional[str] = None

--- a/server/catgo/utils/connection_pool.py
+++ b/server/catgo/utils/connection_pool.py
@@ -249,6 +249,16 @@ class HPCConnectionPool:
                 connect_kwargs["client_keys"] = []
                 preferred_auth = "password,keyboard-interactive"
                 logger.info("[CatGo:HPC] Password auth: skipping publickey")
+            elif config.key_content:
+                # Browser/mobile file pickers cannot expose a stable local path.
+                # Use the selected private key from memory and never persist it.
+                key_text = config.key_content.get_secret_value()
+                passphrase = password if password else None
+                connect_kwargs["client_keys"] = [asyncssh.import_private_key(key_text, passphrase)]
+                connect_kwargs["agent_forwarding"] = False
+                connect_kwargs["agent_path"] = None
+                preferred_auth = "publickey,keyboard-interactive"
+                logger.info("[CatGo:HPC] Using imported in-memory private key")
             elif config.key_file:
                 # Key-based auth with explicit key file
                 expanded = str(Path(config.key_file).expanduser())
@@ -278,11 +288,12 @@ class HPCConnectionPool:
                 connect_kwargs["password"] = password
 
             logger.info(
-                "[CatGo:HPC] DEBUG auth_method=%s, has_password=%s, has_key_file=%s, "
+                "[CatGo:HPC] DEBUG auth_method=%s, has_password=%s, has_key_file=%s, has_key_content=%s, "
                 "preferred_auth=%s, client_keys=%s",
                 config.auth_method.value,
                 bool(password),
                 bool(config.key_file),
+                bool(config.key_content),
                 preferred_auth,
                 connect_kwargs.get("client_keys", "not set"),
             )

--- a/src-tauri/src/ssh/auth.rs
+++ b/src-tauri/src/ssh/auth.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
 use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse, Prompt};
-use russh::keys::{load_secret_key, HashAlg, PrivateKeyWithHashAlg};
+use russh::keys::{decode_secret_key, load_secret_key, HashAlg, PrivateKeyWithHashAlg};
 
 use super::handler::MobileHandler;
 use super::state::{PendingAuth, PendingStage, SshHandle, SshSession, SshState, TargetPlan};
@@ -55,9 +55,13 @@ pub enum AuthConfig {
     /// Username + password.
     Password { password: String },
     /// Public key loaded from a file path on disk. `passphrase` decrypts an
-    /// encrypted private key (`None`/empty => unencrypted).
+    /// encrypted private key (`None`/empty => unencrypted). `key_content` is
+    /// used by browser/mobile pickers which cannot expose a stable file path.
     Publickey {
-        key_path: String,
+        #[serde(default)]
+        key_path: Option<String>,
+        #[serde(default)]
+        key_content: Option<String>,
         #[serde(default)]
         passphrase: Option<String>,
     },
@@ -152,13 +156,24 @@ async fn authenticate(mut handle: SshHandle, username: &str, auth: &AuthConfig) 
                 Err(e) => AuthOutcome::Failed(format!("Password auth error: {e}")),
             }
         }
-        AuthConfig::Publickey { key_path, passphrase } => {
+        AuthConfig::Publickey { key_path, key_content, passphrase } => {
             let pass_ref = passphrase.as_deref().filter(|s| !s.is_empty());
-            let key = match load_secret_key(key_path, pass_ref) {
-                Ok(k) => k,
-                Err(e) => {
-                    return AuthOutcome::Failed(format!("Could not load private key {key_path}: {e}"))
+            let key = if let Some(content) = key_content.as_deref().filter(|s| !s.trim().is_empty()) {
+                match decode_secret_key(content, pass_ref) {
+                    Ok(k) => k,
+                    Err(e) => {
+                        return AuthOutcome::Failed(format!("Could not parse selected private key: {e}"))
+                    }
                 }
+            } else if let Some(path) = key_path.as_deref().filter(|s| !s.trim().is_empty()) {
+                match load_secret_key(path, pass_ref) {
+                    Ok(k) => k,
+                    Err(e) => {
+                        return AuthOutcome::Failed(format!("Could not load private key {path}: {e}"))
+                    }
+                }
+            } else {
+                return AuthOutcome::Failed("Public-key authentication requires a key file".into())
             };
             let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key), Some(HashAlg::Sha512));
             match handle.authenticate_publickey(username, key_with_alg).await {

--- a/src/lib/ConnectDialog.svelte
+++ b/src/lib/ConnectDialog.svelte
@@ -15,6 +15,7 @@
   } from '$lib/api/hpc'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import { hpc_session_store, refresh_hpc_sessions, add_session, remove_session } from '$lib/hpc-sessions.svelte'
+  import { pick_hpc_key_file } from '$lib/hpc-key-file'
 
   load_i18n_module('common')
   load_i18n_module('structure')
@@ -43,6 +44,8 @@
   let password = $state(``)
   let auth_method = $state<AuthMethod>(`password`)
   let key_file = $state(``)
+  let key_content = $state(``)
+  let key_selected_name = $state(``)
   let use_jump = $state(false)
   let jump_host = $state(``)
   let jump_port = $state(22)
@@ -90,6 +93,8 @@
     username = p.username
     auth_method = p.auth_method
     key_file = p.key_file ?? ``
+    key_content = ``
+    key_selected_name = ``
     scheduler = p.scheduler
     ssh_alias = p.ssh_alias ?? ``
     work_root = p.work_root ?? ``
@@ -177,6 +182,7 @@
       password: password || undefined,
       auth_method,
       key_file: key_file || undefined,
+      key_content: key_content || undefined,
       scheduler,
       jump_host: use_jump ? jump_host : undefined,
       jump_port: use_jump ? jump_port : undefined,
@@ -277,6 +283,19 @@
     try {
       await disconnectSession(session_id)
     } catch { /* already closed */ }
+  }
+
+  async function choose_key_file() {
+    const selected = await pick_hpc_key_file()
+    if (!selected) return
+    key_selected_name = selected.name
+    if (selected.path) {
+      key_file = selected.path
+      key_content = ``
+    } else if (selected.content) {
+      key_file = selected.name
+      key_content = selected.content
+    }
   }
 
   function close() {
@@ -468,7 +487,13 @@
                 {/if}
                 <label class="full-span">
                   {t('structure.key_file')} <span class="hint">{t('common.optional')}</span>
-                  <input type="text" bind:value={key_file} placeholder={t('structure.key_file_placeholder')} />
+                  <div class="key-file-row">
+                    <input type="text" bind:value={key_file} placeholder={t('structure.key_file_placeholder')} oninput={() => { key_content = ``; key_selected_name = `` }} />
+                    <button type="button" class="btn-secondary key-file-btn" onclick={choose_key_file}>{t('common.choose')}</button>
+                  </div>
+                  {#if key_content && key_selected_name}
+                    <span class="hint">{t('structure.key_file_imported', { name: key_selected_name })}</span>
+                  {/if}
                 </label>
               {/if}
               <label>
@@ -905,6 +930,22 @@
   .hint {
     font-weight: 400;
     color: var(--text-color-dim, light-dark(#9ca3af, #94a3b8));
+  }
+
+  .key-file-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .key-file-row input {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .key-file-btn {
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   .form-hint {

--- a/src/lib/api/hpc.ts
+++ b/src/lib/api/hpc.ts
@@ -31,6 +31,7 @@ export interface HPCConnectionConfig {
   password?: string
   auth_method: AuthMethod
   key_file?: string // For key/key_otp auth (e.g. ~/.ssh/id_rsa_kaust)
+  key_content?: string // In-memory key material from browser/mobile file pickers; never persisted
   jump_host?: string
   jump_port?: number
   jump_username?: string

--- a/src/lib/api/transport/index.ts
+++ b/src/lib/api/transport/index.ts
@@ -28,6 +28,8 @@ export interface HpcHostConfig {
   password?: string
   /** Path to the private key file when `method === 'publickey'`. */
   keyPath?: string
+  /** In-memory private key text when the platform cannot expose a stable path. */
+  keyContent?: string
   /** Optional passphrase decrypting an encrypted private key. */
   passphrase?: string
 }

--- a/src/lib/api/transport/tauri-ssh.ts
+++ b/src/lib/api/transport/tauri-ssh.ts
@@ -70,6 +70,7 @@ function toRustHost(h: {
   method: HpcConnectConfig[`method`]
   password?: string
   keyPath?: string
+  keyContent?: string
   passphrase?: string
 }): Record<string, unknown> {
   return {
@@ -81,6 +82,7 @@ function toRustHost(h: {
     method: h.method,
     password: h.password,
     key_path: h.keyPath,
+    key_content: h.keyContent,
     passphrase: h.passphrase,
   }
 }

--- a/src/lib/hpc-key-file.ts
+++ b/src/lib/hpc-key-file.ts
@@ -1,0 +1,73 @@
+export interface SelectedKeyFile {
+  path?: string
+  name: string
+  content?: string
+}
+
+function is_tauri_runtime(): boolean {
+  return typeof window !== `undefined` && (`__TAURI__` in window || `__TAURI_INTERNALS__` in window)
+}
+
+function is_mobile_runtime(): boolean {
+  if (typeof navigator === `undefined`) return false
+  const ua = navigator.userAgent
+  return /android|iphone|ipod|ipad/i.test(ua) || (/macintosh/i.test(ua) && navigator.maxTouchPoints > 1)
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
+}
+
+async function pick_browser_key_file(): Promise<SelectedKeyFile | null> {
+  if (typeof document === `undefined`) return null
+
+  return new Promise((resolve) => {
+    const input = document.createElement(`input`)
+    input.type = `file`
+    input.accept = `.pem,.key,.rsa,.ed25519,.openssh,.ppk,*`
+    input.style.display = `none`
+
+    input.onchange = async () => {
+      const file = input.files?.[0]
+      input.remove()
+      if (!file) {
+        resolve(null)
+        return
+      }
+      try {
+        resolve({
+          name: file.name,
+          content: await file.text(),
+        })
+      } catch {
+        resolve(null)
+      }
+    }
+
+    document.body.appendChild(input)
+    input.click()
+  })
+}
+
+export async function pick_hpc_key_file(): Promise<SelectedKeyFile | null> {
+  if (is_tauri_runtime() && !is_mobile_runtime()) {
+    try {
+      const { open } = await import(`@tauri-apps/plugin-dialog`)
+      const picked = await open({
+        multiple: false,
+        directory: false,
+        filters: [
+          { name: `SSH private keys`, extensions: [`pem`, `key`, `rsa`, `ed25519`, `openssh`, `ppk`] },
+          { name: `All files`, extensions: [`*`] },
+        ],
+      })
+      if (typeof picked === `string` && picked) {
+        return { path: picked, name: basename(picked) }
+      }
+    } catch {
+      // Browser builds cannot import Tauri plugins; fall back to content import.
+    }
+  }
+
+  return pick_browser_key_file()
+}

--- a/src/lib/i18n/en/common.ts
+++ b/src/lib/i18n/en/common.ts
@@ -37,6 +37,7 @@ const common: Record<string, string> = {
   reset:              `Reset`,
   clear:              `Clear`,
   clear_all:          `Clear All`,
+  choose:             `Choose`,
   select:             `Select`,
   select_all:         `Select All`,
   deselect_all:       `Deselect All`,

--- a/src/lib/i18n/en/mobile.ts
+++ b/src/lib/i18n/en/mobile.ts
@@ -63,6 +63,7 @@ const mobile: Record<string, string> = {
   method_keyboard: `Keyboard-interactive`,
   field_password: `Password`,
   field_private_key_path: `Private key path`,
+  key_file_imported: `Selected private key: {name}. It will be used for this connection only and will not be saved.`,
   field_passphrase: `Passphrase (optional)`,
   keyboard_hint: `You'll be prompted for any codes after connecting.`,
   use_jump_host: `Use a jump host (ProxyJump)`,

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -180,6 +180,7 @@ const structure: Record<string, string> = {
   password: `Password`,
   key_file: `Key File`,
   key_file_hint: `(optional — specify if server needs a specific key)`,
+  key_file_imported: `Selected private key: {name}. It will be used for this connection only and will not be saved.`,
   scheduler: `Scheduler`,
   work_root: `Work root`,
   work_root_placeholder: `e.g. ~/projects/my-work or /work/home/user/project`,

--- a/src/lib/i18n/zh/common.ts
+++ b/src/lib/i18n/zh/common.ts
@@ -36,6 +36,7 @@ const common: Record<string, string> = {
   reset:              `重置`,
   clear:              `清除`,
   clear_all:          `全部清除`,
+  choose:             `选择`,
   select:             `选择`,
   select_all:         `全选`,
   deselect_all:       `取消全选`,

--- a/src/lib/i18n/zh/mobile.ts
+++ b/src/lib/i18n/zh/mobile.ts
@@ -63,6 +63,7 @@ const mobile: Record<string, string> = {
   method_keyboard: `键盘交互`,
   field_password: `密码`,
   field_private_key_path: `私钥路径`,
+  key_file_imported: `已选择私钥：{name}。仅用于本次连接，不会保存。`,
   field_passphrase: `私钥口令（可选）`,
   keyboard_hint: `连接后系统会提示你输入所需的验证码。`,
   use_jump_host: `使用跳板机 (ProxyJump)`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -180,6 +180,7 @@ const structure: Record<string, string> = {
   password: `密码`,
   key_file: `密钥文件`,
   key_file_hint: `（可选——服务器需要指定密钥时填写）`,
+  key_file_imported: `已选择私钥：{name}。仅用于本次连接，不会保存。`,
   scheduler: `调度器`,
   work_root: `工作根目录`,
   work_root_placeholder: `例如 ~/projects/my-work 或 /work/home/user/project`,

--- a/src/lib/mobile/MobileConnect.svelte
+++ b/src/lib/mobile/MobileConnect.svelte
@@ -28,6 +28,7 @@
   import { endpointKey, reuseSession, rememberSession } from './sessions'
   import { clusters } from './clusters.svelte'
   import { t } from '$lib/i18n/index.svelte'
+  import { pick_hpc_key_file } from '$lib/hpc-key-file'
 
   export interface ConnectedMeta {
     host: string
@@ -68,6 +69,8 @@
   let method = $state<HpcAuthMethod>(`password`)
   let password = $state(``)
   let key_path = $state(``)
+  let key_content = $state(``)
+  let key_selected_name = $state(``)
   let passphrase = $state(``)
 
   // Optional jump host (ProxyJump / bastion). When `jump_enabled`, the jump host
@@ -80,6 +83,8 @@
   let jump_method = $state<HpcAuthMethod>(`password`)
   let jump_password = $state(``)
   let jump_key_path = $state(``)
+  let jump_key_content = $state(``)
+  let jump_key_selected_name = $state(``)
   let jump_passphrase = $state(``)
 
   // ─── Flow state ───
@@ -161,6 +166,8 @@
     username = c.username
     method = c.method
     key_path = c.keyPath ?? ``
+    key_content = ``
+    key_selected_name = ``
     password = `` // reset; filled (masked) from the store below for password auth
     error_msg = ``
     auto_password = ``
@@ -189,6 +196,8 @@
     username = ``
     method = `keyboard-interactive`
     key_path = ``
+    key_content = ``
+    key_selected_name = ``
     password = ``
     passphrase = ``
     auto_password = ``
@@ -216,6 +225,30 @@
       },
       Date.now(),
     )
+  }
+
+  async function choose_key_file(kind: `target` | `jump`): Promise<void> {
+    const selected = await pick_hpc_key_file()
+    if (!selected) return
+    if (kind === `jump`) {
+      jump_key_selected_name = selected.name
+      if (selected.path) {
+        jump_key_path = selected.path
+        jump_key_content = ``
+      } else if (selected.content) {
+        jump_key_path = selected.name
+        jump_key_content = selected.content
+      }
+      return
+    }
+    key_selected_name = selected.name
+    if (selected.path) {
+      key_path = selected.path
+      key_content = ``
+    } else if (selected.content) {
+      key_path = selected.name
+      key_content = selected.content
+    }
   }
 
   /** Apply a connect / submitOtp result: succeed, advance OTP round, or error. */
@@ -346,6 +379,7 @@
         method,
         password: method === `password` ? password : undefined,
         keyPath: method === `publickey` ? key_path.trim() || undefined : undefined,
+        keyContent: method === `publickey` ? key_content || undefined : undefined,
         passphrase: method === `publickey` ? passphrase || undefined : undefined,
         jump: jump_enabled && jump_host.trim()
           ? {
@@ -355,6 +389,7 @@
               method: jump_method,
               password: jump_method === `password` ? jump_password : undefined,
               keyPath: jump_method === `publickey` ? jump_key_path.trim() || undefined : undefined,
+              keyContent: jump_method === `publickey` ? jump_key_content || undefined : undefined,
               passphrase: jump_method === `publickey` ? jump_passphrase || undefined : undefined,
             }
           : undefined,
@@ -426,6 +461,8 @@
   const can_submit = $derived(
     host.trim().length > 0 &&
       username.trim().length > 0 &&
+      (method !== `publickey` || key_path.trim().length > 0 || key_content.length > 0) &&
+      (!jump_enabled || jump_method !== `publickey` || jump_key_path.trim().length > 0 || jump_key_content.length > 0) &&
       !connecting,
   )
 </script>
@@ -576,14 +613,21 @@
       {:else if method === `publickey`}
         <label class="field">
           <span>{t(`mobile.field_private_key_path`)}</span>
-          <input
-            type="text"
-            autocapitalize="off"
-            autocorrect="off"
-            spellcheck="false"
-            placeholder="~/.ssh/id_ed25519"
-            bind:value={key_path}
-          />
+          <div class="key-file-row">
+            <input
+              type="text"
+              autocapitalize="off"
+              autocorrect="off"
+              spellcheck="false"
+              placeholder="~/.ssh/id_ed25519"
+              bind:value={key_path}
+              oninput={() => { key_content = ``; key_selected_name = `` }}
+            />
+            <button type="button" class="key-file-btn" onclick={() => choose_key_file(`target`)}>{t('common.choose')}</button>
+          </div>
+          {#if key_content && key_selected_name}
+            <small>{t('mobile.key_file_imported', { name: key_selected_name })}</small>
+          {/if}
         </label>
         <label class="field">
           <span>{t(`mobile.field_passphrase`)}</span>
@@ -644,14 +688,21 @@
           {:else if jump_method === `publickey`}
             <label class="field">
               <span>{t(`mobile.field_private_key_path`)}</span>
-              <input
-                type="text"
-                autocapitalize="off"
-                autocorrect="off"
-                spellcheck="false"
-                placeholder="~/.ssh/id_ed25519"
-                bind:value={jump_key_path}
-              />
+              <div class="key-file-row">
+                <input
+                  type="text"
+                  autocapitalize="off"
+                  autocorrect="off"
+                  spellcheck="false"
+                  placeholder="~/.ssh/id_ed25519"
+                  bind:value={jump_key_path}
+                  oninput={() => { jump_key_content = ``; jump_key_selected_name = `` }}
+                />
+                <button type="button" class="key-file-btn" onclick={() => choose_key_file(`jump`)}>{t('common.choose')}</button>
+              </div>
+              {#if jump_key_content && jump_key_selected_name}
+                <small>{t('mobile.key_file_imported', { name: jump_key_selected_name })}</small>
+              {/if}
             </label>
             <label class="field">
               <span>{t(`mobile.field_passphrase`)}</span>
@@ -953,6 +1004,30 @@
   .field input:focus,
   .field select:focus {
     border-color: var(--accent-color, #3b82f6);
+  }
+  .field small {
+    color: var(--text-color-muted, #94a3b8);
+    font-size: 0.78em;
+  }
+  .key-file-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+  .key-file-row input {
+    flex: 1;
+    min-width: 0;
+  }
+  .key-file-btn {
+    flex-shrink: 0;
+    min-height: 44px;
+    padding: 0 12px;
+    color: var(--accent-color, #3b82f6);
+    background: rgba(59, 130, 246, 0.1);
+    border: 1px solid rgba(59, 130, 246, 0.3);
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
   }
   .method-hint {
     font-size: 0.82em;

--- a/src/lib/structure/ServerPane.svelte
+++ b/src/lib/structure/ServerPane.svelte
@@ -58,6 +58,7 @@
     filter_jobs,
   } from './server-utils'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import { pick_hpc_key_file } from '$lib/hpc-key-file'
 
   load_i18n_module('structure')
   load_i18n_module('common')
@@ -178,6 +179,8 @@
   let password = $state(``)
   let auth_method = $state<AuthMethod>(`password`)
   let key_file = $state(``)
+  let key_content = $state(``)
+  let key_selected_name = $state(``)
   let use_jump = $state(false)
   let jump_host = $state(``)
   let jump_port = $state(22)
@@ -302,6 +305,8 @@
     username = p.username
     auth_method = p.auth_method
     key_file = p.key_file ?? ``
+    key_content = ``
+    key_selected_name = ``
     scheduler = p.scheduler
     ssh_alias = p.ssh_alias ?? ``
     work_root = p.work_root ?? ``
@@ -395,6 +400,7 @@
       password: password || undefined,
       auth_method,
       key_file: key_file || undefined,
+      key_content: key_content || undefined,
       scheduler,
       jump_host: use_jump ? jump_host : undefined,
       jump_port: use_jump ? jump_port : undefined,
@@ -447,6 +453,19 @@
     // Store ws_conn on the reactive proxy
     const s = get_session(sid)
     if (s) s.ws_conn = ws
+  }
+
+  async function choose_key_file() {
+    const selected = await pick_hpc_key_file()
+    if (!selected) return
+    key_selected_name = selected.name
+    if (selected.path) {
+      key_file = selected.path
+      key_content = ``
+    } else if (selected.content) {
+      key_file = selected.name
+      key_content = selected.content
+    }
   }
 
   async function do_connect_ssh_config() {
@@ -1494,7 +1513,13 @@
                 {/if}
                 <label class="full-span">
                   {t('structure.key_file')} <span class="optional-hint">{t('structure.key_file_hint')}</span>
-                  <input type="text" bind:value={key_file} placeholder={t('structure.key_file_placeholder')} />
+                  <div class="key-file-row">
+                    <input type="text" bind:value={key_file} placeholder={t('structure.key_file_placeholder')} oninput={() => { key_content = ``; key_selected_name = `` }} />
+                    <button type="button" class="secondary key-file-btn" onclick={choose_key_file}>{t('common.choose')}</button>
+                  </div>
+                  {#if key_content && key_selected_name}
+                    <span class="optional-hint">{t('structure.key_file_imported', { name: key_selected_name })}</span>
+                  {/if}
                 </label>
               {/if}
               <label>
@@ -1958,6 +1983,19 @@
     font-size: 0.85em;
     opacity: 0.5;
     font-weight: normal;
+  }
+  .key-file-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+  .key-file-row input {
+    flex: 1;
+    min-width: 0;
+  }
+  .key-file-btn {
+    flex-shrink: 0;
+    white-space: nowrap;
   }
   .form-hint.warning {
     font-size: 0.82em;


### PR DESCRIPTION
## Summary
- Add a unified private-key file picker for HPC login.
- Desktop Tauri builds on Windows/macOS/Linux use the native file picker and pass the selected local key path.
- Browser, iOS, and Android read the selected private key content and use it only for the current connection.
- Add backend support for in-memory private key authentication via `key_content`.
- Add mobile Rust SSH support for in-memory private keys.
- Keep saved profiles non-secret: private key content is never persisted.

## Verification
- `git diff --check` passed.
- `py -m py_compile server\catgo\models\hpc.py server\catgo\utils\connection_pool.py` passed.
- `pnpm exec svelte-check --tsconfig ./tsconfig.json --threshold error` still reports existing unrelated missing module errors:
  - `@tauri-apps/plugin-opener`
  - `@tauri-apps/plugin-clipboard-manager`
- `pnpm test` still fails on existing unrelated issues, including missing `@tauri-apps/plugin-opener`, Gemini CLI spawn `EFTYPE`, a timing-sensitive settings test, and an RDF timeout.
- `cargo check --manifest-path src-tauri\Cargo.toml -p catgo` is blocked locally because `aws-lc-sys` requires NASM and NASM is not installed/found.
