### PR TITLE
fix(band): blue Load buttons + stack electronic plots beside structure

### DIFF
--- a/src/lib/electronic/BandAnalysisPane.svelte
+++ b/src/lib/electronic/BandAnalysisPane.svelte
@@ -522,7 +522,8 @@
   .checkbox-label { display: flex; align-items: center; gap: 5px; font-size: 0.85em; color: var(--text-color-muted, rgba(255, 255, 255, 0.7)); cursor: pointer; }
   .range-row { display: flex; align-items: center; gap: 4px; font-size: 0.85em; color: var(--text-color-muted, rgba(255, 255, 255, 0.6)); }
   .range-input { width: 55px; padding: 2px 4px; background: light-dark(rgba(0, 0, 0, 0.04), rgba(255, 255, 255, 0.08)); border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; color: var(--text-color, #fff); font-size: 0.9em; }
-  .btn-compute { padding: 6px 12px; background: var(--accent-color, #007acc); color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-compute { padding: 6px 12px; background: #2563eb; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-compute:hover:not(:disabled) { background: #1d4ed8; }
   .btn-compute:disabled { opacity: 0.5; cursor: not-allowed; }
   .btn-small { padding: 3px 8px; background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1)); border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; color: var(--text-color, #fff); cursor: pointer; font-size: 0.85em; }
   .btn-small:hover { background: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.2)); }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1445,6 +1445,16 @@
   let cohp_exporting: string | null = $state(null)
   let show_cohp_panel = $derived(cohp_state.cohp_result !== null)
 
+  // Number of open electronic plots (DOS / COHP / Band) sharing the dos-split grid.
+  // They stack beside (or below) the structure; this count drives the grid track count.
+  let electronic_plot_count = $derived(
+    (show_dos_panel ? 1 : 0) + (show_cohp_panel ? 1 : 0) + (show_band_panel ? 1 : 0),
+  )
+  // Whichever electronic panel is open picks the split orientation (DOS > COHP > Band).
+  let electronic_split_layout = $derived(
+    show_dos_panel ? dos_layout : show_cohp_panel ? cohp_layout : band_layout,
+  )
+
   type ElectronicPlotRef = DosPlot | CohpPlot | BandPlot
   type ExportFormat = `png` | `svg` | `csv`
 
@@ -1705,6 +1715,14 @@
   let preview_filename = $state(``)
   let preview_file_path = $state(``)
   let preview_session_id = $state(``)
+
+  // True when a chat or side (terminal/editor/preview) panel is open and therefore
+  // owns the grid-template (an earlier branch in the inline grid-template ternary
+  // fires). The electronic-plot grid-template must only apply when this is false,
+  // otherwise it would clobber the chat/side layout (e.g. chat-bottom + a DOS panel).
+  let chat_side_owns_grid = $derived(
+    chat_pane_open || show_terminal || show_editor || show_preview,
+  )
 
   // --- Remote structure origin (for push-back) --- (now a $bindable prop, see props block)
 
@@ -2988,9 +3006,9 @@
   class:xrd-split={xrd.show_panel}
   class:xrd-horizontal={xrd.show_panel && xrd.layout === `horizontal`}
   class:xrd-vertical={xrd.show_panel && xrd.layout === `vertical`}
-  class:dos-split={show_dos_panel || show_cohp_panel}
-  class:dos-horizontal={(show_dos_panel || show_cohp_panel) && (show_dos_panel ? dos_layout : cohp_layout) === `horizontal`}
-  class:dos-vertical={(show_dos_panel || show_cohp_panel) && (show_dos_panel ? dos_layout : cohp_layout) === `vertical`}
+  class:dos-split={show_dos_panel || show_cohp_panel || show_band_panel}
+  class:dos-horizontal={(show_dos_panel || show_cohp_panel || show_band_panel) && electronic_split_layout === `horizontal`}
+  class:dos-vertical={(show_dos_panel || show_cohp_panel || show_band_panel) && electronic_split_layout === `vertical`}
   class:slice-split={show_slice_panel}
   class:slice-horizontal={show_slice_panel && slice_layout === `horizontal`}
   class:slice-vertical={show_slice_panel && slice_layout === `vertical`}
@@ -3007,7 +3025,11 @@
       ? side_panel_minimized ? `1fr 0px 28px` : `1fr 4px ${side_panel_size}%`
       : chat_pane_open && chat_position.value === `right`
         ? `1fr 5px minmax(280px, ${chat_panel_size}%)`
-        : undefined}
+        : !chat_side_owns_grid && electronic_plot_count > 0 && electronic_split_layout === `horizontal`
+          ? `1fr 1fr`
+          : !chat_side_owns_grid && electronic_plot_count > 0 && electronic_split_layout === `vertical`
+            ? `1fr`
+            : undefined}
   style:grid-template-rows={chat_pane_open && chat_position.value === `bottom` && !(show_terminal || show_editor || show_preview)
       ? `1fr 5px ${chat_bottom_size}%`
       : chat_pane_open && chat_position.value === `bottom` && (show_terminal || show_editor || show_preview) && !side_panel_minimized
@@ -3016,7 +3038,11 @@
           ? `1fr 1fr`
           : !chat_pane_open && (show_terminal || show_editor || show_preview) && (show_terminal && !show_editor && !show_preview && terminal_layout === `vertical`)
             ? side_panel_minimized ? `1fr 0px 28px` : `1fr 4px ${side_panel_size}%`
-            : undefined}
+            : !chat_side_owns_grid && electronic_plot_count > 0 && electronic_split_layout === `horizontal`
+              ? `repeat(${electronic_plot_count}, 1fr)`
+              : !chat_side_owns_grid && electronic_plot_count > 0 && electronic_split_layout === `vertical`
+                ? `1fr repeat(${electronic_plot_count}, 1fr)`
+                : undefined}
 >
   <div class="structure-main">
   <!-- Box selection overlay - uses transform for GPU-accelerated positioning -->
