### PR TITLE
chore(release): v1.1.16 — Windows installer Claude-integration auto-setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.1.15"
+version = "1.1.16"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Release v1.1.16. Version bump (package.json / tauri.conf.json / Cargo.toml / Cargo.lock 1.1.15 → 1.1.16).

Headline: ships #348 — the bundled server auto-registers the catgo MCP + campaign skills with Claude Code on startup (writes `~/.claude.json`, copies skills), fixing the Windows-installer case where Claude couldn't find the catgo MCP / campaign with no CLI and no admin.

Merging this, then tagging `v1.1.16` triggers the desktop build/release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)