### PR TITLE
feat(bio): visualize biological systems via embedded Mol*

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -3,6 +3,8 @@
   import { init_i18n, t, load_i18n_module } from '$lib/i18n/index.svelte'
   import LocaleSwitch from '$lib/i18n/LocaleSwitch.svelte'
   import { Structure, Trajectory } from '$lib'
+  import MolstarViewer from '$lib/structure/bio/MolstarViewer.svelte'
+  import BioViewerToggle from '$lib/structure/bio/BioViewerToggle.svelte'
   import { PathwayControls } from '$lib/trajectory'
   import type { AnyStructure } from '$lib'
   import { parse_cube_header, cube_atoms_to_molecule } from '$lib/cube'
@@ -14,6 +16,7 @@
   import { is_trajectory_file, parse_trajectory_data } from '$lib/trajectory/parse'
   import type { TrajectoryType } from '$lib/trajectory'
   import { parse_structure_file, is_structure_file } from '$lib/structure/parse'
+  import { detect_bio } from '$lib/structure/bio/detect'
   import '$lib/theme/themes.js'
   import StatusPopout from '$lib/workflow/StatusPopout.svelte'
   import { apply_theme_to_dom, get_theme_preference } from '$lib/theme'
@@ -990,6 +993,22 @@
       }
     }
 
