### PR TITLE
feat(parsers): niche cases — QE ibrav -5/-13, ORCA internal coordinates

### DIFF
--- a/src/lib/structure/parsers/__tests__/dft-parsers-niche.test.ts
+++ b/src/lib/structure/parsers/__tests__/dft-parsers-niche.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { parse_qe } from '../qe'
+import { parse_orca } from '../orca'
+import type { Site } from '$lib'
+
+const BOHR = 0.52917721090
+const dist = (a: Site, b: Site) =>
+  Math.hypot(a.xyz[0] - b.xyz[0], a.xyz[1] - b.xyz[1], a.xyz[2] - b.xyz[2])
+const angle = (a: Site, v: Site, b: Site) => {
+  const u = [a.xyz[0] - v.xyz[0], a.xyz[1] - v.xyz[1], a.xyz[2] - v.xyz[2]]
+  const w = [b.xyz[0] - v.xyz[0], b.xyz[1] - v.xyz[1], b.xyz[2] - v.xyz[2]]
+  const d = (u[0] * w[0] + u[1] * w[1] + u[2] * w[2]) / (Math.hypot(...u) * Math.hypot(...w))
+  return Math.acos(Math.max(-1, Math.min(1, d))) * 180 / Math.PI
+}
+
+describe(`QE niche ibrav`, () => {
+  it(`ibrav=-5 (trigonal, 3-fold ‖ z): equal lengths a, equal angles arccos(cd4)`, () => {
+    const a = 6 * BOHR
+    const L = parse_qe(`&SYSTEM\n ibrav = -5\n celldm(1) = 6\n celldm(4) = 0.4\n/\nATOMIC_POSITIONS crystal\nAl 0 0 0\n`)!.lattice!
+    for (const len of [L.a, L.b, L.c]) expect(len).toBeCloseTo(a, 4)
+    const target = Math.acos(0.4) * 180 / Math.PI
+    for (const ang of [L.alpha, L.beta, L.gamma]) expect(ang).toBeCloseTo(target, 1)
+  })
+
+  it(`ibrav=-13 (base-centered monoclinic, axis b): volume a·b·c·sinβ/2`, () => {
+    const a = 5 * BOHR, boa = 1.2, coa = 1.4, cb = 0.25
+    const L = parse_qe(
+      `&SYSTEM\n ibrav = -13\n celldm(1) = 5\n celldm(2) = 1.2\n celldm(3) = 1.4\n celldm(5) = 0.25\n/\nATOMIC_POSITIONS crystal\nAl 0 0 0\n`,
+    )!.lattice!
+    const vol = a * (boa * a) * (coa * a) * Math.sqrt(1 - cb * cb) / 2
+    expect(L.volume).toBeCloseTo(vol, 3)
+  })
+})
+
+describe(`ORCA internal coordinates (* int)`, () => {
+  it(`water: O–H = 0.96 Å, H–O–H = 104.5°`, () => {
+    const inp = `! B3LYP\n* int 0 1\n  O  0 0 0  0.0   0.0   0.0\n  H  1 0 0  0.96  0.0   0.0\n  H  1 2 0  0.96  104.5 0.0\n*\n`
+    const s = parse_orca(inp)!
+    expect(s.sites).toHaveLength(3)
+    expect(s.sites.map((x) => x.species[0].element)).toEqual([`O`, `H`, `H`])
+    expect(dist(s.sites[0], s.sites[1])).toBeCloseTo(0.96, 4)
+    expect(dist(s.sites[0], s.sites[2])).toBeCloseTo(0.96, 4)
+    expect(angle(s.sites[1], s.sites[0], s.sites[2])).toBeCloseTo(104.5, 2)
+  })
+})

--- a/src/lib/structure/parsers/orca.ts
+++ b/src/lib/structure/parsers/orca.ts
@@ -8,6 +8,27 @@
 import type { Site, Vec3 } from '$lib'
 import { type ParsedStructure, validate_element_symbol } from './common'
 import { make_site, strip_comment } from './dft-common'
