### PR TITLE
fix(hpc): jump-host plain-password auth + DNS-failure hint

### DIFF
--- a/server/catgo/utils/connection_pool.py
+++ b/server/catgo/utils/connection_pool.py
@@ -196,14 +196,22 @@ class HPCConnectionPool:
                     jump_kwargs["tunnel"] = tunnel
 
                 if config.jump_password:
-                    # Jump host has its own password → use kbdint
+                    # Jump host has its own password.
+                    # KbdintSSHClient only answers the "keyboard-interactive"
+                    # method, so we ALSO pass `password` for the plain SSH
+                    # "password" method — many ordinary Linux boxes (e.g. a lab
+                    # machine over Tailscale) only offer "password", not kbdint.
+                    # Without this, the only attempted method is kbdint and the
+                    # jump host returns "Permission denied".
                     jp = config.jump_password.get_secret_value()
 
                     def jump_client_factory() -> KbdintSSHClient:
                         return KbdintSSHClient(password=jp)
 
                     jump_kwargs["client_factory"] = jump_client_factory
-                    jump_kwargs["preferred_auth"] = "keyboard-interactive,password"
+                    jump_kwargs["password"] = jp
+                    jump_kwargs["preferred_auth"] = "password,keyboard-interactive"
+                    jump_kwargs["client_keys"] = []
                     jump_conn = await asyncssh.connect(**jump_kwargs)
                 else:
                     # No jump password → use SSH key auth

--- a/server/catgo/utils/connection_pool.py
+++ b/server/catgo/utils/connection_pool.py
@@ -394,7 +394,14 @@ class HPCConnectionPool:
                     f"(e.g. ~/.ssh/id_rsa_myhost) to avoid trying wrong keys."
                 )
                 raise ConnectionError(hint) from exc
-            if "getaddrinfo" in msg.lower():
+            dns_markers = (
+                "getaddrinfo",
+                "name or service not known",
+                "nodename nor servname",
+                "temporary failure in name resolution",
+                "could not resolve hostname",
+            )
+            if any(marker in msg.lower() for marker in dns_markers):
                 # DNS resolution failed — identify which host
                 failed_host = config.host
                 all_resolved = True


### PR DESCRIPTION
## What

Two desktop HPC connection fixes, found while debugging a real lab-machine→Shaheen jump connection.

### 1. Jump host plain-password auth (the actual bug)
The jump-host branch wired only a kbdint `client_factory` + `preferred_auth`, but never set the `password` connect kwarg. `KbdintSSHClient` answers only the **keyboard-interactive** method, so the plain SSH **`password`** method had no password to send. Ordinary boxes that offer only `password` (e.g. a lab machine over Tailscale) returned `Permission denied`, even though a **direct** connection to the same host worked (the target path *does* set `password`).

Fix: mirror the target path — set `password`, prefer `password,keyboard-interactive`, clear `client_keys`.

### 2. DNS-failure hint never fired
The error-handling branch only matched `"getaddrinfo"`, but `socket.gaierror` / tunnelled connects surface `Name or service not known` / `Could not resolve hostname` without that token, so the "which host failed, check spelling" hint was skipped and users saw only the raw message. Broadened the match.

## Why it matters
Connecting through a bastion to an HPC cluster (target = SSH key + OTP, jump = password) is a common setup; the jump leg was simply unauthenticatable. The DNS hint would have surfaced a hostname typo immediately instead of a bare error.

## Scope / safety
- Single file: `server/catgo/utils/connection_pool.py`.
- No-jump path unchanged. Target path unchanged.
- `py_compile` clean. Backend exercised live during debugging (jump leg now authenticates; full chain reaches Shaheen).

## Not included
Mobile (Rust russh) is unaffected — its jump path already calls `authenticate_password` (the real password method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)