### PR TITLE
feat(vscode): server.url + server.sidecarPath escape hatches for offline/Remote-SSH

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -467,6 +467,16 @@
           "minimum": 0,
           "maximum": 65535
         },
+        "catgo.server.url": {
+          "type": "string",
+          "default": "",
+          "description": "Connect to an already-running CatGo server instead of downloading and spawning the bundled sidecar. Accepts a full URL (e.g. http://127.0.0.1:8000) or a bare port. Only the port is used; the server must be reachable on localhost of the extension host. Useful on offline / Remote-SSH hosts where you run the Python server from source (e.g. `python -m catgo.server --port 8000`)."
+        },
+        "catgo.server.sidecarPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to a pre-placed catgo-server binary. When set, the extension uses it and skips the ~460MB download. Useful on offline / Remote-SSH hosts where you scp the binary in once."
+        },
         "catgo.trajectory.auto_play": {
           "type": "boolean",
           "default": false,

--- a/extensions/vscode/src/server.ts
+++ b/extensions/vscode/src/server.ts
@@ -17,6 +17,56 @@ function health_check(port: number, timeout_ms = 2000): Promise<boolean> {
   })
 }
 
+/** Extract a port from `catgo.server.url` — accepts a bare port ("8000") or a URL. */
+function parse_external_port(raw: string): number | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  if (/^\d+$/.test(trimmed)) {
+    const n = Number(trimmed)
+    return n > 0 && n <= 65535 ? n : null
+  }
+  try {
+    const u = new URL(trimmed)
+    const n = u.port ? Number(u.port) : u.protocol === 'https:' ? 443 : 80
+    return n > 0 && n <= 65535 ? n : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * When `catgo.server.url` is set, connect to that already-running server instead
+ * of downloading/spawning the bundled sidecar. We never own this process, so
+ * `server_process` stays null (stop_server won't touch it). The webview reaches
+ * it via `127.0.0.1:<port>` — under Remote-SSH VS Code forwards the host's
+ * localhost, so a server run on the extension host is reachable as-is.
+ */
+async function adopt_external_server(): Promise<number | null> {
+  const url = vscode.workspace.getConfiguration('catgo.server').get<string>('url', '')
+  const port = parse_external_port(url)
+  if (port === null) {
+    if (url.trim()) {
+      vscode.window.showErrorMessage(
+        `catgo.server.url ("${url}") is not a valid URL or port; ignoring.`,
+      )
+    }
+    return null
+  }
+  // The external server may still be coming up — retry a few times.
+  for (let attempt = 0; attempt < 6; attempt++) {
+    if (await health_check(port)) {
+      server_port = port
+      return port
+    }
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  vscode.window.showErrorMessage(
+    `catgo.server.url is set but no healthy CatGo server responded on port ${port}. ` +
+    `Start it on the extension host (e.g. \`python -m catgo.server --port ${port}\`) and reload.`,
+  )
+  return null
+}
+
 export async function start_server(context: vscode.ExtensionContext): Promise<number | null> {
   // If a start is already in flight, return the same promise (prevents concurrent spawns)
   if (in_flight_start) return in_flight_start
@@ -25,6 +75,12 @@ export async function start_server(context: vscode.ExtensionContext): Promise<nu
     const alive = await health_check(server_port)
     if (alive) return server_port
     stop_server()
+  }
+
+  // Adopt an externally-managed server when configured (skips download + spawn).
+  if (vscode.workspace.getConfiguration('catgo.server').get<string>('url', '').trim()) {
+    if (server_port && (await health_check(server_port))) return server_port
+    return adopt_external_server()
   }
 
   let binary: string

--- a/extensions/vscode/src/sidecar.ts
+++ b/extensions/vscode/src/sidecar.ts
@@ -145,6 +145,24 @@ async function follow_redirect_download(
 export async function ensure_sidecar_binary(
   context: vscode.ExtensionContext,
 ): Promise<string> {
+  // User-provided binary takes precedence and skips the ~460MB download — the
+  // escape hatch for offline / Remote-SSH hosts (scp the binary in once).
+  const override_path = vscode.workspace
+    .getConfiguration('catgo.server')
+    .get<string>('sidecarPath', '')
+    .trim()
+  if (override_path) {
+    if (!(await file_exists(override_path))) {
+      const reason = `catgo.server.sidecarPath is set to "${override_path}" but no file exists there.`
+      vscode.window.showErrorMessage(reason)
+      throw new Error(reason)
+    }
+    if (process.platform !== `win32`) {
+      try { await fsp.chmod(override_path, 0o755) } catch { /* not owner / already +x */ }
+    }
+    return override_path
+  }
+
   const bundled = bundled_binary_path(context)
   if (await file_exists(bundled)) return bundled
 


### PR DESCRIPTION
## Why

The VS Code extension is `extensionKind: ["workspace"]`, so under Remote-SSH it runs on the **remote host** and downloads the ~460MB sidecar there + spawns it. Air-gapped HPC login nodes (no outbound internet) or unsupported arches can't get the binary, so the viewer never starts.

Keeping compute on the remote is the *right* default (large trajectories are read on the cluster; only frames cross the tunnel — moving the extension local would pull whole files over SSH, capped at 1GB). So instead of moving it local, these two opt-in overrides bypass just the download.

## Changes

- **`catgo.server.url`** — connect to an already-running CatGo server (bare port `8000` or full URL). `start_server` adopts it (health-check with retry) instead of download+spawn; the process isn't ours, so `stop_server` leaves it alone. Webview keeps `127.0.0.1:<port>` (VS Code forwards the remote host's localhost under Remote-SSH).
- **`catgo.server.sidecarPath`** — absolute path to a pre-placed binary; skips the download (scp it in once).

Both default to empty → existing download+spawn behavior unchanged.

## Usage on an offline / Remote-SSH host

```jsonc
// either: run the server from source on the remote, then
"catgo.server.url": "8000"
// or: scp the binary in, then
"catgo.server.sidecarPath": "/home/me/bin/catgo-server-linux-x64"
```

(Combine with the user-side `"remote.extensionKind": { "<publisher>.catgo": ["ui"] }` if you instead want it to run locally — same approach matterviz documents in janosh/matterviz#129.)

## Verification

- `pnpm build` (vite webview + extension) — exit 0.
- Edits are isolated to `server.ts` / `sidecar.ts` / `package.json`; defaults preserve current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)