### PR TITLE
feat(bio): move "Open in Mol*" into the structure toolbar (DNA icon)

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1851,14 +1851,6 @@
                   </div>
                 </div>
               {:else if pane.structure}
-                <!-- Universal manual entry: any loaded structure can be opened
-                     in Mol* (serialized on demand by toggle_pane_viewer). -->
-                <div class="bio-float-tl">
-                  <BioViewerToggle
-                    is_molstar={false}
-                    on_toggle={() => toggle_pane_viewer(ts, idx)}
-                  />
-                </div>
                 <Structure
                   tab_id={tab.id}
                   is_active={ts.active_pane === idx && tab.id === tm.active_tab_id}
@@ -1887,6 +1879,7 @@
                   on_open_workflow_editor={(workflow_id: string) => {
                     handle_sidebar_open_workflow(workflow_id)
                   }}
+                  on_open_in_molstar={() => toggle_pane_viewer(ts, idx)}
                   fullscreen_toggle={false}
                   allow_file_drop={false}
                   show_controls={true}
@@ -2409,14 +2402,6 @@
     flex: 1 1 auto;
     min-height: 0;
     position: relative;
-  }
-  /* Universal "Open in Mol*" button over a native viewer — top-left, clear of
-     the native viewer's own bottom/right controls. */
-  .bio-float-tl {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    z-index: 20;
   }
   .sidebar-editor-overlay {
     position: fixed;

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -596,6 +596,11 @@ export const icon_data = {
     path:
       `<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></g>`,
   },
+  Dna: { // mdi:dna — double-helix for opening a structure in the Mol* bio viewer
+    viewBox: `0 0 24 24`,
+    path:
+      `M4 2h2v2c0 1.42.68 2.66 1.73 3.5C6.68 8.34 6 9.58 6 11v2c0 1.42.68 2.66 1.73 3.5C6.68 17.34 6 18.58 6 20v2H4v-2c0-1.42.68-2.66 1.73-3.5C4.68 15.66 4 14.42 4 13v-2c0-1.42.68-2.66 1.73-3.5C4.68 6.66 4 5.42 4 4V2m14 0h2v2c0 1.42-.68 2.66-1.73 3.5C19.32 8.34 20 9.58 20 11v2c0 1.42-.68 2.66-1.73 3.5C19.32 17.34 20 18.58 20 20v2h-2v-2c0-1.42-.68-2.66-1.73-3.5C17.32 15.66 18 14.42 18 13v-2c0-1.42-.68-2.66-1.73-3.5C17.32 6.66 18 5.42 18 4V2M8 5v.5c0 .56.18 1.08.5 1.5h7c.32-.42.5-.94.5-1.5V5H8m.5 4c-.16.21-.29.45-.36.7L8 10h8l-.14-.3c-.07-.25-.2-.49-.36-.7h-7m-.34 6c.07.25.2.49.36.7h7c.16-.21.29-.45.36-.7H8.16M8 19v-.5c0-.56.18-1.08.5-1.5h7c.32.42.5.94.5 1.5v.5H8Z`,
+  },
 } as const
 
 export type IconName = keyof typeof icon_data

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -841,6 +841,7 @@
     on_edit_as_text,
     on_open_file_overlay,
     on_open_workflow_editor,
+    on_open_in_molstar,
     hide_extra_tools = false,
     persist_settings = true,
     initial_panel,
@@ -976,6 +977,9 @@
       on_open_file_overlay?: (file_path: string, filename: string, session_id: string) => void
       // Callback to open a workflow in the full editor. Receives workflow_id.
       on_open_workflow_editor?: (workflow_id: string) => void
+      // Callback to open the current structure in the Mol* bio viewer. When provided,
+      // a DNA toolbar button is shown (used by the desktop multi-pane host).
+      on_open_in_molstar?: () => void
       // Hide extra toolbar buttons (Build, Analysis, Workflow, IO, Server) — used in trajectory view
       hide_extra_tools?: boolean
       /** Set false for preview/readonly instances to prevent writing settings to localStorage. */
@@ -3096,6 +3100,7 @@
       {remote_origin}
       {structure}
       on_upload_to_hpc={() => { hpc_upload_open = true }}
+      {on_open_in_molstar}
       {molecular_fragments}
       {reset_text}
       {wrapper}

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -88,6 +88,7 @@
     delete_selected_atoms = () => {},
     on_popout_chat = undefined as (() => void) | undefined,
     on_upload_to_hpc = undefined as (() => void) | undefined,
+    on_open_in_molstar = undefined as (() => void) | undefined,
 
     // ── 子组件 snippet (面板组件从 Structure.svelte 传入) ──
     children,
@@ -146,6 +147,7 @@
     delete_selected_atoms?: () => void
     on_popout_chat?: () => void
     on_upload_to_hpc?: () => void
+    on_open_in_molstar?: () => void
 
     // 子组件 snippet
     children?: Snippet
@@ -469,6 +471,20 @@
         </button>
         <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.analysis_tools')}</span>
       </span>
+
+      {#if on_open_in_molstar}
+      <!-- === Open current structure in the Mol* bio viewer === -->
+      <span class="struct-toolbar-tooltip-wrap">
+        <button
+          type="button"
+          onclick={() => on_open_in_molstar?.()}
+          class="build-tools-toggle"
+        >
+          <Icon icon="Dna" />
+        </button>
+        <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.bio_open_in_molstar')}</span>
+      </span>
+      {/if}
 
       {#if !hidden_toolbar_items.includes('workflow') && !STATIC_ONLY}
       <!-- === Workflow === -->


### PR DESCRIPTION
## What

The bio-viewer "Open in Mol*" entry (added in #339) was a **floating overlay** button at the viewer's top-left — visually inconsistent with the structure viewer's own toolbar. This moves it **into the toolbar** as a proper DNA icon button, consistent with the other tools.

## Changes

- **`src/lib/icons.ts`** — add a `Dna` icon (mdi:dna double-helix, `viewBox 0 0 24 24`, `currentColor` fill — same convention as sibling fill icons).
- **`StructureToolbar.svelte`** — add an `on_open_in_molstar?: () => void` prop and a toolbar button (gated on the prop), placed between Analysis and Workflow. Markup mirrors the sibling "Upload to HPC" button (non-toggle action), tooltip = `t('structure.bio_open_in_molstar')`.
- **`Structure.svelte`** — thread `on_open_in_molstar` through to `<StructureToolbar>`.
- **`desktop/App.svelte`** — pass `on_open_in_molstar={() => toggle_pane_viewer(ts, idx)}` to `<Structure>`, and **remove** the floating `.bio-float-tl` overlay block + its CSS.

The Mol* pane's own "← back to native" toolbar toggle is untouched.

## Verification

- `pnpm check`: 0 errors.
- Live (headless): DNA button appears in the toolbar when a structure is loaded; the floating top-left overlay is gone; clicking the DNA button opens the structure in Mol*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)