### PR TITLE
fix(vscode): claim Open VSX namespace to clear unverified-publisher warning

### DIFF
--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -103,6 +103,28 @@ jobs:
             fi
           fi
 
+      # Claim ownership of the Open VSX namespace so published extensions are not
+      # flagged "not a verified publisher of the namespace". The token's account
+      # becomes the namespace owner. Idempotent: a namespace that already exists
+      # (owned by this account from a prior run) is a tolerated no-op. If the
+      # namespace exists but is owned by a DIFFERENT account, this step warns and
+      # the one-time ownership transfer must be requested manually — see
+      # deploy/vscode/OPEN-VSX-NAMESPACE.md.
+      - name: Ensure Open VSX namespace ownership
+        if: ${{ (github.event_name == 'push' || inputs.dry_run == false) && env.OVSX_PAT != '' }}
+        working-directory: extensions/vscode
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          set +e
+          ns=$(node -p "require('./package.json').publisher")
+          out=$(pnpm dlx ovsx create-namespace "$ns" 2>&1)
+          code=$?
+          echo "$out"
+          if [ "$code" -ne 0 ] && ! echo "$out" | grep -qiE "already (exists|owned)"; then
+            echo "::warning::Could not create/claim Open VSX namespace '$ns' (exit $code). If it is owned by another account, request ownership manually — see deploy/vscode/OPEN-VSX-NAMESPACE.md."
+          fi
+
       - name: Publish to Open VSX (Cursor / VSCodium / Theia)
         if: ${{ (github.event_name == 'push' || inputs.dry_run == false) && env.OVSX_PAT != '' }}
         working-directory: extensions/vscode

--- a/deploy/vscode/OPEN-VSX-NAMESPACE.md
+++ b/deploy/vscode/OPEN-VSX-NAMESPACE.md
@@ -1,0 +1,66 @@
+# Open VSX namespace ownership
+
+## The warning
+
+On the Open VSX listing (used by Cursor / VSCodium / Theia) the CatGo extension shows:
+
+> This version of the "CatGo" extension was published by **RedStar-Iron**. That user
+> account is not a verified publisher of the namespace **"Guangsheng"** of this
+> extension.
+
+### What it means
+
+On Open VSX a *namespace* (the `publisher` field in `extensions/vscode/package.json`,
+here `Guangsheng`) is separate from the *account* whose token (`OVSX_PAT`) runs the
+publish (here `RedStar-Iron`). When the namespace has **no owner**, anyone may publish
+into it, and Open VSX flags every version as coming from an unverified publisher.
+
+The fix is to make the publishing account a verified **owner/member** of the
+`Guangsheng` namespace.
+
+## What the repo already does
+
+`.github/workflows/vsix-publish.yml` runs `ovsx create-namespace "$publisher"` before
+publishing. That makes the `OVSX_PAT` account the namespace owner **the first time the
+namespace is created**. It is idempotent (an already-owned namespace is a no-op).
+
+`extensions/vscode/package.json` uses the object form of `repository` pointing at the
+GitHub repo — Open VSX reads this for self-service ownership verification.
+
+## One-time manual step (required for an *existing* un-owned namespace)
+
+`create-namespace` cannot retroactively claim a namespace that already exists without an
+owner (which is the current state). Do this once:
+
+1. Sign in to <https://open-vsx.org> with the **GitHub account that owns the
+   `OVSX_PAT`** (i.e. `RedStar-Iron`, or whichever account you want to publish from).
+2. Generate / confirm an access token under *Settings → Access Tokens* and make sure the
+   GitHub secret **`OVSX_PAT`** matches that account.
+3. Claim the namespace. Either:
+   - **CLI:** `npx ovsx create-namespace Guangsheng -p <token>` (works only if the
+     namespace is genuinely un-owned), **or**
+   - **Ownership request:** open an issue at
+     <https://github.com/EclipseFdn/open-vsx.org> using the *namespace ownership*
+     template, naming the `Guangsheng` namespace and proving control of
+     `github.com/Hello-QM/catgo-LRG`.
+4. For the **verified** badge, the linked GitHub account must have push access to the
+   repo named in `repository` (`Hello-QM/catgo-LRG`). Add `RedStar-Iron` to the
+   `Hello-QM` org / repo, or publish from an account that already has access.
+
+### Alternative: publish under an owned namespace
+
+If claiming `Guangsheng` is not practical, change `publisher` in
+`extensions/vscode/package.json` to a namespace the publishing account already owns.
+Note this changes the extension's Open VSX identity (URL, install id) and loses
+continuity with existing installs — only do this deliberately.
+
+## Verify
+
+After the namespace is owned, re-run the publish workflow:
+
+```bash
+gh workflow run vsix-publish.yml --ref main
+```
+
+The warning disappears on the next published version. The VS Code Marketplace
+(`vsce`) is unaffected — it has no equivalent namespace-ownership concept.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -6,7 +6,10 @@
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",
-  "repository": "https://github.com/Hello-QM/catgo-LRG",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Hello-QM/catgo-LRG.git"
+  },
   "categories": [
     "Data Science",
     "Machine Learning",


### PR DESCRIPTION
## Problem

Open VSX (Cursor / VSCodium / Theia) shows on every CatGo version:

> This version of the "CatGo" extension was published by **RedStar-Iron**. That user account is not a verified publisher of the namespace **"Guangsheng"** of this extension.

On Open VSX the *namespace* (`publisher` field = `Guangsheng`) is separate from the *account* whose `OVSX_PAT` runs the publish (`RedStar-Iron`). The namespace currently has no owner, so every version is flagged unverified.

## Changes

- **`.github/workflows/vsix-publish.yml`** — new idempotent `ovsx create-namespace <publisher>` step before the Open VSX publish, so the publishing account claims/owns the namespace. Already-owned → no-op; foreign-owned → warning pointing at the doc.
- **`extensions/vscode/package.json`** — `repository` switched to the object form with `.git`, which Open VSX uses for self-service ownership verification.
- **`deploy/vscode/OPEN-VSX-NAMESPACE.md`** — documents the **one-time manual claim** required for the already-existing un-owned namespace (CLI `ovsx create-namespace`, or an Eclipse ownership request + linking `RedStar-Iron` to `Hello-QM/catgo-LRG` for the verified badge).

## Notes

- `create-namespace` cannot retroactively claim a namespace that already exists without an owner — hence the manual step. The workflow change prevents this recurring and is the right path once ownership is granted.
- VS Code Marketplace (`vsce`) is unaffected — no namespace-ownership concept there.

## Verification

- `node -e` parse of `package.json` — valid, `publisher=Guangsheng`, repo object form.
- `python3 -c yaml.safe_load` of the workflow — valid YAML.
- The namespace step reads `publisher` from package.json (trusted), no untrusted workflow input → no injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)