### PR TITLE
feat(parsers): long-tail — full QE ibrav table, Gaussian Z-matrix, ORCA %coords

### DIFF
--- a/src/lib/structure/parsers/__tests__/dft-parsers-longtail.test.ts
+++ b/src/lib/structure/parsers/__tests__/dft-parsers-longtail.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { parse_qe } from '../qe'
+import { parse_orca } from '../orca'
+import { parse_gaussian_input } from '../gaussian-input'
+import type { Site } from '$lib'
+
+const BOHR = 0.52917721090
+const dist = (a: Site, b: Site) =>
+  Math.hypot(a.xyz[0] - b.xyz[0], a.xyz[1] - b.xyz[1], a.xyz[2] - b.xyz[2])
+const angle = (a: Site, v: Site, b: Site) => {
+  const u = [a.xyz[0] - v.xyz[0], a.xyz[1] - v.xyz[1], a.xyz[2] - v.xyz[2]]
+  const w = [b.xyz[0] - v.xyz[0], b.xyz[1] - v.xyz[1], b.xyz[2] - v.xyz[2]]
+  const d = (u[0] * w[0] + u[1] * w[1] + u[2] * w[2]) /
+    (Math.hypot(...u) * Math.hypot(...w))
+  return Math.acos(Math.max(-1, Math.min(1, d))) * 180 / Math.PI
+}
+const qe = (ibrav: number, extra: string, pos = `crystal\nAl 0 0 0`) =>
+  `&SYSTEM\n  ibrav = ${ibrav}\n${extra}\n/\nATOMIC_POSITIONS ${pos}\n`
+
+describe(`QE full ibrav table (lattice invariants)`, () => {
+  it(`ibrav=3 (bcc): volume a³/2, |v|=a√3/2`, () => {
+    const a = 5 * BOHR
+    const L = parse_qe(qe(3, `  celldm(1) = 5`))!.lattice!
+    expect(L.volume).toBeCloseTo(a ** 3 / 2, 3)
+    for (const len of [L.a, L.b, L.c]) expect(len).toBeCloseTo((a * Math.sqrt(3)) / 2, 4)
+  })
+
+  it(`ibrav=5 (trigonal): equal lengths a, equal angles arccos(cd4)`, () => {
+    const a = 6 * BOHR
+    const L = parse_qe(qe(5, `  celldm(1) = 6\n  celldm(4) = 0.5`))!.lattice!
+    for (const len of [L.a, L.b, L.c]) expect(len).toBeCloseTo(a, 4)
+    for (const ang of [L.alpha, L.beta, L.gamma]) expect(ang).toBeCloseTo(60, 2) // arccos(0.5)
+  })
+
+  it(`ibrav=7 (bct): volume a²c/2`, () => {
+    const a = 5 * BOHR, c = 1.5 * a
+    const L = parse_qe(qe(7, `  celldm(1) = 5\n  celldm(3) = 1.5`))!.lattice!
+    expect(L.volume).toBeCloseTo((a * a * c) / 2, 3)
+  })
+
+  it(`ibrav=12 (monoclinic): a,b,c + gamma=arccos(cd4)`, () => {
+    const a = 5 * BOHR
+    const L = parse_qe(qe(12, `  celldm(1) = 5\n  celldm(2) = 1.2\n  celldm(3) = 1.5\n  celldm(4) = 0.3`))!.lattice!
+    expect(L.a).toBeCloseTo(a, 4)
+    expect(L.b).toBeCloseTo(1.2 * a, 4)
+    expect(L.c).toBeCloseTo(1.5 * a, 4)
+    expect(L.gamma).toBeCloseTo(Math.acos(0.3) * 180 / Math.PI, 2)
+    expect(L.alpha).toBeCloseTo(90, 2)
+  })
+
+  it(`ibrav=14 (triclinic): angles match cosBC/cosAC/cosAB`, () => {
+    const L = parse_qe(qe(14,
+      `  celldm(1) = 5\n  celldm(2) = 1.1\n  celldm(3) = 1.3\n  celldm(4) = 0.2\n  celldm(5) = 0.15\n  celldm(6) = 0.25`))!.lattice!
+    expect(L.alpha).toBeCloseTo(Math.acos(0.2) * 180 / Math.PI, 2)
+    expect(L.beta).toBeCloseTo(Math.acos(0.15) * 180 / Math.PI, 2)
+    expect(L.gamma).toBeCloseTo(Math.acos(0.25) * 180 / Math.PI, 2)
+  })
+})
+
+describe(`Gaussian Z-matrix → Cartesian`, () => {
+  it(`methane: 4 C–H = 1.089 Å, H–C–H = 109.471°`, () => {
+    const gjf = `#P\n\nmethane\n\n0 1\nC\nH 1 1.089\nH 1 1.089 2 109.471\nH 1 1.089 2 109.471 3 120.0\nH 1 1.089 2 109.471 3 -120.0\n\n`
+    const s = parse_gaussian_input(gjf)!
+    expect(s.sites).toHaveLength(5)
+    const [C, ...H] = s.sites
+    for (const h of H) expect(dist(C, h)).toBeCloseTo(1.089, 3)
+    for (const h of H) expect(angle(H[0], C, h === H[0] ? H[1] : h)).toBeCloseTo(109.471, 1)
+  })
+
+  it(`water with variables`, () => {
+    const gjf = `#\n\nwater\n\n0 1\nO\nH 1 R\nH 1 R 2 A\n\nR 0.96\nA 104.5\n`
+    const s = parse_gaussian_input(gjf)!
+    expect(s.sites).toHaveLength(3)
+    expect(dist(s.sites[0], s.sites[1])).toBeCloseTo(0.96, 4)
+    expect(dist(s.sites[0], s.sites[2])).toBeCloseTo(0.96, 4)
+    expect(angle(s.sites[1], s.sites[0], s.sites[2])).toBeCloseTo(104.5, 2)
+  })
+})
+
+describe(`ORCA %coords block`, () => {
+  it(`parses Coords ... end`, () => {
+    const inp = `! B3LYP\n%coords\n  CTyp xyz\n  Charge 0\n  Mult 1\n  Coords\n    O 0.0 0.0 0.0\n    H 0.0 0.0 0.96\n  end\nend\n`
+    const s = parse_orca(inp)!
+    expect(s.sites).toHaveLength(2)
+    expect(s.sites.map((x) => x.species[0].element)).toEqual([`O`, `H`])
+    expect(s.sites[1].xyz[2]).toBeCloseTo(0.96, 5)
+  })
+
+  it(`returns null for xyzfile (external)`, () => {
+    expect(parse_orca(`! B3LYP\n* xyzfile 0 1 mol.xyz\n`)).toBeNull()
+  })
+})

