### PR TITLE
docs(campaign): enforce input-file gate (sync local, user confirms before submit)

### DIFF
--- a/server/catgo/workflow/skills/catgo-campaign-loop/SKILL.md
+++ b/server/catgo/workflow/skills/catgo-campaign-loop/SKILL.md
@@ -30,7 +30,11 @@ must not submit/cancel jobs or touch the :8000 backend.
 4. **Auto-advance each newly-converged calc to its NEXT plan step — per species, PIPELINE,
    not a barrier.** A converged geo_opt immediately triggers that species' next step (e.g.
    freq in a Gibbs study) from its CONTCAR; don't wait for siblings, don't wait for a user
-   reminder. Render next-step inputs → input-file gate → `submit_calc.py`.
+   reminder. Render next-step inputs → **input-file gate** → `submit_calc.py`.
+   **⛔ INPUT-FILE GATE (hard rule):** "auto-advance" means auto-PREP, NOT auto-submit. Sync the
+   converged CONTCAR **and** the next-step INCAR to the LOCAL folder, tell the user the exact LOCAL
+   paths of INCAR + CONTCAR, and WAIT — the user checks/edits the files on disk. Submit ONLY after
+   the user confirms. Do NOT push to the CatGO viewer as a substitute, and NEVER auto-submit. (YOLO waives.)
 5. Stage/decision point → `python aggregate.py --project <dir> --plot` → summary → checkpoint.
 6. Group meeting → `python make_report.py --project <dir> --occasion groupmeeting`.
 7. Unhandleable problem → write it to STATUS/LESSONS and stop (surface to the user).

--- a/server/catgo/workflow/skills/catgo-campaign/SKILL.md
+++ b/server/catgo/workflow/skills/catgo-campaign/SKILL.md
@@ -34,10 +34,16 @@ complete. A wrong path fails every job — if unsure, STOP and ask.
 2. **Plan** — ASK the user: brainstorm the plan together (literature-grounded, one
    question at a time, propose approaches) OR use the template / generate directly.
 3. **Reference script** (optional): `catgo campaign fetch-ref --project <dir> --ssh <alias> --remote_path <.sb>`
-4. **Per calc**: build inputs (catgo slab/convert/… into the calc folder), SHOW the
-   rendered inputs to the user (input-file gate), then
-   `catgo campaign submit --project <dir> --calc calc/<stage>/<candidate> --ssh <alias>`
+4. **Per calc**: build inputs into the LOCAL calc folder, then the **input-file gate** (below),
+   then `catgo campaign submit --project <dir> --calc calc/<stage>/<candidate> --ssh <alias>`
    (skip the gate only on explicit YOLO opt-in).
+
+   **⛔ INPUT-FILE GATE (hard rule — catgo-campaign + autochem).** Before ANY submit (and after a
+   calc converges, before building the NEXT step's inputs): sync the CONTCAR **and** the INCAR to
+   the LOCAL campaign folder, and **tell the user the exact LOCAL file paths** of the INCAR +
+   CONTCAR. The user reviews / edits / confirms the files THEMSELVES on disk. Submit ONLY after the
+   user explicitly confirms. Do **NOT** push structures to the CatGO viewer as a substitute for
+   local-file review of inputs, and **NEVER auto-submit**. (Waived only by explicit YOLO.)
 5. **Loop** (~10 min, user-triggered): `catgo campaign poll --project <dir> --ssh <alias>`
    marks DONE/FAILED via squeue→sacct. A scheduler DONE != converged — open the
    work_dir outputs to confirm, write numbers into the calc's `result.md`, log gotchas


### PR DESCRIPTION
The catgo-campaign + catgo-campaign-loop skills said only 'input-file gate' (vague), which in practice permitted pushing inputs to the CatGO viewer and auto-submitting. This makes it a **hard rule**:

After a calc converges (and before any submit), sync the CONTCAR **and** INCAR to the LOCAL campaign folder, tell the user the exact local paths, the user reviews/edits the files on disk, and submit **only after explicit confirmation**. No CatGO-viewer substitute for local input review; never auto-submit. 'Auto-advance' = auto-PREP, not auto-submit. (YOLO waives.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)