### PR TITLE
fix(workflow): make uid() collision-proof (fix flaky CI unit test)

### DIFF
--- a/src/lib/workflow/graph-model.ts
+++ b/src/lib/workflow/graph-model.ts
@@ -37,8 +37,12 @@ export function snap(v: number): number {
   return Math.round(v / GRID) * GRID
 }
 
+// Monotonic counter: guarantees unique ids even within the same millisecond.
+// (Math.random alone collided ~0.3% per 100 calls and intermittently flaked the
+// uniqueness test in CI.)
+let _id_seq = 0
 export function uid(): string {
-  return `n${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+  return `n${Date.now().toString(36)}-${(_id_seq++).toString(36)}`
 }
 
 // ─── Param display helpers ───
@@ -182,7 +186,7 @@ export function clone_for_paste(
     return { ...n, id: new_id, x: n.x + 40, y: n.y + 40 }
   })
   const new_edges = clipboard.edges.map(e => ({
-    ...e, id: `e${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    ...e, id: `e${Date.now().toString(36)}-${(_id_seq++).toString(36)}`,
     from: id_map[e.from], to: id_map[e.to],
   }))
   return { nodes: new_nodes, edges: new_edges }


### PR DESCRIPTION
## Problem

The `unit` CI job intermittently failed on `tests/vitest/workflow/graph-model.test.ts > uid > returns unique strings on repeated calls` with `AssertionError: expected 99 to be 100`. It tripped on the #343 merge commit but is **unrelated to #343** — it's a long-standing flake.

`uid()` was:
```ts
`n${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
```
In a tight loop `Date.now()` is constant, so uniqueness rode on 4 random base36 chars (36⁴ ≈ 1.68M). Birthday-collision over 100 draws ≈ 0.3% per run → occasionally two ids collide → 99 unique → test fails. (Also a real, if rare, latent bug: two workflow nodes could get the same id.)

## Fix

Use a module-level monotonic counter so ids are unique even within the same millisecond:
```ts
`n${Date.now().toString(36)}-${(_id_seq++).toString(36)}`
```
Applied to both `uid()` and the paste edge-id (same pattern). Deterministic — no more flake, no collision possibility.

## Verification
- `tests/vitest/workflow/graph-model.test.ts`: 206/206 passed.
- `pnpm check`: 0 errors (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)