--- a/src/lib/structure/parsers/gaussian-input.ts
+++ b/src/lib/structure/parsers/gaussian-input.ts
@@ -1,64 +1,74 @@
 // Gaussian input (.gjf / .com) parser (molecule, no lattice).
 // Layout: Link0 (%...) → route (#...) → blank → title → blank → "charge mult"
-// → Cartesian atom lines → blank. Z-matrix / internal coords return null.
+// → geometry (Cartesian OR Z-matrix) → blank → optional variables.
 // Written from the Gaussian input file structure.
 
 import type { Site, Vec3 } from '$lib'
 import { type ParsedStructure, validate_element_symbol } from './common'
 import { make_site } from './dft-common'
+import { parse_zmatrix } from './zmatrix'
 
 // "C", "C1", "6", "C(Iso=13)", "C-C3" → element symbol
 function element_token(tok: string): string {
   const m = tok.match(/^([A-Za-z]{1,2})/)
-  if (m) return m[1]
-  return tok
+  return m ? m[1] : tok
 }
+
+const is_num = (s: string) => s !== `` && !isNaN(Number(s))
 
 export function parse_gaussian_input(content: string): ParsedStructure | null {
   try {
-    // Sections are separated by blank lines. Drop Link0/route, keep through coords.
-    const raw_lines = content.split(/\r?\n/).map((l) => l.replace(/!.*$/, ``).trimEnd())
+    const lines = content.split(/\r?\n/).map((l) => l.replace(/!.*$/, ``).trimEnd())
 
-    // Locate the route section (line starting with #), then skip: blank, title,
-    // blank, charge/mult line — the atoms follow.
+    // route (#...) → blank → title → blank → charge/mult
     let i = 0
-    while (i < raw_lines.length && !raw_lines[i].trim().startsWith(`#`)) i++
-    if (i >= raw_lines.length) return null
-    // advance past route (may span multiple lines until a blank)
-    while (i < raw_lines.length && raw_lines[i].trim() !== ``) i++
-    i++ // blank after route
-    // title (until blank)
-    while (i < raw_lines.length && raw_lines[i].trim() !== ``) i++
-    i++ // blank after title
-    // charge / multiplicity line
-    const cm = raw_lines[i]?.trim().split(/\s+/)
+    while (i < lines.length && !lines[i].trim().startsWith(`#`)) i++
+    if (i >= lines.length) return null
+    while (i < lines.length && lines[i].trim() !== ``) i++ // end of route
+    i++
+    while (i < lines.length && lines[i].trim() !== ``) i++ // end of title
+    i++
+    const cm = lines[i]?.trim().split(/\s+/)
     if (!cm || cm.length < 2 || cm.some((t) => isNaN(Number(t)))) return null
     i++
 
-    const sites: Site[] = []
-    const counters: Record<string, number> = {}
-    for (; i < raw_lines.length; i++) {
-      const line = raw_lines[i].trim()
-      if (line === ``) break
-      const tok = line.split(/\s+/)
-      // Cartesian forms: "El x y z" or "El freeze x y z". Need the last 3 numeric.
-      const nums = tok.slice(-3).map(Number)
-      if (tok.length < 4 || nums.some(isNaN)) {
-        // Not Cartesian (likely a Z-matrix) → unsupported.
-        return sites.length > 0 ? finalize(sites) : null
-      }
-      const element = validate_element_symbol(element_token(tok[0]), sites.length)
-      counters[element] = (counters[element] ?? 0) + 1
-      sites.push(make_site(element, nums as Vec3, [0, 0, 0], `${element}${counters[element]}`))
+    // geometry block (until blank)
+    const geom: string[] = []
+    for (; i < lines.length && lines[i].trim() !== ``; i++) geom.push(lines[i].trim())
+    if (geom.length === 0) return null
+
+    // optional variable block (after the blank): "name value" or "name= value"
+    const vars = new Map<string, number>()
+    i++ // blank
+    for (; i < lines.length && lines[i].trim() !== ``; i++) {
+      const t = lines[i].trim().replace(/=/, ` `).split(/\s+/)
+      if (t.length >= 2 && is_num(t[1])) vars.set(t[0].toLowerCase(), Number(t[1]))
     }
 
-    return sites.length > 0 ? finalize(sites) : null
+    // Cartesian if every line is `El x y z` (last 3 numeric, ≥4 tokens).
+    const cartesian = geom.every((l) => {
+      const tk = l.split(/\s+/)
+      return tk.length >= 4 && tk.slice(-3).every(is_num)
+    })
+
+    if (cartesian) {
+      const sites: Site[] = []
+      const counters: Record<string, number> = {}
+      for (const l of geom) {
+        const tk = l.split(/\s+/)
+        const nums = tk.slice(-3).map(Number) as Vec3
+        const element = validate_element_symbol(element_token(tk[0]), sites.length)
+        counters[element] = (counters[element] ?? 0) + 1
+        sites.push(make_site(element, nums, [0, 0, 0], `${element}${counters[element]}`))
+      }
+      return sites.length > 0 ? { sites } : null
+    }
+
+    // Otherwise treat as a Z-matrix.
+    const sites = parse_zmatrix(geom, vars)
+    return sites && sites.length > 0 ? { sites } : null
   } catch (error) {
     console.error(`Error parsing Gaussian input:`, error)
     return null
   }
-}
-
-function finalize(sites: Site[]): ParsedStructure {
-  return { sites }
 }

--- a/src/lib/structure/parsers/orca.ts
+++ b/src/lib/structure/parsers/orca.ts
@@ -1,52 +1,61 @@
 // ORCA input geometry parser (molecule, no lattice).
-// Supports the `* xyz <charge> <mult> ... *` Cartesian block. `* xyzfile ...`
-// (external coords) and internal-coordinate (`* int`) blocks return null.
+// Supports:
+//   * xyz <charge> <mult> ... *           (inline Cartesian block)
+//   %coords ... CTyp xyz ... Coords ... <atoms> end ... end
+// `* xyzfile ...` / `* int ...` (external file / internal coords) return null.
 // Written from the ORCA input format.
 
 import type { Site, Vec3 } from '$lib'
 import { type ParsedStructure, validate_element_symbol } from './common'
 import { make_site, strip_comment } from './dft-common'
 
+function atoms_from_lines(lines: string[], start: number, stop: (l: string) => boolean): Site[] {
+  const sites: Site[] = []
+  const counters: Record<string, number> = {}
+  for (let i = start; i < lines.length; i++) {
+    const line = strip_comment(lines[i])
+    if (!line) continue
+    if (stop(line)) break
+    const tok = line.split(/\s+/)
+    if (tok.length < 4) continue
+    const nums = tok.slice(1, 4).map(Number)
+    if (nums.some(isNaN)) continue
+    const element = validate_element_symbol(tok[0], sites.length)
+    counters[element] = (counters[element] ?? 0) + 1
+    sites.push(make_site(element, nums as Vec3, [0, 0, 0], `${element}${counters[element]}`))
+  }
+  return sites
+}
+
 export function parse_orca(content: string): ParsedStructure | null {
   try {
     const lines = content.split(/\r?\n/)
-    // Find the coordinate block opener: `* xyz charge mult`
-    let start = -1
-    let cartesian = false
+
+    // Form 1: `* xyz charge mult` … `*`
     for (let i = 0; i < lines.length; i++) {
       const line = strip_comment(lines[i])
       const m = line.match(/^\*\s*(\w+)/)
-      if (m) {
-        const kind = m[1].toLowerCase()
-        if (kind === `xyz`) {
-          start = i
-          cartesian = true
-        }
-        break // first geometry block only
+      if (!m) continue
+      if (m[1].toLowerCase() === `xyz`) {
+        const sites = atoms_from_lines(lines, i + 1, (l) => l.startsWith(`*`))
+        return sites.length > 0 ? { sites } : null
       }
-      // `%coords` block alternative
-      const c = line.match(/^%coords/i)
-      if (c) break // not supported here → null below
-    }
-    if (start < 0 || !cartesian) return null
-
-    const sites: Site[] = []
-    const counters: Record<string, number> = {}
-    for (let i = start + 1; i < lines.length; i++) {
-      const line = strip_comment(lines[i])
-      if (!line) continue
-      if (line.startsWith(`*`)) break // block terminator
-      const tok = line.split(/\s+/)
-      if (tok.length < 4) continue
-      const nums = tok.slice(1, 4).map(Number)
-      if (nums.some(isNaN)) continue
-      const element = validate_element_symbol(tok[0], sites.length)
-      counters[element] = (counters[element] ?? 0) + 1
-      sites.push(make_site(element, nums as Vec3, [0, 0, 0], `${element}${counters[element]}`))
+      break // `* xyzfile` / `* int` etc. → not inline Cartesian
     }
 
-    if (sites.length === 0) return null
-    return { sites }
+    // Form 2: `%coords … Coords … end … end`
+    const coords_open = lines.findIndex((l) => /^%coords\b/i.test(strip_comment(l)))
+    if (coords_open >= 0) {
+      const ctyp = lines.slice(coords_open).find((l) => /^\s*CTyp\s+/i.test(l))
+      if (ctyp && !/xyz/i.test(ctyp)) return null // internal coords
+      const block_start = lines.findIndex((l, idx) => idx > coords_open && /^\s*Coords\b/i.test(strip_comment(l)))
+      if (block_start >= 0) {
+        const sites = atoms_from_lines(lines, block_start + 1, (l) => /^end$/i.test(l))
+        return sites.length > 0 ? { sites } : null
+      }
+    }
+
+    return null
   } catch (error) {
     console.error(`Error parsing ORCA input:`, error)
     return null

--- a/src/lib/structure/parsers/qe-bravais.ts
+++ b/src/lib/structure/parsers/qe-bravais.ts
@@ -1,0 +1,101 @@
+// Quantum ESPRESSO ibrav → lattice vectors (Å), the full standard table from
+// the pw.x input documentation. Vectors are returned as row matrix in Å.
+//
+// Inputs (already resolved to Å / ratios / cosines by the caller):
+//   a       : celldm(1) in Å (= celldm(1)·bohr, or `A`)
+//   boa     : b/a   (celldm(2), or B/A)
+//   coa     : c/a   (celldm(3), or C/A)
+//   cd4/5/6 : celldm(4..6) cosines (meaning depends on ibrav)
+
+import type { Matrix3x3 } from '$lib/math'
+import type { Vec3 } from '$lib'
+
+type N = number | null
+
+export function lattice_from_ibrav(
+  ibrav: number,
+  a: N,
+  boa: N,
+  coa: N,
+  cd4: N,
+  cd5: N,
+  cd6: N,
+): Matrix3x3 | null {
+  if (!a) return null
+  const b = boa ? boa * a : null
+  const c = coa ? coa * a : null
+  const S3 = Math.sqrt(3)
+  // helper: scale unit (alat) vectors by a
+  const M = (rows: Vec3[]): Matrix3x3 => rows.map((r) => [r[0] * a, r[1] * a, r[2] * a] as Vec3) as Matrix3x3
+
+  switch (ibrav) {
+    case 1:
+      return M([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    case 2:
+      return M([[-0.5, 0, 0.5], [0, 0.5, 0.5], [-0.5, 0.5, 0]])
+    case 3:
+      return M([[0.5, 0.5, 0.5], [-0.5, 0.5, 0.5], [-0.5, -0.5, 0.5]])
+    case -3:
+      return M([[-0.5, 0.5, 0.5], [0.5, -0.5, 0.5], [0.5, 0.5, -0.5]])
+    case 4:
+      if (!coa) return null
+      return M([[1, 0, 0], [-0.5, S3 / 2, 0], [0, 0, coa]])
+    case 5: { // trigonal R, 3-fold axis <111>; cd4 = cos(α)
+      if (cd4 === null) return null
+      const cc = cd4
+      const tx = Math.sqrt((1 - cc) / 2)
+      const ty = Math.sqrt((1 - cc) / 6)
+      const tz = Math.sqrt((1 + 2 * cc) / 3)
+      return M([[tx, -ty, tz], [0, 2 * ty, tz], [-tx, -ty, tz]])
+    }
+    case 6:
+      if (!coa) return null
+      return M([[1, 0, 0], [0, 1, 0], [0, 0, coa]])
+    case 7: // body-centered tetragonal
+      if (!coa) return null
+      return M([[0.5, -0.5, coa / 2], [0.5, 0.5, coa / 2], [-0.5, -0.5, coa / 2]])
+    case 8: // simple orthorhombic
+      if (!boa || !coa) return null
+      return M([[1, 0, 0], [0, boa, 0], [0, 0, coa]])
+    case 9: // base-centered orthorhombic (C-type)
+      if (!boa || !coa) return null
+      return M([[0.5, boa / 2, 0], [-0.5, boa / 2, 0], [0, 0, coa]])
+    case -9:
+      if (!boa || !coa) return null
+      return M([[0.5, -boa / 2, 0], [0.5, boa / 2, 0], [0, 0, coa]])
+    case 10: // face-centered orthorhombic
+      if (!boa || !coa) return null
+      return M([[0.5, 0, coa / 2], [0.5, boa / 2, 0], [0, boa / 2, coa / 2]])
+    case 11: // body-centered orthorhombic
+      if (!boa || !coa) return null
+      return M([[0.5, boa / 2, coa / 2], [-0.5, boa / 2, coa / 2], [-0.5, -boa / 2, coa / 2]])
+    case 12: { // monoclinic P, unique axis c; cd4 = cos(γ)
+      if (!boa || !coa || cd4 === null) return null
+      const sg = Math.sqrt(1 - cd4 * cd4)
+      return M([[1, 0, 0], [boa * cd4, boa * sg, 0], [0, 0, coa]])
+    }
+    case -12: { // monoclinic P, unique axis b; cd5 = cos(β)
+      if (!boa || !coa || cd5 === null) return null
+      const sb = Math.sqrt(1 - cd5 * cd5)
+      return M([[1, 0, 0], [0, boa, 0], [coa * cd5, 0, coa * sb]])
+    }
+    case 13: { // base-centered monoclinic, unique axis c; cd4 = cos(γ)
+      if (!boa || !coa || cd4 === null) return null
+      const sg = Math.sqrt(1 - cd4 * cd4)
+      return M([[0.5, 0, -coa / 2], [boa * cd4, boa * sg, 0], [0.5, 0, coa / 2]])
+    }
+    case 14: { // triclinic; cd4=cos(bc)=cosα, cd5=cos(ac)=cosβ, cd6=cos(ab)=cosγ
+      if (!boa || !coa || cd4 === null || cd5 === null || cd6 === null) return null
+      const ca = cd4, cb = cd5, cg = cd6
+      const sg = Math.sqrt(1 - cg * cg)
+      const v3z = Math.sqrt(1 + 2 * ca * cb * cg - ca * ca - cb * cb - cg * cg) / sg
+      return M([
+        [1, 0, 0],
+        [boa * cg, boa * sg, 0],
+        [coa * cb, coa * (ca - cb * cg) / sg, coa * v3z],
+      ])
+    }
+    default:
+      return null
+  }
+}

--- a/src/lib/structure/parsers/qe.ts
+++ b/src/lib/structure/parsers/qe.ts
@@ -1,6 +1,7 @@
 // Quantum ESPRESSO (pw.x) input parser.
-// Scope: ibrav=0 with an explicit CELL_PARAMETERS card. Handles ATOMIC_POSITIONS
-// in alat/bohr/angstrom/crystal. Written from the pw.x input description.
+// Handles ibrav=0 (explicit CELL_PARAMETERS) and the full ibrav≠0 Bravais table
+// (see qe-bravais.ts). ATOMIC_POSITIONS in alat/bohr/angstrom/crystal.
+// Written from the pw.x input description.
 
 import type { Matrix3x3 } from '$lib/math'
 import type { Site, Vec3 } from '$lib'
@@ -9,6 +10,7 @@ import {
   normalize_scientific_notation,
   validate_element_symbol,
 } from './common'
+import { lattice_from_ibrav } from './qe-bravais'
 import {
   BOHR_TO_ANG,
   cart_to_frac,
@@ -46,36 +48,6 @@ function is_card_header(line: string): boolean {
   return CARD_HEADERS.has(first)
 }
 
-// Build the cell (Å) from ibrav + lattice lengths for the common Bravais types.
-// Returns null for ibrav values not handled here. a/b/c are in Å.
-function lattice_from_ibrav(
-  ibrav: number,
-  a: number | null,
-  b: number | null,
-  c: number | null,
-): Matrix3x3 | null {
-  if (!a) return null
-  switch (ibrav) {
-    case 1: // simple cubic
-      return [[a, 0, 0], [0, a, 0], [0, 0, a]]
-    case 2: // fcc
-      return [[-a / 2, 0, a / 2], [0, a / 2, a / 2], [-a / 2, a / 2, 0]]
-    case 3: // bcc
-      return [[a / 2, a / 2, a / 2], [-a / 2, a / 2, a / 2], [-a / 2, -a / 2, a / 2]]
-    case 4: // hexagonal
-      if (!c) return null
-      return [[a, 0, 0], [-a / 2, (a * Math.sqrt(3)) / 2, 0], [0, 0, c]]
-    case 6: // simple tetragonal
-      if (!c) return null
-      return [[a, 0, 0], [0, a, 0], [0, 0, c]]
-    case 8: // simple orthorhombic
-      if (!b || !c) return null
-      return [[a, 0, 0], [0, b, 0], [0, 0, c]]
-    default:
-      return null
-  }
-}
-
 export function parse_qe(content: string): ParsedStructure | null {
   try {
     const ibrav_str = scalar(content, /ibrav\s*=\s*(-?\d+)/i)
@@ -87,22 +59,36 @@ export function parse_qe(content: string): ParsedStructure | null {
     const celldm1 = num(scalar(content, /celldm\(1\)\s*=\s*([\d.eEdD+-]+)/i))
     const alat: number | null = a_ang ?? (celldm1 !== null ? celldm1 * BOHR_TO_ANG : null)
 
-    // b, c in Å for ibrav≠0: prefer B/C (Å), else celldm(2)/celldm(3) (× alat).
+    // b/a, c/a ratios: from celldm(2)/(3), or B/A, C/A.
     const b_ang = num(scalar(content, /(?:^|[\s,&])B\s*=\s*([\d.eEdD+-]+)/im))
     const c_ang = num(scalar(content, /(?:^|[\s,&])C\s*=\s*([\d.eEdD+-]+)/im))
     const celldm2 = num(scalar(content, /celldm\(2\)\s*=\s*([\d.eEdD+-]+)/i))
     const celldm3 = num(scalar(content, /celldm\(3\)\s*=\s*([\d.eEdD+-]+)/i))
-    const b_len = b_ang ?? (celldm2 !== null && alat !== null ? celldm2 * alat : null)
-    const c_len = c_ang ?? (celldm3 !== null && alat !== null ? celldm3 * alat : null)
+    const boa = celldm2 ?? (b_ang !== null && a_ang ? b_ang / a_ang : null)
+    const coa = celldm3 ?? (c_ang !== null && a_ang ? c_ang / a_ang : null)
+
+    // Angle cosines: celldm(4..6), or cosBC/cosAC/cosAB mapped per QE convention.
+    const celldm4 = num(scalar(content, /celldm\(4\)\s*=\s*([\d.eEdD+-]+)/i))
+    const celldm5 = num(scalar(content, /celldm\(5\)\s*=\s*([\d.eEdD+-]+)/i))
+    const celldm6 = num(scalar(content, /celldm\(6\)\s*=\s*([\d.eEdD+-]+)/i))
+    const cosbc = num(scalar(content, /cosBC\s*=\s*([\d.eEdD+-]+)/i))
+    const cosac = num(scalar(content, /cosAC\s*=\s*([\d.eEdD+-]+)/i))
+    const cosab = num(scalar(content, /cosAB\s*=\s*([\d.eEdD+-]+)/i))
+    // QE: for ibrav=14 celldm(4,5,6)=cos(bc,ac,ab); for 12/13 celldm(4)=cos(ab=γ);
+    // for -12 celldm(5)=cos(ac=β); for 5 celldm(4)=cos(α). The cos* keywords map:
+    //   celldm(4)←cosBC (ibrav 14) or cosAB (ibrav 12/13); celldm(5)←cosAC; celldm(6)←cosAB.
+    const cd4 = celldm4 ?? (ibrav === 14 ? cosbc : cosab)
+    const cd5 = celldm5 ?? cosac
+    const cd6 = celldm6 ?? cosab
 
     const lines = content.split(/\r?\n/).map(strip_comment)
 
     // ── Lattice: ibrav≠0 generates the cell; ibrav=0 reads CELL_PARAMETERS ──
     let matrix: Matrix3x3 | null = null
     if (ibrav !== 0) {
-      matrix = lattice_from_ibrav(ibrav, alat, b_len, c_len)
+      matrix = lattice_from_ibrav(ibrav, alat, boa, coa, cd4, cd5, cd6)
       if (!matrix) {
-        console.warn(`QE parser: ibrav=${ibrav} not supported (or missing cell lengths).`)
+        console.warn(`QE parser: ibrav=${ibrav} not supported (or missing cell parameters).`)
         return null
       }
     }

--- a/src/lib/structure/parsers/zmatrix.ts
+++ b/src/lib/structure/parsers/zmatrix.ts
@@ -1,0 +1,131 @@
+// Z-matrix (internal coordinates) → Cartesian, via NeRF placement.
+// Used by the Gaussian input parser for molecules given as a Z-matrix.
+// Angles/dihedrals are in degrees (Gaussian convention).
+
+import type { Site, Vec3 } from '$lib'
+import { validate_element_symbol } from './common'
+import { make_site } from './dft-common'
+
+const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+const scl = (a: Vec3, s: number): Vec3 => [a[0] * s, a[1] * s, a[2] * s]
+const dot = (a: Vec3, b: Vec3) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+const cross = (a: Vec3, b: Vec3): Vec3 =>
+  [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+function unit(a: Vec3): Vec3 {
+  const n = Math.hypot(a[0], a[1], a[2])
+  return n > 1e-12 ? [a[0] / n, a[1] / n, a[2] / n] : [0, 0, 0]
+}
+const DEG = Math.PI / 180
+
+interface ZRow {
+  el: string
+  r1?: number // 1-based ref
+  bond?: number
+  r2?: number
+  angle?: number
+  r3?: number
+  dih?: number
+}
+
+function resolve(tok: string, vars: Map<string, number>): number | null {
+  const neg = tok.startsWith(`-`)
+  const key = (neg ? tok.slice(1) : tok).toLowerCase()
+  const direct = parseFloat(tok)
+  if (!isNaN(direct) && /^[-+]?[\d.eE]+$/.test(tok)) return direct
+  if (vars.has(key)) return (neg ? -1 : 1) * vars.get(key)!
+  return null
+}
+
+/** Place an atom by bond/angle/dihedral relative to C(r1), B(r2), A(r3). */
+function place(C: Vec3, B: Vec3, A: Vec3, bond: number, angle: number, dih: number): Vec3 {
+  const bc = unit(sub(C, B))
+  const n = unit(cross(sub(B, A), bc))
+  const nbc = cross(n, bc)
+  const d2: Vec3 = [
+    -bond * Math.cos(angle),
+    bond * Math.cos(dih) * Math.sin(angle),
+    bond * Math.sin(dih) * Math.sin(angle),
+  ]
+  return add(C, [
+    bc[0] * d2[0] + nbc[0] * d2[1] + n[0] * d2[2],
+    bc[1] * d2[0] + nbc[1] * d2[1] + n[1] * d2[2],
+    bc[2] * d2[0] + nbc[2] * d2[1] + n[2] * d2[2],
+  ])
+}
+
+export function zmatrix_to_sites(rows: ZRow[]): Site[] | null {
+  const pos: Vec3[] = []
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i]
+    if (i === 0) {
+      pos.push([0, 0, 0])
+    } else if (i === 1) {
+      if (r.r1 === undefined || r.bond === undefined) return null
+      pos.push([r.bond, 0, 0])
+    } else if (i === 2) {
+      if (r.r1 === undefined || r.bond === undefined || r.r2 === undefined || r.angle === undefined) {
+        return null
+      }
+      const C = pos[r.r1 - 1]
+      const B = pos[r.r2 - 1]
+      const u = unit(sub(B, C))
+      // perpendicular to u
+      let ref: Vec3 = Math.abs(u[2]) < 0.9 ? [0, 0, 1] : [1, 0, 0]
+      const w = unit(cross(u, ref))
+      const ang = r.angle * DEG
+      pos.push(add(C, scl(add(scl(u, Math.cos(ang)), scl(w, Math.sin(ang))), r.bond)))
+    } else {
+      if (
+        r.r1 === undefined || r.bond === undefined || r.r2 === undefined ||
+        r.angle === undefined || r.r3 === undefined || r.dih === undefined
+      ) return null
+      pos.push(place(pos[r.r1 - 1], pos[r.r2 - 1], pos[r.r3 - 1], r.bond, r.angle * DEG, r.dih * DEG))
+    }
+  }
+
+  const sites: Site[] = []
+  const counters: Record<string, number> = {}
+  for (let i = 0; i < rows.length; i++) {
+    const element = validate_element_symbol(rows[i].el, i)
+    counters[element] = (counters[element] ?? 0) + 1
+    sites.push(make_site(element, pos[i], [0, 0, 0], `${element}${counters[element]}`))
+  }
+  return sites
+}
+
+/** Parse Z-matrix text lines (no blanks) + a variable map into rows. */
+export function parse_zmatrix(geom: string[], vars: Map<string, number>): Site[] | null {
+  const rows: ZRow[] = []
+  for (let i = 0; i < geom.length; i++) {
+    const tok = geom[i].trim().split(/\s+/)
+    if (tok.length === 0 || !tok[0]) continue
+    const row: ZRow = { el: tok[0] }
+    if (i >= 1) {
+      row.r1 = parseInt(tok[1], 10)
+      const b = resolve(tok[2], vars)
+      if (b === null) return null
+      row.bond = b
+    }
+    if (i >= 2) {
+      row.r2 = parseInt(tok[3], 10)
+      const a = resolve(tok[4], vars)
+      if (a === null) return null
+      row.angle = a
+    }
+    if (i >= 3) {
+      row.r3 = parseInt(tok[5], 10)
+      const d = resolve(tok[6], vars)
+      if (d === null) return null
+      row.dih = d
+    }
+    if (
+      (i >= 1 && (isNaN(row.r1!) || row.bond === undefined)) ||
+      (i >= 2 && isNaN(row.r2!)) ||
+      (i >= 3 && isNaN(row.r3!))
+    ) return null
+    rows.push(row)
+  }
+  if (rows.length === 0) return null
+  return zmatrix_to_sites(rows)
+}


### PR DESCRIPTION
Completes the client-side DFT parser coverage on top of #333/#334. Clean-room from each format's public spec.

## Added
- **Full QE `ibrav` table** (`qe-bravais.ts`): ibrav 1, 2, 3, −3, 4, 5, 6, 7, 8, 9, −9, 10, 11, 12, −12, 13, 14 — driven by `celldm(1..6)` or `A/B/C` + `cosBC/cosAC/cosAB`. `qe.ts` resolves all parameters and delegates (replaces the earlier 6-case stub; ibrav 1/2/4/6/8 still pass unchanged).
- **Gaussian Z-matrix** (`zmatrix.ts`): internal coords → Cartesian via NeRF placement, with a variable-definitions block. `gaussian-input.ts` auto-detects Cartesian vs Z-matrix.
- **ORCA `%coords`** block (`CTyp xyz` … `Coords` … `end`) in addition to `* xyz`; external `* xyzfile` returns `null`.

## Verification — convention-independent geometry (9 tests)
- **QE** ibrav 3/5/7/12/14: bcc volume = a³/2; trigonal equal lengths + angles = arccos(celldm4); bct volume = a²c/2; monoclinic γ + triclinic α/β/γ = arccos(celldm) (proves the cell regardless of basis orientation)
- **Z-matrix**: methane (4× C–H = 1.089 Å, H–C–H = 109.471°), water with `R`/`A` variables
- **ORCA**: `%coords` parsed; `* xyzfile` → null

```
pnpm vitest run .../parsers/__tests__/ tests/vitest/trajectory/outcar.test.ts → 35/35
full pnpm test → 4017 passed, 0 test failures (only the pre-existing flaky external-links network file)
pnpm check → no type errors in new files
```

This closes the parser roadmap in `plan/ts-parser-port-from-acoord.md`. Remaining truly-niche cases (QE ibrav −5/−13, ORCA internal coords) intentionally return null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)