### PR TITLE
fix(band): proactive + friendly KPOINTS guidance (no raw error)

### DIFF
--- a/src/lib/electronic/BandAnalysisPane.svelte
+++ b/src/lib/electronic/BandAnalysisPane.svelte
@@ -67,6 +67,21 @@
   // File inputs
   let kpoints_file = $state<File | null>(null)
   let show_file_dialog = $state(false)
+  // Set when a line-mode band vasprun was uploaded without the required KPOINTS;
+  // drives a friendly reminder + highlights the KPOINTS field instead of dumping
+  // the raw pymatgen error.
+  let kpoints_needed = $state(false)
+
+  /** Map an upload error to a user-facing message (friendly KPOINTS hint). */
+  function upload_error_message(e: any): string {
+    const raw = e?.message ?? ``
+    if (/KPOINTS not found|symmetry lines/i.test(raw)) {
+      kpoints_needed = true
+      return t('structure.band_kpoints_required')
+    }
+    kpoints_needed = false
+    return raw || t('structure.dos_upload_failed')
+  }
 
   // Derived
   let unique_elements: string[] = $derived(
@@ -82,6 +97,7 @@
     error_msg = ``
     try {
       session = await upload_band_vasprun(file, kpoints_file ?? undefined)
+      kpoints_needed = false
       proj_groups = []
       band_state.band_data = null
       band_state.projections = null
@@ -89,7 +105,7 @@
         on_structure_loaded(session.structure as PymatgenStructure)
       }
     } catch (e: any) {
-      error_msg = e.message || t('structure.dos_upload_failed')
+      error_msg = upload_error_message(e)
     } finally {
       uploading = false
     }
@@ -104,6 +120,7 @@
     error_msg = ``
     try {
       session = await upload_band_vasprun(file, kpoints_file ?? undefined)
+      kpoints_needed = false
       proj_groups = []
       band_state.band_data = null
       band_state.projections = null
@@ -111,7 +128,7 @@
         on_structure_loaded(session.structure as PymatgenStructure)
       }
     } catch (e: any) {
-      error_msg = e.message || t('structure.dos_upload_failed')
+      error_msg = upload_error_message(e)
     } finally {
       uploading = false
     }
@@ -238,7 +255,8 @@
             {t('structure.browse_remote')}
           </button>
         </div>
-        <div class="kpoints-row">
+        <p class="kpoints-hint">{t('structure.band_kpoints_hint')}</p>
+        <div class="kpoints-row" class:needs-kpoints={kpoints_needed}>
           <label class="kpoints-label">
             {t('structure.band_kpoints_optional')}
             <input
@@ -446,6 +464,7 @@
     error_msg = ''
     try {
       session = await upload_band_vasprun(file, kpoints_file ?? undefined)
+      kpoints_needed = false
       proj_groups = []
       band_state.band_data = null
       band_state.projections = null
@@ -453,7 +472,7 @@
         on_structure_loaded(session.structure as PymatgenStructure)
       }
     } catch (e: any) {
-      error_msg = e.message || t('structure.dos_upload_failed')
+      error_msg = upload_error_message(e)
     } finally {
       uploading = false
     }
@@ -485,7 +504,25 @@
     background: var(--accent-color, #007acc); color: white;
     border-radius: 4px; cursor: pointer; font-size: 0.9em;
   }
-  .kpoints-row { margin-top: 10px; }
+  .kpoints-hint {
+    margin: 10px 0 2px;
+    font-size: 0.8em;
+    line-height: 1.35;
+    color: var(--text-color-muted, rgba(255, 255, 255, 0.6));
+  }
+  .kpoints-row { margin-top: 4px; }
+  .kpoints-row.needs-kpoints {
+    border: 1px solid var(--error-color, #f88);
+    border-radius: 4px;
+    padding: 4px 6px;
+    background: light-dark(rgba(220, 38, 38, 0.06), rgba(255, 60, 60, 0.1));
+    animation: kpoints-pulse 1.2s ease-in-out 2;
+  }
+  .kpoints-row.needs-kpoints .kpoints-label { color: var(--error-color, #f88); }
+  @keyframes kpoints-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 transparent; }
+    50% { box-shadow: 0 0 0 3px var(--error-color, rgba(255, 136, 136, 0.45)); }
+  }
   .kpoints-label { font-size: 0.85em; color: var(--text-color-muted, rgba(255, 255, 255, 0.5)); }
   .kpoints-label input { font-size: 0.85em; margin-left: 4px; }
   .info-bar {

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -1429,6 +1429,8 @@ const structure: Record<string, string> = {
   band_projection_failed: `Projection failed`,
   band_parsing: `Parsing...`,
   band_kpoints_optional: `KPOINTS (optional):`,
+  band_kpoints_required: `This band run needs a line-mode KPOINTS file. Pick it in the KPOINTS field above first, then re-select vasprun.xml.`,
+  band_kpoints_hint: `Tip: a band structure along symmetry lines also needs its line-mode KPOINTS file. Set it below BEFORE choosing vasprun.xml.`,
   band_metal_status: `Metal?`,
   band_metal: `metal`,
   band_semicond: `semicond`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -1429,6 +1429,8 @@ const structure: Record<string, string> = {
   band_projection_failed: `投影计算失败`,
   band_parsing: `正在解析...`,
   band_kpoints_optional: `KPOINTS（可选）：`,
+  band_kpoints_required: `该能带需要 line-mode 的 KPOINTS 文件。请先在上方 KPOINTS 栏选择，再重新选 vasprun.xml。`,
+  band_kpoints_hint: `提示：沿对称线的能带还需要 line-mode 的 KPOINTS 文件。请在下方设置，并在选 vasprun.xml 之前先设好。`,
   band_metal_status: `金属性？`,
   band_metal: `金属`,
   band_semicond: `半导体`,


### PR DESCRIPTION
## Problem

Loading a band structure (line-mode) requires a KPOINTS file so pymatgen can map the k-path to symmetry labels. Without it, the upload failed with the raw pymatgen error: `Failed to parse band structure: KPOINTS not found but needed to obtain band structure along symmetry lines.` — unfriendly, and it gave no guidance. The KPOINTS field was also labeled merely "(optional)", under-selling that it's required for band paths. (Selecting the vasprun also auto-triggers the upload, so KPOINTS must be set *first*.)

## Fix (`BandAnalysisPane.svelte` + i18n)

- **Proactive**: an up-front hint in the band upload zone — *"a band structure along symmetry lines also needs its line-mode KPOINTS file; set it below BEFORE choosing vasprun.xml."*
- **Reactive**: when the upload fails specifically because KPOINTS is missing, replace the raw error with a friendly reminder (`band_kpoints_required`) and **highlight the KPOINTS field** (pulse) so the user knows exactly where to attach it. Other upload errors still surface normally.
- en/zh i18n in parity.

Applies to all three upload paths (file picker, drag-drop, remote file dialog).

## Verification
- `pnpm check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)