### PR TITLE
fix(mobile): move 'Open in Mol*' into the toolbar (DNA icon, drop floating button)

### DIFF
--- a/src/lib/mobile/MobileWorkspace.svelte
+++ b/src/lib/mobile/MobileWorkspace.svelte
@@ -625,10 +625,6 @@
             </div>
           </div>
         {:else if has_structure}
-          <!-- Universal manual entry: any loaded structure → Mol* on demand. -->
-          <div class="mw-bio-float">
-            <BioViewerToggle is_molstar={false} on_toggle={toggle_mobile_viewer} />
-          </div>
           <Structure
             bind:structure
             bind:saveable_structure
@@ -638,6 +634,7 @@
             allow_file_drop={false}
             persist_settings={false}
             hidden_toolbar_items={HIDDEN_TOOLBAR}
+            on_open_in_molstar={toggle_mobile_viewer}
             tab_id="mobile"
             is_active={true}
           />
@@ -1138,12 +1135,6 @@
     flex: 1 1 auto;
     min-height: 0;
     position: relative;
-  }
-  .mw-bio-float {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    z-index: 20;
   }
   .mw-body.split-h .mw-struct,
   .mw-body.split-v .mw-struct {


### PR DESCRIPTION
Mobile follow-up to #343. That PR moved the desktop `Open in Mol*` entry into the structure toolbar but left **mobile** with the old floating `.mw-bio-float` overlay — inconsistent with the other mobile toolbar icons.

Fix: pass `on_open_in_molstar` to the mobile `<Structure>` (so the shared StructureToolbar shows the DNA button) and remove the floating button + its CSS. The Mol* pane's back-to-native toggle is untouched.

`pnpm check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)