+    // Biological macromolecule (protein / nucleic acid) → render in Mol*.
+    // Bio files bypass pymatgen/ferrox entirely: handing Mol* the raw text
+    // preserves residue/chain/secondary-structure and skips the (expensive,
+    // metadata-lossy) native parse of large proteins.
+    const bio = detect_bio(text, filename)
+    if (bio.isBio && bio.format) {
+      return {
+        kind: `entry`,
+        entry: {
+          filename, source_path: null, format: ext, structure: undefined,
+          trajectory: undefined, is_trajectory: false, cube_file: null,
+          viewer_kind: `molstar`, bio_raw_content: text, bio_format: bio.format,
+        },
+      }
+    }
+
     const parsed = parse_structure_file(text, filename)
     if (parsed?.sites?.length) {
       return { kind: `entry`, entry: { filename, source_path: null, format: ext, structure: parsed, trajectory: undefined, is_trajectory: false, cube_file: null } }
@@ -1008,7 +1027,15 @@
     local_file_path: string | null = null,
   ) {
     const p = ts.panes[target]
-    if (e.cube_file) {
+    if (e.viewer_kind === `molstar`) {
+      // Bio file → Mol* pane; no parsed structure, raw text carried below.
+      p.is_trajectory_mode = false
+      p.trajectory = null
+      p.structure = undefined
+      p.cube_file = null
+      p.initial_site_count = 0
+      p.initial_structure_ref = null
+    } else if (e.cube_file) {
       p.structure = clone_structure(e.structure)
       p.initial_site_count = e.structure?.sites?.length ?? 0
       p.initial_structure_ref = e.structure ?? null
@@ -1038,8 +1065,29 @@
     p.remote_origin = remote_origin
     p.local_file_path = local_file_path
     p.source_filename = e.filename
+    p.viewer_kind = e.viewer_kind ?? `native`
+    p.bio_raw_content = e.bio_raw_content
+    p.bio_format = e.bio_format
     ts.active_pane = target
     update_tab_label(tab_id)
+  }
+
+  /** Flip a pane between Mol* and the native viewer (manual override). */
+  function toggle_pane_viewer(ts: StructureTabState, idx: number) {
+    const p = ts.panes[idx]
+    if (!p.bio_raw_content) return
+    if (p.viewer_kind === `molstar`) {
+      // → native: parse the raw text on demand (lazy; only when overridden).
+      const parsed = parse_structure_file(p.bio_raw_content, p.source_filename || `bio`)
+      if (parsed?.sites?.length) {
+        p.structure = parsed
+        p.initial_site_count = parsed.sites.length
+        p.initial_structure_ref = parsed
+      }
+      p.viewer_kind = `native`
+    } else {
+      p.viewer_kind = `molstar`
+    }
   }
 
   async function process_file_content(tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) {
@@ -1766,7 +1814,27 @@
                     />
                   {/snippet}
                 </Trajectory>
+              {:else if pane.viewer_kind === `molstar` && pane.bio_raw_content}
+                <div class="bio-pane-wrap">
+                  <BioViewerToggle
+                    is_molstar={true}
+                    on_toggle={() => toggle_pane_viewer(ts, idx)}
+                  />
+                  {#key pane.bio_raw_content}
+                    <MolstarViewer
+                      content={pane.bio_raw_content}
+                      format={pane.bio_format ?? `pdb`}
+                      label={pane.source_filename ?? `structure`}
+                    />
+                  {/key}
+                </div>
               {:else if pane.structure}
+                {#if pane.bio_raw_content}
+                  <BioViewerToggle
+                    is_molstar={false}
+                    on_toggle={() => toggle_pane_viewer(ts, idx)}
+                  />
+                {/if}
                 <Structure
                   tab_id={tab.id}
                   is_active={ts.active_pane === idx && tab.id === tm.active_tab_id}
@@ -2289,6 +2357,11 @@
 <Toast />
 
 <style>
+  .bio-pane-wrap {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
   .sidebar-editor-overlay {
     position: fixed;
     top: 50%;

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1072,21 +1072,37 @@
     update_tab_label(tab_id)
   }
 
-  /** Flip a pane between Mol* and the native viewer (manual override). */
-  function toggle_pane_viewer(ts: StructureTabState, idx: number) {
+  /**
+   * Flip a pane between Mol* and the native viewer (manual override).
+   * Works for ANY loaded structure, not just auto-detected bio files: when a
+   * pane has no bio raw text yet (a crystal, a built/fetched structure), we
+   * serialize its current structure to a format Mol* reads (CIF when periodic
+   * so the cell survives, else XYZ) and hand that to Mol*.
+   */
+  async function toggle_pane_viewer(ts: StructureTabState, idx: number) {
     const p = ts.panes[idx]
-    if (!p.bio_raw_content) return
     if (p.viewer_kind === `molstar`) {
       // → native: parse the raw text on demand (lazy; only when overridden).
-      const parsed = parse_structure_file(p.bio_raw_content, p.source_filename || `bio`)
-      if (parsed?.sites?.length) {
-        p.structure = parsed
-        p.initial_site_count = parsed.sites.length
-        p.initial_structure_ref = parsed
+      if (p.bio_raw_content) {
+        const parsed = parse_structure_file(p.bio_raw_content, p.source_filename || `bio`)
+        if (parsed?.sites?.length) {
+          p.structure = parsed
+          p.initial_site_count = parsed.sites.length
+          p.initial_structure_ref = parsed
+        }
       }
       p.viewer_kind = `native`
     } else {
-      p.viewer_kind = `molstar`
+      // → Mol*: ensure we have raw text Mol* can parse.
+      if (!p.bio_raw_content && p.structure?.sites?.length) {
+        const { structure_to_cif_str, structure_to_xyz_str } = await import(`$lib/structure/export`)
+        const periodic = !!(p.structure as { lattice?: { matrix?: unknown } })?.lattice?.matrix
+        p.bio_raw_content = periodic
+          ? structure_to_cif_str(p.structure)
+          : structure_to_xyz_str(p.structure)
+        p.bio_format = periodic ? `mmcif` : `xyz`
+      }
+      if (p.bio_raw_content) p.viewer_kind = `molstar`
     }
   }
 
@@ -1816,25 +1832,32 @@
                 </Trajectory>
               {:else if pane.viewer_kind === `molstar` && pane.bio_raw_content}
                 <div class="bio-pane-wrap">
-                  <BioViewerToggle
-                    is_molstar={true}
-                    on_toggle={() => toggle_pane_viewer(ts, idx)}
-                  />
-                  {#key pane.bio_raw_content}
-                    <MolstarViewer
-                      content={pane.bio_raw_content}
-                      format={pane.bio_format ?? `pdb`}
-                      label={pane.source_filename ?? `structure`}
+                  <div class="bio-toolbar">
+                    <BioViewerToggle
+                      is_molstar={true}
+                      on_toggle={() => toggle_pane_viewer(ts, idx)}
                     />
-                  {/key}
+                    <span class="bio-toolbar-name">{pane.source_filename ?? `structure`}</span>
+                  </div>
+                  <div class="bio-viewer-fill">
+                    {#key pane.bio_raw_content}
+                      <MolstarViewer
+                        content={pane.bio_raw_content}
+                        format={pane.bio_format ?? `pdb`}
+                        label={pane.source_filename ?? `structure`}
+                      />
+                    {/key}
+                  </div>
                 </div>
               {:else if pane.structure}
-                {#if pane.bio_raw_content}
+                <!-- Universal manual entry: any loaded structure can be opened
+                     in Mol* (serialized on demand by toggle_pane_viewer). -->
+                <div class="bio-float-tl">
                   <BioViewerToggle
                     is_molstar={false}
                     on_toggle={() => toggle_pane_viewer(ts, idx)}
                   />
-                {/if}
+                </div>
                 <Structure
                   tab_id={tab.id}
                   is_active={ts.active_pane === idx && tab.id === tm.active_tab_id}
@@ -2361,6 +2384,37 @@
     position: relative;
     width: 100%;
     height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .bio-toolbar {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border-color, #ddd);
+    background: var(--panel-bg, rgba(0, 0, 0, 0.03));
+  }
+  .bio-toolbar-name {
+    font-size: 0.78rem;
+    color: var(--text-muted, #777);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .bio-viewer-fill {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+  }
+  /* Universal "Open in Mol*" button over a native viewer — top-left, clear of
+     the native viewer's own bottom/right controls. */
+  .bio-float-tl {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 20;
   }
   .sidebar-editor-overlay {
     position: fixed;

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -32,6 +32,12 @@ export interface PaneState {
   local_file_path?: string | null
   /** Filename of the loaded structure file */
   source_filename?: string | null
+  /** Which viewer renders this pane. Absent/'native' = Three.js viewer. */
+  viewer_kind?: 'native' | 'molstar'
+  /** Raw file text for Mol* (bio files bypass pymatgen parsing). */
+  bio_raw_content?: string
+  /** Mol* format string ('pdb' | 'mmcif') for loadStructureFromData. */
+  bio_format?: string
 }
 
 export type LayoutType = 'single' | 'splitH' | 'splitV' | 'quad'
@@ -55,6 +61,9 @@ export interface LibraryEntry {
   cube_file?: File | null
   raw_traj_b64?: string
   raw_traj_format?: string
+  viewer_kind?: 'native' | 'molstar'
+  bio_raw_content?: string
+  bio_format?: string
 }
 
 export interface StructureTabState {

--- a/docs/superpowers/plans/2026-06-14-molstar-bio-viewer.md
+++ b/docs/superpowers/plans/2026-06-14-molstar-bio-viewer.md
@@ -1,0 +1,780 @@
+# Mol\* Bio Viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render biomolecular files (PDB / bio-mmCIF) in an embedded Mol\* viewer pane, auto-routed by a content sniffer, while materials files keep using the native Three.js viewer.
+
+**Architecture:** Mol\* is a *parallel* viewer pane with its own WebGL2 context and parser. A pure content sniffer (`detect_bio`) decides bio vs. material at file-ingest time. Bio files bypass the pymatgen/ferrox pipeline entirely — their raw text is handed straight to Mol\*, which preserves residue/chain/secondary-structure. A per-pane `viewer_kind` field plus a small floating toggle gives the user a manual override either direction.
+
+**Tech Stack:** SvelteKit 2 / Svelte 5 runes, Vite 7, `molstar` npm package (lazy `import()`), vitest.
+
+---
+
+## File Structure
+
+| File | Responsibility | Create/Modify |
+|------|----------------|---------------|
+| `package.json` | add `molstar` dep | Modify |
+| `src/lib/structure/bio/detect.ts` | pure sniffer: raw text + filename → `{isBio, kind, format, reason}` | Create |
+| `src/lib/structure/bio/detect.test.ts` | vitest unit tests for the sniffer | Create |
+| `src/lib/structure/bio/MolstarViewer.svelte` | lazy-loads Mol\*, mounts the all-in-one Viewer, loads raw data, disposes on unmount | Create |
+| `src/lib/structure/bio/BioViewerToggle.svelte` | floating "open in native ⇄ open in Mol\*" override button | Create |
+| `desktop/pane-utils.ts` | extend `PaneState` + `LibraryEntry` with `viewer_kind` / `bio_raw_content` / `bio_format` | Modify |
+| `desktop/App.svelte` | route bio in `ingest_one`, copy fields in `apply_entry_to_pane`, add render branch + toggle | Modify |
+| `src/lib/mobile/MobileWorkspace.svelte` | mirror the render branch on mobile | Modify |
+| `src/lib/i18n/en/structure.ts` / `zh/structure.ts` | toggle-button strings (en+zh parity) | Modify |
+
+**Conventions reminder:** `deno fmt` is enforced by a pre-commit hook — single quotes, **no semicolons**, 2-space indent, 90-col. `.svelte` files are excluded from `deno fmt`. Let the hook format `.ts` files, then re-stage. Use Svelte 5 runes (`$props`, `$state`, `$effect`), never `export let`.
+
+---
+
+## Task 1: Add the `molstar` dependency
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install molstar**
+
+Run:
+```bash
+cd /home/james0001/project/catgo-LRG && pnpm add molstar
+```
+Expected: `package.json` gains a `"molstar": "^4.x.x"` line under `dependencies`; `pnpm-lock.yaml` updates.
+
+- [ ] **Step 2: Confirm the embed entry points resolve**
+
+Run:
+```bash
+ls node_modules/molstar/lib/apps/viewer/app.js node_modules/molstar/build/viewer/molstar.css
+```
+Expected: both paths exist (the JS entry we import, and the prebuilt CSS skin — prebuilt avoids needing a sass toolchain).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "build(bio): add molstar dependency for bio viewer"
+```
+
+---
+
+## Task 2: Content sniffer `detect_bio` (TDD)
+
+**Files:**
+- Create: `src/lib/structure/bio/detect.ts`
+- Test: `src/lib/structure/bio/detect.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/structure/bio/detect.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { detect_bio } from './detect'
+
+const PROTEIN_PDB = `HEADER    OXYGEN TRANSPORT
+SEQRES   1 A    3  VAL LEU SER
+ATOM      1  N   VAL A   1      11.104  13.207  10.000  1.00 20.00           N
+ATOM      2  CA  VAL A   1      12.560  13.100  10.100  1.00 20.00           C
+ATOM      3  N   LEU A   2      13.000  14.000  10.200  1.00 20.00           N
+ATOM      4  CA  SER A   3      14.000  15.000  10.300  1.00 20.00           C
+END`
+
+const NUCLEIC_PDB = `ATOM      1  P    DA A   1      11.000  13.000  10.000  1.00 20.00           P
+ATOM      2  P    DT A   2      12.000  13.000  10.100  1.00 20.00           P
+ATOM      3  P    DG A   3      13.000  14.000  10.200  1.00 20.00           P
+END`
+
+const LIGAND_PDB = `HETATM    1  C1  LIG A   1      11.000  13.000  10.000  1.00 20.00           C
+HETATM    2  O1  LIG A   1      12.000  13.000  10.100  1.00 20.00           O
+END`
+
+const PROTEIN_MMCIF = `data_1ABC
+loop_
+_entity_poly.entity_id
+_entity_poly.type
+1 'polypeptide(L)'`
+
+const CRYSTAL_CIF = `data_NaCl
+_cell_length_a   5.64
+_cell_length_b   5.64
+_symmetry_space_group_name_H-M 'Fm-3m'
+loop_
+_atom_site_label
+Na1 0 0 0`
+
+describe('detect_bio', () => {
+  it('flags a protein PDB (SEQRES + amino residues)', () => {
+    const r = detect_bio(PROTEIN_PDB, 'prot.pdb')
+    expect(r.isBio).toBe(true)
+    expect(r.kind).toBe('protein')
+    expect(r.format).toBe('pdb')
+  })
+
+  it('flags a nucleic-acid PDB', () => {
+    const r = detect_bio(NUCLEIC_PDB, 'dna.pdb')
+    expect(r.isBio).toBe(true)
+    expect(r.kind).toBe('nucleic')
+    expect(r.format).toBe('pdb')
+  })
+
+  it('does NOT flag a small-molecule/ligand-only PDB', () => {
+    expect(detect_bio(LIGAND_PDB, 'lig.pdb').isBio).toBe(false)
+  })
+
+  it('flags a polypeptide mmCIF', () => {
+    const r = detect_bio(PROTEIN_MMCIF, 'prot.cif')
+    expect(r.isBio).toBe(true)
+    expect(r.kind).toBe('protein')
+    expect(r.format).toBe('mmcif')
+  })
+
+  it('does NOT flag a crystal CIF', () => {
+    expect(detect_bio(CRYSTAL_CIF, 'nacl.cif').isBio).toBe(false)
+  })
+
+  it('does NOT flag a non-candidate extension (POSCAR)', () => {
+    expect(detect_bio('Si\n1.0\n...', 'POSCAR').isBio).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/bio/detect.test.ts`
+Expected: FAIL — `Cannot find module './detect'` (or `detect_bio is not a function`).
+
+(Note: use `rtk proxy pnpm exec vitest` — RTK is known to serve stale `pnpm vitest` output in this project.)
+
+- [ ] **Step 3: Implement `detect.ts`**
+
+Create `src/lib/structure/bio/detect.ts`:
+
+```ts
+/**
+ * Content sniffer: decide whether a file is a biological macromolecule
+ * (protein / nucleic acid) that should render in Mol* rather than the native
+ * viewer. Pure function — no I/O, fully unit-tested.
+ *
+ * Only PDB and (mm)CIF extensions are candidates; within those we sniff content
+ * (heuristic B). Conservative: when ambiguous, return isBio:false so the file
+ * falls through to the native pipeline (the user can still force Mol* via the
+ * manual override).
+ */
+
+export type BioKind = 'protein' | 'nucleic' | 'mixed'
+export type BioFormat = 'pdb' | 'mmcif'
+
+export interface BioDetectResult {
+  isBio: boolean
+  kind: BioKind | null
+  /** Mol* BuiltInTrajectoryFormat string to feed loadStructureFromData. */
+  format: BioFormat | null
+  /** Human-readable explanation (drives the override hint + debugging). */
+  reason: string
+}
+
+const AMINO = new Set([
+  'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE',
+  'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+  'SEC', 'PYL', 'MSE', 'HSD', 'HSE', 'HSP',
+])
+const NUCLEIC = new Set([
+  'DA', 'DT', 'DG', 'DC', 'DU', 'A', 'U', 'G', 'C', 'I',
+  'RA', 'RU', 'RG', 'RC',
+])
+
+function ext_of(filename: string): string {
+  return filename.replace(/\.(gz|bz2|xz|zst)$/i, '').split('.').pop()?.toLowerCase() || ''
+}
+
+function not_bio(format: BioFormat | null, reason: string): BioDetectResult {
+  return { isBio: false, kind: null, format: null, reason }
+}
+
+function bio(kind: BioKind, format: BioFormat, reason: string): BioDetectResult {
+  return { isBio: true, kind, format, reason }
+}
+
+function detect_pdb(text: string): BioDetectResult {
+  const amino_res = new Set<string>()
+  const nucleic_res = new Set<string>()
+  let has_seqres = false
+  let has_helix_sheet = false
+
+  for (const ln of text.split(/\r?\n/)) {
+    const rec = ln.slice(0, 6).trim()
+    if (rec === 'SEQRES') has_seqres = true
+    if (rec === 'HELIX' || rec === 'SHEET') has_helix_sheet = true
+    if (rec === 'ATOM' || rec === 'HETATM') {
+      const res = ln.slice(17, 20).trim().toUpperCase()
+      const res_key = ln.slice(21, 26) // chainID + resSeq
+      if (AMINO.has(res)) amino_res.add(res_key)
+      else if (NUCLEIC.has(res)) nucleic_res.add(res_key)
+    }
+  }
+
+  const protein_like = has_seqres || has_helix_sheet || amino_res.size >= 3
+  const nucleic_like = nucleic_res.size >= 2
+
+  if (protein_like && nucleic_like) {
+    return bio('mixed', 'pdb', 'protein + nucleic residues present')
+  }
+  if (protein_like) {
+    const why = has_seqres
+      ? 'SEQRES record present'
+      : has_helix_sheet
+      ? 'HELIX/SHEET record present'
+      : `${amino_res.size} amino-acid residues`
+    return bio('protein', 'pdb', why)
+  }
+  if (nucleic_like) return bio('nucleic', 'pdb', `${nucleic_res.size} nucleotide residues`)
+  return not_bio('pdb', `no polymer markers (amino=${amino_res.size}, nucleic=${nucleic_res.size})`)
+}
+
+function detect_cif(text: string): BioDetectResult {
+  const t = text.toLowerCase()
+  const protein = t.includes('polypeptide')
+  const nucleic = t.includes('polyribonucleotide') || t.includes('polydeoxyribonucleotide')
+  const has_conf = t.includes('_struct_conf') || t.includes('_struct_sheet')
+
+  if (protein && nucleic) return bio('mixed', 'mmcif', '_entity_poly: protein + nucleic')
+  if (protein) return bio('protein', 'mmcif', '_entity_poly polypeptide')
+  if (nucleic) return bio('nucleic', 'mmcif', '_entity_poly polynucleotide')
+  if (has_conf) return bio('protein', 'mmcif', '_struct_conf/_struct_sheet present')
+  return not_bio('mmcif', 'no _entity_poly polypeptide/nucleotide markers')
+}
+
+export function detect_bio(text: string, filename: string): BioDetectResult {
+  const ext = ext_of(filename)
+  if (ext === 'pdb' || ext === 'ent') return detect_pdb(text)
+  if (ext === 'cif' || ext === 'mmcif' || ext === 'mcif') return detect_cif(text)
+  return not_bio(null, `.${ext} is not a bio-candidate extension`)
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `rtk proxy pnpm exec vitest run src/lib/structure/bio/detect.test.ts`
+Expected: PASS — 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/bio/detect.ts src/lib/structure/bio/detect.test.ts
+git commit -m "feat(bio): content sniffer to route protein/nucleic files to Mol*"
+```
+
+---
+
+## Task 3: `MolstarViewer.svelte` component
+
+**Files:**
+- Create: `src/lib/structure/bio/MolstarViewer.svelte`
+
+This component owns the Mol\* lifecycle. It lazy-loads molstar (JS + CSS) inside
+`onMount` so the multi-MB bundle is split out of the main chunk and only fetched
+when a bio file is actually opened — mirroring the existing dynamic-import
+patterns (`TerminalPanel.svelte` lazy-loads `@xterm`, `App.svelte` lazy-loads
+`chgdiff-wasm`).
+
+- [ ] **Step 1: Create the component**
+
+Create `src/lib/structure/bio/MolstarViewer.svelte`:
+
+```svelte
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte'
+
+  let {
+    content,
+    format = `pdb`,
+    label = `structure`,
+  }: { content: string; format?: string; label?: string } = $props()
+
+  let container = $state<HTMLDivElement>()
+  let viewer: {
+    dispose: () => void
+    loadStructureFromData: (
+      data: string,
+      format: string,
+      options?: { dataLabel?: string },
+    ) => Promise<void>
+  } | null = null
+  let error = $state<string | null>(null)
+
+  onMount(async () => {
+    try {
+      // Prebuilt CSS skin (plain CSS — no sass toolchain needed).
+      await import(`molstar/build/viewer/molstar.css`)
+      const { Viewer } = await import(`molstar/lib/apps/viewer/app`)
+      if (!container) return
+      viewer = await Viewer.create(container, {
+        layoutIsExpanded: false,
+        layoutShowControls: true,
+        layoutShowSequence: true,
+        layoutShowLog: false,
+        layoutShowLeftPanel: true,
+        viewportShowExpand: true,
+        viewportShowSelectionMode: true,
+      })
+      await viewer.loadStructureFromData(content, format, { dataLabel: label })
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+      console.error(`[MolstarViewer] failed to load:`, e)
+    }
+  })
+
+  onDestroy(() => {
+    viewer?.dispose()
+    viewer = null
+  })
+</script>
+
+<div class="molstar-pane" bind:this={container}>
+  {#if error}
+    <div class="molstar-error">Mol* failed to load: {error}</div>
+  {/if}
+</div>
+
+<style>
+  /* Mol*'s UI positions absolutely inside this box; it needs relative + size.
+     Never display:none this pane on mobile — it zeroes the WebGL canvas
+     (see CLAUDE.md iOS invariants). */
+  .molstar-pane {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+  .molstar-error {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    color: var(--error-color, #c0392b);
+    font-size: 0.9rem;
+    text-align: center;
+  }
+</style>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm check`
+Expected: no new errors referencing `MolstarViewer.svelte`. (If `molstar/lib/apps/viewer/app` has no bundled types, the structural `viewer` type annotation above keeps `pnpm check` green without a `molstar.d.ts` shim. If `check` complains about the dynamic-import module path, add `// @ts-expect-error molstar ships no types for this entry` directly above the `import(\`molstar/lib/apps/viewer/app\`)` line.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/structure/bio/MolstarViewer.svelte
+git commit -m "feat(bio): MolstarViewer component (lazy-loaded Mol* pane)"
+```
+
+---
+
+## Task 4: `BioViewerToggle.svelte` override control
+
+**Files:**
+- Create: `src/lib/structure/bio/BioViewerToggle.svelte`
+- Modify: `src/lib/i18n/en/structure.ts`, `src/lib/i18n/zh/structure.ts`
+
+A small floating button that flips a pane between Mol\* and native. Rendered by
+App.svelte (and mobile) only when the pane carries `bio_raw_content`, so it never
+touches the heavy `Structure.svelte` internals.
+
+- [ ] **Step 1: Add i18n strings (en)**
+
+In `src/lib/i18n/en/structure.ts`, add to the exported `structure` record:
+
+```ts
+  bio_open_in_native: `Open in native viewer`,
+  bio_open_in_molstar: `Open in Mol*`,
+```
+
+- [ ] **Step 2: Add i18n strings (zh) — keep key parity**
+
+In `src/lib/i18n/zh/structure.ts`, add the SAME keys:
+
+```ts
+  bio_open_in_native: `用原生查看器打开`,
+  bio_open_in_molstar: `在 Mol* 中打开`,
+```
+
+- [ ] **Step 3: Create the toggle component**
+
+Create `src/lib/structure/bio/BioViewerToggle.svelte`:
+
+```svelte
+<script lang="ts">
+  import { t } from '$lib/i18n/index.svelte'
+
+  let {
+    is_molstar,
+    on_toggle,
+  }: { is_molstar: boolean; on_toggle: () => void } = $props()
+</script>
+
+<button class="bio-toggle" onclick={on_toggle} type="button">
+  {is_molstar ? t(`structure.bio_open_in_native`) : t(`structure.bio_open_in_molstar`)}
+</button>
+
+<style>
+  .bio-toggle {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 20;
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    border: 1px solid var(--border-color, #ccc);
+    border-radius: 6px;
+    background: var(--panel-bg, rgba(255, 255, 255, 0.9));
+    color: var(--text-color, #222);
+    cursor: pointer;
+  }
+  .bio-toggle:hover {
+    background: var(--hover-bg, rgba(0, 0, 0, 0.06));
+  }
+</style>
+```
+
+- [ ] **Step 4: Verify i18n key parity**
+
+Run:
+```bash
+rtk proxy pnpm exec vitest run -t i18n
+```
+Expected: PASS — if a parity test exists it stays green (en/zh key sets match). If no such test runs, instead confirm both files have the two new keys with:
+```bash
+grep -c "bio_open_in_native\|bio_open_in_molstar" src/lib/i18n/en/structure.ts src/lib/i18n/zh/structure.ts
+```
+Expected: each file reports `2`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/bio/BioViewerToggle.svelte src/lib/i18n/en/structure.ts src/lib/i18n/zh/structure.ts
+git commit -m "feat(bio): viewer override toggle + i18n strings"
+```
+
+---
+
+## Task 5: Extend pane / library types
+
+**Files:**
+- Modify: `desktop/pane-utils.ts:11-58`
+
+- [ ] **Step 1: Add fields to `PaneState`**
+
+In `desktop/pane-utils.ts`, inside `interface PaneState` (after `source_filename` at line 34), add:
+
+```ts
+  /** Which viewer renders this pane. Absent/'native' = Three.js viewer. */
+  viewer_kind?: 'native' | 'molstar'
+  /** Raw file text for Mol* (bio files bypass pymatgen parsing). */
+  bio_raw_content?: string
+  /** Mol* format string ('pdb' | 'mmcif') for loadStructureFromData. */
+  bio_format?: string
+```
+
+- [ ] **Step 2: Add the same fields to `LibraryEntry`**
+
+In the same file, inside `interface LibraryEntry` (after `raw_traj_format?` at line 57), add:
+
+```ts
+  viewer_kind?: 'native' | 'molstar'
+  bio_raw_content?: string
+  bio_format?: string
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm check`
+Expected: no new errors (fields are optional; existing code unaffected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add desktop/pane-utils.ts
+git commit -m "feat(bio): pane/library fields for Mol* routing"
+```
+
+---
+
+## Task 6: Route bio files through `ingest_one` + carry into the pane
+
+**Files:**
+- Modify: `desktop/App.svelte` (imports near line 16; `ingest_one` ~993; `apply_entry_to_pane` ~1027)
+
+- [ ] **Step 1: Import the sniffer**
+
+In `desktop/App.svelte`, near the other `$lib/structure` imports (around line 16), add:
+
+```ts
+  import { detect_bio } from '$lib/structure/bio/detect'
+```
+
+- [ ] **Step 2: Add the bio branch in `ingest_one`**
+
+In `ingest_one`, immediately BEFORE the final `const parsed = parse_structure_file(text, filename)` (currently line 993), insert:
+
+```ts
+    // Biological macromolecule (protein / nucleic acid) → render in Mol*.
+    // Bio files bypass pymatgen/ferrox entirely: handing Mol* the raw text
+    // preserves residue/chain/secondary-structure and skips the (expensive,
+    // metadata-lossy) native parse of large proteins.
+    const bio = detect_bio(text, filename)
+    if (bio.isBio && bio.format) {
+      return {
+        kind: `entry`,
+        entry: {
+          filename, source_path: null, format: ext, structure: undefined,
+          trajectory: undefined, is_trajectory: false, cube_file: null,
+          viewer_kind: `molstar`, bio_raw_content: text, bio_format: bio.format,
+        },
+      }
+    }
+```
+
+- [ ] **Step 3: Carry the fields into the pane in `apply_entry_to_pane`**
+
+In `apply_entry_to_pane`, find the trailing common assignments (after the `if/else if/else` structure block, around line 1035 where `p.selected_sites = []` begins) and add, right after `p.source_filename = e.filename` (line 1040):
+
+```ts
+    p.viewer_kind = e.viewer_kind ?? `native`
+    p.bio_raw_content = e.bio_raw_content
+    p.bio_format = e.bio_format
+```
+
+Also, at the TOP of `apply_entry_to_pane`, the existing branches set `p.structure`. For a molstar entry `e.structure` is `undefined`, so it falls into the final `else` branch and sets `p.structure = undefined` — correct (the molstar render branch does not need a parsed structure). No change needed there.
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm check`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop/App.svelte
+git commit -m "feat(bio): route detected bio files to Mol* at ingest"
+```
+
+---
+
+## Task 7: Desktop render branch + override wiring
+
+**Files:**
+- Modify: `desktop/App.svelte` (imports ~line 5; render switch ~1769)
+
+- [ ] **Step 1: Import the new components**
+
+Near the top component imports of `desktop/App.svelte` (the `import { Structure, Trajectory } from '$lib'` line is line 5), add:
+
+```ts
+  import MolstarViewer from '$lib/structure/bio/MolstarViewer.svelte'
+  import BioViewerToggle from '$lib/structure/bio/BioViewerToggle.svelte'
+```
+
+- [ ] **Step 2: Add a helper to toggle a pane's viewer**
+
+In the `<script>` block of `desktop/App.svelte` (near `apply_entry_to_pane`), add:
+
+```ts
+  /** Flip a pane between Mol* and the native viewer (manual override). */
+  function toggle_pane_viewer(ts: StructureTabState, idx: number) {
+    const p = ts.panes[idx]
+    if (!p.bio_raw_content) return
+    if (p.viewer_kind === `molstar`) {
+      // → native: parse the raw text on demand (lazy; only when overridden).
+      const parsed = parse_structure_file(p.bio_raw_content, p.source_filename || `bio`)
+      if (parsed?.sites?.length) {
+        p.structure = parsed
+        p.initial_site_count = parsed.sites.length
+        p.initial_structure_ref = parsed
+      }
+      p.viewer_kind = `native`
+    } else {
+      p.viewer_kind = `molstar`
+    }
+  }
+```
+
+- [ ] **Step 3: Insert the molstar render branch**
+
+In the render switch, the chain currently is: trajectory branch → `{:else if pane.structure}` (line 1769) → `{:else}` landing. Insert a molstar branch BEFORE `{:else if pane.structure}` so a bio pane never falls into the native `Structure` branch.
+
+Replace the line `{:else if pane.structure}` (1769) with:
+
+```svelte
+              {:else if pane.viewer_kind === `molstar` && pane.bio_raw_content}
+                <div class="bio-pane-wrap">
+                  <BioViewerToggle
+                    is_molstar={true}
+                    on_toggle={() => toggle_pane_viewer(ts, idx)}
+                  />
+                  {#key pane.bio_raw_content}
+                    <MolstarViewer
+                      content={pane.bio_raw_content}
+                      format={pane.bio_format ?? `pdb`}
+                      label={pane.source_filename ?? `structure`}
+                    />
+                  {/key}
+                </div>
+              {:else if pane.structure}
+```
+
+The `{#key pane.bio_raw_content}` remounts Mol\* when a different bio file lands
+in the same pane (Mol\* loads once in `onMount`).
+
+- [ ] **Step 4: Add the "back to Mol\*" override on the native branch**
+
+So a user who overrode to native (or whose bio file they want re-opened in Mol\*) can switch back: inside the existing `{:else if pane.structure}` branch, wrap the `<Structure .../>` so the toggle shows when the pane has bio content. Immediately AFTER the opening of that branch and BEFORE `<Structure`, add:
+
+```svelte
+                {#if pane.bio_raw_content}
+                  <BioViewerToggle
+                    is_molstar={false}
+                    on_toggle={() => toggle_pane_viewer(ts, idx)}
+                  />
+                {/if}
+```
+
+(The pane container is already `position: relative` for the existing layout; the toggle is absolutely positioned. If the toggle does not appear, confirm the immediate wrapper has `position: relative` and add it in Step 6 styling.)
+
+- [ ] **Step 5: Add wrapper styling**
+
+In the `<style>` block of `desktop/App.svelte`, add:
+
+```css
+  .bio-pane-wrap {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+```
+
+- [ ] **Step 6: Type-check**
+
+Run: `pnpm check`
+Expected: no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add desktop/App.svelte
+git commit -m "feat(bio): desktop Mol* render branch + manual override toggle"
+```
+
+---
+
+## Task 8: Mobile render branch
+
+**Files:**
+- Modify: `src/lib/mobile/MobileWorkspace.svelte`
+
+- [ ] **Step 1: Locate the mobile structure mount**
+
+Run:
+```bash
+grep -n "<Structure\|import Structure\|viewer_kind\|pane.structure" src/lib/mobile/MobileWorkspace.svelte
+```
+Expected: shows the `import Structure from '$lib/structure/Structure.svelte'` (~line 19) and the `<Structure ... />` mount site.
+
+- [ ] **Step 2: Import MolstarViewer + toggle**
+
+Near the existing `import Structure` line in `src/lib/mobile/MobileWorkspace.svelte`, add:
+
+```ts
+  import MolstarViewer from '$lib/structure/bio/MolstarViewer.svelte'
+  import BioViewerToggle from '$lib/structure/bio/BioViewerToggle.svelte'
+```
+
+- [ ] **Step 3: Mirror the desktop branch**
+
+At the `<Structure ... />` mount site, wrap it in the same conditional used on
+desktop. The mobile workspace uses a single active pane (call its pane object
+`pane` — match the variable the surrounding markup already uses). Add BEFORE the
+`<Structure` mount:
+
+```svelte
+{#if pane.viewer_kind === `molstar` && pane.bio_raw_content}
+  <div class="bio-pane-wrap">
+    <BioViewerToggle is_molstar={true} on_toggle={() => /* mobile toggle handler */ toggle_mobile_viewer()} />
+    {#key pane.bio_raw_content}
+      <MolstarViewer content={pane.bio_raw_content} format={pane.bio_format ?? `pdb`} label={pane.source_filename ?? `structure`} />
+    {/key}
+  </div>
+{:else}
+  <!-- existing <Structure ... /> mount stays here, unchanged -->
+{/if}
+```
+
+Implement `toggle_mobile_viewer()` to flip the active pane's `viewer_kind`
+the same way `toggle_pane_viewer` does on desktop (parse `bio_raw_content` via
+`parse_any_structure` — already imported in this file at ~line 22 — when
+switching to native). Add `.bio-pane-wrap { position: relative; width: 100%; height: 100%; }` to the component `<style>`.
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm check`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mobile/MobileWorkspace.svelte
+git commit -m "feat(bio): mobile Mol* render branch"
+```
+
+---
+
+## Task 9: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `rtk proxy pnpm exec vitest run`
+Expected: PASS — the prior baseline (≈3872 tests / 142 files) plus the 6 new `detect_bio` tests, no regressions.
+
+- [ ] **Step 2: Type-check the whole project**
+
+Run: `pnpm check`
+Expected: no new errors introduced by this branch.
+
+- [ ] **Step 3: Desktop manual verification (agent-browser)**
+
+Use the `verify` skill / agent-browser against the dev app (`pnpm desktop:serve`).
+Fetch a real small protein PDB to disk first, e.g.:
+```bash
+curl -sL https://files.rcsb.org/download/1CRN.pdb -o /tmp/1crn.pdb
+```
+Then, in the running app: load `/tmp/1crn.pdb` (drag-drop or the file-open flow).
+
+Verify:
+- The pane renders the Mol\* UI (cartoon ribbon for crangin), not the native ball-and-stick viewer.
+- The floating "Open in native viewer" toggle is visible; clicking it switches to the native Three.js viewer (ball-and-stick), and the toggle now reads "Open in Mol\*"; clicking again returns to Mol\*.
+- Load a crystal file (`.cif`/POSCAR) and confirm it still opens in the **native** viewer (no regression, no Mol\* pane, no toggle).
+
+- [ ] **Step 4: Mobile smoke test (on device, per iOS notes)**
+
+Per `deploy/ios/LOCAL-TESTING-PROGRESS.md`, launch the iOS dev build
+(`TAURI_DEV_HOST=<Mac LAN IP> pnpm tauri ios dev "<device>"`). Load a small PDB
+and confirm Mol\* initializes (WebGL2) and renders without the WKWebView going
+blank. Note any UI-cramping of Mol\*'s panels on the small screen as a known
+follow-up (acceptable for v1).
+
+- [ ] **Step 5: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to decide merge / PR.
+
+---
+
+## Self-Review notes (addressed)
+
+- **Spec coverage:** sniffer (Task 2) = §Components.1 + heuristic B; MolstarViewer (Task 3) = §Components.2 + full Mol\* UI decision; routing (Tasks 6–7) = §Components.3 + data-flow (raw bytes bypass pymatgen); override toggle (Tasks 4,7) = decision C; mobile (Task 8) = §Mobile; testing (Task 9) = §Testing. HTTP/MCP path is explicitly Deferred in the spec — no task, by design.
+- **Type consistency:** `viewer_kind`/`bio_raw_content`/`bio_format` names identical across `PaneState`, `LibraryEntry`, `ingest_one` entry, `apply_entry_to_pane`, and render branch. `detect_bio` returns `format: 'pdb'|'mmcif'` which is exactly what Mol\*'s `loadStructureFromData` accepts and what the pane stores in `bio_format`.
+- **No placeholders:** every code step is concrete. The two grep-and-mirror steps (mobile Task 8, native-branch wrapper) reference exact files and give the full code to insert; the only deliberately open detail is the surrounding mobile pane variable name, which must match existing markup (cannot be hard-coded blind).

--- a/docs/superpowers/plans/2026-06-14-molstar-bio-viewer.md
+++ b/docs/superpowers/plans/2026-06-14-molstar-bio-viewer.md
@@ -35,9 +35,9 @@
 
 - [ ] **Step 1: Install molstar**
 
-Run:
+Run (from the repo root):
 ```bash
-cd /home/james0001/project/catgo-LRG && pnpm add molstar
+pnpm add molstar
 ```
 Expected: `package.json` gains a `"molstar": "^4.x.x"` line under `dependencies`; `pnpm-lock.yaml` updates.
 

--- a/docs/superpowers/specs/2026-06-14-molstar-bio-viewer-design.md
+++ b/docs/superpowers/specs/2026-06-14-molstar-bio-viewer-design.md
@@ -1,0 +1,166 @@
+# Mol\* Bio Viewer — Design
+
+**Date:** 2026-06-14
+**Branch:** `feat/molstar-bio-viewer`
+**Status:** Approved design, pending implementation plan
+
+## Goal
+
+Let CatGo visualize biological systems (proteins, nucleic acids). When the user
+opens a biomolecular structure file (PDB / mmCIF), render it with **Mol\***
+(molstar) — which provides cartoon/ribbon, surface, sequence view, and
+measurement out of the box. Materials systems (crystals, slabs, molecules)
+continue to use the existing native Three.js viewer, unchanged.
+
+**Scope: pure viewing only.** No compute handoff, no active-site cutout, no
+bridge into the DFT/QM pipeline. User clicks a file → it visualizes.
+
+## Non-goals (explicit YAGNI)
+
+- No Mol\* → CatGo compute bridge (no "cut active site → QM region").
+- No custom cartoon/surface re-implementation in the native Three.js viewer.
+- No re-skinning Mol\*; we use its built-in UI as-is.
+- No routing for the HTTP/MCP/`curl` `upload-and-load` path in v1 (see Deferred).
+- No editing of biomolecules inside Mol\* persisted back to CatGo.
+
+## Background (current state)
+
+From codebase exploration:
+
+- PDB/mmCIF already load via pymatgen + a custom TS PDB parser, but the pipeline
+  **drops** residue name/number, chain id, B-factor, occupancy — `Site` keeps
+  only `label`. (`src/lib/structure/index.ts:87-93`, `src/lib/structure/parsers/pdb.ts`)
+- The native viewer is ball-and-stick + polyhedra only — **no cartoon/ribbon,
+  no surface mesh, no residue/chain coloring**. (`src/lib/structure/StructureScene.svelte`)
+- Bonds come from ferrox-wasm distance/solid-angle detection; fine for crystals,
+  not built for protein-scale secondary structure.
+- Non-periodic (no-cell) systems already render via a synthetic padding box, so
+  "molecule mode" works.
+
+Conclusion: matching PyMOL/Mol\* fidelity natively is months of work. Embedding
+Mol\* gets full bio fidelity fast. We embed it as a **parallel viewer**.
+
+## Architecture — parallel viewer
+
+Mol\* ships its own WebGL2 context, canvas, camera, scene graph, and file
+parsers. It does **not** reuse CatGo's Three.js scene, ferrox bonding, or
+pymatgen pipeline. It is a **second viewer pane** that lives alongside the
+native viewer.
+
+```
+file opened (raw text + filename)
+        │
+        ▼
+   bio sniffer  ──── not bio ────▶  existing native load path (unchanged)
+        │
+       bio
+        │
+        ▼
+   Mol* pane  ◀── raw bytes fed straight to Mol*'s own parser
+   (cartoon + ligand, full Mol* UI)
+        │
+   manual override toggle ⇄ "open in native" / "open in Mol*"
+```
+
+Two **parallel pipelines** that do not interfere. Bio files bypass
+pymatgen/ferrox entirely (which is what preserves residue/chain/B-factor —
+Mol\* keeps all of it).
+
+## Components
+
+### 1. `src/lib/structure/bio/detect.ts` — content sniffer (pure)
+
+- **Input:** raw file text + filename.
+- **Output:** `{ isBio: boolean, kind: 'protein' | 'nucleic' | 'mixed' | null, reason: string }`.
+- **Heuristics (B — content sniff, not just extension):**
+  - PDB: presence of `SEQRES`, `HELIX`, or `SHEET` records; OR ≥ K (e.g. 10)
+    ATOM records whose residue name is a standard amino acid / nucleotide.
+  - mmCIF: `_entity_poly.type` containing `polypeptide` or `polynucleotide`;
+    OR `_struct_conf` / `_struct_sheet` categories present.
+  - Reason string is human-readable (drives the manual-override UI hint and
+    aids debugging).
+- **Pure function → vitest-unit-testable** (vitest is the CI gate).
+- Conservative: when ambiguous, return `isBio: false` (fall through to native),
+  since the manual override (C) lets the user force Mol\*.
+
+### 2. `src/lib/structure/bio/MolstarViewer.svelte`
+
+- **Lazy-loads** `molstar` via dynamic `import('molstar')` inside `onMount` —
+  keeps the multi-MB Mol\* bundle out of the main chunk; only fetched when a bio
+  file is actually opened.
+- Mounts Mol\*'s **built-in all-in-one `Viewer`** (full UI: left/right control
+  panels, sequence track, representation switcher, measurement). No custom
+  layout.
+- Feeds raw file content (string) + format to Mol\*'s loader; default preset =
+  cartoon for polymer + ball-and-stick for ligands/het.
+- Cleans up the Mol\* plugin on unmount (dispose context, free WebGL).
+
+### 3. Routing integration (frontend file-open flow)
+
+- In the frontend load orchestrator (the function that today receives file
+  content + name and dispatches to the parser — **exact function identified
+  during planning**): after reading content, call `detect()`.
+  - `isBio` → mount a `MolstarViewer` pane for that tab/structure.
+  - else → existing native path, untouched.
+- **Manual override (C):** a small control on the pane to switch
+  "Open in Mol\* ⇄ Open in native viewer", so a misrouted file is one click to
+  fix either direction.
+
+### 4. Pane / tab integration
+
+- The Mol\* pane slots into CatGo's existing tab/pane model the same way the
+  native viewer pane does — a tab can host either a native viewer or a Mol\*
+  viewer.
+- **iOS invariant (from CLAUDE.md):** never `display:none` a live WebGL pane —
+  it zeroes the canvas. Keep Mol\* mounted/off-screen rather than hidden, same
+  rule as the native 3D pane.
+
+## Data flow
+
+Bio files take raw bytes → Mol\*'s in-browser parser. They never touch
+pymatgen serialization or ferrox bond detection, which is precisely why
+residue/chain/secondary-structure/B-factor survive. The native pipeline is
+untouched for everything else.
+
+## Mobile / iOS (in scope)
+
+Mobile is **included**, with these constraints to verify on-device (per the
+`deploy/ios/LOCAL-TESTING-PROGRESS.md` flow):
+
+- Mol\* requires **WebGL2** — supported in iOS 15+ WKWebView; verify it
+  initializes and renders a real PDB on a device.
+- **Bundle size / memory:** lazy import is mandatory on mobile; confirm the
+  chunk loads over `TAURI_DEV_HOST` and the WebView doesn't OOM on a mid-size
+  protein.
+- **Mol\* full UI on a small screen** is desktop-oriented and may be cramped;
+  acceptable for v1 (built-in UI per decision), but note responsiveness as a
+  known rough edge to revisit, not a blocker.
+- Because Mol\* parses raw bytes **client-side**, it has no backend-URL / CORS
+  dependency — fewer mobile gotchas than the native pipeline.
+
+## Testing
+
+- `detect.ts` → vitest unit tests: protein PDB, nucleic-acid PDB, mmCIF polymer,
+  vs. a crystal CIF, a POSCAR, a small-molecule mol2 → assert correct routing.
+- Mol\* rendering (WebGL) is not unit-testable → **agent-browser** manual
+  verification: open a real PDB (e.g. a small protein) on desktop, confirm
+  cartoon renders and the manual override switches to native and back.
+- Mobile: on-device smoke test per iOS notes (load one PDB, confirm render).
+
+## Deferred (future, not v1)
+
+- Routing for the HTTP/MCP/`curl upload-and-load` path. v1 routes only the
+  frontend file-open flow (the user's stated "click a file" use case). Files
+  pushed via curl/MCP continue to the native pipeline, with the manual override
+  available to switch to Mol\*. Porting the sniffer to Python for backend
+  auto-routing is a later step.
+- Compute handoff (active-site cutout → DFT/QM).
+- Custom/trimmed Mol\* layout.
+
+## Open items to resolve in planning
+
+1. Exact frontend load-orchestrator function where routing hooks in.
+2. How a Mol\* pane is represented in the tab/pane store (new pane "kind").
+3. Which `molstar` entry point: the prebuilt `Viewer` wrapper vs. constructing
+   `PluginUIContext` — both give full UI; pick the lower-friction one for the
+   bundler (Vite 7).

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "js-yaml": "^4.1.0",
     "jszip": "^3.10.1",
     "katex": "^0.16.33",
+    "molstar": "^5.9.0",
     "monaco-editor": "^0.55.1",
     "plotly.js-dist-min": "^3.3.1",
     "quickhull3d": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       katex:
         specifier: ^0.16.33
         version: 0.16.33
+      molstar:
+        specifier: ^5.9.0
+        version: 5.9.0(@types/react@18.3.31)(fp-ts@2.16.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -304,7 +307,7 @@ importers:
         version: 7.3.1(@types/node@25.0.10)
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.48.0)(@types/node@25.0.10)(fuse.js@7.1.0)(markdown-it-mathjax3@4.3.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.48.0)(@types/node@25.0.10)(@types/react@18.3.31)(fuse.js@7.1.0)(markdown-it-mathjax3@4.3.2)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.6
         version: 4.0.18(@types/node@25.0.10)(happy-dom@20.3.7)
@@ -1270,6 +1273,9 @@ packages:
   '@sapphi-red/web-noise-suppressor@0.3.5':
     resolution: {integrity: sha512-jh3+V9yM+zxLriQexoGm0GatoPaJWjs6ypFIbFYwQp+AoUb55eUXrjKtKQyuC5zShzzeAQUl0M5JzqB7SSrsRA==}
 
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1494,11 +1500,26 @@ packages:
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
+  '@types/argparse@2.0.17':
+    resolution: {integrity: sha512-fueJssTf+4dW4HODshEGkIZbkLKHzgu1FvCI4cTc/MKum/534Euo3SrN+ilq8xgyHnOjtmg33/hee8iXLRg1XA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/benchmark@2.1.5':
+    resolution: {integrity: sha512-cKio2eFB3v7qmKcvIHLUMw/dIx/8bhWPuzpzRT4unCPRTD8VdA9Zb0afxpcxOqR4PixRS7yT42FqGS8BYL8g1w==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/compression@1.8.1':
+    resolution: {integrity: sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -1539,14 +1560,29 @@ packages:
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -1569,14 +1605,41 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
+
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/node@25.0.10':
     resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/swagger-ui-dist@3.30.6':
+    resolution: {integrity: sha512-FVxN7wjLYRtJsZBscOcOcf8oR++m38vbUFjT33Mr9HBuasX9bRDrJsp7iwixcOtKSHEEa2B7o2+4wEiXqC+Ebw==}
 
   '@types/three@0.181.0':
     resolution: {integrity: sha512-MLF1ks8yRM2k71D7RprFpDb9DOX0p22DbdPqT/uAkc6AtQXjxWCVDjCy23G9t1o8HcQPk7woD2NIyiaWcWPYmA==}
@@ -1973,6 +2036,12 @@ packages:
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   cheerio-select@1.6.0:
     resolution: {integrity: sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==}
 
@@ -2029,6 +2098,14 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  compressible@2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
+    engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2223,6 +2300,14 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2231,6 +2316,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
@@ -2385,6 +2473,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-plugin-svelte@3.14.0:
     resolution: {integrity: sha512-Isw0GvaMm0yHxAj71edAdGFh28ufYs+6rk2KlbbZphnqZAzrH3Se3t12IFh2H9+1F/jlDhBBL4oiOJmLqmYX0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2442,6 +2534,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -2535,6 +2630,9 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  fp-ts@2.16.11:
+    resolution: {integrity: sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==}
+
   frac@1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
@@ -2620,6 +2718,9 @@ packages:
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
+  h264-mp4-encoder@1.0.12:
+    resolution: {integrity: sha512-xih3J+Go0o1RqGjhOt6TwXLWWGqLONRPyS8yoMu/RoS/S8WyEv4HuHp1KBsDDl8srZQ3gw9f95JYkCSjCuZbHQ==}
+
   h5wasm@0.8.11:
     resolution: {integrity: sha512-oZ/sZA155VVQl6d37Gay6RnjwGTrS63Lm8wZzhrbRdJr0nAswr9KCmu8qSUMlQn1TSOIK1kEBnpmH2XztwFq6w==}
 
@@ -2666,6 +2767,9 @@ packages:
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
   hast-util-to-string@3.0.1:
     resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
@@ -2691,6 +2795,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -2724,6 +2831,9 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
+  immutable@5.1.6:
+    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2735,9 +2845,17 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  io-ts@2.2.22:
+    resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
+    peerDependencies:
+      fp-ts: ^2.5.0
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -2746,6 +2864,15 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2758,6 +2885,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -2872,6 +3002,13 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -2898,6 +3035,9 @@ packages:
   markdown-it-mathjax3@4.3.2:
     resolution: {integrity: sha512-TX3GW5NjmupgFtMJGRauioMbbkGsOXAAt1DZ/rzzYmTHqzkO1rNAdiMD4NiruurToPApn2kYy76x02QN26qr2w==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
@@ -2915,8 +3055,50 @@ packages:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
     deprecated: Version 4 replaces this package with the scoped package @mathjax/src
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdsvex@0.12.6:
     resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
@@ -2949,20 +3131,89 @@ packages:
   mhchemparser@4.2.1:
     resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -3001,6 +3252,30 @@ packages:
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
+  molstar@5.9.0:
+    resolution: {integrity: sha512-yNf9FpWVxoo0blc4y0joCE83/OEFNWlhlGYPEWIO0OYgkshT25R5qYJJdsKJwlEG44q2tjKbQ+e0LXV10hpBQg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/storage': ^7.14.0
+      canvas: ^2.11.2
+      gl: ^6.0.2
+      jpeg-js: ^0.4.4
+      pngjs: ^6.0.0
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+    peerDependenciesMeta:
+      '@google-cloud/storage':
+        optional: true
+      canvas:
+        optional: true
+      gl:
+        optional: true
+      jpeg-js:
+        optional: true
+      pngjs:
+        optional: true
+
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
@@ -3015,8 +3290,15 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mutative@1.3.0:
+    resolution: {integrity: sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==}
+    engines: {node: '>=14.0'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3025,6 +3307,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -3065,6 +3351,10 @@ packages:
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -3110,6 +3400,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -3264,8 +3557,23 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -3296,8 +3604,20 @@ packages:
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-math@3.0.1:
     resolution: {integrity: sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3355,8 +3675,14 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -3495,6 +3821,12 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
@@ -3575,6 +3907,9 @@ packages:
   svelte@5.48.0:
     resolution: {integrity: sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==}
     engines: {node: '>=18'}
+
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -3703,6 +4038,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -4199,9 +4537,9 @@ snapshots:
 
   '@docsearch/css@3.8.2': {}
 
-  '@docsearch/js@3.8.2(@algolia/client-search@5.48.0)(search-insights@2.17.3)':
+  '@docsearch/js@3.8.2(@algolia/client-search@5.48.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
     dependencies:
-      '@docsearch/react': 3.8.2(@algolia/client-search@5.48.0)(search-insights@2.17.3)
+      '@docsearch/react': 3.8.2(@algolia/client-search@5.48.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
       preact: 10.28.3
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -4210,13 +4548,16 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@docsearch/react@3.8.2(@algolia/client-search@5.48.0)(search-insights@2.17.3)':
+  '@docsearch/react@3.8.2(@algolia/client-search@5.48.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.48.0)(algoliasearch@5.48.0)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.48.0)(algoliasearch@5.48.0)
       '@docsearch/css': 3.8.2
       algoliasearch: 5.48.0
     optionalDependencies:
+      '@types/react': 18.3.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -4749,6 +5090,8 @@ snapshots:
 
   '@sapphi-red/web-noise-suppressor@0.3.5': {}
 
+  '@scarf/scarf@1.4.0': {}
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -4989,12 +5332,30 @@ snapshots:
 
   '@tweenjs/tween.js@23.1.3': {}
 
+  '@types/argparse@2.0.17': {}
+
   '@types/aria-query@5.0.4': {}
+
+  '@types/benchmark@2.1.5': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.0.10
 
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/compression@1.8.1':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/node': 25.0.10
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.0.10
 
   '@types/cookie@0.6.0': {}
 
@@ -5026,13 +5387,36 @@ snapshots:
 
   '@types/d3-time@3.0.4': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.0.10
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/js-yaml@4.0.9': {}
 
@@ -5053,6 +5437,12 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/ms@2.1.0': {}
+
+  '@types/node@22.19.21':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.12.0':
     dependencies:
       undici-types: 7.16.0
@@ -5060,9 +5450,30 @@ snapshots:
   '@types/node@25.0.10':
     dependencies:
       undici-types: 7.16.0
-    optional: true
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.0.10
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.0.10
 
   '@types/stats.js@0.17.4': {}
+
+  '@types/swagger-ui-dist@3.30.6': {}
 
   '@types/three@0.181.0':
     dependencies:
@@ -5518,6 +5929,10 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   cheerio-select@1.6.0:
     dependencies:
       css-select: 4.3.0
@@ -5571,6 +5986,22 @@ snapshots:
   commander@7.2.0: {}
 
   commander@8.3.0: {}
+
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.54.0
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   concat-map@0.0.1: {}
 
@@ -5780,9 +6211,17 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   dedent-js@1.0.1: {}
 
@@ -5955,6 +6394,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-plugin-svelte@3.14.0(eslint@9.39.2)(svelte@5.48.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
@@ -6044,6 +6485,8 @@ snapshots:
       estraverse: 5.3.0
 
   estraverse@5.3.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@2.0.2: {}
 
@@ -6152,6 +6595,8 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  fp-ts@2.16.11: {}
+
   frac@1.1.2: {}
 
   fresh@2.0.0: {}
@@ -6231,6 +6676,8 @@ snapshots:
   gopd@1.2.0: {}
 
   guid-typescript@1.0.9: {}
+
+  h264-mp4-encoder@1.0.12: {}
 
   h5wasm@0.8.11: {}
 
@@ -6317,6 +6764,26 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-to-string@3.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -6347,6 +6814,8 @@ snapshots:
   hookable@5.5.3: {}
 
   html-escaper@2.0.2: {}
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -6386,6 +6855,8 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  immutable@5.1.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6395,11 +6866,26 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   internmap@2.0.3: {}
+
+  io-ts@2.2.22(fp-ts@2.16.11):
+    dependencies:
+      fp-ts: 2.16.11
 
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -6408,6 +6894,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -6513,6 +7001,12 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.181.0)(three@0.181.2(patch_hash=135875ae2386a6ee9ff9516832e12ff0e50270b82597b4a26a8a70e725b5ea60)):
@@ -6543,6 +7037,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  markdown-table@3.0.4: {}
+
   marked@14.0.0: {}
 
   matcher@3.0.0:
@@ -6558,6 +7054,131 @@ snapshots:
       mj-context-menu: 0.6.1
       speech-rule-engine: 4.1.2
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -6569,6 +7190,22 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdsvex@0.12.6(svelte@5.48.0):
     dependencies:
@@ -6602,12 +7239,157 @@ snapshots:
 
   mhchemparser@4.2.1: {}
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
@@ -6615,9 +7397,38 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.54.0: {}
 
@@ -6647,6 +7458,34 @@ snapshots:
 
   mj-context-menu@0.6.1: {}
 
+  molstar@5.9.0(@types/react@18.3.31)(fp-ts@2.16.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@types/argparse': 2.0.17
+      '@types/benchmark': 2.1.5
+      '@types/compression': 1.8.1
+      '@types/express': 5.0.6
+      '@types/node': 22.19.21
+      '@types/swagger-ui-dist': 3.30.6
+      argparse: 2.0.1
+      compression: 1.8.1
+      cors: 2.8.6
+      express: 5.2.1
+      h264-mp4-encoder: 1.0.12
+      immutable: 5.1.6
+      io-ts: 2.2.22(fp-ts@2.16.11)
+      mutative: 1.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-markdown: 10.1.0(@types/react@18.3.31)(react@18.3.1)
+      remark-gfm: 4.0.1
+      rxjs: 7.8.2
+      swagger-ui-dist: 5.32.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - fp-ts
+      - supports-color
+
   monaco-editor@0.55.1:
     dependencies:
       dompurify: 3.2.7
@@ -6660,11 +7499,17 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
+
+  mutative@1.3.0: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.4: {}
 
   negotiator@1.0.0: {}
 
@@ -6693,6 +7538,8 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:
@@ -6756,6 +7603,16 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
@@ -6898,7 +7755,35 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.31
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -6951,7 +7836,41 @@ snapshots:
       hast-util-to-string: 3.0.1
       unist-util-visit: 5.1.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-math@3.0.1: {}
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -7041,7 +7960,13 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scule@1.3.0: {}
 
@@ -7223,6 +8148,14 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
@@ -7294,6 +8227,10 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.21
       zimmerframe: 1.1.4
+
+  swagger-ui-dist@5.32.6:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   tabbable@6.4.0: {}
 
@@ -7403,6 +8340,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 
@@ -7530,10 +8469,10 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.0.10)
 
-  vitepress@1.6.4(@algolia/client-search@5.48.0)(@types/node@25.0.10)(fuse.js@7.1.0)(markdown-it-mathjax3@4.3.2)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.48.0)(@types/node@25.0.10)(@types/react@18.3.31)(fuse.js@7.1.0)(markdown-it-mathjax3@4.3.2)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.8.2
-      '@docsearch/js': 3.8.2(@algolia/client-search@5.48.0)(search-insights@2.17.3)
+      '@docsearch/js': 3.8.2(@algolia/client-search@5.48.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
       '@iconify-json/simple-icons': 1.2.70
       '@shikijs/core': 2.5.0
       '@shikijs/transformers': 2.5.0

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -1627,5 +1627,7 @@ const structure: Record<string, string> = {
   trajectory_format_ase: `ASE trajectory (.traj)`,
   trajectory_format_pymatgen: `Pymatgen trajectory JSON`,
   trajectory_format_compressed: `Compressed files (.gz)`,
+  bio_open_in_native: `Open in native viewer`,
+  bio_open_in_molstar: `Open in Mol*`,
 }
 export default structure

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -1627,5 +1627,7 @@ const structure: Record<string, string> = {
   trajectory_format_ase: `ASE 轨迹 (.traj)`,
   trajectory_format_pymatgen: `Pymatgen 轨迹 JSON`,
   trajectory_format_compressed: `压缩文件 (.gz)`,
+  bio_open_in_native: `用原生查看器打开`,
+  bio_open_in_molstar: `在 Mol* 中打开`,
 }
 export default structure

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -17,6 +17,9 @@
 -->
 <script lang="ts">
   import Structure from '$lib/structure/Structure.svelte'
+  import MolstarViewer from '$lib/structure/bio/MolstarViewer.svelte'
+  import BioViewerToggle from '$lib/structure/bio/BioViewerToggle.svelte'
+  import { detect_bio } from '$lib/structure/bio/detect'
   import Trajectory from '$lib/trajectory/Trajectory.svelte'
   import OptimadeSearchModal from '$lib/structure/OptimadeSearchModal.svelte'
   import { parse_any_structure } from '$lib/structure/parsers/dispatch'
@@ -82,6 +85,10 @@
   // Where the open structure came from, so Save knows to write it back.
   let remote_origin = $state<{ path: string; filename: string } | null>(null)
   let local_filename = $state(`structure.vasp`)
+  // Biomolecular files (PDB / bio-mmCIF) render in Mol*, not the native viewer.
+  let bio_raw_content = $state<string | null>(null)
+  let bio_format = $state(`pdb`)
+  let bio_viewer = $state(true)
   let files_open = $state(false)
   // AI chat overlay — available whenever the workspace is shown (works without a
   // cluster connection: the key-direct LLM path needs no backend).
@@ -246,6 +253,11 @@
     filename: string,
     origin: { path: string } | null,
   ): Promise<void> {
+    // Clear any prior bio state so a later trajectory/material load isn't
+    // hijacked by a stale protein.
+    bio_raw_content = null
+    bio_format = `pdb`
+    bio_viewer = true
     // Multi-frame file -> load the whole trajectory (with playback), not frame 1.
     if (is_trajectory_file(filename, content)) {
       try {
@@ -261,6 +273,19 @@
         /* fall back to single-structure parsing */
       }
     }
+    // Biological macromolecule → render in Mol* (bypass pymatgen parsing,
+    // which would drop residue/chain and choke on large proteins).
+    const bio = detect_bio(content, filename)
+    if (bio.isBio && bio.format) {
+      bio_raw_content = content
+      bio_format = bio.format
+      bio_viewer = true
+      structure = undefined
+      trajectory = undefined
+      saveable_structure = undefined
+      show_loaded(filename, origin)
+      return
+    }
     const parsed = parse_any_structure(content, filename)
     if (!parsed) {
       save_msg = t(`mobile.could_not_parse`, { filename })
@@ -270,6 +295,21 @@
     trajectory = undefined
     saveable_structure = undefined
     show_loaded(filename, origin)
+  }
+
+  /** Flip the mobile viewer between Mol* and native (manual override). */
+  function toggle_mobile_viewer(): void {
+    if (!bio_raw_content) return
+    if (bio_viewer) {
+      // → native: parse the raw text on demand
+      const parsed = parse_any_structure(bio_raw_content, local_filename)
+      if (parsed) structure = parsed
+      bio_viewer = false
+    } else {
+      // → Mol*
+      structure = undefined
+      bio_viewer = true
+    }
   }
 
   // ── Local file open (no cluster needed) ──
@@ -557,7 +597,17 @@
               hidden_toolbar_items: HIDDEN_TOOLBAR,
             }}
           />
+        {:else if bio_raw_content && bio_viewer && !structure}
+          <div class="mw-bio-wrap">
+            <BioViewerToggle is_molstar={true} on_toggle={toggle_mobile_viewer} />
+            {#key bio_raw_content}
+              <MolstarViewer content={bio_raw_content} format={bio_format} label={local_filename} />
+            {/key}
+          </div>
         {:else if has_structure}
+          {#if bio_raw_content}
+            <BioViewerToggle is_molstar={false} on_toggle={toggle_mobile_viewer} />
+          {/if}
           <Structure
             bind:structure
             bind:saveable_structure
@@ -1039,6 +1089,11 @@
   .mw-struct :global(.structure-main) {
     height: 100%;
     width: 100%;
+  }
+  .mw-bio-wrap {
+    position: relative;
+    width: 100%;
+    height: 100%;
   }
   .mw-body.split-h .mw-struct,
   .mw-body.split-v .mw-struct {

--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -297,18 +297,33 @@
     show_loaded(filename, origin)
   }
 
-  /** Flip the mobile viewer between Mol* and native (manual override). */
-  function toggle_mobile_viewer(): void {
-    if (!bio_raw_content) return
-    if (bio_viewer) {
+  /**
+   * Flip the mobile viewer between Mol* and native (manual override). Works for
+   * ANY loaded structure: with no bio raw text yet we serialize the current
+   * structure (CIF when periodic, else XYZ) and hand it to Mol*.
+   */
+  async function toggle_mobile_viewer(): Promise<void> {
+    if (bio_viewer && bio_raw_content) {
       // → native: parse the raw text on demand
       const parsed = parse_any_structure(bio_raw_content, local_filename)
       if (parsed) structure = parsed
       bio_viewer = false
     } else {
-      // → Mol*
-      structure = undefined
-      bio_viewer = true
+      // → Mol*: serialize the current structure if we have no raw text yet
+      if (!bio_raw_content && structure?.sites?.length) {
+        const { structure_to_cif_str, structure_to_xyz_str } = await import(
+          '$lib/structure/export'
+        )
+        const periodic = !!structure?.lattice?.matrix
+        bio_raw_content = periodic
+          ? structure_to_cif_str(structure)
+          : structure_to_xyz_str(structure)
+        bio_format = periodic ? 'mmcif' : 'xyz'
+      }
+      if (bio_raw_content) {
+        structure = undefined
+        bio_viewer = true
+      }
     }
   }
 
@@ -599,15 +614,21 @@
           />
         {:else if bio_raw_content && bio_viewer && !structure}
           <div class="mw-bio-wrap">
-            <BioViewerToggle is_molstar={true} on_toggle={toggle_mobile_viewer} />
-            {#key bio_raw_content}
-              <MolstarViewer content={bio_raw_content} format={bio_format} label={local_filename} />
-            {/key}
+            <div class="mw-bio-toolbar">
+              <BioViewerToggle is_molstar={true} on_toggle={toggle_mobile_viewer} />
+              <span class="mw-bio-name">{local_filename}</span>
+            </div>
+            <div class="mw-bio-fill">
+              {#key bio_raw_content}
+                <MolstarViewer content={bio_raw_content} format={bio_format} label={local_filename} />
+              {/key}
+            </div>
           </div>
         {:else if has_structure}
-          {#if bio_raw_content}
+          <!-- Universal manual entry: any loaded structure → Mol* on demand. -->
+          <div class="mw-bio-float">
             <BioViewerToggle is_molstar={false} on_toggle={toggle_mobile_viewer} />
-          {/if}
+          </div>
           <Structure
             bind:structure
             bind:saveable_structure
@@ -1094,6 +1115,35 @@
     position: relative;
     width: 100%;
     height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .mw-bio-toolbar {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border-color, #ddd);
+    background: var(--panel-bg, rgba(0, 0, 0, 0.03));
+  }
+  .mw-bio-name {
+    font-size: 0.78rem;
+    color: var(--text-muted, #777);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mw-bio-fill {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+  }
+  .mw-bio-float {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 20;
   }
   .mw-body.split-h .mw-struct,
   .mw-body.split-v .mw-struct {

--- a/src/lib/structure/bio/BioViewerToggle.svelte
+++ b/src/lib/structure/bio/BioViewerToggle.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { t } from '$lib/i18n/index.svelte'
+
+  let {
+    is_molstar,
+    on_toggle,
+  }: { is_molstar: boolean; on_toggle: () => void } = $props()
+</script>
+
+<button class="bio-toggle" onclick={on_toggle} type="button">
+  {is_molstar ? t(`structure.bio_open_in_native`) : t(`structure.bio_open_in_molstar`)}
+</button>
+
+<style>
+  .bio-toggle {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 20;
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    border: 1px solid var(--border-color, #ccc);
+    border-radius: 6px;
+    background: var(--panel-bg, rgba(255, 255, 255, 0.9));
+    color: var(--text-color, #222);
+    cursor: pointer;
+  }
+  .bio-toggle:hover {
+    background: var(--hover-bg, rgba(0, 0, 0, 0.06));
+  }
+</style>

--- a/src/lib/structure/bio/BioViewerToggle.svelte
+++ b/src/lib/structure/bio/BioViewerToggle.svelte
@@ -7,25 +7,39 @@
   }: { is_molstar: boolean; on_toggle: () => void } = $props()
 </script>
 
-<button class="bio-toggle" onclick={on_toggle} type="button">
+<button class="bio-toggle" class:to-molstar={!is_molstar} onclick={on_toggle} type="button">
+  <span class="bio-toggle-icon">{is_molstar ? `←` : `🧬`}</span>
   {is_molstar ? t(`structure.bio_open_in_native`) : t(`structure.bio_open_in_molstar`)}
 </button>
 
 <style>
+  /* Unpositioned by design — the parent (Mol* toolbar or native float wrapper)
+     decides placement, so the button never collides with Mol*'s own UI. */
   .bio-toggle {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    z-index: 20;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
     padding: 4px 10px;
     font-size: 0.78rem;
+    line-height: 1.2;
+    white-space: nowrap;
     border: 1px solid var(--border-color, #ccc);
     border-radius: 6px;
-    background: var(--panel-bg, rgba(255, 255, 255, 0.9));
+    background: var(--panel-bg, rgba(255, 255, 255, 0.92));
     color: var(--text-color, #222);
     cursor: pointer;
   }
+  /* "Open in Mol*" gets an accent so it's easy to find on a busy native viewer. */
+  .bio-toggle.to-molstar {
+    border-color: var(--accent-color, #2e8b6f);
+    color: var(--accent-color, #2e8b6f);
+    background: var(--panel-bg, rgba(255, 255, 255, 0.92));
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+  }
   .bio-toggle:hover {
     background: var(--hover-bg, rgba(0, 0, 0, 0.06));
+  }
+  .bio-toggle-icon {
+    font-size: 0.85rem;
   }
 </style>

--- a/src/lib/structure/bio/MolstarViewer.svelte
+++ b/src/lib/structure/bio/MolstarViewer.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte'
+
+  let {
+    content,
+    format = `pdb`,
+    label = `structure`,
+  }: { content: string; format?: string; label?: string } = $props()
+
+  let container = $state<HTMLDivElement>()
+  // Inferred from molstar's own d.ts (it ships resolvable types). Awaited
+  // return of Viewer.create — keeps `format` as molstar's BuiltInTrajectoryFormat
+  // literal union so loadStructureFromData type-checks.
+  type Mol = Awaited<
+    ReturnType<typeof import('molstar/lib/apps/viewer/app').Viewer.create>
+  >
+  let viewer: Mol | null = null
+  let error = $state<string | null>(null)
+
+  onMount(async () => {
+    try {
+      // Prebuilt CSS skin (plain CSS — no sass toolchain needed).
+      await import(`molstar/build/viewer/molstar.css`)
+      const { Viewer } = await import(`molstar/lib/apps/viewer/app`)
+      if (!container) return
+      const v = await Viewer.create(container, {
+        layoutIsExpanded: false,
+        layoutShowControls: true,
+        layoutShowSequence: true,
+        layoutShowLog: false,
+        layoutShowLeftPanel: true,
+        viewportShowExpand: true,
+        viewportShowSelectionMode: true,
+      })
+      viewer = v
+      await v.loadStructureFromData(content, format as never, {
+        dataLabel: label,
+      })
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+      console.error(`[MolstarViewer] failed to load:`, e)
+    }
+  })
+
+  onDestroy(() => {
+    viewer?.dispose()
+    viewer = null
+  })
+</script>
+
+<div class="molstar-pane" bind:this={container}>
+  {#if error}
+    <div class="molstar-error">Mol* failed to load: {error}</div>
+  {/if}
+</div>
+
+<style>
+  /* Mol*'s UI positions absolutely inside this box; it needs relative + size.
+     Never display:none this pane on mobile — it zeroes the WebGL canvas
+     (see CLAUDE.md iOS invariants). */
+  .molstar-pane {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+  .molstar-error {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    color: var(--error-color, #c0392b);
+    font-size: 0.9rem;
+    text-align: center;
+  }
+</style>

--- a/src/lib/structure/bio/__tests__/detect.test.ts
+++ b/src/lib/structure/bio/__tests__/detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detect_bio } from './detect'
+import { detect_bio } from '../detect'
 
 const PROTEIN_PDB = `HEADER    OXYGEN TRANSPORT
 SEQRES   1 A    3  VAL LEU SER

--- a/src/lib/structure/bio/detect.test.ts
+++ b/src/lib/structure/bio/detect.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { detect_bio } from './detect'
+
+const PROTEIN_PDB = `HEADER    OXYGEN TRANSPORT
+SEQRES   1 A    3  VAL LEU SER
+ATOM      1  N   VAL A   1      11.104  13.207  10.000  1.00 20.00           N
+ATOM      2  CA  VAL A   1      12.560  13.100  10.100  1.00 20.00           C
+ATOM      3  N   LEU A   2      13.000  14.000  10.200  1.00 20.00           N
+ATOM      4  CA  SER A   3      14.000  15.000  10.300  1.00 20.00           C
+END`
+
+const NUCLEIC_PDB = `ATOM      1  P    DA A   1      11.000  13.000  10.000  1.00 20.00           P
+ATOM      2  P    DT A   2      12.000  13.000  10.100  1.00 20.00           P
+ATOM      3  P    DG A   3      13.000  14.000  10.200  1.00 20.00           P
+END`
+
+const LIGAND_PDB = `HETATM    1  C1  LIG A   1      11.000  13.000  10.000  1.00 20.00           C
+HETATM    2  O1  LIG A   1      12.000  13.000  10.100  1.00 20.00           O
+END`
+
+const PROTEIN_MMCIF = `data_1ABC
+loop_
+_entity_poly.entity_id
+_entity_poly.type
+1 'polypeptide(L)'`
+
+const CRYSTAL_CIF = `data_NaCl
+_cell_length_a   5.64
+_cell_length_b   5.64
+_symmetry_space_group_name_H-M 'Fm-3m'
+loop_
+_atom_site_label
+Na1 0 0 0`
+
+describe('detect_bio', () => {
+  it('flags a protein PDB (SEQRES + amino residues)', () => {
+    const r = detect_bio(PROTEIN_PDB, 'prot.pdb')
+    expect(r.isBio).toBe(true)
+    expect(r.kind).toBe('protein')
+    expect(r.format).toBe('pdb')
+  })
+
+  it('flags a nucleic-acid PDB', () => {
+    const r = detect_bio(NUCLEIC_PDB, 'dna.pdb')
+    expect(r.isBio).toBe(true)
+    expect(r.kind).toBe('nucleic')
+    expect(r.format).toBe('pdb')
+  })
+
+  it('does NOT flag a small-molecule/ligand-only PDB', () => {
+    expect(detect_bio(LIGAND_PDB, 'lig.pdb').isBio).toBe(false)
+  })
+
+  it('flags a polypeptide mmCIF', () => {
+    const r = detect_bio(PROTEIN_MMCIF, 'prot.cif')
+    expect(r.isBio).toBe(true)
+    expect(r.kind).toBe('protein')
+    expect(r.format).toBe('mmcif')
+  })
+
+  it('does NOT flag a crystal CIF', () => {
+    expect(detect_bio(CRYSTAL_CIF, 'nacl.cif').isBio).toBe(false)
+  })
+
+  it('does NOT flag a non-candidate extension (POSCAR)', () => {
+    expect(detect_bio('Si\n1.0\n...', 'POSCAR').isBio).toBe(false)
+  })
+})

--- a/src/lib/structure/bio/detect.ts
+++ b/src/lib/structure/bio/detect.ts
@@ -1,0 +1,100 @@
+/**
+ * Content sniffer: decide whether a file is a biological macromolecule
+ * (protein / nucleic acid) that should render in Mol* rather than the native
+ * viewer. Pure function — no I/O, fully unit-tested.
+ *
+ * Only PDB and (mm)CIF extensions are candidates; within those we sniff content
+ * (heuristic B). Conservative: when ambiguous, return isBio:false so the file
+ * falls through to the native pipeline (the user can still force Mol* via the
+ * manual override).
+ */
+
+export type BioKind = 'protein' | 'nucleic' | 'mixed'
+export type BioFormat = 'pdb' | 'mmcif'
+
+export interface BioDetectResult {
+  isBio: boolean
+  kind: BioKind | null
+  /** Mol* BuiltInTrajectoryFormat string to feed loadStructureFromData. */
+  format: BioFormat | null
+  /** Human-readable explanation (drives the override hint + debugging). */
+  reason: string
+}
+
+const AMINO = new Set([
+  'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE',
+  'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+  'SEC', 'PYL', 'MSE', 'HSD', 'HSE', 'HSP',
+])
+const NUCLEIC = new Set([
+  'DA', 'DT', 'DG', 'DC', 'DU', 'A', 'U', 'G', 'C', 'I',
+  'RA', 'RU', 'RG', 'RC',
+])
+
+function ext_of(filename: string): string {
+  return filename.replace(/\.(gz|bz2|xz|zst)$/i, '').split('.').pop()?.toLowerCase() || ''
+}
+
+function not_bio(format: BioFormat | null, reason: string): BioDetectResult {
+  return { isBio: false, kind: null, format: null, reason }
+}
+
+function bio(kind: BioKind, format: BioFormat, reason: string): BioDetectResult {
+  return { isBio: true, kind, format, reason }
+}
+
+function detect_pdb(text: string): BioDetectResult {
+  const amino_res = new Set<string>()
+  const nucleic_res = new Set<string>()
+  let has_seqres = false
+  let has_helix_sheet = false
+
+  for (const ln of text.split(/\r?\n/)) {
+    const rec = ln.slice(0, 6).trim()
+    if (rec === 'SEQRES') has_seqres = true
+    if (rec === 'HELIX' || rec === 'SHEET') has_helix_sheet = true
+    if (rec === 'ATOM' || rec === 'HETATM') {
+      const res = ln.slice(17, 20).trim().toUpperCase()
+      const res_key = ln.slice(21, 26) // chainID + resSeq
+      if (AMINO.has(res)) amino_res.add(res_key)
+      else if (NUCLEIC.has(res)) nucleic_res.add(res_key)
+    }
+  }
+
+  const protein_like = has_seqres || has_helix_sheet || amino_res.size >= 3
+  const nucleic_like = nucleic_res.size >= 2
+
+  if (protein_like && nucleic_like) {
+    return bio('mixed', 'pdb', 'protein + nucleic residues present')
+  }
+  if (protein_like) {
+    const why = has_seqres
+      ? 'SEQRES record present'
+      : has_helix_sheet
+      ? 'HELIX/SHEET record present'
+      : `${amino_res.size} amino-acid residues`
+    return bio('protein', 'pdb', why)
+  }
+  if (nucleic_like) return bio('nucleic', 'pdb', `${nucleic_res.size} nucleotide residues`)
+  return not_bio('pdb', `no polymer markers (amino=${amino_res.size}, nucleic=${nucleic_res.size})`)
+}
+
+function detect_cif(text: string): BioDetectResult {
+  const t = text.toLowerCase()
+  const protein = t.includes('polypeptide')
+  const nucleic = t.includes('polyribonucleotide') || t.includes('polydeoxyribonucleotide')
+  const has_conf = t.includes('_struct_conf') || t.includes('_struct_sheet')
+
+  if (protein && nucleic) return bio('mixed', 'mmcif', '_entity_poly: protein + nucleic')
+  if (protein) return bio('protein', 'mmcif', '_entity_poly polypeptide')
+  if (nucleic) return bio('nucleic', 'mmcif', '_entity_poly polynucleotide')
+  if (has_conf) return bio('protein', 'mmcif', '_struct_conf/_struct_sheet present')
+  return not_bio('mmcif', 'no _entity_poly polypeptide/nucleotide markers')
+}
+
+export function detect_bio(text: string, filename: string): BioDetectResult {
+  const ext = ext_of(filename)
+  if (ext === 'pdb' || ext === 'ent') return detect_pdb(text)
+  if (ext === 'cif' || ext === 'mmcif' || ext === 'mcif') return detect_cif(text)
+  return not_bio(null, `.${ext} is not a bio-candidate extension`)
+}


### PR DESCRIPTION
## What

Adds biological-system visualization to CatGo by embedding **Mol\*** (molstar) as a parallel viewer pane. Open a PDB / bio-mmCIF and it renders with cartoon/ribbon, surface, sequence view, and measurements — Mol\*'s full all-in-one viewer. Materials systems (crystals, slabs, molecules) keep the native Three.js viewer, unchanged.

Scope is **pure viewing**: no compute handoff, no active-site cutout.

## How

- **Parallel viewer.** Mol\* ships its own WebGL2 context + parser; it does *not* reuse the native Three.js scene, ferrox bonding, or pymatgen. It's a second pane kind selected per-pane via `viewer_kind`.
- **Bypass pymatgen for bio.** Biomolecular files hand their *raw text* straight to Mol\* — this preserves residue/chain/secondary-structure (the native pipeline drops them) and skips the expensive native parse of large proteins.
- **Content sniffer** (`src/lib/structure/bio/detect.ts`): only `.pdb`/`.cif`/`.mmcif` are candidates; sniffs `SEQRES`/`HELIX`/`SHEET` + amino/nucleotide residues (PDB) or `_entity_poly` polypeptide/polynucleotide (mmCIF). Conservative — ambiguous → native.
- **Manual override (universal).** A "🧬 Open in Mol\*" button on **any** loaded structure serializes it on demand (CIF when periodic → keeps the cell, else XYZ) and opens it in Mol\*. The Mol\* pane's "← back to native" button sits in a CatGo toolbar strip (not floated over Mol\*'s own UI).
- **Lazy-loaded.** `import('molstar/lib/apps/viewer/app')` + dynamic CSS — verified the production build code-splits molstar into its own ~4.8M chunk, **not** in the main entry.
- Wired on **desktop** (`desktop/App.svelte`) and **mobile** (`src/lib/mobile/MobileWorkspace.svelte`); pane fields in `desktop/pane-utils.ts`; en/zh i18n in parity.

## Testing

- `detect_bio` — 6 vitest unit tests (protein/nucleic/ligand PDB, polymer mmCIF, crystal CIF, POSCAR). Placed under `__tests__/` so CI's include globs actually collect it.
- Full suite: **3982 passed, 0 failed**. `pnpm check`: **0 errors**.
- Production build succeeds; molstar confirmed code-split + lazy (not in main bundle).
- **Live-verified** (headless browser): loaded 1CRN/crambin → green cartoon ribbon + 46-residue sequence track + full Mol\* UI; universal "Open in Mol\*" on a plain structure → serialize → Mol\* mount → "← native" round-trip.

## Known gaps / follow-ups

- The auto-detect path through CatGo's own **file-open UI** wasn't drivable headlessly (Tauri file dialog / drag-drop quirks) — needs a click-test in the real desktop app. The render + routing logic are each verified independently.
- **iOS on-device** smoke test (Mol\* needs WebGL2 in WKWebView) still pending.
- HTTP/MCP/`curl upload-and-load` path is deliberately out of scope for v1 (frontend file-open only).

Design + plan: `docs/superpowers/{specs,plans}/2026-06-14-molstar-bio-viewer-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)