### PR TITLE
Fix PBS resource parameters in workflow runs

### DIFF
--- a/server/catgo/mcp_tools/tools/misc.py
+++ b/server/catgo/mcp_tools/tools/misc.py
@@ -164,7 +164,7 @@ TOOLS: list[dict] = [
                 "page": {"type": "integer", "default": 1, "description": "Page number for batch_results (default 1)."},
                 "params": {"type": "object", "description": "Node parameters (for set_params, add_node). For structure_input: pass mp_id (e.g. 'mp-825') to fetch a specific material instead of capturing the viewer."},
                 "category": {"type": "string", "description": "Filter category (for node_types)."},
-                "run_config": {"type": "object", "description": "HPC run config (for run). Keys: hpc_session_id, queue, nodes, ppn, walltime, modules, env_commands."},
+                "run_config": {"type": "object", "description": "HPC run config (for run). Accepts hpc_session_id/default_session_id, queue/partition, nodes, ppn/cpus_per_task, ntasks, walltime, memory, account, modules/module_loads, env_commands/python_env."},
                 "operations": {
                     "type": "array",
                     "description": "Array of operations for batch action.",

--- a/server/catgo/mcp_tools/workflow_tools.py
+++ b/server/catgo/mcp_tools/workflow_tools.py
@@ -1062,6 +1062,64 @@ _ACTION_REQUIRED: dict[str, list[str]] = {
 }
 
 
+def _normalize_run_config_aliases(user_config: dict) -> dict:
+    """Accept user-facing HPC aliases and emit WorkflowRunConfig fields."""
+    config = dict(user_config or {})
+    if not config:
+        return config
+
+    job_params = dict(config.get("default_job_params") or {})
+
+    session_id = config.pop("hpc_session_id", None) or config.pop("session_id", None)
+    if session_id and not config.get("default_session_id"):
+        config["default_session_id"] = session_id
+
+    alias_to_job_param = {
+        "nodes": "nodes",
+        "ntasks": "ntasks",
+        "ppn": "cpus_per_task",
+        "cpus_per_task": "cpus_per_task",
+        "walltime": "walltime",
+        "time_limit": "walltime",
+        "queue": "partition",
+        "partition": "partition",
+        "memory": "memory",
+        "account": "account",
+    }
+    for alias, target in alias_to_job_param.items():
+        if alias in config:
+            val = config.pop(alias)
+            if val is not None and val != "":
+                job_params[target] = val
+
+    if job_params:
+        config["default_job_params"] = job_params
+
+    module_loads = config.pop("modules", None) or config.pop("module_loads", None)
+    python_env = config.pop("env_commands", None) or config.pop("python_env", None)
+    active_session = config.get("default_session_id")
+    if active_session and (module_loads or python_env):
+        cluster_configs = dict(config.get("cluster_configs") or {})
+        cluster_cfg = dict(cluster_configs.get(active_session) or {})
+        if module_loads:
+            cluster_cfg["module_loads"] = module_loads
+        if python_env:
+            cluster_cfg["python_env"] = python_env
+        if job_params:
+            cluster_cfg["default_job_params"] = {
+                **dict(cluster_cfg.get("default_job_params") or {}),
+                **job_params,
+            }
+        cluster_configs[active_session] = cluster_cfg
+        config["cluster_configs"] = cluster_configs
+
+    hpc_markers = {"default_session_id", "default_job_params", "cluster_configs"}
+    if "execution_mode" not in config and any(k in config for k in hpc_markers):
+        config["execution_mode"] = "hpc"
+
+    return config
+
+
 async def _handle_workflow(client: httpx.AsyncClient, args: dict) -> list[TextContent]:
     """Handle all workflow operations via a single unified tool.
 
@@ -1822,7 +1880,7 @@ async def _handle_workflow(client: httpx.AsyncClient, args: dict) -> list[TextCo
                 ))]
 
             # Safety: require explicit run_config or confirm=true to prevent accidental execution
-            user_config = args.get("run_config") or args.get("params") or {}
+            user_config = _normalize_run_config_aliases(args.get("run_config") or args.get("params") or {})
             if not user_config and not args.get("confirm"):
                 return [_t(type="text", text=(
                     "\u26a0\ufe0f MCP `run` will IMMEDIATELY execute the workflow (not open a UI dialog). "
@@ -1861,7 +1919,7 @@ async def _handle_workflow(client: httpx.AsyncClient, args: dict) -> list[TextCo
             return [_t(type="text", text=f"Workflow {wf_id} paused. Use action='resume' to continue.")]
 
         if action == "resume":
-            user_config = args.get("run_config") or args.get("params") or {}
+            user_config = _normalize_run_config_aliases(args.get("run_config") or args.get("params") or {})
             config = {
                 "execution_mode": user_config.get("execution_mode", "local"),
                 "base_work_dir": user_config.get("base_work_dir", "~/calculations"),

--- a/server/catgo/workflow/engine/job_script.py
+++ b/server/catgo/workflow/engine/job_script.py
@@ -141,7 +141,22 @@ def generate_job_script(
 
     # Resolve each field with priority: params > job_defaults > fallback
     def _get(key: str, fallback: str = "") -> str:
-        val = params.get(key) or job_defaults.get(key) or fallback
+        aliases = {
+            "cpus_per_task": ("ppn",),
+            "partition": ("queue",),
+            "walltime": ("time_limit",),
+        }
+        keys = (key, *aliases.get(key, ()))
+        val = None
+        for candidate in keys:
+            val = params.get(candidate)
+            if val:
+                break
+            val = job_defaults.get(candidate)
+            if val:
+                break
+        if not val:
+            val = fallback
         return str(val) if val else ""
 
     task_id = task.get("id", "")[:8]

--- a/server/catgo/workflow/engine/submitter.py
+++ b/server/catgo/workflow/engine/submitter.py
@@ -300,7 +300,7 @@ async def _submit_one(
     job_script_param = params.get("job_script", "")
     has_placeholders = "{{" in job_script_param and "}}" in job_script_param
 
-    if job_script_param and "#SBATCH" in job_script_param and not has_placeholders:
+    if job_script_param and _has_scheduler_directives(job_script_param) and not has_placeholders:
         # Fully-substituted explicit script — pass through unchanged.
         job_script = job_script_param
     else:
@@ -312,7 +312,7 @@ async def _submit_one(
                 wf_config.get("job_script_template", "")
                 or wf_config.get("hpc", {}).get("job_script_template", "")
             )
-        if template_source and "#SBATCH" in template_source:
+        if template_source and _has_scheduler_directives(template_source):
             params_with_template = {**params, "job_script_template": template_source}
             params_with_template.pop("job_script", None)
             job_script = generate_job_script(engine_key, work_dir, task, params_with_template, config)
@@ -388,45 +388,119 @@ async def _submit_job(
 ) -> tuple[bool, str, str]:
     """Submit job to HPC scheduler. Returns (success, message, job_id).
 
-    If job_script contains #SBATCH, write it as submit.sh and sbatch directly.
-    Otherwise fall through to scheduler's auto-header generation.
+    If job_script contains scheduler directives, write it as submit.sh and submit
+    directly. Otherwise fall through to scheduler auto-header generation.
     """
-    if job_script and "#SBATCH" in job_script:
-        # Write complete script and submit via sbatch
+    directive_kind = _scheduler_directive_kind(job_script)
+    if directive_kind:
+        submit_cmd = _submit_command_for_script(hpc, directive_kind)
+        if not submit_cmd:
+            return (False, f"Unsupported scheduler directive: {directive_kind}", "")
+
         script_path = f"{work_dir}/submit.sh"
+        safe_script_path = shlex.quote(script_path)
+        safe_work_dir = shlex.quote(work_dir)
         await hpc.run_on_owner(lambda: hpc.conn.run(
-            f"cat > {script_path} << 'CATGO_EOF'\n{job_script}\nCATGO_EOF", check=True
+            f"cat > {safe_script_path} << 'CATGO_EOF'\n{job_script}\nCATGO_EOF", check=True
         ))
-        await hpc.run_on_owner(lambda: hpc.conn.run(f"chmod +x {script_path}", check=True))
+        await hpc.run_on_owner(lambda: hpc.conn.run(f"chmod +x {safe_script_path}", check=True))
         result = await hpc.run_on_owner(
-            lambda: hpc.conn.run(f"cd {work_dir} && sbatch submit.sh", check=False)
+            lambda: hpc.conn.run(f"cd {safe_work_dir} && {submit_cmd} submit.sh", check=False)
         )
         stdout = (result.stdout or "").strip() if hasattr(result, 'stdout') else str(result)
         stderr = (result.stderr or "").strip() if hasattr(result, 'stderr') else ""
-        # Parse job ID from "Submitted batch job 12345"
-        job_id = ""
-        for word in stdout.split():
-            if word.isdigit():
-                job_id = word
-                break
+        job_id = _parse_scheduler_job_id(stdout, directive_kind)
         if job_id:
             return (True, f"Job submitted: {job_id}", job_id)
-        # Include both stdout and stderr in the error message
         err_detail = stderr or stdout or "(no output)"
-        return (False, f"sbatch failed: {err_detail}", "")
-    else:
-        return await hpc.run_on_owner(lambda: hpc.scheduler.submit_job(
-            hpc.conn,
-            script_content=job_script or "",
-            job_name=f"catgo-{node_type}",
-            work_dir=work_dir,
-            partition=params.get("partition"),
-            nodes=params.get("nodes"),
-            ntasks=params.get("ntasks"),
-            cpus_per_task=params.get("cpus_per_task"),
-            time_limit=params.get("walltime"),
-            memory=params.get("memory"),
-        ))
+        return (False, f"{submit_cmd} failed: {err_detail}", "")
+
+    scheduler_params = _scheduler_submit_params(params, config)
+    return await hpc.run_on_owner(lambda: hpc.scheduler.submit_job(
+        hpc.conn,
+        script_content=job_script or "",
+        job_name=f"catgo-{node_type}",
+        work_dir=work_dir,
+        partition=scheduler_params["partition"],
+        nodes=scheduler_params["nodes"],
+        ntasks=scheduler_params["ntasks"],
+        cpus_per_task=scheduler_params["cpus_per_task"],
+        time_limit=scheduler_params["walltime"],
+        memory=scheduler_params["memory"],
+    ))
+
+
+def _has_scheduler_directives(job_script: str) -> bool:
+    return _scheduler_directive_kind(job_script) is not None
+
+
+def _scheduler_directive_kind(job_script: str) -> str | None:
+    if not job_script:
+        return None
+    has_slurm = "#SBATCH" in job_script
+    has_pbs = "#PBS" in job_script
+    if has_pbs and not has_slurm:
+        return "pbs"
+    if has_slurm and not has_pbs:
+        return "slurm"
+    if has_pbs and has_slurm:
+        return "mixed"
+    return None
+
+
+def _submit_command_for_script(hpc, directive_kind: str) -> str:
+    scheduler_name = hpc.scheduler.__class__.__name__.lower()
+    if directive_kind == "pbs":
+        return "qsub"
+    if directive_kind == "slurm":
+        return "sbatch"
+    if directive_kind == "mixed":
+        if "pbs" in scheduler_name:
+            return "qsub"
+        if "slurm" in scheduler_name:
+            return "sbatch"
+    return ""
+
+
+def _parse_scheduler_job_id(stdout: str, directive_kind: str) -> str:
+    if not stdout:
+        return ""
+    words = stdout.split()
+    if directive_kind == "pbs":
+        return words[0].strip() if words else ""
+
+    for word in reversed(words):
+        if word.isdigit():
+            return word
+    return ""
+
+
+def _scheduler_submit_params(params: dict, config: dict) -> dict:
+    """Merge task params with workflow job defaults for scheduler auto-headers."""
+    job_defaults = config.get("hpc", {}).get("job_defaults", {})
+
+    def _pick(*keys: str, fallback=None):
+        for source in (params, job_defaults):
+            for key in keys:
+                val = source.get(key)
+                if val is not None and val != "":
+                    return val
+        return fallback
+
+    def _as_int(value, fallback: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return fallback
+
+    return {
+        "partition": _pick("partition", "queue", fallback=None),
+        "nodes": _as_int(_pick("nodes", fallback=1), 1),
+        "ntasks": _as_int(_pick("ntasks", fallback=1), 1),
+        "cpus_per_task": _as_int(_pick("cpus_per_task", "ppn", fallback=1), 1),
+        "walltime": str(_pick("walltime", "time_limit", fallback="24:00:00")),
+        "memory": _pick("memory", fallback=None),
+    }
 
 
 # Recommended POTCAR variants (same as pymatgen defaults)

--- a/server/tests/test_pbs_run_config.py
+++ b/server/tests/test_pbs_run_config.py
@@ -1,0 +1,149 @@
+import inspect
+
+import pytest
+
+from catgo.mcp_tools.workflow_tools import _normalize_run_config_aliases
+from catgo.workflow.engine.job_script import generate_job_script
+from catgo.workflow.engine.submitter import _submit_job
+
+
+class _Result:
+    def __init__(self, stdout="", stderr="", exit_status=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+class _Conn:
+    def __init__(self):
+        self.commands = []
+
+    async def run(self, command, check=False):
+        self.commands.append(command)
+        if "qsub submit.sh" in command:
+            return _Result(stdout="12345.server\n")
+        return _Result()
+
+
+class _Scheduler:
+    def __init__(self):
+        self.calls = []
+
+    async def submit_job(self, *args, **kwargs):
+        self.calls.append(kwargs)
+        return True, "Job submitted: 99", "99"
+
+
+class _Hpc:
+    def __init__(self):
+        self.conn = _Conn()
+        self.scheduler = _Scheduler()
+
+    async def run_on_owner(self, fn):
+        result = fn()
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+@pytest.mark.asyncio
+async def test_pbs_directive_script_uses_qsub_without_wrapping():
+    hpc = _Hpc()
+    script = """#!/bin/bash
+#PBS -N catgo-test
+#PBS -l nodes=2:ppn=8
+#PBS -l walltime=12:00:00
+
+echo run
+"""
+
+    success, _message, job_id = await _submit_job(
+        hpc, "/work/calc", "geo_opt", script, {}, {}
+    )
+
+    assert success
+    assert job_id == "12345.server"
+    assert any("qsub submit.sh" in cmd for cmd in hpc.conn.commands)
+    assert hpc.scheduler.calls == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_auto_header_uses_job_defaults_and_ppn_alias():
+    hpc = _Hpc()
+    config = {
+        "hpc": {
+            "job_defaults": {
+                "nodes": 3,
+                "ppn": 12,
+                "walltime": "08:30:00",
+                "queue": "batch",
+            }
+        }
+    }
+
+    success, _message, job_id = await _submit_job(
+        hpc, "/work/calc", "geo_opt", "echo run", {}, config
+    )
+
+    assert success
+    assert job_id == "99"
+    call = hpc.scheduler.calls[0]
+    assert call["nodes"] == 3
+    assert call["cpus_per_task"] == 12
+    assert call["time_limit"] == "08:30:00"
+    assert call["partition"] == "batch"
+
+
+def test_mcp_run_config_accepts_pbs_aliases():
+    config = _normalize_run_config_aliases({
+        "hpc_session_id": "sess-pbs",
+        "queue": "batch",
+        "nodes": 2,
+        "ppn": 16,
+        "walltime": "10:00:00",
+        "modules": "module load vasp",
+        "env_commands": "source ~/.bashrc",
+    })
+
+    assert config["execution_mode"] == "hpc"
+    assert config["default_session_id"] == "sess-pbs"
+    assert config["default_job_params"] == {
+        "partition": "batch",
+        "nodes": 2,
+        "cpus_per_task": 16,
+        "walltime": "10:00:00",
+    }
+    assert config["cluster_configs"]["sess-pbs"]["module_loads"] == "module load vasp"
+    assert config["cluster_configs"]["sess-pbs"]["python_env"] == "source ~/.bashrc"
+
+
+def test_pbs_template_accepts_ppn_queue_aliases():
+    script = generate_job_script(
+        "vasp",
+        "/work/calc",
+        {"id": "task-12345678", "task_type": "geo_opt"},
+        {},
+        {
+            "hpc": {
+                "job_script_template": (
+                    "#!/bin/bash\n"
+                    "#PBS -N {{job_name}}\n"
+                    "#PBS -l nodes={{nodes}}:ppn={{cpus_per_task}}\n"
+                    "#PBS -l walltime={{walltime}}\n"
+                    "#PBS -q {{partition}}\n"
+                    "cd {{work_dir}}\n"
+                    "{{run_command}}\n"
+                ),
+                "job_defaults": {
+                    "nodes": 4,
+                    "ppn": 10,
+                    "time_limit": "02:15:00",
+                    "queue": "workq",
+                },
+            }
+        },
+    )
+
+    assert "#PBS -l nodes=4:ppn=10" in script
+    assert "#PBS -l walltime=02:15:00" in script
+    assert "#PBS -q workq" in script


### PR DESCRIPTION
This fixes PBS workflow submission so nodes, ppn, walltime, queue and related HPC parameters are correctly accepted and passed through during structure optimization runs.

Changes:
- Detect PBS directives and submit PBS scripts with qsub
- Preserve PBS resource aliases such as ppn, queue and walltime
- Normalize run_config HPC aliases from MCP workflow tools
- Add tests for PBS run config handling


submitter.py这是核心修复。
原来代码只认 Slurm：sbatch
所以如果 job script 是 PBS 的：
#PBS -l nodes=...
#PBS -l walltime=...
它不会正确当成 PBS 脚本处理，容易导致 nodes、ppn、walltime 没进真正提交的任务。
现在改成：
看到 #PBS 就用 qsub
看到 #SBATCH 就用 sbatch
PBS job id 按 PBS 输出格式解析，比如 12345.server
如果没有完整 job script，就从 params 和 job_defaults 里合并参数
支持 ppn、queue、walltime 这些 PBS 常用名字
也就是说这里是修“提交到集群时参数丢失/识别错”的地方。

job_script.py 这里改的是模板替换。
原来模板主要认这些内部名字：
cpus_per_task
partition
walltime
但 PBS 用户常写：
ppn
queue
time_limit
现在加了别名映射：
ppn -> cpus_per_task
queue -> partition
time_limit -> walltime
所以 PBS 模板里这种会正确生成：
#PBS -l nodes={{nodes}}:ppn={{cpus_per_task}}
#PBS -l walltime={{walltime}}
#PBS -q {{partition}}

test_pbs_run_config.py 是个测试脚本，不影响软件运行，只是在开始前测试

