### PR TITLE
fix(build): pin @tauri-apps/api to 2.9.x (unblock v1.1.16 release build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@sapphi-red/web-noise-suppressor": "^0.3.5",
     "@spglib/moyo-wasm": "^0.7.1",
     "@sveltejs/kit": "^2.48.4",
-    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/api": "~2.9.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
@@ -211,6 +211,9 @@
     "dist"
   ],
   "pnpm": {
+    "overrides": {
+      "@tauri-apps/api": "2.9.1"
+    },
     "onlyBuiltDependencies": [
       "esbuild",
       "node-pty",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tauri-apps/api': 2.9.1
+
 patchedDependencies:
   '@openai/codex-sdk@0.132.0-alpha.1':
     hash: 9a82114b2cce8ca4a05e4ef971eab411712e1f9e273f5557f3f7b79e981af1c6
@@ -44,8 +47,8 @@ importers:
         specifier: ^2.48.4
         version: 2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@25.0.10)))(svelte@5.48.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10))
       '@tauri-apps/api':
-        specifier: ^2.11.0
-        version: 2.11.0
+        specifier: 2.9.1
+        version: 2.9.1
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
@@ -1360,8 +1363,8 @@ packages:
       svelte: ^5.0.0
       vite: ^6.3.0 || ^7.0.0
 
-  '@tauri-apps/api@2.11.0':
-    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+  '@tauri-apps/api@2.9.1':
+    resolution: {integrity: sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==}
 
   '@tauri-apps/cli-darwin-arm64@2.9.6':
     resolution: {integrity: sha512-gf5no6N9FCk1qMrti4lfwP77JHP5haASZgVbBgpZG7BUepB3fhiLCXGUK8LvuOjP36HivXewjg72LTnPDScnQQ==}
@@ -5203,7 +5206,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.0.10)
       vitefu: 1.1.1(vite@7.3.1(@types/node@25.0.10))
 
-  '@tauri-apps/api@2.11.0': {}
+  '@tauri-apps/api@2.9.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.9.6':
     optional: true
@@ -5254,27 +5257,27 @@ snapshots:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.9.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.9.1
 
   '@tauri-apps/plugin-fs@2.4.5':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.9.1
 
   '@tauri-apps/plugin-http@2.5.6':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.9.1
 
   '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.9.1
 
   '@tauri-apps/plugin-shell@2.3.4':
     dependencies:
-      '@tauri-apps/api': 2.11.0
+      '@tauri-apps/api': 2.9.1
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
The v1.1.16 tag build failed on **all platforms** at the "Build Tauri app" step:

```
Found version mismatched Tauri packages.
tauri (v2.9.5) : @tauri-apps/api (v2.11.0)
```

`@tauri-apps/api` had drifted to `^2.11.0` (v1.1.15 shipped 2.9.1) while the Rust `tauri` crate stayed 2.9.5; `@tauri-apps/plugin-opener` also pulled api 2.11 transitively. Fix: pin the direct dep to `~2.9.0` + a pnpm `overrides` forcing `@tauri-apps/api=2.9.1` everywhere — restores the v1.1.15 proven-working alignment. `pnpm check` 0 errors; lock now resolves only api 2.9.1.

Long-term, upgrade the whole Tauri stack to 2.11 deliberately (Rust crate + npm together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)