### PR TITLE
fix(ci): Android workflow — '--apk true' + build dispatched ref

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -118,7 +118,7 @@ jobs:
         # already hidden on mobile.
         env:
           VITE_STATIC_ONLY: '1'
-        run: pnpm tauri android build --apk
+        run: pnpm tauri android build --apk true
 
       - name: Sign the APK (apksigner)
         id: sign

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -38,9 +38,10 @@ jobs:
       NDK_VERSION: 26.1.10909125
     steps:
       - name: Checkout repository
+        # Builds the dispatched ref (--ref). `release_tag` is ONLY the upload
+        # target, not the build source — so you can build `main` and upload the
+        # APK to an existing release tag.
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -29,6 +29,10 @@ on:
         required: false
         default: ''
 
+# Needed for `gh release upload` to attach the APK to a release.
+permissions:
+  contents: write
+
 jobs:
   android:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Two fixes from the first live runs of `android-build.yml` (#351):
1. `tauri android build --apk` → **`--apk true`** (the CLI requires a value, like `--aab true`).
2. Checkout builds the **dispatched ref** (`--ref`), not `release_tag` — so you can build `main` and upload the APK to an existing release tag.

Verified live: build + apksigner sign both succeed; signed universal APK produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)