+import { type ZRow, zmatrix_to_sites } from './zmatrix'
+
+// ORCA internal coords: `El r1 r2 r3 bond angle dihedral` (refs 1-based, 0 = none).
+function internal_to_sites(lines: string[], start: number): Site[] | null {
+  const rows: ZRow[] = []
+  for (let i = start; i < lines.length; i++) {
+    const line = strip_comment(lines[i])
+    if (!line) continue
+    if (line.startsWith(`*`)) break
+    const t = line.split(/\s+/)
+    if (t.length < 7) continue
+    const [r1, r2, r3] = [Number(t[1]), Number(t[2]), Number(t[3])]
+    const [bond, angle, dih] = [Number(t[4]), Number(t[5]), Number(t[6])]
+    const row: ZRow = { el: t[0] }
+    if (r1 > 0) { row.r1 = r1; row.bond = bond }
+    if (r2 > 0) { row.r2 = r2; row.angle = angle }
+    if (r3 > 0) { row.r3 = r3; row.dih = dih }
+    rows.push(row)
+  }
+  return rows.length > 0 ? zmatrix_to_sites(rows) : null
+}
 
 function atoms_from_lines(lines: string[], start: number, stop: (l: string) => boolean): Site[] {
   const sites: Site[] = []
@@ -36,11 +57,16 @@ export function parse_orca(content: string): ParsedStructure | null {
       const line = strip_comment(lines[i])
       const m = line.match(/^\*\s*(\w+)/)
       if (!m) continue
-      if (m[1].toLowerCase() === `xyz`) {
+      const kind = m[1].toLowerCase()
+      if (kind === `xyz`) {
         const sites = atoms_from_lines(lines, i + 1, (l) => l.startsWith(`*`))
         return sites.length > 0 ? { sites } : null
       }
-      break // `* xyzfile` / `* int` etc. → not inline Cartesian
+      if (kind === `int` || kind === `internal`) {
+        const sites = internal_to_sites(lines, i + 1)
+        return sites && sites.length > 0 ? { sites } : null
+      }
+      break // `* xyzfile` (external) → null
     }
 
     // Form 2: `%coords … Coords … end … end`

--- a/src/lib/structure/parsers/qe-bravais.ts
+++ b/src/lib/structure/parsers/qe-bravais.ts
@@ -48,6 +48,16 @@ export function lattice_from_ibrav(
       const tz = Math.sqrt((1 + 2 * cc) / 3)
       return M([[tx, -ty, tz], [0, 2 * ty, tz], [-tx, -ty, tz]])
     }
+    case -5: { // trigonal R, 3-fold axis along z; cd4 = cos(α)
+      if (cd4 === null) return null
+      const cc = cd4
+      const ty = Math.sqrt((1 - cc) / 6)
+      const tz = Math.sqrt((1 + 2 * cc) / 3)
+      const ap = 1 / S3 // a'/a
+      const u = tz - 2 * Math.SQRT2 * ty
+      const v = tz + Math.SQRT2 * ty
+      return M([[ap * u, ap * v, ap * v], [ap * v, ap * u, ap * v], [ap * v, ap * v, ap * u]])
+    }
     case 6:
       if (!coa) return null
       return M([[1, 0, 0], [0, 1, 0], [0, 0, coa]])
@@ -83,6 +93,11 @@ export function lattice_from_ibrav(
       if (!boa || !coa || cd4 === null) return null
       const sg = Math.sqrt(1 - cd4 * cd4)
       return M([[0.5, 0, -coa / 2], [boa * cd4, boa * sg, 0], [0.5, 0, coa / 2]])
+    }
+    case -13: { // base-centered monoclinic, unique axis b; cd5 = cos(β)
+      if (!boa || !coa || cd5 === null) return null
+      const sb = Math.sqrt(1 - cd5 * cd5)
+      return M([[0.5, boa / 2, 0], [-0.5, boa / 2, 0], [coa * cd5, 0, coa * sb]])
     }
     case 14: { // triclinic; cd4=cos(bc)=cosα, cd5=cos(ac)=cosβ, cd6=cos(ab)=cosγ
       if (!boa || !coa || cd4 === null || cd5 === null || cd6 === null) return null

--- a/src/lib/structure/parsers/zmatrix.ts
+++ b/src/lib/structure/parsers/zmatrix.ts
@@ -18,7 +18,7 @@ function unit(a: Vec3): Vec3 {
 }
 const DEG = Math.PI / 180
 
-interface ZRow {
+export interface ZRow {
   el: string
   r1?: number // 1-based ref
   bond?: number


### PR DESCRIPTION
Closes the last parser gaps on top of #335.

## Added
- **QE `ibrav=-5`** (trigonal R, 3-fold axis ‖ z) and **`ibrav=-13`** (base-centered monoclinic, unique axis b) in `qe-bravais.ts` — the full QE ibrav set is now supported.
- **ORCA `* int` / `* internal`** Z-matrix blocks (`orca.ts`), reusing the NeRF placement in `zmatrix.ts` (refs `0` = none). `zmatrix.ts` now exports `ZRow`.

## Verification — convention-independent geometry
- `ibrav=-5`: equal lengths = a, equal angles = arccos(celldm4)
- `ibrav=-13`: volume = a·b·c·sinβ/2
- ORCA `* int`: water O–H = 0.96 Å, H–O–H = 104.5°

```
pnpm vitest run .../parsers/__tests__/ tests/vitest/trajectory/outcar.test.ts → 38/38
pnpm check → no type errors in new files
```

With this, every format in `plan/ts-parser-port-from-acoord.md` (and beyond) is parsed client-side. No known remaining gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)