### PR TITLE
fix(vscode): inline catrender WASM so it loads under webview CSP

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -67,6 +67,7 @@ interface WebviewData {
   wasm_binary?: string // base64-encoded ferrox WASM binary
   moyo_wasm_binary?: string // base64-encoded moyo WASM binary
   chgdiff_wasm_binary?: string // base64-encoded chgdiff WASM binary
+  catrender_wasm_binary?: string // base64-encoded catrender WASM binary
   server_port?: number // backend server port for API calls
 }
 
@@ -384,6 +385,19 @@ export const create_html = (
         console.log(`[CatGO] Successfully loaded chgdiff WASM binary (${chgdiff_buffer.length} bytes → ${data_with_wasm.chgdiff_wasm_binary.length} base64 chars)`)
       } else {
         console.warn(`[CatGO] No chgdiff WASM files found in ${assets_dir}`)
+      }
+
+      // Load catrender WASM (molecular SVG renderer)
+      const catrender_files = fs
+        .readdirSync(assets_dir)
+        .filter((f) => f.startsWith(`catrender_wasm_bg-`) && f.endsWith(`.wasm`))
+      if (catrender_files.length > 0) {
+        const catrender_path = path.join(assets_dir, catrender_files[0])
+        const catrender_buffer = fs.readFileSync(catrender_path)
+        data_with_wasm.catrender_wasm_binary = catrender_buffer.toString(`base64`)
+        console.log(`[CatGO] Successfully loaded catrender WASM binary (${catrender_buffer.length} bytes → ${data_with_wasm.catrender_wasm_binary.length} base64 chars)`)
+      } else {
+        console.warn(`[CatGO] No catrender WASM files found in ${assets_dir}`)
       }
     } else {
       console.warn(`[CatGO] Assets directory does not exist: ${assets_dir}`)

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -58,6 +58,7 @@ export interface CatGoData {
   wasm_binary?: string // base64-encoded ferrox WASM binary from extension
   moyo_wasm_binary?: string // base64-encoded moyo WASM binary from extension
   chgdiff_wasm_binary?: string // base64-encoded chgdiff WASM binary from extension
+  catrender_wasm_binary?: string // base64-encoded catrender WASM binary from extension
 }
 
 export interface ParseResult {
@@ -833,6 +834,21 @@ async function initialize() {
     }
   } else {
     console.log(`[CatGO Webview] No chgdiff WASM binary provided by extension - will fetch from bundled assets`)
+  }
+
+  // Stash catrender WASM binary for lazy init when the molecular SVG renderer
+  // is first used. catrender-wasm.ts reads globalThis.__catgo_catrender_wasm.
+  if (catgo_data?.catrender_wasm_binary) {
+    try {
+      console.log(`[CatGO Webview] Received catrender WASM binary (${catgo_data.catrender_wasm_binary.length} base64 chars)`)
+      const catrender_buffer = base64_to_array_buffer(catgo_data.catrender_wasm_binary)
+      ;(globalThis as unknown as { __catgo_catrender_wasm?: ArrayBuffer }).__catgo_catrender_wasm = catrender_buffer
+      console.log(`[CatGO Webview] Stashed catrender WASM binary on globalThis (${catrender_buffer.byteLength} bytes)`)
+    } catch (error) {
+      console.warn(`[CatGO Webview] Failed to decode catrender WASM binary:`, error)
+    }
+  } else {
+    console.log(`[CatGO Webview] No catrender WASM binary provided by extension - will fetch from bundled assets`)
   }
 
   // Initialize moyo WASM with binary data if provided by extension


### PR DESCRIPTION
Fixes #346

## Problem

Opening a structure in the VS Code extension throws in the webview:

```
TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok
```

The newly added **catrender** SVG renderer (`catrender_wasm_bg.wasm`) is initialized in `src/lib/structure/catrender/catrender-wasm.ts` by fetching its `.wasm` URL unless a preloaded binary exists on `globalThis.__catgo_catrender_wasm`. Under the webview CSP (`default-src 'none'`) that URL fetch fails, so `WebAssembly.compile` rejects.

`ferrox`, `moyo`, and `chgdiff` already sidestep this by being read as base64 in the extension host and passed to the webview inline. The extension just didn't know about `catrender`.

## Change

Mirror the existing `chgdiff` inline path:

- **`extensions/vscode/src/extension.ts`** — read `dist/assets/catrender_wasm_bg-*.wasm`, base64-encode into `catgoData.catrender_wasm_binary`.
- **`extensions/vscode/src/webview/main.ts`** — decode and stash on `globalThis.__catgo_catrender_wasm`, which `catrender-wasm.ts` already prefers over the URL fetch.

No web/desktop behavior change — those builds keep loading catrender via the bundled asset URL as before; only the webview path is affected.

## Testing

- `pnpm build` (webview + extension) succeeds.
- `vsce package` produces the `.vsix`; reinstalling, the catrender renderer initializes from the inlined binary and the WASM compile error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)