@@ -5284,6 +5310,25 @@
     position: relative;
     min-height: 0;
     min-width: 0;
+  }
+  /* Electronic plots (DOS / COHP / Band) stack beside the structure.
+     The grid-template tracks are set inline (one row per open plot); these
+     rules pin the structure to one track and flow the plots into the other. */
+  /* Horizontal: structure on the left spanning all rows, plots stacked in col 2 */
+  .structure.dos-split.dos-horizontal > .structure-main {
+    grid-column: 1;
+    grid-row: 1 / -1;
+  }
+  .structure.dos-split.dos-horizontal > .dos-panel {
+    grid-column: 2;
+  }
+  /* Vertical: structure on top (row 1), plots stacked below in col 1 */
+  .structure.dos-split.dos-vertical > .structure-main {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .structure.dos-split.dos-vertical > .dos-panel {
+    grid-column: 1;
   }
   /* Chat split-view grid layout */
   .structure.chat-split {


### PR DESCRIPTION
## Problem

Two issues in the band-structure (能带) analysis UI:

1. **Band plot rendered squished at the bottom / looked like "load did nothing".** The split-grid class condition (`Structure.svelte`) only activated for `show_dos_panel || show_cohp_panel` — it **excluded `show_band_panel`**. So opening Bands alone never turned the grid on (band panel fell outside the grid → cramped at the bottom), and opening Bands alongside COHP overflowed the fixed 2-cell grid (the 3rd panel wrapped to the bottom). The band data actually loaded fine — it just rendered in a broken position.
2. **The Load Bands / Load Projections buttons read as dull gray.** `.btn-compute` used `var(--accent-color, #007acc)`; `--accent-color` is defined nowhere, so it fell back to a muted `#007acc`.

## Fix

- **Wire `show_band_panel` into the split-grid** (`dos-split` / `dos-horizontal` / `dos-vertical`) and pick the orientation from whichever electronic panel is open (`electronic_split_layout`).
- **Stack multiple plots beside the structure** (user-chosen layout): the structure spans one full track; DOS/COHP/Band flow into the other track, stacked. Driven by a dynamic inline `grid-template` from `electronic_plot_count` (one track per open plot) + grid-placement CSS. A `chat_side_owns_grid` guard keeps the existing chat/side grid layouts from being clobbered.
- **Buttons → vivid blue** `#2563eb` (+ hover), white text, disabled-opacity kept for the genuine loading state (`BandAnalysisPane.svelte`).

DOS-only / COHP-only behavior is unchanged (single plot beside structure).

## Verification

- `pnpm check`: 0 errors.
- Grid math verified with an isolated CSS repro: structure spans the left column full-height; COHP top-right, Band bottom-right (stacked) — matches the intended layout.
- Live: band rendered in a proper panel (no longer squished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)