### PR TITLE
chore(hpc): harden in-memory key import, drop no-op download update

### DIFF
--- a/server/catgo/utils/connection_pool.py
+++ b/server/catgo/utils/connection_pool.py
@@ -252,9 +252,20 @@ class HPCConnectionPool:
             elif config.key_content:
                 # Browser/mobile file pickers cannot expose a stable local path.
                 # Use the selected private key from memory and never persist it.
+                # The desktop UI has no dedicated passphrase field, so `password`
+                # doubles as the key passphrase here (and is still passed below as
+                # the SSH "password" for servers that want it as a second factor).
                 key_text = config.key_content.get_secret_value()
                 passphrase = password if password else None
-                connect_kwargs["client_keys"] = [asyncssh.import_private_key(key_text, passphrase)]
+                try:
+                    imported_key = asyncssh.import_private_key(key_text, passphrase)
+                except (asyncssh.KeyImportError, ValueError) as exc:
+                    # Never include key material in the error surfaced to the user.
+                    raise ValueError(
+                        "Could not parse the selected private key "
+                        "(wrong passphrase or unsupported format)"
+                    ) from exc
+                connect_kwargs["client_keys"] = [imported_key]
                 connect_kwargs["agent_forwarding"] = False
                 connect_kwargs["agent_path"] = None
                 preferred_auth = "publickey,keyboard-interactive"

--- a/src/lib/downloads/hpc-download.ts
+++ b/src/lib/downloads/hpc-download.ts
@@ -95,7 +95,8 @@ export async function start_hpc_managed_download_with_deps(
   if (!deps.check_tauri()) return false
 
   if (deps.is_mobile()) {
-    const task = deps.manager.add({
+    // `add` already opens the panel; just record the unsupported-platform task.
+    deps.manager.add({
       filename: input.filename,
       source_path: input.remote_path,
       platform: 'mobile',
@@ -105,8 +106,6 @@ export async function start_hpc_managed_download_with_deps(
       total_bytes: null,
       error: deps.translate('common.download_mobile_unsupported'),
     })
-    deps.manager.panel_open = true
-    deps.manager.update(task.id, {})
     return true
   }
 


### PR DESCRIPTION
## Summary

Small follow-ups from the #326 / #327 review (both already merged).

- **`server/catgo/utils/connection_pool.py`** — wrap `asyncssh.import_private_key` in `try/except (KeyImportError, ValueError)`. A wrong passphrase or unsupported key format now surfaces a friendly `ValueError` instead of a raw traceback, and the error message never includes key material. Added a comment explaining that the desktop UI reuses the `password` field as the key passphrase.
- **`src/lib/downloads/hpc-download.ts`** — drop the redundant `panel_open = true` and no-op `manager.update(task.id, {})` in the mobile-unsupported branch (`add()` already opens the panel).

## Verification

- `python3 -m py_compile server/catgo/utils/connection_pool.py` — OK
- `pnpm vitest run src/lib/downloads/__tests__/` — 10/10 passed
- Confirmed `asyncssh.KeyImportError` exists in the installed asyncssh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)