### PR TITLE
Pane tree (1/5): unified recursive pane-tree foundation

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -47,13 +47,19 @@
   import { terminal } from './state/terminal-state.svelte'
   // Extracted pure utilities
   import {
-    type PaneState, type LayoutType, type StructureTabState, type SampleStructure, type LibraryEntry,
-    layout_panel_count, get_pane_label, create_empty_pane, pane_has_content,
+    type PaneState, type StructureTabState, type SampleStructure, type LibraryEntry,
+    get_pane_label, create_empty_pane, pane_has_content,
     content_to_base64, create_tab_state, auto_name as _auto_name,
-    find_import_target_pane, get_visible_panes, get_grid_style, get_pane_position,
     is_chgcar_file, NON_STRUCTURE_EXTS, update_export_format, format_from_ext,
     serialize_structure_content,
   } from './pane-utils'
+  // Recursive pane tree (replaces the fixed single/splitH/splitV/quad grid)
+  import PaneTree from './PaneTree.svelte'
+  import {
+    type LeafNode, type PresetId,
+    leaves, leafCount, findLeafById, findFirstEmptyLeaf,
+    escalateForImport, setRatio, create_empty_leaf,
+  } from './pane-tree'
   // Deep-clone structures on assignment into a pane so panes/tabs never alias
   // the same object (module-level samples, library entries, reused DB imports).
   import { clone_structure } from '$lib/structure/clone'
@@ -110,9 +116,8 @@
   } from './lib/drag-drop-handlers'
   // Extracted resize handlers
   import {
-    on_divider_mousedown as _on_divider_mousedown,
-    on_center_mousedown as _on_center_mousedown,
-    type ResizeDeps,
+    on_split_drag,
+    type ResizeDepsMin,
   } from './lib/resize-handlers'
   // Extracted dialog sub-components
   import ExportSaveDialog from './components/ExportSaveDialog.svelte'
@@ -143,9 +148,9 @@
   let popout_doping_pt_mode = $state(false)
   let is_loading = $state(false)
   let loading_text = $state(``)
-  let drag_target_pane = $state<number | null>(null)
+  let drag_target_leaf = $state<string | null>(null)
   let is_panel_resizing = $state(false)
-  let resize_axis = $state<`col` | `row`>(`col`)
+  let active_split_id = $state<string | null>(null)
 
   // Dep objects wired to local $state
   const sidebar_deps: SidebarHandlerDeps = {
@@ -175,7 +180,7 @@
     set_pending_layout_change: (v) => { tm.pending_layout_change = v },
   }
   const export_deps: ExportHandlerDeps = {
-    close_panel: (tab_id, pane_idx) => _close_panel(pane_deps, tab_id, pane_idx),
+    close_panel: (tab_id, leaf_id) => _close_panel(pane_deps, tab_id, leaf_id),
     load_close_save_projects,
   }
   const drag_deps: DragDropDeps = {
@@ -186,18 +191,17 @@
     import_many,
     stream_trajectory: (path, filename) => stream_path_if_large(path, filename),
     stream_trajectory_file: (file) => stream_file_if_large(file),
-    get_drag_target_pane: () => drag_target_pane,
-    set_drag_target_pane: (v) => { drag_target_pane = v },
+    get_drag_target_pane: () => drag_target_leaf,
+    set_drag_target_pane: (v) => { drag_target_leaf = v },
     set_is_loading: (v) => { is_loading = v },
   }
-  const resize_deps: ResizeDeps = {
+  const resize_deps_min: ResizeDepsMin = {
     tab_states,
     set_is_panel_resizing: (v) => { is_panel_resizing = v },
-    set_resize_axis: (v) => { resize_axis = v },
   }
 
   // Thin wrappers that pass deps
-  function popout_pane(tab_id: string, pane_idx: number) { return _popout_pane(tab_id, pane_idx, tab_states, is_tauri) }
+  function popout_pane(tab_id: string, leaf_id: string) { return _popout_pane(tab_id, leaf_id, tab_states, is_tauri) }
   function popout_workflow() { return _popout_workflow(is_tauri, close_tab, switch_to_structure) }
   function popout_terminal() { return _popout_terminal(is_tauri, terminal, close_tab, switch_to_structure) }
   function handle_sidebar_load(content: string | ArrayBuffer, filename: string, file_path?: string, session_id?: string) { _handle_sidebar_load(sidebar_deps, content, filename, file_path, session_id) }
@@ -212,13 +216,17 @@
     let tab_id = tm.active_tab_id
     let ts = tab_states[tab_id]
     if (!ts) return
-    let target = find_import_target_pane(ts, ts.active_pane)
-    if (target === -1) {
+    let target: string
+    const r = escalateForImport(ts.root, ts.active_leaf_id)
+    if (!r) {
       open_tab(`structure`)
       tab_id = tm.active_tab_id
       ts = tab_states[tab_id]
       if (!ts) return
-      target = 0
+      target = ts.active_leaf_id
+    } else {
+      ts.root = r.root
+      target = r.leafId
     }
     try {
       const { load_remote_trajectory } = await import(`$lib/trajectory/remote-frame-loader`)
@@ -271,10 +279,10 @@
     return false
   }
   function handle_terminal_open_file(file_path: string, filename: string, session_id: string) { return _handle_terminal_open_file(sidebar_deps, file_path, filename, session_id) }
-  function handle_unload(tab_id: string, pane_idx: number) { _handle_unload(pane_deps, tab_id, pane_idx) }
-  function close_panel(tab_id: string, pane_idx: number) { _close_panel(pane_deps, tab_id, pane_idx) }
-  function save_and_close_panel(tab_id: string, pane_idx: number) { return _save_and_close_panel(pane_deps, tab_id, pane_idx) }
-  function handle_layout_change(new_layout: LayoutType) { _handle_layout_change(layout_deps, new_layout) }
+  function handle_unload(tab_id: string, leaf_id: string) { _handle_unload(pane_deps, tab_id, leaf_id) }
+  function close_panel(tab_id: string, leaf_id: string) { _close_panel(pane_deps, tab_id, leaf_id) }
+  function save_and_close_panel(tab_id: string, leaf_id: string) { return _save_and_close_panel(pane_deps, tab_id, leaf_id) }
+  function handle_layout_change(new_layout: PresetId) { _handle_layout_change(layout_deps, new_layout) }
   function confirm_layout_change() { _confirm_layout_change(layout_deps) }
   function open_save_dialog(structure: Record<string, unknown>) { _open_save_dialog(export_deps, structure) }
   function open_export_to_hpc(structure: Record<string, unknown>) { _open_export_to_hpc(structure) }
@@ -283,24 +291,25 @@
   function handle_dragover(event: DragEvent) { _handle_dragover(drag_deps, event) }
   function handle_dragleave(event: DragEvent) { _handle_dragleave(drag_deps, event) }
   function handle_drop(event: DragEvent) { return _handle_drop(drag_deps, event) }
-  function on_divider_mousedown(e: MouseEvent, axis: `col` | `row`, tab_id: string) { _on_divider_mousedown(resize_deps, e, axis, tab_id) }
-  function on_center_mousedown(e: MouseEvent, tab_id: string) { _on_center_mousedown(resize_deps, e, tab_id) }
+  function start_split_resize(e: MouseEvent, split_id: string, dir: `h` | `v`, tab_id: string) {
+    on_split_drag(resize_deps_min, e, split_id, dir, tab_id, () => active_split_id = split_id, () => active_split_id = null)
+  }
 
   // ========== Plugin Hub (via Structure.svelte counter prop) ==========
 
-  function open_plugin_hub_on_active_pane() {
+  function open_plugin_hub_on_active_leaf() {
     const ts = get_active_ts()
     if (!ts) return
-    const idx = ts.active_pane
-    const pane = ts.panes[idx]
-    if (!pane) return
+    const leaf = findLeafById(ts.root, ts.active_leaf_id)
+    if (!leaf) return
+    const pane = leaf.content.pane
     // If pane has no structure, load water so Structure mounts
     if (!pane.structure && !pane.trajectory && !pane.cube_file) {
-      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
-      ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
-      ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
+      pane.structure = clone_structure(water as unknown as AnyStructure)
+      pane.initial_site_count = (water as any).sites?.length ?? 0
+      pane.initial_structure_ref = water as unknown as AnyStructure
     }
-    ts.panes[idx].open_plugin_hub = (ts.panes[idx].open_plugin_hub ?? 0) + 1
+    pane.open_plugin_hub = (pane.open_plugin_hub ?? 0) + 1
   }
 
   // ========== Close All Tabs (extracted to ./lib/close-all-helper.ts) ==========
@@ -405,7 +414,9 @@
   async function open_edit_as_text(structure: Record<string, unknown>) {
     const ts = get_active_ts()
     if (!ts) return
-    const pane = ts.panes[ts.active_pane]
+    const active_leaf = findLeafById(ts.root, ts.active_leaf_id)
+    if (!active_leaf) return
+    const pane = active_leaf.content.pane
     const filename = pane.source_filename || `structure.cif`
 
     // Determine format from filename
@@ -432,9 +443,9 @@
       else content = structure_to_cif_str(s)
     }
 
-    // Track which tab/pane this editor is tied to for applying changes back
+    // Track which tab/leaf this editor is tied to for applying changes back
     const target_tab_id = tm.active_tab_id
-    const target_pane_idx = ts.active_pane
+    const target_leaf_id = ts.active_leaf_id
 
     sidebar.editor_content = content
     sidebar.editor_filename = filename
@@ -447,11 +458,13 @@
         const parsed = parse_structure_file(new_content, filename)
         if (parsed?.sites?.length) {
           const target_ts = tab_states[target_tab_id]
-          if (target_ts) {
-            target_ts.panes[target_pane_idx].structure = clone_structure(parsed)
-            target_ts.panes[target_pane_idx].initial_structure_ref = parsed
-            target_ts.panes[target_pane_idx].initial_site_count = parsed.sites.length
-            target_ts.panes[target_pane_idx].modified = false
+          const leaf = target_ts ? findLeafById(target_ts.root, target_leaf_id) : null
+          if (target_ts && leaf) {
+            const p = leaf.content.pane
+            p.structure = clone_structure(parsed)
+            p.initial_structure_ref = parsed
+            p.initial_site_count = parsed.sites.length
+            p.modified = false
             update_tab_label(target_tab_id)
           }
         }
@@ -471,19 +484,18 @@
     const ts = tm.tab_states[ts_tab_id]
     if (!ts) return
     // If this workflow is already open in a pane, switch to it and signal reload
-    const existing = ts.panes.findIndex(p => p.mode === `workflow` && p.workflow_id === workflow_id)
-    if (existing >= 0) {
+    const existing = leaves(ts.root).find(l => l.content.pane.mode === `workflow` && l.content.pane.workflow_id === workflow_id)
+    if (existing) {
       tm.active_tab_id = ts_tab_id
-      ts.active_pane = existing
+      ts.active_leaf_id = existing.id
       // Signal WorkflowEditor to reload from DB (MCP may have added nodes)
       get_workflow_slice(ts_tab_id).workflow_reload_seq.seq++
       return
     }
-    const pane_idx = ts.panes.findIndex(p => !pane_has_content(p))
-    const target = pane_idx >= 0 ? pane_idx : ts.active_pane
-    ts.panes[target] = { ...create_empty_pane(), mode: `workflow`, workflow_id, workflow_compact: compact }
-    ts.panes = [...ts.panes]
-    ts.active_pane = target
+    const target = findFirstEmptyLeaf(ts.root) ?? findLeafById(ts.root, ts.active_leaf_id)
+    if (!target) return
+    Object.assign(target.content.pane, { ...create_empty_pane(), mode: `workflow`, workflow_id, workflow_compact: compact })
+    ts.active_leaf_id = target.id
     tm.active_tab_id = ts_tab_id
     update_tab_label(ts_tab_id)
   }
@@ -528,16 +540,17 @@
     const tab_id = tm.active_tab_id
     const ts = tm.tab_states[tab_id]
     if (!ts) return
+    const leaf = leaves(ts.root)[0]
     // Guard: if create_tab hit the 12-tab limit, active_tab didn't change —
     // don't silently overwrite the existing tab's structure
-    if (tab_id === prev_tab_id && ts.panes[0].structure) {
+    if (tab_id === prev_tab_id && leaf.content.pane.structure) {
       console.warn(`[App] Tab limit reached, cannot open structure in new tab`)
       return
     }
-    ts.panes[0].structure = clone_structure(struct)
-    ts.panes[0].initial_structure_ref = struct
-    ts.panes[0].initial_site_count = struct.sites?.length ?? 0
-    ts.panes[0].modified = false
+    leaf.content.pane.structure = clone_structure(struct)
+    leaf.content.pane.initial_structure_ref = struct
+    leaf.content.pane.initial_site_count = struct.sites?.length ?? 0
+    leaf.content.pane.modified = false
     // Set tab label — use tm.tabs (raw $state), not tabs_with_badges ($derived copy)
     const tab = tm.tabs.find(t => t.id === tab_id)
     if (tab && label) tab.label = label
@@ -547,7 +560,7 @@
   function get_current_structure(): Record<string, unknown> | null {
     const ts = get_active_ts()
     if (!ts) return null
-    const pane = ts.panes[ts.active_pane]
+    const pane = findLeafById(ts.root, ts.active_leaf_id)?.content.pane
     if (!pane?.structure) return null
     return pane.structure as unknown as Record<string, unknown>
   }
@@ -588,21 +601,11 @@
   // ========== Global Effects ==========
   $effect(() => {
     for (const ts of Object.values(tab_states)) {
-      const cc = ts.panes.filter(p => pane_has_content(p)).length
-      const current_count = layout_panel_count(ts.layout)
-      if (cc > current_count) {
-        ts.layout = cc <= 2 ? `splitH` : `quad`
-      }
-    }
-  })
-
-  $effect(() => {
-    for (const ts of Object.values(tab_states)) {
-      for (let i = 0; i < ts.panes.length; i++) {
-        const pane = ts.panes[i]
+      for (const leaf of leaves(ts.root)) {
+        const pane = leaf.content.pane
         if (pane.structure && !pane.modified) {
           if (pane.initial_site_count > 0 && pane.structure.sites.length !== pane.initial_site_count) {
-            ts.panes[i].modified = true
+            pane.modified = true
           }
         }
       }
@@ -619,9 +622,9 @@
     try {
       const content = await readFile(file_path)
       const text = new TextDecoder().decode(content)
-      const target_pane = ts.panes.findIndex(p => !pane_has_content(p))
-      const pane_idx = target_pane >= 0 ? target_pane : ts.active_pane
-      await process_file_content(tm.active_tab_id, text, filename, pane_idx, null, file_path)
+      const empty = findFirstEmptyLeaf(ts.root)
+      const leaf_id = empty ? empty.id : ts.active_leaf_id
+      await process_file_content(tm.active_tab_id, text, filename, leaf_id, null, file_path)
     } catch (err) {
       console.error(`[Tauri] Error reading file:`, err)
     } finally {
@@ -671,12 +674,12 @@
   let file_input_ref = $state<HTMLInputElement | undefined>()
   let folder_input_ref = $state<HTMLInputElement | undefined>()
   let file_input_target_tab = ``
-  let file_input_target_pane = 0
+  let file_input_target_leaf = ``
 
-  async function handle_open_file(tab_id: string, pane_idx: number) {
+  async function handle_open_file(tab_id: string, leaf_id: string) {
     const ts = tab_states[tab_id]
     if (!ts) return
-    ts.active_pane = pane_idx
+    ts.active_leaf_id = leaf_id
     if (is_tauri) {
       try {
         // Pick paths first; divert large trajectories to the backend streamer
@@ -692,7 +695,7 @@
           const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
           const results = await tauri_read_dropped_paths(read_paths, accept)
           if (results.length > 0) {
-            await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+            await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), leaf_id)
           }
         }
       } catch (err) {
@@ -700,16 +703,16 @@
       }
     } else {
       file_input_target_tab = tab_id
-      file_input_target_pane = pane_idx
+      file_input_target_leaf = leaf_id
       file_input_ref?.click()
     }
   }
 
   /** Open a folder and import every recognizable structure file inside it. */
-  async function handle_open_folder(tab_id: string, pane_idx: number) {
+  async function handle_open_folder(tab_id: string, leaf_id: string) {
     const ts = tab_states[tab_id]
     if (!ts) return
-    ts.active_pane = pane_idx
+    ts.active_leaf_id = leaf_id
     const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
     if (is_tauri) {
       try {
@@ -725,7 +728,7 @@
         if (read_paths.length > 0) {
           const results = await tauri_read_dropped_paths(read_paths, accept)
           if (results.length > 0) {
-            await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), pane_idx)
+            await import_many(tab_id, results.map(r => ({ content: r.content, filename: r.filename, path: r.path })), leaf_id)
           }
         }
       } catch (err) {
@@ -733,7 +736,7 @@
       }
     } else {
       file_input_target_tab = tab_id
-      file_input_target_pane = pane_idx
+      file_input_target_leaf = leaf_id
       folder_input_ref?.click()
     }
   }
@@ -752,7 +755,7 @@
         await import_many(
           file_input_target_tab,
           to_import.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
-          file_input_target_pane,
+          file_input_target_leaf,
         )
       }
     } catch (err) {
@@ -778,7 +781,7 @@
         await import_many(
           file_input_target_tab,
           to_import.map(f => ({ file: f, filename: f.name, path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || null })),
-          file_input_target_pane,
+          file_input_target_leaf,
         )
       }
     } catch (err) {
@@ -793,9 +796,10 @@
     if (!ts) return
     if (!imported?.sites?.length) return
 
-    const target = modal.import_target_pane
+    const leaf = findLeafById(ts.root, modal.import_target_leaf)
+    if (!leaf) return
     // Mutate the pane in-place so Svelte 5's deep $state proxy tracks the change
-    const pane = ts.panes[target]
+    const pane = leaf.content.pane
     pane.structure = clone_structure(imported as AnyStructure)
     pane.initial_site_count = imported.sites.length
     pane.initial_structure_ref = imported as AnyStructure
@@ -1003,12 +1007,14 @@
   function apply_entry_to_pane(
     tab_id: string,
     ts: StructureTabState,
-    target: number,
+    leaf_id: string,
     e: LibraryEntry,
     remote_origin: { session_id: string; file_path: string } | null = null,
     local_file_path: string | null = null,
   ) {
-    const p = ts.panes[target]
+    const leaf = findLeafById(ts.root, leaf_id)
+    if (!leaf) return
+    const p = leaf.content.pane
     if (e.cube_file) {
       p.structure = clone_structure(e.structure)
       p.initial_site_count = e.structure?.sites?.length ?? 0
@@ -1039,21 +1045,24 @@
     p.remote_origin = remote_origin
     p.local_file_path = local_file_path
     p.source_filename = e.filename
-    ts.active_pane = target
+    ts.active_leaf_id = leaf_id
     update_tab_label(tab_id)
   }
 
-  async function process_file_content(tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) {
+  async function process_file_content(tab_id: string, content: string | ArrayBuffer, filename: string, leaf_id: string, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) {
     const ts = tab_states[tab_id]
     if (!ts) return
-    let target = find_import_target_pane(ts, pane_idx)
-    if (target === -1) {
+    let target: string
+    const r = escalateForImport(ts.root, leaf_id)
+    if (!r) {
       // All panes full — open a new tab and load there
       open_tab(`structure`)
       const new_ts = tab_states[tm.active_tab_id]
       if (!new_ts) return
-      return process_file_content(tm.active_tab_id, content, filename, 0, remote_origin, local_file_path)
+      return process_file_content(tm.active_tab_id, content, filename, new_ts.active_leaf_id, remote_origin, local_file_path)
     }
+    ts.root = r.root
+    target = r.leafId
     const outcome = await ingest_one(content, filename)
     if (outcome.kind === `skip`) return
     if (outcome.kind === `editor`) {
@@ -1077,11 +1086,11 @@
   async function import_many(
     tab_id: string,
     items: Array<{ content?: string | ArrayBuffer; filename: string; file?: File; path?: string | null }>,
-    pane_idx: number,
+    leaf_id: string,
   ) {
     const ts = tab_states[tab_id]
     if (!ts) return
-    ts.active_pane = pane_idx
+    ts.active_leaf_id = leaf_id
     is_loading = true
     const start = ts.library.length
     let failures = 0
@@ -1119,7 +1128,7 @@
     if (!ts) return
     const entry = ts.library.find(e => e.id === id)
     if (!entry) return
-    apply_entry_to_pane(tab_id, ts, ts.active_pane, entry)
+    apply_entry_to_pane(tab_id, ts, ts.active_leaf_id, entry)
     ts.active_library_id = id
     tick().then(() => window.dispatchEvent(new Event(`resize`)))
   }
@@ -1135,7 +1144,8 @@
       select_library_entry(tab_id, ts.library[0].id)
     } else {
       ts.active_library_id = null
-      ts.panes[ts.active_pane] = create_empty_pane()
+      const leaf = findLeafById(ts.root, ts.active_leaf_id)
+      if (leaf) Object.assign(leaf.content.pane, create_empty_pane())
       update_tab_label(tab_id)
     }
   }
@@ -1148,11 +1158,11 @@
     ts.active_library_id = null
   }
 
-  function create_on_file_drop(tab_id: string, pane_idx: number) {
+  function create_on_file_drop(tab_id: string, leaf_id: string) {
     return async (content: string | ArrayBuffer, filename: string) => {
       is_loading = true
       try {
-        await process_file_content(tab_id, content, filename, pane_idx)
+        await process_file_content(tab_id, content, filename, leaf_id)
       } catch (err) {
         console.error(err)
       } finally {
@@ -1161,66 +1171,70 @@
     }
   }
 
-  function create_on_file_load(tab_id: string, pane_idx: number) {
+  function create_on_file_load(tab_id: string, leaf_id: string) {
     return (data: { structure?: AnyStructure; filename?: string; trajectory?: unknown }) => {
       const ts = tab_states[tab_id]
       if (!ts) return
-      let target = find_import_target_pane(ts, pane_idx)
-      if (target === -1) {
+      const r = escalateForImport(ts.root, leaf_id)
+      if (!r) {
         // All panes full — open a new tab
         open_tab(`structure`)
         const new_ts = tab_states[tm.active_tab_id]
         if (!new_ts) return
-        target = 0
-        // Re-bind to new tab
-        const new_panes = new_ts.panes
+        const new_leaf = leaves(new_ts.root)[0]
         if (data.structure) {
-          new_panes[0].structure = clone_structure(data.structure)
-          new_panes[0].is_trajectory_mode = false
-          new_panes[0].trajectory = null
-          new_panes[0].initial_site_count = data.structure.sites?.length ?? 0
-          new_panes[0].initial_structure_ref = data.structure
-          new_panes[0].modified = false
-          new_ts.panes = [...new_panes]
+          const p = new_leaf.content.pane
+          p.structure = clone_structure(data.structure)
+          p.is_trajectory_mode = false
+          p.trajectory = null
+          p.initial_site_count = data.structure.sites?.length ?? 0
+          p.initial_structure_ref = data.structure
+          p.modified = false
+          new_ts.active_leaf_id = new_leaf.id
           update_tab_label(tm.active_tab_id)
         }
         return
       }
+      ts.root = r.root
+      const target_id = r.leafId
+      const target_leaf = findLeafById(ts.root, target_id)
+      if (!target_leaf) return
+      const p = target_leaf.content.pane
       if (data.structure) {
-        ts.panes[target].structure = clone_structure(data.structure)
-        ts.panes[target].is_trajectory_mode = false
-        ts.panes[target].trajectory = null
-        ts.panes[target].initial_site_count = data.structure.sites?.length ?? 0
-        ts.panes[target].initial_structure_ref = data.structure
-        ts.panes[target].modified = false
+        p.structure = clone_structure(data.structure)
+        p.is_trajectory_mode = false
+        p.trajectory = null
+        p.initial_site_count = data.structure.sites?.length ?? 0
+        p.initial_structure_ref = data.structure
+        p.modified = false
       }
       if (data.trajectory) {
         const traj = data.trajectory as { frames?: unknown[]; metadata?: { source_format?: string } }
         if (traj.metadata?.source_format === `single_structure` && traj.frames?.length === 1) {
           const frame = traj.frames[0] as { structure?: AnyStructure }
           if (frame?.structure) {
-            ts.panes[target].structure = clone_structure(frame.structure)
-            ts.panes[target].is_trajectory_mode = false
-            ts.panes[target].trajectory = null
-            ts.panes[target].initial_site_count = frame.structure.sites?.length ?? 0
-            ts.panes[target].initial_structure_ref = frame.structure
-            ts.panes[target].modified = false
-            ts.panes[target].selected_sites = []
-            ts.panes[target].current_step_idx = 0
-            ts.active_pane = target
+            p.structure = clone_structure(frame.structure)
+            p.is_trajectory_mode = false
+            p.trajectory = null
+            p.initial_site_count = frame.structure.sites?.length ?? 0
+            p.initial_structure_ref = frame.structure
+            p.modified = false
+            p.selected_sites = []
+            p.current_step_idx = 0
+            ts.active_leaf_id = target_id
             update_tab_label(tab_id)
             return
           }
         }
-        ts.panes[target].trajectory = data.trajectory
-        ts.panes[target].is_trajectory_mode = true
-        ts.panes[target].structure = undefined
-        ts.panes[target].initial_site_count = 0
-        ts.panes[target].modified = false
+        p.trajectory = data.trajectory
+        p.is_trajectory_mode = true
+        p.structure = undefined
+        p.initial_site_count = 0
+        p.modified = false
       }
-      ts.panes[target].selected_sites = []
-      ts.panes[target].current_step_idx = 0
-      ts.active_pane = target
+      p.selected_sites = []
+      p.current_step_idx = 0
+      ts.active_leaf_id = target_id
       update_tab_label(tab_id)
     }
   }
@@ -1297,10 +1311,10 @@
             try {
               const accept = (name: string) => is_structure_file(name) || is_trajectory_file(name) || is_chgcar_file(name)
               const files = await tauri_read_dropped_paths(read_paths, accept)
-              const target_pane = ts.panes.findIndex(p => !pane_has_content(p))
-              const pane_idx = target_pane >= 0 ? target_pane : ts.active_pane
+              const empty = findFirstEmptyLeaf(ts.root)
+              const leaf_id = empty ? empty.id : ts.active_leaf_id
               if (files.length > 0) {
-                await import_many(tm.active_tab_id, files.map(f => ({ content: f.content, filename: f.filename, path: f.path })), pane_idx)
+                await import_many(tm.active_tab_id, files.map(f => ({ content: f.content, filename: f.filename, path: f.path })), leaf_id)
               } else {
                 show_toast({ message: `Could not read any file from the drop`, variant: `warning` })
               }
@@ -1346,7 +1360,8 @@
     if (!t || t.type !== `structure`) return false
     const ts = tab_states[t.id]
     if (!ts) return false
-    return !pane_has_content(ts.panes[0])
+    const first = leaves(ts.root)[0]
+    return !!first && !pane_has_content(first.content.pane)
   })
 
   // Global SSE listener for the External/MCP "default" panel.
@@ -1373,8 +1388,9 @@
     function inject_into_external(struct: AnyStructure | null | undefined): boolean {
       if (!struct) return false
       const ts = tab_states[`default`]
-      if (!ts || !ts.panes?.[0]) return false
-      ts.panes[0].structure = clone_structure(struct)
+      const first = ts ? leaves(ts.root)[0] : null
+      if (!ts || !first) return false
+      first.content.pane.structure = clone_structure(struct)
       update_tab_label(`default`)
       return true
     }
@@ -1424,8 +1440,9 @@
 
     function inject_trajectory_into_external(traj: TrajectoryType, raw: string, filename: string): boolean {
       const ts = tab_states[`default`]
-      if (!ts || !ts.panes?.[0]) return false
-      const pane = ts.panes[0]
+      const first = ts ? leaves(ts.root)[0] : null
+      if (!ts || !first) return false
+      const pane = first.content.pane
       pane.trajectory = traj
       pane.structure = undefined  // mutually exclusive
       pane.is_trajectory_mode = true
@@ -1498,8 +1515,9 @@
     tm.create_remote_tab()
     if (struct?.sites?.length) {
       const ts = tab_states[`default`]
-      if (ts?.panes?.[0]) {
-        ts.panes[0].structure = clone_structure(struct)
+      const first = ts ? leaves(ts.root)[0] : null
+      if (first) {
+        first.content.pane.structure = clone_structure(struct)
         update_tab_label(`default`)
       }
       return
@@ -1510,8 +1528,9 @@
       .then((cached: AnyStructure | null) => {
         if (!cached?.sites?.length) return
         const ts = tab_states[`default`]
-        if (ts?.panes?.[0]) {
-          ts.panes[0].structure = clone_structure(cached)
+        const first = ts ? leaves(ts.root)[0] : null
+        if (first) {
+          first.content.pane.structure = clone_structure(cached)
           update_tab_label(`default`)
         }
       })
@@ -1547,7 +1566,7 @@
   onclose={request_close_tab}
   oncloseall={open_close_all_dialog}
   onadd={open_tab}
-  layout={tm.active_layout}
+  layout={tm.active_layout ?? undefined}
   onlayoutchange={handle_layout_change}
 >
   <!-- Sidebar toggle button -->
@@ -1607,8 +1626,8 @@
     on_save_workflow={() => {
       const ts = get_active_ts()
       if (!ts) return null
-      const pane = ts.panes[ts.active_pane]
-      return pane.mode === `workflow` ? (pane.workflow_id ?? null) : null
+      const pane = findLeafById(ts.root, ts.active_leaf_id)?.content.pane
+      return pane?.mode === `workflow` ? (pane.workflow_id ?? null) : null
     }}
     refresh_counter={sidebar.refresh_counter}
   />
@@ -1632,9 +1651,6 @@
     {#if tab.type === `structure`}
       {@const ts = tab_states[tab.id]}
       {#if ts}
-        {@const visible = get_visible_panes(ts)}
-        {@const panel_count = layout_panel_count(ts.layout)}
-
         <div class="structure-workspace">
         {#if ts.library.length >= 2}
           <StructureLibrary
@@ -1645,457 +1661,405 @@
             on_clear={() => clear_library(tab.id)}
           />
         {/if}
-        <div class="grid-container" class:resizing={is_panel_resizing} style={get_grid_style(ts)}>
-          {#each visible as idx (idx)}
-            {@const pane = ts.panes[idx]}
-            <div
-              class="pane"
-              class:active={ts.active_pane === idx}
-              class:dragover={tab.id === tm.active_tab_id && drag_target_pane === idx}
-              class:warn-glow={ts.close_confirm_pane === idx}
-              data-pane={idx}
-              style={get_pane_position(ts.layout, idx)}
-              onclick={() => ts.active_pane = idx}
-              role="button"
-              tabindex="0"
-            >
-              <!-- Panel header bar -->
-              {#if panel_count > 1}
-                <div class="panel-header">
-                  {#if pane_has_content(pane)}
-                    <span class="panel-dot"></span>
-                  {/if}
-                  <span class="panel-label">{get_pane_label(pane)}</span>
-                  {#if pane_has_content(pane)}
-                    <button
-                      class="panel-popout-btn"
-                      onclick={(e) => { e.stopPropagation(); popout_pane(tab.id, idx) }}
-                      title={t(`app.open_in_new_window`)}
-                    >
-                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-                        <polyline points="15 3 21 3 21 9"/>
-                        <line x1="10" y1="14" x2="21" y2="3"/>
-                      </svg>
-                    </button>
-                  {/if}
-                  <button
-                    class="panel-close-btn"
-                    onclick={(e) => { e.stopPropagation(); handle_unload(tab.id, idx) }}
-                    title={t(`app.close_panel`)}
-                  >
-                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-                      <path d="M18 6L6 18M6 6l12 12" />
-                    </svg>
-                  </button>
-                </div>
-              {/if}
+        <PaneTree
+          node={ts.root}
+          multi={leafCount(ts.root) > 1}
+          active_leaf_id={ts.active_leaf_id}
+          drag_target_leaf={tab.id === tm.active_tab_id ? drag_target_leaf : null}
+          close_confirm_leaf_id={ts.close_confirm_leaf_id}
+          {active_split_id}
+          on_activate={(id) => ts.active_leaf_id = id}
+          on_split_mousedown={(e, sid, dir) => start_split_resize(e, sid, dir, tab.id)}
+          on_split_dblclick={(sid) => { ts.root = setRatio(ts.root, sid, 0.5) }}
+          {leaf_body}
+          {header}
+          {banner}
+        />
 
-              <!-- Inline close confirmation banner -->
-              {#if ts.close_confirm_pane === idx}
-                <div class="panel-close-banner">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M12 9v2m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
-                  </svg>
-                  {#if ts.panes[idx].mode === `workflow`}
-                    <span>{t(`app.workflow_will_be_closed`)}</span>
-                    <button class="banner-btn cancel" onclick={(e) => { e.stopPropagation(); ts.close_confirm_pane = null }}>{t(`common.cancel`)}</button>
-                    <button class="banner-btn close" onclick={(e) => { e.stopPropagation(); close_panel(tab.id, idx) }}>{t(`common.close`)}</button>
-                  {:else}
-                    <span>{t(`common.save_before_closing`)}</span>
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <select class="banner-select target-select" bind:value={exp.close_save_target} onclick={(e) => e.stopPropagation()}>
-                      <option value="local">{t(`app.local`)}</option>
-                      {#if ts.panes[idx].remote_origin?.session_id}
-                        <option value="hpc">{t(`app.hpc`)}</option>
-                      {/if}
-                      <option value="project">{t(`app.catgo_db`)}</option>
-                    </select>
-                    {#if exp.close_save_target === `project` && exp.close_save_projects.length > 0}
-                      <!-- svelte-ignore a11y_no_static_element_interactions -->
-                      <select class="banner-select" bind:value={exp.close_save_project_id} onclick={(e) => e.stopPropagation()}>
-                        {#snippet banner_select_options(projects: ProjectSummary[], depth: number)}
-                          {#each projects as p (p.id)}
-                            <option value={p.id}>{`\u00A0\u00A0`.repeat(depth)}{p.name}</option>
-                            {#if save_project_children[p.id]?.length}
-                              {@render banner_select_options(save_project_children[p.id], depth + 1)}
-                            {/if}
-                          {/each}
-                        {/snippet}
-                        {@render banner_select_options(save_project_roots, 0)}
-                      </select>
-                    {/if}
-                    {#if exp.close_save_target === `hpc`}
-                      <span class="banner-path" title={ts.panes[idx].remote_origin?.file_path}>{ts.panes[idx].remote_origin?.file_path?.split(/[/\\]/).pop()}</span>
-                    {/if}
-                    <button class="banner-btn save" disabled={exp.close_saving} onclick={(e) => { e.stopPropagation(); save_and_close_panel(tab.id, idx) }}>
-                      {exp.close_saving ? t(`common.saving`) : t(`common.save_and_close`)}
-                    </button>
-                    <button class="banner-btn close" onclick={(e) => { e.stopPropagation(); close_panel(tab.id, idx) }}>{t(`common.close`)}</button>
-                    <button class="banner-btn cancel" onclick={(e) => { e.stopPropagation(); ts.close_confirm_pane = null }}>{t(`common.cancel`)}</button>
-                  {/if}
-                </div>
-              {/if}
-
-              <!-- Panel content -->
-              <div class="panel-content">
-              {#if pane.mode === `workflow`}
-                <WorkflowView
-                  initial_workflow_id={pane.workflow_id}
-                  compact={pane.workflow_compact ?? false}
-                  tab_id={tab.id}
-                  onclose={() => { ts.panes[idx] = create_empty_pane(); ts.panes = [...ts.panes]; update_tab_label(tab.id) }}
-                  onchange={() => { ts.panes[idx].modified = true }}
-                  ondbchange={() => { sidebar.refresh_counter++ }}
-                />
-              {:else if pane.is_trajectory_mode && pane.trajectory}
-                <Trajectory
-                  trajectory={pane.trajectory as any}
-                  bind:selected_sites={ts.panes[idx].selected_sites}
-                  bind:current_step_idx={ts.panes[idx].current_step_idx}
-                  on_file_load={create_on_file_load(tab.id, idx)}
-                  fullscreen_toggle={false}
-                  allow_file_drop={false}
-                  structure_props={{ fullscreen_toggle: false, hide_extra_tools: false, initial_traj_b64: pane.raw_traj_b64, initial_traj_format: pane.raw_traj_format, tab_id: tab.id, is_active: ts.active_pane === idx && tab.id === tm.active_tab_id }}
-                  style="--struct-height: 100%; --struct-width: 100%; border-radius: 0;"
-                >
-                  {#snippet trajectory_controls({ trajectory: traj, current_step_idx: step, on_step_change })}
-                    <PathwayControls
-                      trajectory={traj}
-                      current_step_idx={step}
-                      {on_step_change}
-                    />
-                  {/snippet}
-                </Trajectory>
-              {:else if pane.structure}
-                <Structure
-                  tab_id={tab.id}
-                  is_active={ts.active_pane === idx && tab.id === tm.active_tab_id}
-                  bind:structure={ts.panes[idx].structure}
-                  bind:saveable_structure={ts.panes[idx].saveable_structure}
-                  bind:selected_sites={ts.panes[idx].selected_sites}
-                  bind:remote_origin={ts.panes[idx].remote_origin}
-                  bind:open_plugin_hub={ts.panes[idx].open_plugin_hub}
-                  cube_file={pane.cube_file}
-                  initial_panel={pane.initial_panel}
-                  on_file_load={create_on_file_load(tab.id, idx)}
-                  on_file_drop={create_on_file_drop(tab.id, idx)}
-                  on_structure_imported={() => update_tab_label(tab.id)}
-                  on_save_to_project={open_save_dialog}
-                  on_save_to_database={open_save_dialog}
-                  on_clear_structure={() => {
-                    ts.panes[idx] = create_empty_pane()
-                    update_tab_label(tab.id)
-                  }}
-                  on_export_to_hpc={open_export_to_hpc}
-                  on_export_to_file={open_export_to_file}
-                  on_edit_as_text={open_edit_as_text}
-                  on_open_file_overlay={(file_path: string, filename: string, session_id: string) => {
-                    handle_terminal_open_file(file_path, filename, session_id)
-                  }}
-                  on_open_workflow_editor={(workflow_id: string) => {
-                    handle_sidebar_open_workflow(workflow_id)
-                  }}
-                  fullscreen_toggle={false}
-                  allow_file_drop={false}
-                  show_controls={true}
-                  style="--struct-height: 100%; --struct-width: 100%; border-radius: 0;"
-                />
-              {:else}
-                <div class="landing-page" class:secondary-pane={idx > 0} class:quad-layout={ts.layout === `quad`} class:stacked-layout={ts.layout === `splitV`}>
-                  {#if idx === 0}
-                    <!-- Landing-only GitHub link — invites users to star the repo -->
-                    <a
-                      class="github-star"
-                      href="https://github.com/Hello-QM/catgo-LRG"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      title="Star CatGo on GitHub"
-                    >
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 012-.27c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                      </svg>
-                      <span class="github-star-text">Star on GitHub</span>
-                      <svg class="github-star-icon" width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                        <path d="M12 17.27l5.18 3.13-1.37-5.9 4.59-3.97-6.04-.52L12 4.5 9.64 10l-6.04.52 4.59 3.97-1.37 5.9z"/>
-                      </svg>
-                    </a>
-                    <div class="samples-grid">
-                      {#each sample_structures as sample}
-                        <button
-                          class="sample-card"
-                          onclick={() => {
-                            ts.panes[idx].structure = clone_structure(sample.data)
-                            ts.panes[idx].initial_site_count = sample.data.sites?.length ?? 0
-                            ts.panes[idx].initial_structure_ref = sample.data
-                            ts.panes[idx].modified = false
-                            ts.active_pane = idx
-                            update_tab_label(tab.id)
-                          }}
-                        >
-                          <div class="sample-preview">
-                            <!-- align_on_load="none" prevents auto principal-axes rotation that
-                                 would flatten the water V-shape into the XY plane (invisible from -Y camera).
-                                 Orthographic projection + zoom for consistent sizing in the preview card. -->
-                            <Structure
-                              structure={sample.data}
-                              show_controls={false}
-                              fullscreen_toggle={false}
-                              allow_file_drop={false}
-                              align_on_load="none"
-                              persist_settings={false}
-                              scene_props={{ atom_radius: 1.6, camera_projection: `orthographic`, initial_zoom: 100 } as any}
-                              style="--struct-height: 100%; --struct-width: 100%; pointer-events: none;"
-                            />
-                          </div>
-                          <div class="sample-info">
-                            <span class="sample-name">{sample.name}</span>
-                            <span class="sample-formula">{sample.formula}</span>
-                          </div>
-                        </button>
-                      {/each}
-                    </div>
-                  {/if}
-
-                  <div class="import-sidebar">
-                    <button class="import-card add-own-card" onclick={() => handle_open_file(tab.id, idx)}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`common.open_file`)}</span>
-                        <span class="import-desc">{t(`app.multi_select_or_drop`)}</span>
-                      </div>
-                    </button>
-
-                    <button class="import-card add-own-card" onclick={() => handle_open_folder(tab.id, idx)}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-                        <path d="M2 10h20"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`common.open_folder`)}</span>
-                        <span class="import-desc">{t(`app.load_all_structures`)}</span>
-                      </div>
-                    </button>
-
-                    <button class="import-card database-card" onclick={() => { modal.import_target_tab = tab.id; modal.import_target_pane = idx; modal.optimade_search_element = ``; modal.search_provider = STATIC_ONLY ? `pubchem` : `mp`; modal.search_visible = true }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M12 3C7.58 3 4 4.79 4 7s3.58 4 8 4s8-1.79 8-4s-3.58-4-8-4M4 9v3c0 2.21 3.58 4 8 4s8-1.79 8-4V9M4 14v3c0 2.21 3.58 4 8 4s8-1.79 8-4v-3"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`app.search_database`)}</span>
-                        <span class="import-desc">{STATIC_ONLY ? t(`app.pubchem_molecules`) : t(`app.optimade_pubchem`)}</span>
-                      </div>
-                    </button>
-
-                    <button class="import-card paste-card" onclick={() => { modal.import_target_tab = tab.id; modal.import_target_pane = idx; modal.paste_content_visible = true }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
-                        <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
-                        <path d="M9 12h6M9 16h6"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`common.paste`)}</span>
-                        <span class="import-desc">POSCAR/CONTCAR</span>
-                      </div>
-                    </button>
-
-                    {#if !STATIC_ONLY}
-                    <button class="import-card workflow-card" onclick={() => { ts.panes[idx].mode = `workflow`; ts.panes = [...ts.panes]; update_tab_label(tab.id) }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <rect x="2" y="3" width="6" height="5" rx="1" />
-                        <rect x="16" y="3" width="6" height="5" rx="1" />
-                        <rect x="9" y="16" width="6" height="5" rx="1" />
-                        <path d="M5 8v3a2 2 0 002 2h10a2 2 0 002-2V8" />
-                        <path d="M12 13v3" />
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`common.workflow`)}</span>
-                        <span class="import-desc">{t(`app.pipeline_editor`)}</span>
-                      </div>
-                    </button>
-                    {/if}
-
-                    <button class="import-card builder-card" onclick={() => {
-                      ts.panes[idx].structure = {
-                        lattice: {
-                          matrix: [[2.46, 0, 0], [1.23, 2.1304, 0], [0, 0, 20]] as [number[], number[], number[]],
-                          a: 2.46, b: 2.46, c: 20,
-                          alpha: 90, beta: 90, gamma: 120,
-                          volume: 104.82,
-                          pbc: [true, true, true] as [boolean, boolean, boolean],
-                        },
-                        sites: [
-                          { species: [{ element: `C`, occu: 1, oxidation_state: 0 }], abc: [0, 0, 0.5], xyz: [0, 0, 10], label: `C`, properties: {} },
-                          { species: [{ element: `C`, occu: 1, oxidation_state: 0 }], abc: [0.3333, 0.3333, 0.5], xyz: [1.23, 0.7101, 10], label: `C`, properties: {} },
-                        ],
-                      } as unknown as AnyStructure
-                      ts.panes[idx].initial_site_count = 2
-                      ts.panes[idx].initial_structure_ref = ts.panes[idx].structure
-                      ts.panes[idx].modified = false
-                      ts.active_pane = idx
-                    }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <circle cx="12" cy="8" r="2.5"/>
-                        <circle cx="6" cy="16" r="2.5"/>
-                        <circle cx="18" cy="16" r="2.5"/>
-                        <path d="M12 10.5v2.5l-4.5 3M12 13l4.5 3"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`app.build`)}</span>
-                        <span class="import-desc">{t(`app.build_desc`)}</span>
-                      </div>
-                    </button>
-
-                    <!-- AI Chat: shown in STATIC_ONLY too — CatBot runs client-direct
-                         in-browser (no backend) and can fetch/build structures from empty state. -->
-                    <button class="import-card chat-card" onclick={() => {
-                      console.log(`[CatGo:UI] Welcome card clicked: AI Chat → loading structure + opening Chat panel`)
-                      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
-                      ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
-                      ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
-                      ts.panes[idx].initial_panel = `chat`
-                      ts.active_pane = idx
-                      update_tab_label(tab.id)
-                    }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`app.ai_chat`)}</span>
-                        <span class="import-desc">{t(`app.ask_questions`)}</span>
-                      </div>
-                    </button>
-
-                    {#if !STATIC_ONLY}
-                    <button class="import-card hpc-card" onclick={() => {
-                      console.log(`[CatGo:UI] Welcome card clicked: HPC → loading structure + opening HPC panel`)
-                      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
-                      ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
-                      ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
-                      ts.panes[idx].initial_panel = `hpc`
-                      ts.active_pane = idx
-                      update_tab_label(tab.id)
-                    }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`app.hpc`)}</span>
-                        <span class="import-desc">{t(`app.remote_connect`)}</span>
-                      </div>
-                    </button>
-
-                    <button class="import-card terminal-card" onclick={() => {
-                      console.log(`[CatGo:UI] Welcome card clicked: Terminal → loading structure + opening Terminal panel`)
-                      ts.panes[idx].structure = clone_structure(water as unknown as AnyStructure)
-                      ts.panes[idx].initial_site_count = (water as any).sites?.length ?? 0
-                      ts.panes[idx].initial_structure_ref = water as unknown as AnyStructure
-                      ts.panes[idx].initial_panel = `terminal`
-                      ts.active_pane = idx
-                      update_tab_label(tab.id)
-                    }}>
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
-                      </svg>
-                      <div class="import-text">
-                        <span class="import-title">{t(`app.terminal`)}</span>
-                        <span class="import-desc">{t(`app.local_shell`)}</span>
-                      </div>
-                    </button>
-                    {/if}
-
-                    <!-- Plugins Card (only show on main pane, hide in static mode) -->
-                    {#if !STATIC_ONLY && idx === 0}
-                      <button class="import-card plugins-card" onclick={() => open_plugin_hub_on_active_pane()}>
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                          <path d="M12 2L2 7l10 5 10-5-10-5z"/>
-                          <path d="M2 17l10 5 10-5"/>
-                          <path d="M2 12l10 5 10-5"/>
-                        </svg>
-                        <div class="import-text">
-                          <span class="import-title">{t(`app.plugins`)}</span>
-                          <span class="import-desc">{t(`app.extend_catgo`)}</span>
-                        </div>
-                      </button>
-
-                      <!-- External Card — opens (or focuses) the 🤖 External tab.
-                           Lab claude / external MCP pushes land here without
-                           clobbering your working panes. Distinct from the HPC
-                           card above (which is SSH/Slurm). -->
-                      <button class="import-card external-card" onclick={() => open_external_tab()}>
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                          <circle cx="12" cy="12" r="2"/>
-                          <path d="M16.24 7.76a6 6 0 0 1 0 8.49"/>
-                          <path d="M7.76 16.25a6 6 0 0 1 0-8.49"/>
-                          <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
-                          <path d="M4.93 19.07a10 10 0 0 1 0-14.14"/>
-                        </svg>
-                        <div class="import-text">
-                          <span class="import-title">{t(`app.external`)}</span>
-                          <span class="import-desc">{t(`app.receive_from_lab`)}</span>
-                        </div>
-                      </button>
-                    {/if}
-                  </div>
-                </div>
-              {/if}
-
-              </div><!-- end panel-content -->
-            </div>
-          {/each}
-
-          <!-- Resize handles -->
-          {#if ts.layout === `splitH`}
-            <div
-              class="grid-divider grid-divider-col"
-              class:active={is_panel_resizing && resize_axis === `col`}
-              style="grid-column: 2; grid-row: 1;"
-              onmousedown={(e) => on_divider_mousedown(e, `col`, tab.id)}
-              ondblclick={() => { ts.col_split = 50 }}
-              role="separator"
-              aria-orientation="vertical"
-            ></div>
-          {:else if ts.layout === `splitV`}
-            <div
-              class="grid-divider grid-divider-row"
-              class:active={is_panel_resizing && resize_axis === `row`}
-              style="grid-column: 1; grid-row: 2;"
-              onmousedown={(e) => on_divider_mousedown(e, `row`, tab.id)}
-              ondblclick={() => { ts.row_split = 50 }}
-              role="separator"
-              aria-orientation="horizontal"
-            ></div>
-          {:else if ts.layout === `quad`}
-            <div
-              class="grid-divider grid-divider-col"
-              class:active={is_panel_resizing && resize_axis === `col`}
-              style="grid-column: 2; grid-row: 1 / span 3;"
-              onmousedown={(e) => on_divider_mousedown(e, `col`, tab.id)}
-              ondblclick={() => { ts.col_split = 50 }}
-              role="separator"
-              aria-orientation="vertical"
-            ></div>
-            <div
-              class="grid-divider grid-divider-row"
-              class:active={is_panel_resizing && resize_axis === `row`}
-              style="grid-column: 1 / span 3; grid-row: 2;"
-              onmousedown={(e) => on_divider_mousedown(e, `row`, tab.id)}
-              ondblclick={() => { ts.row_split = 50 }}
-              role="separator"
-              aria-orientation="horizontal"
-            ></div>
-            <div
-              class="grid-divider grid-divider-center"
-              class:active={is_panel_resizing}
-              style="grid-column: 2; grid-row: 2; z-index: 2;"
-              onmousedown={(e) => on_center_mousedown(e, tab.id)}
-              ondblclick={() => { ts.col_split = 50; ts.row_split = 50 }}
-              role="separator"
-            ></div>
+        {#snippet header(leaf: LeafNode)}
+          {@const pane = leaf.content.pane}
+          {#if pane_has_content(pane)}
+            <span class="panel-dot"></span>
           {/if}
-        </div>
+          <span class="panel-label">{get_pane_label(pane)}</span>
+          {#if pane_has_content(pane)}
+            <button
+              class="panel-popout-btn"
+              onclick={(e) => { e.stopPropagation(); popout_pane(tab.id, leaf.id) }}
+              title={t(`app.open_in_new_window`)}
+            >
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                <polyline points="15 3 21 3 21 9"/>
+                <line x1="10" y1="14" x2="21" y2="3"/>
+              </svg>
+            </button>
+          {/if}
+          <button
+            class="panel-close-btn"
+            onclick={(e) => { e.stopPropagation(); handle_unload(tab.id, leaf.id) }}
+            title={t(`app.close_panel`)}
+          >
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        {/snippet}
+
+        {#snippet banner(leaf: LeafNode)}
+          {#if ts.close_confirm_leaf_id === leaf.id}
+            {@const pane = leaf.content.pane}
+            <div class="panel-close-banner">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 9v2m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
+              </svg>
+              {#if pane.mode === `workflow`}
+                <span>{t(`app.workflow_will_be_closed`)}</span>
+                <button class="banner-btn cancel" onclick={(e) => { e.stopPropagation(); ts.close_confirm_leaf_id = null }}>{t(`common.cancel`)}</button>
+                <button class="banner-btn close" onclick={(e) => { e.stopPropagation(); close_panel(tab.id, leaf.id) }}>{t(`common.close`)}</button>
+              {:else}
+                <span>{t(`common.save_before_closing`)}</span>
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <select class="banner-select target-select" bind:value={exp.close_save_target} onclick={(e) => e.stopPropagation()}>
+                  <option value="local">{t(`app.local`)}</option>
+                  {#if pane.remote_origin?.session_id}
+                    <option value="hpc">{t(`app.hpc`)}</option>
+                  {/if}
+                  <option value="project">{t(`app.catgo_db`)}</option>
+                </select>
+                {#if exp.close_save_target === `project` && exp.close_save_projects.length > 0}
+                  <!-- svelte-ignore a11y_no_static_element_interactions -->
+                  <select class="banner-select" bind:value={exp.close_save_project_id} onclick={(e) => e.stopPropagation()}>
+                    {#snippet banner_select_options(projects: ProjectSummary[], depth: number)}
+                      {#each projects as p (p.id)}
+                        <option value={p.id}>{`  `.repeat(depth)}{p.name}</option>
+                        {#if save_project_children[p.id]?.length}
+                          {@render banner_select_options(save_project_children[p.id], depth + 1)}
+                        {/if}
+                      {/each}
+                    {/snippet}
+                    {@render banner_select_options(save_project_roots, 0)}
+                  </select>
+                {/if}
+                {#if exp.close_save_target === `hpc`}
+                  <span class="banner-path" title={pane.remote_origin?.file_path}>{pane.remote_origin?.file_path?.split(/[/\\]/).pop()}</span>
+                {/if}
+                <button class="banner-btn save" disabled={exp.close_saving} onclick={(e) => { e.stopPropagation(); save_and_close_panel(tab.id, leaf.id) }}>
+                  {exp.close_saving ? t(`common.saving`) : t(`common.save_and_close`)}
+                </button>
+                <button class="banner-btn close" onclick={(e) => { e.stopPropagation(); close_panel(tab.id, leaf.id) }}>{t(`common.close`)}</button>
+                <button class="banner-btn cancel" onclick={(e) => { e.stopPropagation(); ts.close_confirm_leaf_id = null }}>{t(`common.cancel`)}</button>
+              {/if}
+            </div>
+          {/if}
+        {/snippet}
+
+        {#snippet leaf_body(leaf: LeafNode)}
+          {@const pane = leaf.content.pane}
+          {#if pane.mode === `workflow`}
+            <WorkflowView
+              initial_workflow_id={pane.workflow_id}
+              compact={pane.workflow_compact ?? false}
+              tab_id={tab.id}
+              onclose={() => { Object.assign(pane, create_empty_pane()); update_tab_label(tab.id) }}
+              onchange={() => { pane.modified = true }}
+              ondbchange={() => { sidebar.refresh_counter++ }}
+            />
+          {:else if pane.is_trajectory_mode && pane.trajectory}
+            <Trajectory
+              trajectory={pane.trajectory as any}
+              bind:selected_sites={pane.selected_sites}
+              bind:current_step_idx={pane.current_step_idx}
+              on_file_load={create_on_file_load(tab.id, leaf.id)}
+              fullscreen_toggle={false}
+              allow_file_drop={false}
+              structure_props={{ fullscreen_toggle: false, hide_extra_tools: false, initial_traj_b64: pane.raw_traj_b64, initial_traj_format: pane.raw_traj_format, tab_id: tab.id, is_active: ts.active_leaf_id === leaf.id && tab.id === tm.active_tab_id }}
+              style="--struct-height: 100%; --struct-width: 100%; border-radius: 0;"
+            >
+              {#snippet trajectory_controls({ trajectory: traj, current_step_idx: step, on_step_change })}
+                <PathwayControls
+                  trajectory={traj}
+                  current_step_idx={step}
+                  {on_step_change}
+                />
+              {/snippet}
+            </Trajectory>
+          {:else if pane.structure}
+            <Structure
+              tab_id={tab.id}
+              is_active={ts.active_leaf_id === leaf.id && tab.id === tm.active_tab_id}
+              bind:structure={pane.structure}
+              bind:saveable_structure={pane.saveable_structure}
+              bind:selected_sites={pane.selected_sites}
+              bind:remote_origin={pane.remote_origin}
+              bind:open_plugin_hub={pane.open_plugin_hub}
+              cube_file={pane.cube_file}
+              initial_panel={pane.initial_panel}
+              on_file_load={create_on_file_load(tab.id, leaf.id)}
+              on_file_drop={create_on_file_drop(tab.id, leaf.id)}
+              on_structure_imported={() => update_tab_label(tab.id)}
+              on_save_to_project={open_save_dialog}
+              on_save_to_database={open_save_dialog}
+              on_clear_structure={() => {
+                Object.assign(pane, create_empty_pane())
+                update_tab_label(tab.id)
+              }}
+              on_export_to_hpc={open_export_to_hpc}
+              on_export_to_file={open_export_to_file}
+              on_edit_as_text={open_edit_as_text}
+              on_open_file_overlay={(file_path: string, filename: string, session_id: string) => {
+                handle_terminal_open_file(file_path, filename, session_id)
+              }}
+              on_open_workflow_editor={(workflow_id: string) => {
+                handle_sidebar_open_workflow(workflow_id)
+              }}
+              fullscreen_toggle={false}
+              allow_file_drop={false}
+              show_controls={true}
+              style="--struct-height: 100%; --struct-width: 100%; border-radius: 0;"
+            />
+          {:else}
+            {@const is_primary = leaf.id === leaves(ts.root)[0].id}
+            <div class="landing-page" class:secondary-pane={!is_primary} class:compact={leafCount(ts.root) > 1}>
+              {#if is_primary}
+                <!-- Landing-only GitHub link — invites users to star the repo -->
+                <a
+                  class="github-star"
+                  href="https://github.com/Hello-QM/catgo-LRG"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Star CatGo on GitHub"
+                >
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 012-.27c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                  </svg>
+                  <span class="github-star-text">Star on GitHub</span>
+                  <svg class="github-star-icon" width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 17.27l5.18 3.13-1.37-5.9 4.59-3.97-6.04-.52L12 4.5 9.64 10l-6.04.52 4.59 3.97-1.37 5.9z"/>
+                  </svg>
+                </a>
+                <div class="samples-grid">
+                  {#each sample_structures as sample}
+                    <button
+                      class="sample-card"
+                      onclick={() => {
+                        pane.structure = clone_structure(sample.data)
+                        pane.initial_site_count = sample.data.sites?.length ?? 0
+                        pane.initial_structure_ref = sample.data
+                        pane.modified = false
+                        ts.active_leaf_id = leaf.id
+                        update_tab_label(tab.id)
+                      }}
+                    >
+                      <div class="sample-preview">
+                        <!-- align_on_load="none" prevents auto principal-axes rotation that
+                             would flatten the water V-shape into the XY plane (invisible from -Y camera).
+                             Orthographic projection + zoom for consistent sizing in the preview card. -->
+                        <Structure
+                          structure={sample.data}
+                          show_controls={false}
+                          fullscreen_toggle={false}
+                          allow_file_drop={false}
+                          align_on_load="none"
+                          persist_settings={false}
+                          scene_props={{ atom_radius: 1.6, camera_projection: `orthographic`, initial_zoom: 100 } as any}
+                          style="--struct-height: 100%; --struct-width: 100%; pointer-events: none;"
+                        />
+                      </div>
+                      <div class="sample-info">
+                        <span class="sample-name">{sample.name}</span>
+                        <span class="sample-formula">{sample.formula}</span>
+                      </div>
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+
+              <div class="import-sidebar">
+                <button class="import-card add-own-card" onclick={() => handle_open_file(tab.id, leaf.id)}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`common.open_file`)}</span>
+                    <span class="import-desc">{t(`app.multi_select_or_drop`)}</span>
+                  </div>
+                </button>
+
+                <button class="import-card add-own-card" onclick={() => handle_open_folder(tab.id, leaf.id)}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+                    <path d="M2 10h20"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`common.open_folder`)}</span>
+                    <span class="import-desc">{t(`app.load_all_structures`)}</span>
+                  </div>
+                </button>
+
+                <button class="import-card database-card" onclick={() => { modal.import_target_tab = tab.id; modal.import_target_leaf = leaf.id; modal.optimade_search_element = ``; modal.search_provider = STATIC_ONLY ? `pubchem` : `mp`; modal.search_visible = true }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M12 3C7.58 3 4 4.79 4 7s3.58 4 8 4s8-1.79 8-4s-3.58-4-8-4M4 9v3c0 2.21 3.58 4 8 4s8-1.79 8-4V9M4 14v3c0 2.21 3.58 4 8 4s8-1.79 8-4v-3"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`app.search_database`)}</span>
+                    <span class="import-desc">{STATIC_ONLY ? t(`app.pubchem_molecules`) : t(`app.optimade_pubchem`)}</span>
+                  </div>
+                </button>
+
+                <button class="import-card paste-card" onclick={() => { modal.import_target_tab = tab.id; modal.import_target_leaf = leaf.id; modal.paste_content_visible = true }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
+                    <path d="M9 12h6M9 16h6"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`common.paste`)}</span>
+                    <span class="import-desc">POSCAR/CONTCAR</span>
+                  </div>
+                </button>
+
+                {#if !STATIC_ONLY}
+                <button class="import-card workflow-card" onclick={() => { pane.mode = `workflow`; update_tab_label(tab.id) }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <rect x="2" y="3" width="6" height="5" rx="1" />
+                    <rect x="16" y="3" width="6" height="5" rx="1" />
+                    <rect x="9" y="16" width="6" height="5" rx="1" />
+                    <path d="M5 8v3a2 2 0 002 2h10a2 2 0 002-2V8" />
+                    <path d="M12 13v3" />
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`common.workflow`)}</span>
+                    <span class="import-desc">{t(`app.pipeline_editor`)}</span>
+                  </div>
+                </button>
+                {/if}
+
+                <button class="import-card builder-card" onclick={() => {
+                  pane.structure = {
+                    lattice: {
+                      matrix: [[2.46, 0, 0], [1.23, 2.1304, 0], [0, 0, 20]] as [number[], number[], number[]],
+                      a: 2.46, b: 2.46, c: 20,
+                      alpha: 90, beta: 90, gamma: 120,
+                      volume: 104.82,
+                      pbc: [true, true, true] as [boolean, boolean, boolean],
+                    },
+                    sites: [
+                      { species: [{ element: `C`, occu: 1, oxidation_state: 0 }], abc: [0, 0, 0.5], xyz: [0, 0, 10], label: `C`, properties: {} },
+                      { species: [{ element: `C`, occu: 1, oxidation_state: 0 }], abc: [0.3333, 0.3333, 0.5], xyz: [1.23, 0.7101, 10], label: `C`, properties: {} },
+                    ],
+                  } as unknown as AnyStructure
+                  pane.initial_site_count = 2
+                  pane.initial_structure_ref = pane.structure
+                  pane.modified = false
+                  ts.active_leaf_id = leaf.id
+                }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <circle cx="12" cy="8" r="2.5"/>
+                    <circle cx="6" cy="16" r="2.5"/>
+                    <circle cx="18" cy="16" r="2.5"/>
+                    <path d="M12 10.5v2.5l-4.5 3M12 13l4.5 3"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`app.build`)}</span>
+                    <span class="import-desc">{t(`app.build_desc`)}</span>
+                  </div>
+                </button>
+
+                <!-- AI Chat: shown in STATIC_ONLY too — CatBot runs client-direct
+                     in-browser (no backend) and can fetch/build structures from empty state. -->
+                <button class="import-card chat-card" onclick={() => {
+                  console.log(`[CatGo:UI] Welcome card clicked: AI Chat → loading structure + opening Chat panel`)
+                  pane.structure = clone_structure(water as unknown as AnyStructure)
+                  pane.initial_site_count = (water as any).sites?.length ?? 0
+                  pane.initial_structure_ref = water as unknown as AnyStructure
+                  pane.initial_panel = `chat`
+                  ts.active_leaf_id = leaf.id
+                  update_tab_label(tab.id)
+                }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`app.ai_chat`)}</span>
+                    <span class="import-desc">{t(`app.ask_questions`)}</span>
+                  </div>
+                </button>
+
+                {#if !STATIC_ONLY}
+                <button class="import-card hpc-card" onclick={() => {
+                  console.log(`[CatGo:UI] Welcome card clicked: HPC → loading structure + opening HPC panel`)
+                  pane.structure = clone_structure(water as unknown as AnyStructure)
+                  pane.initial_site_count = (water as any).sites?.length ?? 0
+                  pane.initial_structure_ref = water as unknown as AnyStructure
+                  pane.initial_panel = `hpc`
+                  ts.active_leaf_id = leaf.id
+                  update_tab_label(tab.id)
+                }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`app.hpc`)}</span>
+                    <span class="import-desc">{t(`app.remote_connect`)}</span>
+                  </div>
+                </button>
+
+                <button class="import-card terminal-card" onclick={() => {
+                  console.log(`[CatGo:UI] Welcome card clicked: Terminal → loading structure + opening Terminal panel`)
+                  pane.structure = clone_structure(water as unknown as AnyStructure)
+                  pane.initial_site_count = (water as any).sites?.length ?? 0
+                  pane.initial_structure_ref = water as unknown as AnyStructure
+                  pane.initial_panel = `terminal`
+                  ts.active_leaf_id = leaf.id
+                  update_tab_label(tab.id)
+                }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
+                  </svg>
+                  <div class="import-text">
+                    <span class="import-title">{t(`app.terminal`)}</span>
+                    <span class="import-desc">{t(`app.local_shell`)}</span>
+                  </div>
+                </button>
+                {/if}
+
+                <!-- Plugins Card (only show on main pane, hide in static mode) -->
+                {#if !STATIC_ONLY && is_primary}
+                  <button class="import-card plugins-card" onclick={() => open_plugin_hub_on_active_leaf()}>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                      <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+                      <path d="M2 17l10 5 10-5"/>
+                      <path d="M2 12l10 5 10-5"/>
+                    </svg>
+                    <div class="import-text">
+                      <span class="import-title">{t(`app.plugins`)}</span>
+                      <span class="import-desc">{t(`app.extend_catgo`)}</span>
+                    </div>
+                  </button>
+
+                  <!-- External Card — opens (or focuses) the 🤖 External tab.
+                       Lab claude / external MCP pushes land here without
+                       clobbering your working panes. Distinct from the HPC
+                       card above (which is SSH/Slurm). -->
+                  <button class="import-card external-card" onclick={() => open_external_tab()}>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                      <circle cx="12" cy="12" r="2"/>
+                      <path d="M16.24 7.76a6 6 0 0 1 0 8.49"/>
+                      <path d="M7.76 16.25a6 6 0 0 1 0-8.49"/>
+                      <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+                      <path d="M4.93 19.07a10 10 0 0 1 0-14.14"/>
+                    </svg>
+                    <div class="import-text">
+                      <span class="import-title">{t(`app.external`)}</span>
+                      <span class="import-desc">{t(`app.receive_from_lab`)}</span>
+                    </div>
+                  </button>
+                {/if}
+              </div>
+            </div>
+          {/if}
+        {/snippet}
         </div><!-- end structure-workspace -->
       {/if}
 
@@ -2223,7 +2187,7 @@
   {@const confirm_tab = tm.tabs.find(t => t.id === tm.tab_close_confirm_id)}
   {@const confirm_ts = tab_states[tm.tab_close_confirm_id]}
   {#if confirm_tab && confirm_ts}
-    {@const structure_count = confirm_ts.panes.slice(0, layout_panel_count(confirm_ts.layout)).filter(p => pane_has_content(p)).length}
+    {@const structure_count = leaves(confirm_ts.root).filter(l => pane_has_content(l.content.pane)).length}
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
     <div class="modal-overlay" onclick={() => tm.tab_close_confirm_id = null}>
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
@@ -2414,57 +2378,16 @@
     width: 100%;
     height: 100%;
   }
-  .structure-workspace > .grid-container {
+  /* PaneTree renders its root (.split or .pane) as the direct child here;
+     the split/pane/divider/content geometry now lives in PaneTree.svelte. */
+  .structure-workspace > :global(.split),
+  .structure-workspace > :global(.pane) {
     flex: 1;
     min-width: 0;
   }
 
-  .grid-container {
-    display: grid;
-    width: 100%;
-    height: 100%;
-  }
-
-  /* Resize dividers */
-  .grid-divider {
-    background: var(--border-color, rgba(128, 128, 128, 0.2));
-    transition: background 0.15s;
-    z-index: 1;
-  }
-  .grid-divider-col { cursor: col-resize; }
-  .grid-divider-row { cursor: row-resize; }
-  .grid-divider-center { cursor: move; }
-  .grid-divider:hover, .grid-divider.active {
-    background: var(--accent-color, #3b82f6);
-  }
-  .grid-container.resizing .pane { pointer-events: none; }
-  .grid-container.resizing { user-select: none; }
-
-  .pane {
-    position: relative;
-    overflow: hidden;
-    background: var(--surface-bg, var(--page-bg));
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .pane.warn-glow {
-    box-shadow: inset 0 0 0 2px rgba(245, 158, 11, 0.5);
-  }
-
-  /* Panel header */
-  .panel-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
-    min-height: 28px;
-    background: var(--page-bg, #0f1520);
-    border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.15));
-    font-size: 11px;
-    user-select: none;
-  }
+  /* .panel-header flex container is PaneTree's element (styled there); the
+     dot/label/buttons below render via App snippets so stay App-scoped. */
 
   .panel-dot {
     width: 6px;
@@ -2501,10 +2424,8 @@
     transition: opacity 0.15s, background 0.15s, color 0.15s;
   }
 
-  .pane:hover .panel-popout-btn,
-  .pane:hover .panel-close-btn {
-    opacity: 1;
-  }
+  /* Hover-reveal lives in PaneTree.svelte (.pane:hover :global(.panel-*-btn))
+     because .pane is rendered there while these buttons render in App's scope. */
 
   .panel-popout-btn:hover {
     background: rgba(59, 130, 246, 0.5);
@@ -2516,15 +2437,7 @@
     color: white;
   }
 
-  /* Panel content area */
-  .panel-content {
-    flex: 1;
-    min-height: 0;
-    position: relative;
-    overflow: hidden;
-    /* Definite height base for percentage-based children (Three.js canvas) */
-    height: 0;
-  }
+  /* .panel-content geometry lives in PaneTree.svelte (height:0 keep-warm base). */
 
   /* Inline panel close confirmation banner */
   .panel-close-banner {
@@ -2737,14 +2650,8 @@
     to { opacity: 1; }
   }
 
-  .pane.dragover::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    z-index: 100000005;
-    box-shadow: inset 0 0 0 3px #22c55e;
-  }
+  /* .pane.dragover glow + add-own-card highlight live in PaneTree.svelte
+     (.pane is rendered there; cards render in App's scope via :global). */
 
   /* Original horizontal layout (restored) */
   .landing-page {
@@ -2929,26 +2836,20 @@
     color: #93c5fd;
   }
 
-  .pane.dragover .import-card.add-own-card {
-    border-color: #22c55e;
-    background: rgba(34, 197, 94, 0.15);
-    color: #22c55e;
-  }
+  /* .pane.dragover .import-card.add-own-card highlight lives in PaneTree.svelte. */
 
-  .pane.dragover .import-card.add-own-card .import-title {
-    color: #22c55e;
-  }
-
-  /* Quad layout responsive import */
-  .landing-page.quad-layout {
+  /* Compact landing — any tab with more than one leaf (was quad/stacked layout):
+     hide the samples grid + descriptions, grid the import cards to avoid scroll. */
+  .landing-page.compact {
     padding: 8px;
+    overflow-y: hidden;
   }
 
-  .landing-page.quad-layout .samples-grid {
+  .landing-page.compact .samples-grid {
     display: none;
   }
 
-  .landing-page.quad-layout .import-sidebar {
+  .landing-page.compact .import-sidebar {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 6px;
@@ -2956,54 +2857,22 @@
     max-width: 280px;
   }
 
-  .landing-page.quad-layout .import-card {
+  .landing-page.compact .import-card {
     padding: 6px 8px;
     gap: 6px;
   }
 
-  .landing-page.quad-layout .import-card svg {
+  .landing-page.compact .import-card svg {
     width: 16px;
     height: 16px;
   }
 
-  .landing-page.quad-layout .import-desc {
+  .landing-page.compact .import-desc {
     display: none;
   }
 
-  .landing-page.quad-layout .import-title {
+  .landing-page.compact .import-title {
     font-size: 0.8rem;
-  }
-
-  /* Stacked (splitV) layout — compact grid to avoid scrolling */
-  .landing-page.stacked-layout {
-    padding: 12px;
-    overflow-y: hidden;
-  }
-
-  .landing-page.stacked-layout .samples-grid {
-    display: none;
-  }
-
-  .landing-page.stacked-layout .import-sidebar {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 8px;
-    width: 100%;
-    max-width: 520px;
-  }
-
-  .landing-page.stacked-layout .import-card {
-    padding: 8px 10px;
-    gap: 8px;
-  }
-
-  .landing-page.stacked-layout .import-card svg {
-    width: 18px;
-    height: 18px;
-  }
-
-  .landing-page.stacked-layout .import-desc {
-    display: none;
 
   /* [2025-02] Alternative vertical layout — commented out for future reference
   .landing-page {

--- a/desktop/PaneTree.svelte
+++ b/desktop/PaneTree.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import type { PaneNode, LeafNode, SplitNode } from './pane-tree'
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    node: PaneNode
+    multi: boolean // leafCount(root) > 1 — gates per-leaf header chrome
+    active_leaf_id: string
+    drag_target_leaf: string | null
+    close_confirm_leaf_id: string | null
+    active_split_id: string | null
+    leaf_body: Snippet<[LeafNode]>     // App renders the viewer/landing for a leaf
+    header: Snippet<[LeafNode]>        // App renders the dot+label+popout+close buttons
+    banner: Snippet<[LeafNode]>        // App renders the close-confirm banner
+    on_activate: (leaf_id: string) => void
+    on_split_mousedown: (e: MouseEvent, split_id: string, dir: 'h' | 'v') => void
+    on_split_dblclick: (split_id: string) => void
+  }
+  let { node, multi, active_leaf_id, drag_target_leaf, close_confirm_leaf_id, active_split_id, leaf_body, header, banner, on_activate, on_split_mousedown, on_split_dblclick }: Props = $props()
+</script>
+
+{#if node.kind === 'split'}
+  {@const s = node as SplitNode}
+  <div class="split {s.direction === 'h' ? 'h' : 'v'}">
+    <div class="split-child" style={s.direction === 'h' ? `flex-basis:${s.ratio * 100}%` : `flex-basis:${s.ratio * 100}%`}>
+      <svelte:self node={s.children[0]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {leaf_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
+    </div>
+    <div
+      class="grid-divider {s.direction === 'h' ? 'grid-divider-col' : 'grid-divider-row'}"
+      class:active={active_split_id === s.id}
+      onmousedown={(e) => on_split_mousedown(e, s.id, s.direction)}
+      ondblclick={() => on_split_dblclick(s.id)}
+      role="separator"
+      aria-orientation={s.direction === 'h' ? 'vertical' : 'horizontal'}
+    ></div>
+    <div class="split-child" style={`flex-basis:${(1 - s.ratio) * 100}%`}>
+      <svelte:self node={s.children[1]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {leaf_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
+    </div>
+  </div>
+{:else}
+  {@const leaf = node as LeafNode}
+  <div
+    class="pane"
+    class:active={active_leaf_id === leaf.id}
+    class:dragover={drag_target_leaf === leaf.id}
+    class:warn-glow={close_confirm_leaf_id === leaf.id}
+    data-leaf-id={leaf.id}
+    role="button"
+    tabindex="0"
+    onclick={() => on_activate(leaf.id)}
+    onkeydown={(e) => { if (e.key === 'Enter') on_activate(leaf.id) }}
+  >
+    {#if multi}
+      <div class="panel-header">{@render header(leaf)}</div>
+    {/if}
+    {@render banner(leaf)}
+    <div class="panel-content">{@render leaf_body(leaf)}</div>
+  </div>
+{/if}
+
+<style>
+  /* Split container geometry — moves grid-container -> flex splits */
+  .split { display: flex; width: 100%; height: 100%; min-width: 0; min-height: 0; }
+  .split.h { flex-direction: row; }
+  .split.v { flex-direction: column; }
+  .split-child { position: relative; min-width: 0; min-height: 0; overflow: hidden; flex: 0 0 auto; }
+
+  /* Resize dividers — var names match App.svelte exactly */
+  .grid-divider { background: var(--border-color, rgba(128, 128, 128, 0.2)); transition: background 0.15s; z-index: 1; flex: 0 0 auto; }
+  .grid-divider-col { width: 6px; cursor: col-resize; }
+  .grid-divider-row { height: 6px; cursor: row-resize; }
+  .grid-divider:hover, .grid-divider.active { background: var(--accent-color, #3b82f6); }
+
+  /* Pane wrapper — var names match App.svelte exactly */
+  .pane { position: relative; overflow: hidden; background: var(--surface-bg, var(--page-bg)); cursor: pointer; display: flex; flex-direction: column; width: 100%; height: 100%; }
+  .pane.warn-glow { box-shadow: inset 0 0 0 2px rgba(245, 158, 11, 0.5); }
+
+  /* Content area — height:0 is load-bearing for the WebGL canvas */
+  .panel-content { flex: 1; min-height: 0; position: relative; overflow: hidden; height: 0; }
+
+  /* NOTE: .panel-header/.panel-dot/.panel-label/.panel-*-btn/.panel-close-banner/.banner-*
+     rules are supplied by App.svelte's global <style> (the header/banner snippets render
+     in App's scope); keep them in App.svelte. Only split/pane/divider/content geometry
+     lives here. */
+</style>

--- a/desktop/PaneTree.svelte
+++ b/desktop/PaneTree.svelte
@@ -22,7 +22,7 @@
 {#if node.kind === 'split'}
   {@const s = node as SplitNode}
   <div class="split {s.direction === 'h' ? 'h' : 'v'}">
-    <div class="split-child" style={s.direction === 'h' ? `flex-basis:${s.ratio * 100}%` : `flex-basis:${s.ratio * 100}%`}>
+    <div class="split-child" style={`flex-basis:calc(${s.ratio * 100}% - 3px)`}>
       <svelte:self node={s.children[0]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {leaf_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
     </div>
     <div
@@ -33,7 +33,7 @@
       role="separator"
       aria-orientation={s.direction === 'h' ? 'vertical' : 'horizontal'}
     ></div>
-    <div class="split-child" style={`flex-basis:${(1 - s.ratio) * 100}%`}>
+    <div class="split-child" style={`flex-basis:calc(${(1 - s.ratio) * 100}% - 3px)`}>
       <svelte:self node={s.children[1]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {leaf_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
     </div>
   </div>

--- a/desktop/PaneTree.svelte
+++ b/desktop/PaneTree.svelte
@@ -75,6 +75,40 @@
   .pane { position: relative; overflow: hidden; background: var(--surface-bg, var(--page-bg)); cursor: pointer; display: flex; flex-direction: column; width: 100%; height: 100%; }
   .pane.warn-glow { box-shadow: inset 0 0 0 2px rgba(245, 158, 11, 0.5); }
 
+  /* Pane state visuals that cross the App<->PaneTree scope boundary: .pane lives
+     here, but its header buttons / import cards render via App-defined snippets,
+     so the descendant parts need :global(). (moved verbatim from App.svelte) */
+  .pane:hover :global(.panel-popout-btn),
+  .pane:hover :global(.panel-close-btn) { opacity: 1; }
+  .pane.dragover::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 100000005;
+    box-shadow: inset 0 0 0 3px #22c55e;
+  }
+  .pane.dragover :global(.import-card.add-own-card) {
+    border-color: #22c55e;
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+  }
+  .pane.dragover :global(.import-card.add-own-card .import-title) { color: #22c55e; }
+
+  /* Panel header flex container (its dot/label/buttons render via App snippets,
+     styled by App's scoped CSS). Moved verbatim from App.svelte. */
+  .panel-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    min-height: 28px;
+    background: var(--page-bg, #0f1520);
+    border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.15));
+    font-size: 11px;
+    user-select: none;
+  }
+
   /* Content area — height:0 is load-bearing for the WebGL canvas */
   .panel-content { flex: 1; min-height: 0; position: relative; overflow: hidden; height: 0; }
 

--- a/desktop/lib/close-all-helper.ts
+++ b/desktop/lib/close-all-helper.ts
@@ -9,9 +9,11 @@ import type { CloseAllEntry } from '../state/modal-state.svelte'
 import type { StructureTabState } from '../pane-utils'
 import type { AppTab } from '../TabBar.svelte'
 import {
-  layout_panel_count, pane_has_content, create_empty_pane,
+  pane_has_content,
   auto_name as _auto_name, serialize_structure_content,
+  create_tab_state,
 } from '../pane-utils'
+import { leaves } from '../pane-tree'
 import { save_structure_to_db, write_file } from '$lib/api/project'
 import { writeRemoteFile } from '$lib/api/hpc'
 
@@ -27,9 +29,8 @@ export function build_close_all_entries(
     if (tab.type !== `structure`) continue
     const ts = tab_states[tab.id]
     if (!ts) continue
-    const count = layout_panel_count(ts.layout)
-    for (let i = 0; i < count; i++) {
-      const pane = ts.panes[i]
+    for (const leaf of leaves(ts.root)) {
+      const pane = leaf.content.pane
       if (!pane_has_content(pane)) continue
       const structure = pane.saveable_structure ?? pane.structure
       const formula = structure?.sites?.length ? _auto_name(structure as Record<string, unknown>) : (pane.trajectory ? `Trajectory` : `Cube`)
@@ -47,7 +48,7 @@ export function build_close_all_entries(
       entries.push({
         tab_id: tab.id,
         label: tab.label,
-        pane_idx: i,
+        leaf_id: leaf.id,
         formula,
         save_target,
         save_path,
@@ -69,7 +70,9 @@ export async function execute_close_all_saves(
     if (!entry.checked) continue
     const ts = tab_states[entry.tab_id]
     if (!ts) continue
-    const pane = ts.panes[entry.pane_idx]
+    const leaf = leaves(ts.root).find(l => l.id === entry.leaf_id)
+    const pane = leaf?.content.pane
+    if (!pane) continue
     const structure = (pane.saveable_structure ?? pane.structure) as Record<string, unknown> | undefined
     if (!structure) continue
 
@@ -110,11 +113,12 @@ export function close_all_structure_tabs(
       // Last structure tab: reset to empty instead of closing
       const ts = tab_states[id]
       if (ts) {
-        for (let i = 0; i < 4; i++) ts.panes[i] = create_empty_pane()
-        ts.layout = `single`
-        ts.active_pane = 0
-        ts.col_split = 50
-        ts.row_split = 50
+        const r = create_tab_state()
+        ts.root = r.root
+        ts.active_leaf_id = r.active_leaf_id
+        ts.close_confirm_leaf_id = null
+        ts.library = []
+        ts.active_library_id = null
         const tab = tabs.find(t => t.id === id)
         if (tab) tab.label = `Structure`
       }

--- a/desktop/lib/drag-drop-handlers.ts
+++ b/desktop/lib/drag-drop-handlers.ts
@@ -5,7 +5,7 @@
  */
 
 import type { StructureTabState } from '../pane-utils'
-import { pane_has_content } from '../pane-utils'
+import { findFirstEmptyLeaf } from '../pane-tree'
 
 export interface ImportItem {
   content?: string | ArrayBuffer
@@ -18,14 +18,14 @@ export interface DragDropDeps {
   get_active_ts: () => StructureTabState | null
   get_active_tab_type: () => string
   get_active_tab_id: () => string
-  process_file_content: (tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number) => Promise<void>
-  import_many: (tab_id: string, items: ImportItem[], pane_idx: number) => Promise<void>
+  process_file_content: (tab_id: string, content: string | ArrayBuffer, filename: string, leaf_id: string) => Promise<void>
+  import_many: (tab_id: string, items: ImportItem[], leaf_id: string) => Promise<void>
   /** If `path` is a large on-disk trajectory, stream it and return true. */
   stream_trajectory: (path: string, filename: string) => Promise<boolean>
   /** If `file` is a large trajectory (web mode, no path), upload+stream it; return true. */
   stream_trajectory_file: (file: File) => Promise<boolean>
-  get_drag_target_pane: () => number | null
-  set_drag_target_pane: (v: number | null) => void
+  get_drag_target_pane: () => string | null
+  set_drag_target_pane: (v: string | null) => void
   set_is_loading: (v: boolean) => void
 }
 
@@ -60,14 +60,12 @@ async function read_entry_files(entry: FsEntry | null, out: Array<{ file: File; 
   }
 }
 
-export function get_pane_from_event(deps: DragDropDeps, event: DragEvent): number {
+export function get_pane_from_event(deps: DragDropDeps, event: DragEvent): string {
   const ts = deps.get_active_ts()
-  if (!ts) return 0
-  const target = event.target as HTMLElement
-  const pane_el = target.closest(`[data-pane]`)
-  if (pane_el) return parseInt(pane_el.getAttribute(`data-pane`) || `0`)
-  const first_empty = ts.panes.findIndex(p => !pane_has_content(p))
-  return first_empty >= 0 ? first_empty : ts.active_pane
+  if (!ts) return ''
+  const el = (event.target as HTMLElement).closest('[data-leaf-id]')
+  if (el) return el.getAttribute('data-leaf-id') || ts.active_leaf_id
+  return findFirstEmptyLeaf(ts.root)?.id ?? ts.active_leaf_id
 }
 
 /** Check if event originates inside sidebar (FileTree has its own drag-drop) */
@@ -111,7 +109,7 @@ export async function handle_drop(deps: DragDropDeps, event: DragEvent) {
   event.stopPropagation()
   const ts = deps.get_active_ts()
   if (!ts) return
-  const pane_idx = get_pane_from_event(deps, event)
+  const target_leaf_id = get_pane_from_event(deps, event)
   deps.set_drag_target_pane(null)
 
   // [2026-03] Handle drag from sidebar filesystem browser (server-side file)
@@ -122,13 +120,13 @@ export async function handle_drop(deps: DragDropDeps, event: DragEvent) {
       // Large on-disk trajectory → stream frame-by-frame, never read it whole.
       const fs_name = fs_path.split(/[/\\]/).pop() || `file`
       if (await deps.stream_trajectory(fs_path, fs_name)) {
-        ts.active_pane = pane_idx
+        ts.active_leaf_id = target_leaf_id
         return
       }
       const { read_file } = await import(`$lib/api/project`)
       const result = await read_file(fs_path)
-      await deps.process_file_content(deps.get_active_tab_id(), result.content, result.name, pane_idx)
-      ts.active_pane = pane_idx
+      await deps.process_file_content(deps.get_active_tab_id(), result.content, result.name, target_leaf_id)
+      ts.active_leaf_id = target_leaf_id
     } catch (err) {
       console.error(`[Drop] Error reading filesystem file:`, err)
     } finally {
@@ -170,13 +168,13 @@ export async function handle_drop(deps: DragDropDeps, event: DragEvent) {
       if (await deps.stream_trajectory_file(c.file)) continue
       to_import.push(c)
     }
-    if (to_import.length === 0) { ts.active_pane = pane_idx; return }
+    if (to_import.length === 0) { ts.active_leaf_id = target_leaf_id; return }
     await deps.import_many(
       deps.get_active_tab_id(),
       to_import.map(c => ({ file: c.file, filename: c.file.name, path: c.path })),
-      pane_idx,
+      target_leaf_id,
     )
-    ts.active_pane = pane_idx
+    ts.active_leaf_id = target_leaf_id
   } catch (err) {
     console.error(`[Drop] Error:`, err)
   } finally {

--- a/desktop/lib/export-handlers.ts
+++ b/desktop/lib/export-handlers.ts
@@ -12,7 +12,7 @@ import { save_structure_to_db, write_file } from '$lib/api/project'
 import { writeRemoteFile } from '$lib/api/hpc'
 
 export interface ExportHandlerDeps {
-  close_panel: (tab_id: string, pane_idx: number) => void
+  close_panel: (tab_id: string, leaf_id: string) => void
   load_close_save_projects: () => void
 }
 
@@ -84,7 +84,7 @@ export async function do_export(deps: ExportHandlerDeps) {
     }
     exp.dialog = null
     if (exp.close_after) {
-      deps.close_panel(exp.close_after.tab_id, exp.close_after.pane_idx)
+      deps.close_panel(exp.close_after.tab_id, exp.close_after.leaf_id)
       exp.close_after = null
     }
   } catch (e) {

--- a/desktop/lib/keyboard-shortcuts.ts
+++ b/desktop/lib/keyboard-shortcuts.ts
@@ -5,8 +5,9 @@
  * No $state needed.
  */
 
-import type { StructureTabState, LayoutType } from '../pane-utils'
-import { layout_panel_count } from '../pane-utils'
+import type { StructureTabState } from '../pane-utils'
+import type { PresetId } from '../pane-tree'
+import { leafCount, leaves } from '../pane-tree'
 
 export interface KeyboardShortcutDeps {
   get_tabs: () => { id: string; type: string }[]
@@ -15,12 +16,12 @@ export interface KeyboardShortcutDeps {
   toggle_sidebar: () => void
   open_tab: (type: `structure` | `workflow`) => void
   get_active_ts: () => StructureTabState | null
-  handle_open_file: (tab_id: string, pane_idx: number) => void
-  handle_unload: (tab_id: string, pane_idx: number) => void
+  handle_open_file: (tab_id: string, leaf_id: string) => void
+  handle_unload: (tab_id: string, leaf_id: string) => void
   request_close_tab: (id: string) => void
   get_tab_close_confirm_id: () => string | null
   set_tab_close_confirm_id: (id: string | null) => void
-  get_pending_layout_change: () => { tab_id: string; new_layout: LayoutType; lost_count: number } | null
+  get_pending_layout_change: () => { tab_id: string; new_layout: PresetId; lost_count: number } | null
   set_pending_layout_change: (v: null) => void
 }
 
@@ -71,13 +72,12 @@ export function create_handle_keydown(deps: KeyboardShortcutDeps) {
 
     if (ctrl && event.key === `o`) {
       event.preventDefault()
-      deps.handle_open_file(active_tab_id, ts.active_pane)
+      deps.handle_open_file(active_tab_id, ts.active_leaf_id)
     }
     if (ctrl && event.key === `w`) {
       event.preventDefault()
-      const panel_count = layout_panel_count(ts.layout)
-      if (panel_count > 1) {
-        deps.handle_unload(active_tab_id, ts.active_pane)
+      if (leafCount(ts.root) > 1) {
+        deps.handle_unload(active_tab_id, ts.active_leaf_id)
       } else {
         deps.request_close_tab(active_tab_id)
       }
@@ -91,8 +91,8 @@ export function create_handle_keydown(deps: KeyboardShortcutDeps) {
         deps.set_pending_layout_change(null)
         return
       }
-      if (ts.close_confirm_pane !== null) {
-        ts.close_confirm_pane = null
+      if (ts.close_confirm_leaf_id !== null) {
+        ts.close_confirm_leaf_id = null
         return
       }
     }
@@ -102,9 +102,8 @@ export function create_handle_keydown(deps: KeyboardShortcutDeps) {
     }
     if (event.key >= `1` && event.key <= `4` && !ctrl) {
       const idx = parseInt(event.key) - 1
-      if (idx < layout_panel_count(ts.layout)) {
-        ts.active_pane = idx
-      }
+      const ids = leaves(ts.root).map(l => l.id)
+      if (idx < ids.length) ts.active_leaf_id = ids[idx]
     }
   }
 }

--- a/desktop/lib/layout-manager.ts
+++ b/desktop/lib/layout-manager.ts
@@ -1,65 +1,55 @@
 /**
  * Layout change management — extracted from App.svelte.
  *
- * Functions for handling layout changes with pane consolidation
- * and confirmation when content would be lost.
+ * Applies a layout preset (single/splitH/splitV/quad) to a tab's pane tree,
+ * consolidating populated panes into the preset's leaves and confirming when
+ * content would be lost.
  */
 
-import type { PaneState, LayoutType, StructureTabState } from '../pane-utils'
-import { layout_panel_count, create_empty_pane, pane_has_content } from '../pane-utils'
+import type { PaneState, StructureTabState } from '../pane-utils'
+import { pane_has_content } from '../pane-utils'
+import { buildPreset, leaves, matchesPreset, type PresetId } from '../pane-tree'
 
 export interface LayoutManagerDeps {
   get_active_ts: () => StructureTabState | null
   get_active_tab_id: () => string
   tab_states: Record<string, StructureTabState>
   update_tab_label: (tab_id: string) => void
-  get_pending_layout_change: () => { tab_id: string; new_layout: LayoutType; lost_count: number } | null
-  set_pending_layout_change: (v: { tab_id: string; new_layout: LayoutType; lost_count: number } | null) => void
+  get_pending_layout_change: () => { tab_id: string; new_layout: PresetId; lost_count: number } | null
+  set_pending_layout_change: (v: { tab_id: string; new_layout: PresetId; lost_count: number } | null) => void
 }
 
-export function handle_layout_change(deps: LayoutManagerDeps, new_layout: LayoutType) {
+/** Number of leaves a preset's tree holds. */
+function preset_leaf_count(preset: PresetId): number {
+  if (preset === 'single') return 1
+  if (preset === 'quad') return 4
+  return 2
+}
+
+/** Rebuild the tab's tree from a preset, dropping populated panes into its leaves. */
+function apply_preset(ts: StructureTabState, preset: PresetId, filled: PaneState[]) {
+  const root = buildPreset(preset)
+  const slots = leaves(root)
+  for (let i = 0; i < slots.length && i < filled.length; i++) slots[i].content.pane = filled[i]
+  ts.root = root
+  ts.active_leaf_id = slots[0].id
+  ts.close_confirm_leaf_id = null
+}
+
+export function handle_layout_change(deps: LayoutManagerDeps, preset: PresetId) {
   const ts = deps.get_active_ts()
   if (!ts) return
-  if (new_layout === ts.layout) return
-  const old_count = layout_panel_count(ts.layout)
-  const new_count = layout_panel_count(new_layout)
+  if (matchesPreset(ts.root) === preset) return
 
-  if (new_count < old_count) {
-    // Check if trimmed panels have structures
-    const filled_beyond: number[] = []
-    for (let i = new_count; i < old_count; i++) {
-      const p = ts.panes[i]
-      if (pane_has_content(p)) filled_beyond.push(i)
-    }
+  const filled = leaves(ts.root).map(l => l.content.pane).filter(pane_has_content)
+  const target = preset_leaf_count(preset)
 
-    if (filled_beyond.length > 0) {
-      // Consolidate non-empty panes into lower indices
-      const all_filled: number[] = []
-      for (let i = 0; i < old_count; i++) {
-        const p = ts.panes[i]
-        if (pane_has_content(p)) all_filled.push(i)
-      }
-      const will_lose = all_filled.length - new_count
-      if (will_lose > 0) {
-        // Show confirmation modal
-        deps.set_pending_layout_change({ tab_id: deps.get_active_tab_id(), new_layout, lost_count: will_lose })
-        return
-      }
-      // No content will be lost — consolidate into lower slots
-      for (let dest = 0; dest < Math.min(new_count, all_filled.length); dest++) {
-        if (all_filled[dest] !== dest) {
-          const src = all_filled[dest]
-          ts.panes[dest] = ts.panes[src]
-          ts.panes[src] = create_empty_pane()
-        }
-      }
-    }
+  if (filled.length > target) {
+    deps.set_pending_layout_change({ tab_id: deps.get_active_tab_id(), new_layout: preset, lost_count: filled.length - target })
+    return
   }
 
-  ts.layout = new_layout
-  ts.col_split = 50
-  ts.row_split = 50
-  if (ts.active_pane >= new_count) ts.active_pane = 0
+  apply_preset(ts, preset, filled)
   deps.update_tab_label(deps.get_active_tab_id())
 }
 
@@ -69,25 +59,12 @@ export function confirm_layout_change(deps: LayoutManagerDeps) {
   const { tab_id, new_layout } = pending
   const ts = deps.tab_states[tab_id]
   if (!ts) { deps.set_pending_layout_change(null); return }
-  const old_count = layout_panel_count(ts.layout)
-  const new_count = layout_panel_count(new_layout)
 
-  // Consolidate non-empty panes into first N slots, drop the rest
-  const filled: PaneState[] = []
-  for (let i = 0; i < old_count; i++) {
-    const p = ts.panes[i]
-    if (pane_has_content(p)) filled.push(p)
-  }
-  for (let i = 0; i < 4; i++) {
-    if (i < new_count && i < filled.length) ts.panes[i] = filled[i]
-    else if (i < new_count) ts.panes[i] = create_empty_pane()
-    else ts.panes[i] = create_empty_pane()
-  }
+  // Truncate: keep only as many populated panes as the preset has leaves.
+  const target = preset_leaf_count(new_layout)
+  const filled = leaves(ts.root).map(l => l.content.pane).filter(pane_has_content).slice(0, target)
 
-  ts.layout = new_layout
-  ts.col_split = 50
-  ts.row_split = 50
-  if (ts.active_pane >= new_count) ts.active_pane = 0
+  apply_preset(ts, new_layout, filled)
   deps.set_pending_layout_change(null)
   deps.update_tab_label(tab_id)
 }

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -6,11 +6,11 @@
  */
 
 import type { PaneState, StructureTabState } from '../pane-utils'
-import { create_empty_pane, pane_has_content, auto_name as _auto_name, serialize_structure_content } from '../pane-utils'
+import { create_empty_pane, auto_name as _auto_name, serialize_structure_content } from '../pane-utils'
 import { findLeafById, leafCount, leaves, removeLeaf } from '../pane-tree'
 import { exp } from '../state/export-state.svelte'
 import { sidebar } from '../state/sidebar-state.svelte'
-import { list_projects, save_structure_to_db, write_file } from '$lib/api/project'
+import { list_projects, save_structure_to_db } from '$lib/api/project'
 import { writeRemoteFile } from '$lib/api/hpc'
 
 export interface PaneManagerDeps {

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -5,8 +5,9 @@
  * and project listing for save dialogs.
  */
 
-import type { PaneState, StructureTabState, LayoutType } from '../pane-utils'
-import { layout_panel_count, create_empty_pane, pane_has_content, auto_name as _auto_name, serialize_structure_content } from '../pane-utils'
+import type { PaneState, StructureTabState } from '../pane-utils'
+import { create_empty_pane, pane_has_content, auto_name as _auto_name, serialize_structure_content } from '../pane-utils'
+import { findLeafById, leafCount, leaves, removeLeaf } from '../pane-tree'
 import { exp } from '../state/export-state.svelte'
 import { sidebar } from '../state/sidebar-state.svelte'
 import { list_projects, save_structure_to_db, write_file } from '$lib/api/project'
@@ -18,68 +19,44 @@ export interface PaneManagerDeps {
   export_fs_browse: (dir: string) => void
 }
 
-export function handle_unload(deps: PaneManagerDeps, tab_id: string, pane_idx: number) {
+export function handle_unload(deps: PaneManagerDeps, tab_id: string, leaf_id: string) {
   const ts = deps.tab_states[tab_id]
   if (!ts) return
-  const pane = ts.panes[pane_idx]
+  const leaf = findLeafById(ts.root, leaf_id)
+  if (!leaf) return
+  const pane = leaf.content.pane
   // Workflow panes: only prompt if user has opened/edited a workflow
   if (pane.mode === 'workflow') {
     if (pane.modified) {
-      ts.close_confirm_pane = pane_idx
+      ts.close_confirm_leaf_id = leaf_id
       return
     }
-    close_panel(deps, tab_id, pane_idx)
+    close_panel(deps, tab_id, leaf_id)
     return
   }
   // Structure panes: prompt if has content
   const has_content = !!(pane.structure || pane.trajectory || pane.cube_file)
   if (has_content) {
-    ts.close_confirm_pane = pane_idx
+    ts.close_confirm_leaf_id = leaf_id
     init_close_save_target(pane)
     if (pane.structure) load_close_save_projects()
     return
   }
-  close_panel(deps, tab_id, pane_idx)
+  close_panel(deps, tab_id, leaf_id)
 }
 
-export function close_panel(deps: PaneManagerDeps, tab_id: string, pane_idx: number) {
+export function close_panel(deps: PaneManagerDeps, tab_id: string, leaf_id: string) {
   const ts = deps.tab_states[tab_id]
   if (!ts) return
-  const panel_count = layout_panel_count(ts.layout)
-
-  // If only 1 panel, reset to single empty (don't close the tab)
-  if (panel_count <= 1) {
-    ts.panes[0] = create_empty_pane()
-    ts.layout = 'single'
-    ts.active_pane = 0
-    ts.close_confirm_pane = null
+  ts.close_confirm_leaf_id = null
+  if (leafCount(ts.root) <= 1) {
+    const leaf = findLeafById(ts.root, leaf_id)
+    if (leaf) Object.assign(leaf.content.pane, create_empty_pane())
     deps.update_tab_label(tab_id)
     return
   }
-
-  // Clear the panel being closed
-  ts.close_confirm_pane = null
-  ts.panes[pane_idx] = create_empty_pane()
-
-  // Consolidate non-empty panes to lower indices
-  const visible: PaneState[] = []
-  for (let i = 0; i < panel_count; i++) {
-    if (i !== pane_idx) visible.push(ts.panes[i])
-  }
-
-  // Fill remaining slots with empty panes
-  for (let i = 0; i < 4; i++) {
-    ts.panes[i] = i < visible.length ? visible[i] : create_empty_pane()
-  }
-
-  // Reduce layout: 4->splitH, 2->single
-  const new_count = panel_count - 1
-  if (new_count <= 1) ts.layout = 'single'
-  else if (new_count <= 2) ts.layout = ts.layout === 'splitV' ? 'splitV' : 'splitH'
-  // new_count === 3 from quad -> go to splitH
-  else ts.layout = 'splitH'
-
-  if (ts.active_pane >= layout_panel_count(ts.layout)) ts.active_pane = 0
+  ts.root = removeLeaf(ts.root, leaf_id)
+  if (!findLeafById(ts.root, ts.active_leaf_id)) ts.active_leaf_id = leaves(ts.root)[0].id
   deps.update_tab_label(tab_id)
 }
 
@@ -98,21 +75,23 @@ export function init_close_save_target(pane: PaneState) {
   else exp.close_save_target = `project`
 }
 
-export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string, pane_idx: number) {
+export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string, leaf_id: string) {
   const ts = deps.tab_states[tab_id]
   if (!ts) return
-  const pane = ts.panes[pane_idx]
+  const leaf = findLeafById(ts.root, leaf_id)
+  const pane = leaf?.content.pane
+  if (!pane) return
   const structure = (pane.saveable_structure ?? pane.structure) as Record<string, unknown> | undefined
   if (!structure) {
-    close_panel(deps, tab_id, pane_idx)
+    close_panel(deps, tab_id, leaf_id)
     return
   }
   exp.close_saving = true
   try {
     if (exp.close_save_target === `local`) {
       // Open export dialog with folder browser, close panel after save
-      exp.close_after = { tab_id, pane_idx }
-      ts.close_confirm_pane = null
+      exp.close_after = { tab_id, leaf_id }
+      ts.close_confirm_leaf_id = null
       const name = _auto_name(structure)
       exp.pending_structure = structure
       exp.error = ``
@@ -143,7 +122,7 @@ export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string
       await save_structure_to_db(structure, _auto_name(structure), exp.close_save_project_id || undefined)
     }
     sidebar.refresh_counter++
-    close_panel(deps, tab_id, pane_idx)
+    close_panel(deps, tab_id, leaf_id)
   } catch (e) {
     exp.error = e instanceof Error ? e.message : `Save failed`
     console.error(`Save before close failed:`, e)

--- a/desktop/lib/popout-manager.ts
+++ b/desktop/lib/popout-manager.ts
@@ -7,6 +7,7 @@
 
 import type { AnyStructure } from '$lib'
 import type { StructureTabState } from '../pane-utils'
+import { findLeafById, leaves } from '../pane-tree'
 
 /** Open a structure in a new popout window via localStorage transfer. */
 export async function open_structure_in_new_window(structure: AnyStructure, filename: string, is_tauri: boolean) {
@@ -71,9 +72,12 @@ export function load_popout_structure(
     // Ensure a structure tab exists and load the data
     const ts = get_active_ts()
     if (ts) {
-      ts.panes[ts.active_pane].structure = structure
-      ts.panes[ts.active_pane].source_filename = filename
-      ts.panes[ts.active_pane].modified = false
+      const leaf = findLeafById(ts.root, ts.active_leaf_id) ?? leaves(ts.root)[0]
+      if (!leaf) return
+      const pane = leaf.content.pane
+      pane.structure = structure
+      pane.source_filename = filename
+      pane.modified = false
       update_tab_label(active_tab_id)
     }
   } catch (e) {
@@ -84,13 +88,15 @@ export function load_popout_structure(
 /** Open a split-view pane in a new window. */
 export async function popout_pane(
   tab_id: string,
-  pane_idx: number,
+  leaf_id: string,
   tab_states: Record<string, StructureTabState>,
   is_tauri: boolean,
 ) {
   const ts = tab_states[tab_id]
   if (!ts) return
-  const pane = ts.panes[pane_idx]
+  const leaf = findLeafById(ts.root, leaf_id)
+  if (!leaf) return
+  const pane = leaf.content.pane
 
   if (pane.mode === `workflow` && pane.workflow_id) {
     // Workflows have their own popout mechanism

--- a/desktop/lib/resize-handlers.ts
+++ b/desktop/lib/resize-handlers.ts
@@ -1,66 +1,49 @@
 /**
  * Panel resize handlers — extracted from App.svelte.
  *
- * Mouse-drag handlers for resizing split panes.
+ * Per-SplitNode ratio drag for the recursive pane tree (replaces the old
+ * fixed col/row grid dividers + quad center handle).
  */
 
 import type { StructureTabState } from '../pane-utils'
+import { findSplit, setRatio } from '../pane-tree'
 
-export interface ResizeDeps {
+export interface ResizeDepsMin {
   tab_states: Record<string, StructureTabState>
   set_is_panel_resizing: (v: boolean) => void
-  set_resize_axis: (v: 'col' | 'row') => void
 }
 
-export function on_divider_mousedown(deps: ResizeDeps, e: MouseEvent, axis: 'col' | 'row', tab_id: string) {
-  e.preventDefault()
+export function on_split_drag(
+  deps: ResizeDepsMin,
+  e: MouseEvent,
+  split_id: string,
+  dir: 'h' | 'v',
+  tab_id: string,
+  on_start: () => void,
+  on_end: () => void,
+) {
   const ts = deps.tab_states[tab_id]
   if (!ts) return
-  const container = (e.target as HTMLElement).closest(`.grid-container`) as HTMLElement
+  const node = findSplit(ts.root, split_id)
+  if (!node) return
+  const container = (e.target as HTMLElement).parentElement // the .split flex container
   if (!container) return
-  deps.set_is_panel_resizing(true)
-  deps.set_resize_axis(axis)
-  const start = axis === 'col' ? e.clientX : e.clientY
-  const start_pct = axis === 'col' ? ts.col_split : ts.row_split
-
-  function on_move(ev: MouseEvent) {
-    const rect = container.getBoundingClientRect()
-    const total = axis === 'col' ? rect.width : rect.height
-    const delta_pct = ((axis === 'col' ? ev.clientX : ev.clientY) - start) / total * 100
-    const new_pct = Math.max(20, Math.min(80, start_pct + delta_pct))
-    if (axis === 'col') ts.col_split = new_pct
-    else ts.row_split = new_pct
-  }
-  function on_up() {
-    deps.set_is_panel_resizing(false)
-    window.removeEventListener(`mousemove`, on_move)
-    window.removeEventListener(`mouseup`, on_up)
-  }
-  window.addEventListener(`mousemove`, on_move)
-  window.addEventListener(`mouseup`, on_up)
-}
-
-export function on_center_mousedown(deps: ResizeDeps, e: MouseEvent, tab_id: string) {
   e.preventDefault()
-  const ts = deps.tab_states[tab_id]
-  if (!ts) return
-  const container = (e.target as HTMLElement).closest(`.grid-container`) as HTMLElement
-  if (!container) return
   deps.set_is_panel_resizing(true)
-  const start_x = e.clientX
-  const start_y = e.clientY
-  const start_col = ts.col_split
-  const start_row = ts.row_split
-
+  on_start()
+  const start = dir === 'h' ? e.clientX : e.clientY
+  const start_ratio = node.ratio
   function on_move(ev: MouseEvent) {
-    const rect = container.getBoundingClientRect()
-    ts.col_split = Math.max(20, Math.min(80, start_col + (ev.clientX - start_x) / rect.width * 100))
-    ts.row_split = Math.max(20, Math.min(80, start_row + (ev.clientY - start_y) / rect.height * 100))
+    const rect = container!.getBoundingClientRect()
+    const total = dir === 'h' ? rect.width : rect.height
+    const delta = ((dir === 'h' ? ev.clientX : ev.clientY) - start) / total
+    ts!.root = setRatio(ts!.root, split_id, start_ratio + delta)
   }
   function on_up() {
-    deps.set_is_panel_resizing(false)
     window.removeEventListener(`mousemove`, on_move)
     window.removeEventListener(`mouseup`, on_up)
+    deps.set_is_panel_resizing(false)
+    on_end()
   }
   window.addEventListener(`mousemove`, on_move)
   window.addEventListener(`mouseup`, on_up)

--- a/desktop/lib/sidebar-handlers.ts
+++ b/desktop/lib/sidebar-handlers.ts
@@ -6,8 +6,8 @@
  */
 
 import type { AnyStructure } from '$lib'
-import type { StructureTabState, PaneState } from '../pane-utils'
-import { pane_has_content } from '../pane-utils'
+import type { StructureTabState } from '../pane-utils'
+import { findFirstEmptyLeaf } from '../pane-tree'
 import { sidebar } from '../state/sidebar-state.svelte'
 import { parse_and_open_structure_window } from './popout-manager'
 
@@ -15,7 +15,7 @@ export interface SidebarHandlerDeps {
   get_active_ts: () => StructureTabState | null
   get_active_tab_id: () => string
   get_active_tab_type: () => string
-  process_file_content: (tab_id: string, content: string | ArrayBuffer, filename: string, pane_idx: number, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) => Promise<void>
+  process_file_content: (tab_id: string, content: string | ArrayBuffer, filename: string, leaf_id: string, remote_origin?: { session_id: string; file_path: string } | null, local_file_path?: string | null) => Promise<void>
   update_tab_label: (tab_id: string) => void
   is_tauri: boolean
   set_is_loading: (v: boolean) => void
@@ -33,8 +33,8 @@ export function handle_sidebar_load(deps: SidebarHandlerDeps, content: string | 
   }
   const ts = deps.get_active_ts()
   if (!ts) return
-  const pane_idx = ts.panes.findIndex(p => !pane_has_content(p))
-  const target = pane_idx >= 0 ? pane_idx : ts.active_pane
+  const empty = findFirstEmptyLeaf(ts.root)
+  const target = empty ? empty.id : ts.active_leaf_id
   const origin = (file_path && session_id) ? { session_id, file_path } : null
   // Local filesystem path: file_path is set but session_id is not (not HPC)
   const local_path = (file_path && !session_id) ? file_path : null
@@ -78,8 +78,8 @@ export function handle_sidebar_load_trajectory(deps: SidebarHandlerDeps, content
   }
   const ts = deps.get_active_ts()
   if (!ts) return
-  const pane_idx = ts.panes.findIndex(p => !pane_has_content(p))
-  const target = pane_idx >= 0 ? pane_idx : ts.active_pane
+  const empty = findFirstEmptyLeaf(ts.root)
+  const target = empty ? empty.id : ts.active_leaf_id
   deps.process_file_content(deps.get_active_tab_id(), content, filename, target)
 }
 

--- a/desktop/lib/tab-manager.svelte.ts
+++ b/desktop/lib/tab-manager.svelte.ts
@@ -7,9 +7,10 @@
 
 import type { AppTab } from '../TabBar.svelte'
 import {
-  type LayoutType, type StructureTabState,
-  layout_panel_count, pane_has_content, create_empty_pane, create_tab_state,
+  type StructureTabState,
+  pane_has_content, create_tab_state,
 } from '../pane-utils'
+import { leaves, matchesPreset, type PresetId } from '../pane-tree'
 import {
   ensure_workflow_slice,
   remove_workflow_slice,
@@ -50,8 +51,7 @@ export function create_tab_manager() {
     // Skip the badge on the currently-active tab — user already sees its
     // content; the count is just visual noise on the active tab.
     if (t.id === active_tab_id) return t
-    const count = layout_panel_count(ts.layout)
-    const badge = ts.panes.slice(0, count).filter(p => pane_has_content(p)).length
+    const badge = leaves(ts.root).filter(l => pane_has_content(l.content.pane)).length
     return { ...t, badge: badge > 0 ? badge : undefined }
   }))
 
@@ -59,11 +59,11 @@ export function create_tab_manager() {
     if (active_tab_type !== `structure`) return undefined
     const ts = tab_states_record[active_tab_id]
     if (!ts) return undefined
-    return ts.layout
+    return matchesPreset(ts.root)
   })
 
   let tab_close_confirm_id = $state<string | null>(null)
-  let pending_layout_change = $state<{ tab_id: string, new_layout: LayoutType, lost_count: number } | null>(null)
+  let pending_layout_change = $state<{ tab_id: string, new_layout: PresetId, lost_count: number } | null>(null)
 
   function create_tab(type: `structure` | `workflow`) {
     if (type === `workflow`) {
@@ -114,6 +114,16 @@ export function create_tab_manager() {
     active_tab_id = `default`
   }
 
+  function reset_ts_to_empty(ts: StructureTabState, tab: AppTab) {
+    const r = create_tab_state()
+    ts.root = r.root
+    ts.active_leaf_id = r.active_leaf_id
+    ts.close_confirm_leaf_id = null
+    ts.library = []
+    ts.active_library_id = null
+    tab.label = `Structure`
+  }
+
   function request_close_tab(id: string) {
     const tab = tabs.find(t => t.id === id)
     if (!tab) return
@@ -122,8 +132,7 @@ export function create_tab_manager() {
     if (tab.type === `structure`) {
       const ts = tab_states_record[id]
       if (ts) {
-        const count = layout_panel_count(ts.layout)
-        const loaded = ts.panes.slice(0, count).filter(p => pane_has_content(p)).length
+        const loaded = leaves(ts.root).filter(l => pane_has_content(l.content.pane)).length
         if (loaded > 0) {
           tab_close_confirm_id = id
           return
@@ -135,16 +144,7 @@ export function create_tab_manager() {
     if (tabs.length <= 1) {
       if (tab.type === `structure`) {
         const ts = tab_states_record[id]
-        if (ts) {
-          for (let i = 0; i < 4; i++) ts.panes[i] = create_empty_pane()
-          ts.layout = 'single'
-          ts.active_pane = 0
-          ts.col_split = 50
-          ts.row_split = 50
-          ts.library = []
-          ts.active_library_id = null
-          tab.label = `Structure`
-        }
+        if (ts) reset_ts_to_empty(ts, tab)
       }
       return
     }
@@ -160,17 +160,7 @@ export function create_tab_manager() {
     // Last tab: reset to empty landing page instead of removing
     if (tabs.length <= 1 && tab.type === `structure`) {
       const ts = tab_states_record[id]
-      if (ts) {
-        for (let i = 0; i < 4; i++) ts.panes[i] = create_empty_pane()
-        ts.layout = 'single'
-        ts.active_pane = 0
-        ts.col_split = 50
-        ts.row_split = 50
-        ts.close_confirm_pane = null
-        ts.library = []
-        ts.active_library_id = null
-        tab.label = `Structure`
-      }
+      if (ts) reset_ts_to_empty(ts, tab)
       return
     }
 
@@ -214,7 +204,7 @@ export function create_tab_manager() {
     // is the lab/MCP receiver, even after a structure loads in it.
     const prefix = tab_id === `default` ? `🤖 ` : ``
     const fallback = tab_id === `default` ? `External` : `Structure`
-    const pane = ts.panes.find(p => p.structure)
+    const pane = leaves(ts.root).map(l => l.content.pane).find(p => p.structure)
     if (pane?.structure?.sites?.length) {
       const counts: Record<string, number> = {}
       for (const site of pane.structure.sites) {
@@ -224,8 +214,7 @@ export function create_tab_manager() {
       const formula = Object.entries(counts).map(([el, n]) => n > 1 ? `${el}${n}` : el).join(``)
       if (formula) { tab.label = `${prefix}${formula}`; return }
     }
-    const count = layout_panel_count(ts.layout)
-    if (ts.panes.slice(0, count).some(p => p.mode === 'workflow')) {
+    if (leaves(ts.root).some(l => l.content.pane.mode === 'workflow')) {
       tab.label = `${prefix}Workflow`
       return
     }
@@ -249,7 +238,8 @@ export function create_tab_manager() {
     get active_tab() { return active_tab },
     get active_tab_type() { return active_tab_type },
     // IMPORTANT: Return the raw $state proxy — do NOT wrap in a getter
-    // so that callers can mutate nested properties (e.g. tab_states[id].panes[0].structure = ...)
+    // so that callers can mutate nested properties
+    // (e.g. findLeafById(tab_states[id].root, leaf_id).content.pane.structure = ...)
     tab_states: tab_states_record,
     get_active_ts,
     get tabs_with_badges() { return tabs_with_badges },
@@ -257,7 +247,7 @@ export function create_tab_manager() {
     get tab_close_confirm_id() { return tab_close_confirm_id },
     set tab_close_confirm_id(v: string | null) { tab_close_confirm_id = v },
     get pending_layout_change() { return pending_layout_change },
-    set pending_layout_change(v: { tab_id: string, new_layout: LayoutType, lost_count: number } | null) { pending_layout_change = v },
+    set pending_layout_change(v: { tab_id: string, new_layout: PresetId, lost_count: number } | null) { pending_layout_change = v },
     create_tab,
     create_remote_tab,
     close_tab,

--- a/desktop/pane-tree.ts
+++ b/desktop/pane-tree.ts
@@ -57,3 +57,17 @@ export function findSplit(node: PaneNode, id: string): SplitNode | null {
   if (node.id === id) return node
   return findSplit(node.children[0], id) ?? findSplit(node.children[1], id)
 }
+
+export function create_empty_leaf(): LeafNode {
+  return { kind: 'leaf', id: next_id('leaf'), content: { type: 'structure', pane: create_empty_pane() } }
+}
+
+/** A leaf is "empty" when it is a structure leaf holding nothing renderable. */
+export function isEmptyLeaf(leaf: LeafNode): boolean {
+  return leaf.content.type === 'structure' && !pane_has_content(leaf.content.pane)
+}
+
+export function findFirstEmptyLeaf(node: PaneNode): LeafNode | null {
+  for (const l of leaves(node)) if (isEmptyLeaf(l)) return l
+  return null
+}

--- a/desktop/pane-tree.ts
+++ b/desktop/pane-tree.ts
@@ -71,3 +71,39 @@ export function findFirstEmptyLeaf(node: PaneNode): LeafNode | null {
   for (const l of leaves(node)) if (isEmptyLeaf(l)) return l
   return null
 }
+
+/** Replace `leafId` with a split of [existing, newEmptyLeaf]. Returns null at CAP. */
+export function splitLeaf(root: PaneNode, leafId: string, direction: SplitDir): { root: PaneNode; newLeafId: string } | null {
+  if (leafCount(root) >= CAP) return null
+  const target = findLeafById(root, leafId)
+  if (!target) return null
+  const newLeaf = create_empty_leaf()
+  const replacement: SplitNode = { kind: 'split', id: next_id('split'), direction, ratio: 0.5, children: [target, newLeaf] }
+  return { root: replaceNode(root, leafId, replacement), newLeafId: newLeaf.id }
+}
+
+/** Remove a leaf; collapse its parent split so the sibling takes the parent's place. */
+export function removeLeaf(root: PaneNode, leafId: string): PaneNode {
+  if (root.kind === 'leaf') return root // never destroy the sole leaf
+  return removeIn(root, leafId)
+}
+
+function removeIn(node: SplitNode, leafId: string): PaneNode {
+  const [a, b] = node.children
+  if (a.kind === 'leaf' && a.id === leafId) return b
+  if (b.kind === 'leaf' && b.id === leafId) return a
+  const na = a.kind === 'split' ? removeIn(a, leafId) : a
+  const nb = b.kind === 'split' ? removeIn(b, leafId) : b
+  if (na === a && nb === b) return node
+  return { ...node, children: [na, nb] }
+}
+
+/** Pure structural replace of a node (by id) anywhere in the tree. */
+function replaceNode(node: PaneNode, id: string, replacement: PaneNode): PaneNode {
+  if (node.kind === 'leaf') return node.id === id ? replacement : node
+  if (node.id === id) return replacement
+  const a = replaceNode(node.children[0], id, replacement)
+  const b = replaceNode(node.children[1], id, replacement)
+  if (a === node.children[0] && b === node.children[1]) return node
+  return { ...node, children: [a, b] }
+}

--- a/desktop/pane-tree.ts
+++ b/desktop/pane-tree.ts
@@ -107,3 +107,48 @@ function replaceNode(node: PaneNode, id: string, replacement: PaneNode): PaneNod
   if (a === node.children[0] && b === node.children[1]) return node
   return { ...node, children: [a, b] }
 }
+
+export function setRatio(root: PaneNode, splitId: string, ratio: number): PaneNode {
+  const clamped = Math.max(0.2, Math.min(0.8, ratio))
+  function go(node: PaneNode): PaneNode {
+    if (node.kind === 'leaf') return node
+    if (node.id === splitId) return { ...node, ratio: clamped }
+    const a = go(node.children[0]); const b = go(node.children[1])
+    if (a === node.children[0] && b === node.children[1]) return node
+    return { ...node, children: [a, b] }
+  }
+  return go(root)
+}
+
+/**
+ * Open-file target: reuse the first empty leaf; else split the active leaf
+ * (one at a time) up to CAP; else null (caller opens a new tab).
+ * Direction reproduces the old single->splitH (first split 'h') then 'v'.
+ */
+export function escalateForImport(root: PaneNode, activeLeafId: string): { root: PaneNode; leafId: string } | null {
+  const empty = findFirstEmptyLeaf(root)
+  if (empty) return { root, leafId: empty.id }
+  const dir: SplitDir = leafCount(root) === 1 ? 'h' : 'v'
+  const split = splitLeaf(root, activeLeafId, dir)
+  if (!split) return null
+  return { root: split.root, leafId: split.newLeafId }
+}
+
+export function buildPreset(preset: PresetId): PaneNode {
+  if (preset === 'single') return create_empty_leaf()
+  if (preset === 'splitH') return { kind: 'split', id: next_id('split'), direction: 'h', ratio: 0.5, children: [create_empty_leaf(), create_empty_leaf()] }
+  if (preset === 'splitV') return { kind: 'split', id: next_id('split'), direction: 'v', ratio: 0.5, children: [create_empty_leaf(), create_empty_leaf()] }
+  // quad = h-split of two v-splits
+  const col = (): SplitNode => ({ kind: 'split', id: next_id('split'), direction: 'v', ratio: 0.5, children: [create_empty_leaf(), create_empty_leaf()] })
+  return { kind: 'split', id: next_id('split'), direction: 'h', ratio: 0.5, children: [col(), col()] }
+}
+
+export function matchesPreset(root: PaneNode): PresetId | null {
+  if (root.kind === 'leaf') return 'single'
+  const [a, b] = root.children
+  if (a.kind === 'leaf' && b.kind === 'leaf') return root.direction === 'h' ? 'splitH' : 'splitV'
+  if (root.direction === 'h' && a.kind === 'split' && b.kind === 'split'
+    && a.direction === 'v' && b.direction === 'v'
+    && a.children.every(c => c.kind === 'leaf') && b.children.every(c => c.kind === 'leaf')) return 'quad'
+  return null
+}

--- a/desktop/pane-tree.ts
+++ b/desktop/pane-tree.ts
@@ -1,0 +1,59 @@
+/**
+ * Recursive pane tree — the desktop layout primitive (replaces the fixed
+ * single/splitH/splitV/quad grid). A tab's layout is one PaneNode.
+ *
+ * Subproject 1: leaf content is only { type: 'structure', pane }. Subproject 2
+ * widens LeafContent to include { type: 'terminal', ... }.
+ */
+import type { PaneState } from './pane-utils'
+import { create_empty_pane, pane_has_content } from './pane-utils'
+
+export type SplitDir = 'h' | 'v' // 'h' = side by side (vertical divider); 'v' = stacked (horizontal divider)
+export type PresetId = 'single' | 'splitH' | 'splitV' | 'quad'
+
+export type LeafContent = { type: 'structure'; pane: PaneState }
+
+export interface LeafNode {
+  kind: 'leaf'
+  id: string
+  content: LeafContent
+}
+
+export interface SplitNode {
+  kind: 'split'
+  id: string
+  direction: SplitDir
+  ratio: number // 0..1 fraction for children[0]; clamped 0.2..0.8 on user drag
+  children: [PaneNode, PaneNode]
+}
+
+export type PaneNode = SplitNode | LeafNode
+
+/** Max leaves per tab (spec D6). Preserves the old single->2->4 GPU envelope. */
+export const CAP = 4
+
+let _id_counter = 0
+function next_id(prefix: string): string {
+  _id_counter += 1
+  return `${prefix}-${_id_counter}`
+}
+
+export function leaves(node: PaneNode): LeafNode[] {
+  if (node.kind === 'leaf') return [node]
+  return [...leaves(node.children[0]), ...leaves(node.children[1])]
+}
+
+export function leafCount(node: PaneNode): number {
+  return node.kind === 'leaf' ? 1 : leafCount(node.children[0]) + leafCount(node.children[1])
+}
+
+export function findLeafById(node: PaneNode, id: string): LeafNode | null {
+  if (node.kind === 'leaf') return node.id === id ? node : null
+  return findLeafById(node.children[0], id) ?? findLeafById(node.children[1], id)
+}
+
+export function findSplit(node: PaneNode, id: string): SplitNode | null {
+  if (node.kind === 'leaf') return null
+  if (node.id === id) return node
+  return findSplit(node.children[0], id) ?? findSplit(node.children[1], id)
+}

--- a/desktop/pane-tree.ts
+++ b/desktop/pane-tree.ts
@@ -32,7 +32,9 @@ export type PaneNode = SplitNode | LeafNode
 /** Max leaves per tab (spec D6). Preserves the old single->2->4 GPU envelope. */
 export const CAP = 4
 
-let _id_counter = 0
+// Seed from a random base so a Vite HMR module reload (which resets module
+// state) mints a disjoint id space and cannot collide with ids in live trees.
+let _id_counter = Math.floor(Math.random() * 1e9)
 function next_id(prefix: string): string {
   _id_counter += 1
   return `${prefix}-${_id_counter}`

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -5,6 +5,8 @@
  */
 
 import type { AnyStructure } from '$lib'
+import type { PaneNode } from './pane-tree'
+import { create_empty_leaf } from './pane-tree'
 
 // ========== Types ==========
 
@@ -34,8 +36,6 @@ export interface PaneState {
   source_filename?: string | null
 }
 
-export type LayoutType = 'single' | 'splitH' | 'splitV' | 'quad'
-
 /**
  * One imported structure held in a tab's structure-library sidebar.
  * Parsed eagerly (see desktop/App.svelte ingest_one): a multi-frame file
@@ -58,24 +58,15 @@ export interface LibraryEntry {
 }
 
 export interface StructureTabState {
-  panes: PaneState[]
-  layout: LayoutType
-  active_pane: number
-  close_confirm_pane: number | null
-  col_split: number
-  row_split: number
+  root: PaneNode
+  active_leaf_id: string
+  close_confirm_leaf_id: string | null
   /** Per-tab structure library (sidebar). Cleared automatically on tab close. */
   library: LibraryEntry[]
   active_library_id: string | null
 }
 
 // ========== Pure Functions ==========
-
-export function layout_panel_count(layout: LayoutType): number {
-  if (layout === 'single') return 1
-  if (layout === 'splitH' || layout === 'splitV') return 2
-  return 4
-}
 
 export function get_pane_label(pane: PaneState): string {
   if (pane.mode === 'workflow') return `Workflow`
@@ -110,13 +101,11 @@ export function content_to_base64(content: string | ArrayBuffer): string {
 }
 
 export function create_tab_state(): StructureTabState {
+  const root = create_empty_leaf()
   return {
-    panes: [create_empty_pane(), create_empty_pane(), create_empty_pane(), create_empty_pane()],
-    layout: 'single',
-    active_pane: 0,
-    close_confirm_pane: null,
-    col_split: 50,
-    row_split: 50,
+    root,
+    active_leaf_id: root.id,
+    close_confirm_leaf_id: null,
     library: [],
     active_library_id: null,
   }
@@ -135,49 +124,6 @@ export function auto_name(structure: Record<string, unknown>): string {
     counts[el] = (counts[el] || 0) + 1
   }
   return Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)).map(([el, n]) => n > 1 ? `${el}${n}` : el).join(``)
-}
-
-/** Determine the import target pane when loading a new structure into a tab. */
-export function find_import_target_pane(ts: StructureTabState, source_pane: number): number {
-  const { panes } = ts
-  const source_has_content = pane_has_content(panes[source_pane])
-  if (!source_has_content) return source_pane
-  const panel_count = layout_panel_count(ts.layout)
-  // Look for empty pane within visible panels first
-  let target = -1
-  for (let i = 0; i < panel_count; i++) {
-    if (!pane_has_content(panes[i])) { target = i; break }
-  }
-  if (target < 0) {
-    if (ts.layout === 'single') { ts.layout = 'splitH'; target = 1 }
-    else if (ts.layout === 'splitH' || ts.layout === 'splitV') { ts.layout = 'quad'; target = 2 }
-    else return -1
-  }
-  return target
-}
-
-// ========== Grid Layout Helpers ==========
-
-export function get_visible_panes(ts: StructureTabState): number[] {
-  return Array.from({ length: layout_panel_count(ts.layout) }, (_, i) => i)
-}
-
-export function get_grid_style(ts: StructureTabState): string {
-  switch (ts.layout) {
-    case 'single': return `grid-template-columns: 1fr; grid-template-rows: 1fr;`
-    case 'splitH': return `grid-template-columns: ${ts.col_split}% 6px 1fr; grid-template-rows: 1fr;`
-    case 'splitV': return `grid-template-columns: 1fr; grid-template-rows: ${ts.row_split}% 6px 1fr;`
-    case 'quad': return `grid-template-columns: ${ts.col_split}% 6px 1fr; grid-template-rows: ${ts.row_split}% 6px 1fr;`
-  }
-}
-
-export function get_pane_position(layout: LayoutType, idx: number): string {
-  if (layout === 'single') return ``
-  if (layout === 'splitH') return `grid-column: ${idx === 0 ? 1 : 3}; grid-row: 1;`
-  if (layout === 'splitV') return `grid-column: 1; grid-row: ${idx === 0 ? 1 : 3};`
-  const col = [1, 3, 1, 3][idx]
-  const row = [1, 1, 3, 3][idx]
-  return `grid-column: ${col}; grid-row: ${row};`
 }
 
 // ========== Sample Structures ==========

--- a/desktop/state/export-state.svelte.ts
+++ b/desktop/state/export-state.svelte.ts
@@ -18,7 +18,7 @@ class ExportState {
   fs_loading = $state(false)
 
   // Close-after-export linkage
-  close_after = $state<{ tab_id: string; pane_idx: number } | null>(null)
+  close_after = $state<{ tab_id: string; leaf_id: string } | null>(null)
 
   // Save-on-close state
   close_save_projects = $state<ProjectSummary[]>([])

--- a/desktop/state/modal-state.svelte.ts
+++ b/desktop/state/modal-state.svelte.ts
@@ -22,7 +22,7 @@ class ModalState {
   search_provider = $state(``)
   paste_content_visible = $state(false)
   import_target_tab = $state(`structure-1`)
-  import_target_pane = $state(0)
+  import_target_leaf = $state('')
   optimade_search_element = $state(``)
   // Database import preview
   db_preview_visible = $state(false)
@@ -41,7 +41,7 @@ class ModalState {
 export interface CloseAllEntry {
   tab_id: string
   label: string
-  pane_idx: number
+  leaf_id: string
   formula: string
   save_target: `local` | `hpc` | `database` | `none`
   save_path?: string

--- a/docs/superpowers/plans/2026-06-16-pane-tree-core.md
+++ b/docs/superpowers/plans/2026-06-16-pane-tree-core.md
@@ -1,0 +1,1143 @@
+# Pane-Tree Core (Subproject 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the desktop fixed 4-pane grid (`single|splitH|splitV|quad`) with one recursive binary **pane tree**, behavior-equivalent except the two deltas in the spec §6.5 (independent quad dividers; one-leaf-at-a-time escalation).
+
+**Architecture:** A pure-data tree (`SplitNode | LeafNode`) plus pure ops in a new `desktop/pane-tree.ts`, rendered by a new recursive `desktop/PaneTree.svelte`. `StructureTabState` swaps `panes[]/layout/active_pane/col_split/row_split` for `root: PaneNode` + `active_leaf_id` + `close_confirm_leaf_id`. Leaf content in this subproject is a single `{type:'structure', pane: PaneState}` variant (subproject 2 widens it to include `terminal`). `PaneState` is **unchanged**.
+
+**Tech Stack:** SvelteKit 2 / Svelte 5 runes (`$state`/`$derived`/`$props`), TypeScript, Vitest, `deno fmt` (single quotes, no semicolons, 2-space, 90-col — let the pre-commit hook format).
+
+**Constraint (spec D8):** Desktop only. `desktop/` is not imported by `src/lib/mobile/*` (verified). The only shared file is `desktop/pane-utils.ts` exports — but mobile imports of it must be re-verified in Task 2 (it changes `StructureTabState`/`create_tab_state`). No edit to `src/lib/mobile/*`.
+
+---
+
+## Contract changes (shared reference — every task below depends on these names)
+
+| Thing | Before | After |
+|------|--------|-------|
+| `StructureTabState` | `panes: PaneState[4]`, `layout: LayoutType`, `active_pane: number`, `close_confirm_pane: number\|null`, `col_split`, `row_split` | `root: PaneNode`, `active_leaf_id: string`, `close_confirm_leaf_id: string\|null` (keeps `library`, `active_library_id`) |
+| App `$state` `drag_target_pane` | `number\|null` | `drag_target_leaf: string\|null` |
+| App `$state` `resize_axis` | `'col'\|'row'` | removed (drag tracks `active_split_id: string\|null`) |
+| App `$state` `file_input_target_pane` | `number` | `file_input_target_leaf: string` |
+| App `$state` `active_pane` usages | `ts.active_pane` | `ts.active_leaf_id` |
+| `modal.import_target_pane` (`desktop/state/modal-state.svelte`) | `number` | `import_target_leaf: string` |
+| `exp.close_after` (`desktop/state/export-state.svelte`) | `{tab_id, pane_idx:number}` | `{tab_id, leaf_id:string}` |
+| `CloseAllEntry` (`desktop/state/modal-state.svelte`) | `pane_idx: number` | `leaf_id: string` |
+| `pending_layout_change.new_layout` (tab-manager) | `LayoutType` | `PresetId` |
+| Dep/fn signatures: `handle_open_file`, `handle_open_folder`, `handle_unload`, `close_panel`, `save_and_close_panel`, `process_file_content`, `import_many`, `popout_pane`, `apply_entry_to_pane`, `create_on_file_load`, `create_on_file_drop` | `…pane_idx: number` | `…leaf_id: string` |
+| `DragDropDeps.get/set_drag_target_pane` | `number\|null` | `string\|null` |
+| DOM attribute | `[data-pane]` | `[data-leaf-id]` |
+| Removed exports from `pane-utils.ts` | `LayoutType`, `layout_panel_count`, `find_import_target_pane`, `get_visible_panes`, `get_grid_style`, `get_pane_position` | — (moved to tree model) |
+
+**Build-red window:** Task 1 (pane-tree.ts) is fully green/committable. Tasks 2–15 are one atomic model flip — `pnpm check` is expected to be RED from Task 2 until the last consumer in Task 15, then GREEN. `pnpm test` for `pane-tree.test.ts` stays green throughout. Commit WIP at each task (feature branch).
+
+---
+
+## Task 1: `desktop/pane-tree.ts` — pure tree model + ops (TDD, fully green)
+
+**Files:**
+- Create: `desktop/pane-tree.ts`
+- Test: `tests/desktop/pane-tree.test.ts`
+
+The canonical API (every later task imports from here):
+`leaves`, `leafCount`, `findLeafById`, `findSplit`, `isEmptyLeaf`, `findFirstEmptyLeaf`, `create_empty_leaf`, `splitLeaf`, `escalateForImport`, `removeLeaf`, `setRatio`, `buildPreset`, `matchesPreset`, `CAP`, and types `PaneNode`/`SplitNode`/`LeafNode`/`LeafContent`/`PresetId`/`SplitDir`.
+
+- [ ] **Step 1.1: Write failing tests for types + `leaves`/`leafCount`/`findLeafById`/`findSplit`**
+
+Create `tests/desktop/pane-tree.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { create_empty_pane } from '../../desktop/pane-utils'
+import {
+  CAP, buildPreset, create_empty_leaf, escalateForImport, findFirstEmptyLeaf,
+  findLeafById, findSplit, isEmptyLeaf, leafCount, leaves, matchesPreset,
+  removeLeaf, setRatio, splitLeaf,
+  type LeafNode, type PaneNode, type SplitNode,
+} from '../../desktop/pane-tree'
+
+const leaf = (id: string): LeafNode => ({ kind: 'leaf', id, content: { type: 'structure', pane: create_empty_pane() } })
+const split = (id: string, dir: 'h' | 'v', ratio: number, a: PaneNode, b: PaneNode): SplitNode => ({ kind: 'split', id, direction: dir, ratio, children: [a, b] })
+
+describe('leaves / leafCount / find', () => {
+  it('single leaf', () => {
+    const root = leaf('L1')
+    expect(leaves(root).map(l => l.id)).toEqual(['L1'])
+    expect(leafCount(root)).toBe(1)
+  })
+  it('nested tree returns leaves left-to-right', () => {
+    const root = split('S1', 'h', 0.5, split('S2', 'v', 0.5, leaf('A'), leaf('B')), leaf('C'))
+    expect(leaves(root).map(l => l.id)).toEqual(['A', 'B', 'C'])
+    expect(leafCount(root)).toBe(3)
+    expect(findLeafById(root, 'B')?.id).toBe('B')
+    expect(findLeafById(root, 'nope')).toBeNull()
+    expect(findSplit(root, 'S2')?.direction).toBe('v')
+    expect(findSplit(root, 'A')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 1.2: Run, verify fail**
+
+Run: `pnpm vitest run tests/desktop/pane-tree.test.ts`
+Expected: FAIL — `pane-tree.ts` does not exist / exports undefined.
+
+- [ ] **Step 1.3: Implement types + traversal in `desktop/pane-tree.ts`**
+
+```ts
+/**
+ * Recursive pane tree — the desktop layout primitive (replaces the fixed
+ * single/splitH/splitV/quad grid). A tab's layout is one PaneNode.
+ *
+ * Subproject 1: leaf content is only { type: 'structure', pane }. Subproject 2
+ * widens LeafContent to include { type: 'terminal', ... }.
+ */
+import type { PaneState } from './pane-utils'
+import { create_empty_pane, pane_has_content } from './pane-utils'
+
+export type SplitDir = 'h' | 'v' // 'h' = side by side (vertical divider); 'v' = stacked (horizontal divider)
+export type PresetId = 'single' | 'splitH' | 'splitV' | 'quad'
+
+export type LeafContent = { type: 'structure'; pane: PaneState }
+
+export interface LeafNode {
+  kind: 'leaf'
+  id: string
+  content: LeafContent
+}
+
+export interface SplitNode {
+  kind: 'split'
+  id: string
+  direction: SplitDir
+  ratio: number // 0..1 fraction for children[0]; clamped 0.2..0.8 on user drag
+  children: [PaneNode, PaneNode]
+}
+
+export type PaneNode = SplitNode | LeafNode
+
+/** Max leaves per tab (spec D6). Preserves the old single->2->4 GPU envelope. */
+export const CAP = 4
+
+let _id_counter = 0
+function next_id(prefix: string): string {
+  _id_counter += 1
+  return `${prefix}-${_id_counter}`
+}
+
+export function leaves(node: PaneNode): LeafNode[] {
+  if (node.kind === 'leaf') return [node]
+  return [...leaves(node.children[0]), ...leaves(node.children[1])]
+}
+
+export function leafCount(node: PaneNode): number {
+  return node.kind === 'leaf' ? 1 : leafCount(node.children[0]) + leafCount(node.children[1])
+}
+
+export function findLeafById(node: PaneNode, id: string): LeafNode | null {
+  if (node.kind === 'leaf') return node.id === id ? node : null
+  return findLeafById(node.children[0], id) ?? findLeafById(node.children[1], id)
+}
+
+export function findSplit(node: PaneNode, id: string): SplitNode | null {
+  if (node.kind === 'leaf') return null
+  if (node.id === id) return node
+  return findSplit(node.children[0], id) ?? findSplit(node.children[1], id)
+}
+```
+
+- [ ] **Step 1.4: Run, verify pass**
+
+Run: `pnpm vitest run tests/desktop/pane-tree.test.ts`
+Expected: PASS (the `leaves / leafCount / find` block).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add desktop/pane-tree.ts tests/desktop/pane-tree.test.ts
+git commit -m "feat(pane-tree): tree types + traversal (leaves/leafCount/find)"
+```
+
+- [ ] **Step 1.6: Add failing tests for `create_empty_leaf`/`isEmptyLeaf`/`findFirstEmptyLeaf`**
+
+Append to the test file:
+
+```ts
+describe('empty leaves', () => {
+  it('create_empty_leaf is an empty structure leaf with a unique id', () => {
+    const a = create_empty_leaf(); const b = create_empty_leaf()
+    expect(a.kind).toBe('leaf')
+    expect(a.content.type).toBe('structure')
+    expect(isEmptyLeaf(a)).toBe(true)
+    expect(a.id).not.toBe(b.id)
+  })
+  it('findFirstEmptyLeaf returns first content-free leaf or null', () => {
+    const filled = create_empty_leaf(); filled.content.pane.structure = { sites: [{}] } as never
+    const empty = create_empty_leaf()
+    const root = split('S', 'h', 0.5, filled, empty)
+    expect(findFirstEmptyLeaf(root)?.id).toBe(empty.id)
+    const full = split('S2', 'h', 0.5, filled, filled)
+    expect(findFirstEmptyLeaf(full)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 1.7: Run, verify fail** — `pnpm vitest run tests/desktop/pane-tree.test.ts` → FAIL (undefined exports).
+
+- [ ] **Step 1.8: Implement empty-leaf helpers** (append to `pane-tree.ts`):
+
+```ts
+export function create_empty_leaf(): LeafNode {
+  return { kind: 'leaf', id: next_id('leaf'), content: { type: 'structure', pane: create_empty_pane() } }
+}
+
+/** A leaf is "empty" when it is a structure leaf holding nothing renderable. */
+export function isEmptyLeaf(leaf: LeafNode): boolean {
+  return leaf.content.type === 'structure' && !pane_has_content(leaf.content.pane)
+}
+
+export function findFirstEmptyLeaf(node: PaneNode): LeafNode | null {
+  for (const l of leaves(node)) if (isEmptyLeaf(l)) return l
+  return null
+}
+```
+
+- [ ] **Step 1.9: Run, verify pass** — `pnpm vitest run tests/desktop/pane-tree.test.ts` → PASS.
+
+- [ ] **Step 1.10: Commit**
+
+```bash
+git add desktop/pane-tree.ts tests/desktop/pane-tree.test.ts
+git commit -m "feat(pane-tree): empty-leaf helpers (create_empty_leaf/isEmptyLeaf/findFirstEmptyLeaf)"
+```
+
+- [ ] **Step 1.11: Add failing tests for `splitLeaf` + `removeLeaf` (collapse) + CAP**
+
+Append:
+
+```ts
+describe('splitLeaf / removeLeaf', () => {
+  it('splitLeaf replaces a leaf with a split of [old, newEmpty]', () => {
+    const root0 = create_empty_leaf()
+    const { root, newLeafId } = splitLeaf(root0, root0.id, 'h')
+    expect(root.kind).toBe('split')
+    expect(leafCount(root)).toBe(2)
+    expect((root as SplitNode).direction).toBe('h')
+    expect((root as SplitNode).ratio).toBe(0.5)
+    expect(findLeafById(root, newLeafId)).not.toBeNull()
+    // original leaf id preserved as children[0]
+    expect(((root as SplitNode).children[0] as LeafNode).id).toBe(root0.id)
+  })
+  it('splitLeaf refuses at CAP leaves', () => {
+    let root: PaneNode = create_empty_leaf()
+    let active = (root as LeafNode).id
+    for (let i = 1; i < CAP; i++) { const r = splitLeaf(root, active, 'v'); root = r.root; active = r.newLeafId }
+    expect(leafCount(root)).toBe(CAP)
+    expect(splitLeaf(root, active, 'v')).toBeNull()
+  })
+  it('removeLeaf collapses parent split, sibling takes its place', () => {
+    const a = create_empty_leaf(); const b = create_empty_leaf(); const c = create_empty_leaf()
+    const root = split('S1', 'h', 0.4, split('S2', 'v', 0.5, a, b), c)
+    const next = removeLeaf(root, b.id) // S2 collapses -> a takes S2's slot
+    expect(leaves(next).map(l => l.id)).toEqual([a.id, c.id])
+    expect((next as SplitNode).id).toBe('S1')
+    expect(((next as SplitNode).children[0] as LeafNode).id).toBe(a.id)
+  })
+  it('removeLeaf of the only leaf returns the leaf unchanged (never empty tree)', () => {
+    const only = create_empty_leaf()
+    expect(removeLeaf(only, only.id)).toBe(only)
+  })
+})
+```
+
+- [ ] **Step 1.12: Run, verify fail.**
+
+- [ ] **Step 1.13: Implement `splitLeaf` + `removeLeaf`** (append):
+
+```ts
+/** Replace `leafId` with a split of [existing, newEmptyLeaf]. Returns null at CAP. */
+export function splitLeaf(root: PaneNode, leafId: string, direction: SplitDir): { root: PaneNode; newLeafId: string } | null {
+  if (leafCount(root) >= CAP) return null
+  const target = findLeafById(root, leafId)
+  if (!target) return null
+  const newLeaf = create_empty_leaf()
+  const replacement: SplitNode = { kind: 'split', id: next_id('split'), direction, ratio: 0.5, children: [target, newLeaf] }
+  return { root: replaceNode(root, leafId, replacement), newLeafId: newLeaf.id }
+}
+
+/** Remove a leaf; collapse its parent split so the sibling takes the parent's place. */
+export function removeLeaf(root: PaneNode, leafId: string): PaneNode {
+  if (root.kind === 'leaf') return root // never destroy the sole leaf
+  return removeIn(root, leafId)
+}
+
+function removeIn(node: SplitNode, leafId: string): PaneNode {
+  const [a, b] = node.children
+  if (a.kind === 'leaf' && a.id === leafId) return b
+  if (b.kind === 'leaf' && b.id === leafId) return a
+  const na = a.kind === 'split' ? removeIn(a, leafId) : a
+  const nb = b.kind === 'split' ? removeIn(b, leafId) : b
+  if (na === a && nb === b) return node
+  return { ...node, children: [na, nb] }
+}
+
+/** Pure structural replace of a node (by id) anywhere in the tree. */
+function replaceNode(node: PaneNode, id: string, replacement: PaneNode): PaneNode {
+  if (node.kind === 'leaf') return node.id === id ? replacement : node
+  if (node.id === id) return replacement
+  const a = replaceNode(node.children[0], id, replacement)
+  const b = replaceNode(node.children[1], id, replacement)
+  if (a === node.children[0] && b === node.children[1]) return node
+  return { ...node, children: [a, b] }
+}
+```
+
+- [ ] **Step 1.14: Run, verify pass. Commit.**
+
+```bash
+git add desktop/pane-tree.ts tests/desktop/pane-tree.test.ts
+git commit -m "feat(pane-tree): splitLeaf (CAP) + removeLeaf (collapse to sibling)"
+```
+
+- [ ] **Step 1.15: Add failing tests for `setRatio`, `escalateForImport`, `buildPreset`, `matchesPreset`**
+
+Append:
+
+```ts
+describe('setRatio', () => {
+  it('sets a split ratio (pure) and clamps 0.2..0.8', () => {
+    const root = split('S', 'h', 0.5, create_empty_leaf(), create_empty_leaf())
+    expect((setRatio(root, 'S', 0.7) as SplitNode).ratio).toBe(0.7)
+    expect((setRatio(root, 'S', 0.01) as SplitNode).ratio).toBe(0.2)
+    expect((setRatio(root, 'S', 0.99) as SplitNode).ratio).toBe(0.8)
+    expect(setRatio(root, 'missing', 0.7)).toBe(root)
+  })
+})
+
+describe('escalateForImport (open-file target policy)', () => {
+  it('1->2->3->4 leaves one at a time, then null at CAP (open new tab)', () => {
+    let root: PaneNode = create_empty_leaf()
+    let active = (root as LeafNode).id
+    // fill the first leaf so it is no longer empty
+    ;(root as LeafNode).content.pane.structure = { sites: [{}] } as never
+    for (let n = 2; n <= CAP; n++) {
+      const r = escalateForImport(root, active)!
+      root = r.root; active = r.leafId
+      expect(leafCount(root)).toBe(n)
+      findLeafById(root, active)!.content.pane.structure = { sites: [{}] } as never
+    }
+    expect(escalateForImport(root, active)).toBeNull()
+  })
+  it('reuses an existing empty leaf instead of splitting', () => {
+    const filled = create_empty_leaf(); filled.content.pane.structure = { sites: [{}] } as never
+    const empty = create_empty_leaf()
+    const root = split('S', 'h', 0.5, filled, empty)
+    const r = escalateForImport(root, filled.id)!
+    expect(r.leafId).toBe(empty.id)
+    expect(leafCount(r.root)).toBe(2) // no new split
+  })
+})
+
+describe('buildPreset / matchesPreset', () => {
+  it('builds canonical preset trees', () => {
+    expect(leafCount(buildPreset('single'))).toBe(1)
+    expect(leafCount(buildPreset('splitH'))).toBe(2)
+    expect((buildPreset('splitH') as SplitNode).direction).toBe('h')
+    expect((buildPreset('splitV') as SplitNode).direction).toBe('v')
+    expect(leafCount(buildPreset('quad'))).toBe(4)
+  })
+  it('matchesPreset recognizes the canonical shapes, else null', () => {
+    expect(matchesPreset(buildPreset('single'))).toBe('single')
+    expect(matchesPreset(buildPreset('splitH'))).toBe('splitH')
+    expect(matchesPreset(buildPreset('splitV'))).toBe('splitV')
+    expect(matchesPreset(buildPreset('quad'))).toBe('quad')
+    const custom = split('S', 'h', 0.5, split('S2', 'v', 0.5, create_empty_leaf(), create_empty_leaf()), create_empty_leaf())
+    expect(matchesPreset(custom)).toBeNull() // left-2-right-1
+  })
+})
+```
+
+- [ ] **Step 1.16: Run, verify fail.**
+
+- [ ] **Step 1.17: Implement `setRatio`, `escalateForImport`, `buildPreset`, `matchesPreset`** (append):
+
+```ts
+export function setRatio(root: PaneNode, splitId: string, ratio: number): PaneNode {
+  const clamped = Math.max(0.2, Math.min(0.8, ratio))
+  function go(node: PaneNode): PaneNode {
+    if (node.kind === 'leaf') return node
+    if (node.id === splitId) return { ...node, ratio: clamped }
+    const a = go(node.children[0]); const b = go(node.children[1])
+    if (a === node.children[0] && b === node.children[1]) return node
+    return { ...node, children: [a, b] }
+  }
+  return go(root)
+}
+
+/**
+ * Open-file target: reuse the first empty leaf; else split the active leaf
+ * (one at a time) up to CAP; else null (caller opens a new tab).
+ * Direction reproduces the old single->splitH (first split 'h') then 'v'.
+ */
+export function escalateForImport(root: PaneNode, activeLeafId: string): { root: PaneNode; leafId: string } | null {
+  const empty = findFirstEmptyLeaf(root)
+  if (empty) return { root, leafId: empty.id }
+  const dir: SplitDir = leafCount(root) === 1 ? 'h' : 'v'
+  const split = splitLeaf(root, activeLeafId, dir)
+  if (!split) return null
+  return { root: split.root, leafId: split.newLeafId }
+}
+
+export function buildPreset(preset: PresetId): PaneNode {
+  if (preset === 'single') return create_empty_leaf()
+  if (preset === 'splitH') return { kind: 'split', id: next_id('split'), direction: 'h', ratio: 0.5, children: [create_empty_leaf(), create_empty_leaf()] }
+  if (preset === 'splitV') return { kind: 'split', id: next_id('split'), direction: 'v', ratio: 0.5, children: [create_empty_leaf(), create_empty_leaf()] }
+  // quad = h-split of two v-splits
+  const col = (): SplitNode => ({ kind: 'split', id: next_id('split'), direction: 'v', ratio: 0.5, children: [create_empty_leaf(), create_empty_leaf()] })
+  return { kind: 'split', id: next_id('split'), direction: 'h', ratio: 0.5, children: [col(), col()] }
+}
+
+export function matchesPreset(root: PaneNode): PresetId | null {
+  if (root.kind === 'leaf') return 'single'
+  const [a, b] = root.children
+  if (a.kind === 'leaf' && b.kind === 'leaf') return root.direction === 'h' ? 'splitH' : 'splitV'
+  if (root.direction === 'h' && a.kind === 'split' && b.kind === 'split'
+    && a.direction === 'v' && b.direction === 'v'
+    && a.children.every(c => c.kind === 'leaf') && b.children.every(c => c.kind === 'leaf')) return 'quad'
+  return null
+}
+```
+
+- [ ] **Step 1.18: Run full pane-tree suite, verify all pass.**
+
+Run: `pnpm vitest run tests/desktop/pane-tree.test.ts`
+Expected: PASS (all describe blocks).
+
+- [ ] **Step 1.19: Commit**
+
+```bash
+git add desktop/pane-tree.ts tests/desktop/pane-tree.test.ts
+git commit -m "feat(pane-tree): setRatio, escalateForImport, buildPreset/matchesPreset"
+```
+
+---
+
+## Task 2: `desktop/pane-utils.ts` — reshape `StructureTabState` + `create_tab_state`
+
+**Files:**
+- Modify: `desktop/pane-utils.ts:37` (remove `LayoutType`), `:60-70` (`StructureTabState`), `:74-78` (`layout_panel_count`), `:112-123` (`create_tab_state`), `:140-181` (remove grid helpers).
+
+> ⚠️ This is the start of the build-red window.
+
+- [ ] **Step 2.1: Verify mobile does not consume the changing exports**
+
+Run: `grep -rn "create_tab_state\|StructureTabState\|\.panes\b\|\.active_pane\|LayoutType\|layout_panel_count\|find_import_target_pane\|get_grid_style\|get_pane_position\|get_visible_panes" src/lib/mobile`
+Expected: NO output. If any hit appears, STOP and report — mobile would be affected (violates D8); the plan must gate the change instead.
+
+- [ ] **Step 2.2: Edit `StructureTabState` (`pane-utils.ts:60-70`)**
+
+Replace:
+
+```ts
+export interface StructureTabState {
+  panes: PaneState[]
+  layout: LayoutType
+  active_pane: number
+  close_confirm_pane: number | null
+  col_split: number
+  row_split: number
+  library: LibraryEntry[]
+  active_library_id: string | null
+}
+```
+
+with:
+
+```ts
+import type { PaneNode } from './pane-tree'
+
+export interface StructureTabState {
+  root: PaneNode
+  active_leaf_id: string
+  close_confirm_leaf_id: string | null
+  library: LibraryEntry[]
+  active_library_id: string | null
+}
+```
+
+(Place the `import type { PaneNode }` with the other top imports to satisfy `deno fmt`/lint ordering.)
+
+- [ ] **Step 2.3: Rewrite `create_tab_state` (`pane-utils.ts:112-123`)**
+
+```ts
+export function create_tab_state(): StructureTabState {
+  const root = create_empty_leaf()
+  return {
+    root,
+    active_leaf_id: root.id,
+    close_confirm_leaf_id: null,
+    library: [],
+    active_library_id: null,
+  }
+}
+```
+
+Add the import at top: `import { create_empty_leaf } from './pane-tree'`.
+
+- [ ] **Step 2.4: Delete the grid-only exports**
+
+Delete `export type LayoutType` (`:37`), `layout_panel_count` (`:74-78`), `find_import_target_pane` (`:140-157`), `get_visible_panes` (`:161-163`), `get_grid_style` (`:165-172`), `get_pane_position` (`:174-181`). KEEP `PaneState`, `LibraryEntry`, `get_pane_label`, `create_empty_pane`, `pane_has_content`, `content_to_base64`, `auto_name`, `is_chgcar_file`, `NON_STRUCTURE_EXTS`, `update_export_format`, `format_from_ext`, `serialize_structure_content`, `SampleStructure`.
+
+- [ ] **Step 2.5: Add a quick test that `create_tab_state` starts on a single empty leaf**
+
+Append to `tests/desktop/pane-tree.test.ts`:
+
+```ts
+import { create_tab_state } from '../../desktop/pane-utils'
+describe('create_tab_state', () => {
+  it('starts as one empty structure leaf, active = that leaf', () => {
+    const ts = create_tab_state()
+    expect(leafCount(ts.root)).toBe(1)
+    expect(ts.active_leaf_id).toBe((ts.root as LeafNode).id)
+    expect(isEmptyLeaf(ts.root as LeafNode)).toBe(true)
+    expect(ts.close_confirm_leaf_id).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2.6: Run pane-tree test (the new block must pass; rest of repo will not type-check yet)**
+
+Run: `pnpm vitest run tests/desktop/pane-tree.test.ts`
+Expected: PASS. (Do not run `pnpm check` yet — consumers are mid-migration.)
+
+- [ ] **Step 2.7: Commit (WIP — build red is expected)**
+
+```bash
+git add desktop/pane-utils.ts desktop/pane-tree.ts tests/desktop/pane-tree.test.ts
+git commit -m "refactor(pane-utils): StructureTabState -> tree root (WIP: consumers migrate next)"
+```
+
+---
+
+## Task 3: `desktop/PaneTree.svelte` — recursive renderer (reproduces pane chrome verbatim)
+
+**Files:**
+- Create: `desktop/PaneTree.svelte`
+
+This renders one `PaneNode`. A `SplitNode` → flex container + one divider between its two recursive children. A `LeafNode` → the exact `.pane` wrapper + `.panel-header` + close-confirm banner + `.panel-content` lifted verbatim from `App.svelte:1649-1803` and CSS from `App.svelte:2417-2576`. It calls back into App for everything stateful.
+
+> The component receives the leaf-body as a Svelte **snippet** from App (so the heavy `<Structure>`/`<Trajectory>`/`<WorkflowView>`/landing markup stays in App.svelte with all its existing imports/handlers, and PaneTree only owns the recursion + chrome). This keeps PaneTree small and avoids moving ~150 lines of viewer wiring.
+
+- [ ] **Step 3.1: Write `PaneTree.svelte`**
+
+```svelte
+<script lang="ts">
+  import type { PaneNode, LeafNode, SplitNode } from './pane-tree'
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    node: PaneNode
+    multi: boolean // leafCount(root) > 1 — gates per-leaf header chrome
+    active_leaf_id: string
+    drag_target_leaf: string | null
+    close_confirm_leaf_id: string | null
+    active_split_id: string | null
+    leaf_body: Snippet<[LeafNode]>     // App renders the viewer/landing for a leaf
+    header: Snippet<[LeafNode]>        // App renders the dot+label+popout+close buttons
+    banner: Snippet<[LeafNode]>        // App renders the close-confirm banner
+    on_activate: (leaf_id: string) => void
+    on_split_mousedown: (e: MouseEvent, split_id: string, dir: 'h' | 'v') => void
+    on_split_dblclick: (split_id: string) => void
+  }
+  let { node, multi, active_leaf_id, drag_target_leaf, close_confirm_leaf_id, active_split_id, leaf_body, header, banner, on_activate, on_split_mousedown, on_split_dblclick }: Props = $props()
+</script>
+
+{#if node.kind === 'split'}
+  {@const s = node as SplitNode}
+  <div class="split {s.direction === 'h' ? 'h' : 'v'}">
+    <div class="split-child" style={s.direction === 'h' ? `flex-basis:${s.ratio * 100}%` : `flex-basis:${s.ratio * 100}%`}>
+      <svelte:self node={s.children[0]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {leaf_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
+    </div>
+    <div
+      class="grid-divider {s.direction === 'h' ? 'grid-divider-col' : 'grid-divider-row'}"
+      class:active={active_split_id === s.id}
+      onmousedown={(e) => on_split_mousedown(e, s.id, s.direction)}
+      ondblclick={() => on_split_dblclick(s.id)}
+      role="separator"
+      aria-orientation={s.direction === 'h' ? 'vertical' : 'horizontal'}
+    ></div>
+    <div class="split-child" style={`flex-basis:${(1 - s.ratio) * 100}%`}>
+      <svelte:self node={s.children[1]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {leaf_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
+    </div>
+  </div>
+{:else}
+  {@const leaf = node as LeafNode}
+  <div
+    class="pane"
+    class:active={active_leaf_id === leaf.id}
+    class:dragover={drag_target_leaf === leaf.id}
+    class:warn-glow={close_confirm_leaf_id === leaf.id}
+    data-leaf-id={leaf.id}
+    role="button"
+    tabindex="0"
+    onclick={() => on_activate(leaf.id)}
+    onkeydown={(e) => { if (e.key === 'Enter') on_activate(leaf.id) }}
+  >
+    {#if multi}
+      <div class="panel-header">{@render header(leaf)}</div>
+    {/if}
+    {@render banner(leaf)}
+    <div class="panel-content">{@render leaf_body(leaf)}</div>
+  </div>
+{/if}
+
+<style>
+  /* moved verbatim from App.svelte:2417-2576 (grid-container -> flex split) */
+  .split { display: flex; width: 100%; height: 100%; min-width: 0; min-height: 0; }
+  .split.h { flex-direction: row; }
+  .split.v { flex-direction: column; }
+  .split-child { position: relative; min-width: 0; min-height: 0; overflow: hidden; }
+  .grid-divider { background: var(--border-color, #2a2a2a); transition: background 0.15s; z-index: 1; flex: 0 0 auto; }
+  .grid-divider-col { width: 6px; cursor: col-resize; }
+  .grid-divider-row { height: 6px; cursor: row-resize; }
+  .grid-divider:hover, .grid-divider.active { background: var(--accent-color, #3b82f6); }
+  .pane { position: relative; overflow: hidden; background: var(--pane-bg, transparent); cursor: pointer; display: flex; flex-direction: column; width: 100%; height: 100%; }
+  .pane.warn-glow { box-shadow: inset 0 0 0 2px rgba(245, 158, 11, 0.5); }
+  .panel-content { flex: 1; min-height: 0; position: relative; overflow: hidden; height: 0; }
+  /* NOTE: .panel-header/.panel-dot/.panel-label/.panel-*-btn/.panel-close-banner/.banner-* rules
+     are supplied by App.svelte's global <style> (the header/banner snippets render there);
+     keep them in App.svelte. Only the split/pane/divider/content geometry moves here. */
+</style>
+```
+
+> Verify against the originals while editing: `App.svelte:2417-2454` (`.grid-container`/`.grid-divider*`/`.pane`/`.panel-content`) and confirm `--border-color`/`--accent-color` var names match the originals (read the file; adjust the fallbacks to whatever the source uses).
+
+- [ ] **Step 3.2: Type-check just this file is deferred to Task 16** (App must provide the snippets first). For now confirm the file parses:
+
+Run: `pnpm exec svelte-check --workspace desktop --threshold error 2>&1 | head -40`
+Expected: errors are limited to App.svelte (not yet migrated) and "unused"/prop-mismatch noise; `PaneTree.svelte` itself should not have syntax errors. (Full green is Task 16.)
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add desktop/PaneTree.svelte
+git commit -m "feat(pane-tree): recursive PaneTree.svelte (flex splits + verbatim pane chrome via snippets)"
+```
+
+---
+
+## Task 4: `App.svelte` — template swap (render `<PaneTree>`) + state renames
+
+**Files:**
+- Modify: `desktop/App.svelte` — imports `49-56`/`112-116`, state `146-148`/`189-196`, wrappers `200`/`286-287`, template `1632-2097`, CSS unchanged blocks stay.
+
+- [ ] **Step 4.1: Fix imports (`App.svelte:49-56`)** — drop `LayoutType, layout_panel_count, find_import_target_pane, get_visible_panes, get_grid_style, get_pane_position`; add:
+
+```ts
+import PaneTree from './PaneTree.svelte'
+import {
+  type PaneNode, type LeafNode,
+  leaves, leafCount, findLeafById, findSplit, findFirstEmptyLeaf,
+  escalateForImport, removeLeaf, setRatio, matchesPreset, create_empty_leaf,
+} from './pane-tree'
+```
+
+Keep `get_pane_label, create_empty_pane, pane_has_content, content_to_base64, create_tab_state, auto_name, PaneState, LibraryEntry, SampleStructure` from `./pane-utils`.
+
+- [ ] **Step 4.2: Rename `$state` (`App.svelte:146-148`)**
+
+```ts
+let drag_target_leaf = $state<string | null>(null)
+let is_panel_resizing = $state(false)
+let active_split_id = $state<string | null>(null)
+```
+
+(Delete `drag_target_pane` and `resize_axis`.)
+
+- [ ] **Step 4.3: Update `drag_deps`/`resize_deps` (`App.svelte:189-196`)** — `get/set_drag_target_pane` → operate on `drag_target_leaf` (string). Replace `resize_deps` (which set `is_panel_resizing`/`resize_axis`) — resize now flows through PaneTree callbacks (Step 4.7); keep a minimal `resize_deps` only if still referenced, else remove it and the `ResizeDeps` import at `112-116`.
+
+- [ ] **Step 4.4: `popout_pane` wrapper (`App.svelte:200`)**
+
+```ts
+function popout_pane(tab_id: string, leaf_id: string) { return _popout_pane(tab_id, leaf_id, tab_states, is_tauri) }
+```
+
+- [ ] **Step 4.5: Replace the grid render block (`App.svelte:1632-1661`)**
+
+Replace the `{@const visible}`/`{@const panel_count}` + `.grid-container` + `{#each visible}` opening with:
+
+```svelte
+{#if tab.type === `structure`}
+  {@const ts = tab_states[tab.id]}
+  {#if ts}
+    <div class="structure-workspace">
+      {#if ts.library.length >= 2}
+        <StructureLibrary ... />  <!-- unchanged props -->
+      {/if}
+      <PaneTree
+        node={ts.root}
+        multi={leafCount(ts.root) > 1}
+        active_leaf_id={ts.active_leaf_id}
+        drag_target_leaf={tab.id === tm.active_tab_id ? drag_target_leaf : null}
+        close_confirm_leaf_id={ts.close_confirm_leaf_id}
+        {active_split_id}
+        on_activate={(id) => ts.active_leaf_id = id}
+        on_split_mousedown={(e, sid, dir) => start_split_resize(e, sid, dir, tab.id)}
+        on_split_dblclick={(sid) => { ts.root = setRatio(ts.root, sid, 0.5) }}
+        {leaf_body}
+        {header}
+        {banner}
+      />
+    </div>
+  {/if}
+{/if}
+```
+
+- [ ] **Step 4.6: Define the three snippets** (`leaf_body`, `header`, `banner`) inside the same `{#if ts}` scope, porting the verbatim markup from `App.svelte:1663-1803` (header buttons + close-confirm banner + viewer/landing dispatch). Each replaces `idx`/`ts.panes[idx]`/`ts.active_pane` per the contract table. Skeleton:
+
+```svelte
+{#snippet header(leaf: LeafNode)}
+  {@const pane = leaf.content.pane}
+  {#if pane_has_content(pane)}<span class="panel-dot"></span>{/if}
+  <span class="panel-label">{get_pane_label(pane)}</span>
+  {#if pane_has_content(pane)}
+    <button class="panel-popout-btn" onclick={(e) => { e.stopPropagation(); popout_pane(tab.id, leaf.id) }} title={t(`app.open_in_new_window`)}>
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+    </button>
+  {/if}
+  <button class="panel-close-btn" onclick={(e) => { e.stopPropagation(); handle_unload(tab.id, leaf.id) }} title={t(`app.close_panel`)}>
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+  </button>
+{/snippet}
+
+{#snippet banner(leaf: LeafNode)}
+  {#if ts.close_confirm_leaf_id === leaf.id}
+    {@const pane = leaf.content.pane}
+    <div class="panel-close-banner">
+      <!-- port verbatim from App.svelte:1695-1735; ts.panes[idx] -> pane;
+           close_panel(tab.id, idx) -> close_panel(tab.id, leaf.id);
+           save_and_close_panel(tab.id, idx) -> (…, leaf.id);
+           ts.close_confirm_pane = null -> ts.close_confirm_leaf_id = null -->
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet leaf_body(leaf: LeafNode)}
+  {@const pane = leaf.content.pane}
+  {#if pane.mode === `workflow`}
+    <WorkflowView ... onclose={() => { Object.assign(findLeafById(ts.root, leaf.id)!.content.pane, create_empty_pane()); update_tab_label(tab.id) }} onchange={() => { pane.modified = true }} ... />
+  {:else if pane.is_trajectory_mode && pane.trajectory}
+    <Trajectory bind:selected_sites={pane.selected_sites} bind:current_step_idx={pane.current_step_idx} structure_props={{ ..., is_active: ts.active_leaf_id === leaf.id && tab.id === tm.active_tab_id }} ... />
+  {:else if pane.structure}
+    <Structure
+      tab_id={tab.id}
+      is_active={ts.active_leaf_id === leaf.id && tab.id === tm.active_tab_id}
+      bind:structure={pane.structure}
+      bind:saveable_structure={pane.saveable_structure}
+      bind:selected_sites={pane.selected_sites}
+      bind:remote_origin={pane.remote_origin}
+      bind:open_plugin_hub={pane.open_plugin_hub}
+      on_file_load={create_on_file_load(tab.id, leaf.id)}
+      on_file_drop={create_on_file_drop(tab.id, leaf.id)}
+      on_clear_structure={() => { Object.assign(pane, create_empty_pane()); update_tab_label(tab.id) }}
+      ... />
+  {:else}
+    <!-- landing page: port App.svelte:1804-2042 -->
+    <!-- class:secondary-pane={leaf.id !== leaves(ts.root)[0].id};
+         drop quad-layout/stacked-layout classes -> class:compact={leafCount(ts.root) > 1};
+         idx===0 gates -> leaf.id === leaves(ts.root)[0].id;
+         sample/builder/chat/hpc/terminal onclick: write pane.* (clone_structure!) + ts.active_leaf_id = leaf.id;
+         handle_open_file(tab.id, idx) -> handle_open_file(tab.id, leaf.id);
+         workflow-card: pane.mode='workflow' (NO panes=[...] needed) + update_tab_label -->
+  {/if}
+{/snippet}
+```
+
+> `bind:` to `pane.X` works because `pane = findLeafById(ts.root, leaf.id).content.pane` resolves the live `$state` proxy node. The old `ts.panes=[...ts.panes]` reactivity nudges are dropped — mutating the proxy's nested fields is reactive. Preserve `clone_structure()` on every structure assignment (memory: structure-must-clone-on-assign).
+
+- [ ] **Step 4.7: Add `start_split_resize` (replaces `on_divider_mousedown`/`on_center_mousedown` wrappers at `286-287`)**
+
+```ts
+function start_split_resize(e: MouseEvent, split_id: string, dir: 'h' | 'v', tab_id: string) {
+  on_split_drag(resize_deps_min, e, split_id, dir, tab_id, () => active_split_id = split_id, () => active_split_id = null)
+}
+```
+
+(The actual drag math lives in `resize-handlers.ts`, Task 6.)
+
+- [ ] **Step 4.8: Delete the divider markup block (`App.svelte:2049-2097`)** entirely (PaneTree renders dividers now).
+
+- [ ] **Step 4.9: Fix the close-confirm count modal (`App.svelte:2224-2226`)**
+
+```svelte
+{@const structure_count = leaves(confirm_ts.root).filter(l => pane_has_content(l.content.pane)).length}
+```
+
+- [ ] **Step 4.10: Commit (WIP)**
+
+```bash
+git add desktop/App.svelte desktop/PaneTree.svelte
+git commit -m "refactor(app): render PaneTree + leaf snippets; drop grid markup/dividers (WIP)"
+```
+
+---
+
+## Task 5: `App.svelte` — logic sites (handlers, effects, injectors)
+
+Apply these exact rewrites (from the grounding). Each `ts.panes[i]` → resolve a leaf; each `ts.active_pane` → `ts.active_leaf_id`; index params → leaf-id params.
+
+- [ ] **Step 5.1:** `open_plugin_hub_on_active_pane` (`291-304`): `const leaf = findLeafById(ts.root, ts.active_leaf_id); if (!leaf) return; const pane = leaf.content.pane;` then keep the water-load + `pane.open_plugin_hub` bump (use `clone_structure`).
+- [ ] **Step 5.2:** `open_edit_as_text` (`405-462`): capture `const target_leaf_id = ts.active_leaf_id`; in `editor_on_save` `const leaf = findLeafById(target_ts.root, target_leaf_id); if (!leaf) return;` then mutate `leaf.content.pane.*`.
+- [ ] **Step 5.3:** `handle_sidebar_open_workflow` (`466-489`): `existing = leaves(ts.root).find(l => l.content.pane.mode==='workflow' && l.content.pane.workflow_id===workflow_id)` → `ts.active_leaf_id = existing.id`; else `const t = findFirstEmptyLeaf(ts.root) ?? findLeafById(ts.root, ts.active_leaf_id)!; Object.assign(t.content.pane, { ...create_empty_pane(), mode:'workflow', workflow_id, workflow_compact }); ts.active_leaf_id = t.id`. Drop `ts.panes=[...]`.
+- [ ] **Step 5.4:** `pending_open_structure` `$effect` (`519-545`): `const leaf = leaves(ts.root)[0]; if (tab_id===prev_tab_id && leaf.content.pane.structure) { warn; return }` then write `leaf.content.pane.*` (clone).
+- [ ] **Step 5.5:** `get_current_structure` (`547-553`): `const leaf = findLeafById(ts.root, ts.active_leaf_id); const pane = leaf?.content.pane; return pane?.structure ?? null`.
+- [ ] **Step 5.6:** DELETE the auto-escalate `$effect` (`589-597`) — impossible in a tree.
+- [ ] **Step 5.7:** dirty-detect `$effect` (`599-610`): `for (const ts of Object.values(tab_states)) for (const leaf of leaves(ts.root)) { const pane = leaf.content.pane; if (pane.structure && !pane.modified && pane.initial_site_count>0 && pane.structure.sites.length!==pane.initial_site_count) pane.modified = true }`.
+- [ ] **Step 5.8:** `load_file_from_path` (`614-624`): `const empty = findFirstEmptyLeaf(ts.root); const leaf_id = empty ? empty.id : ts.active_leaf_id;` pass `leaf_id` to `process_file_content`.
+- [ ] **Step 5.9:** `handle_open_file` (`676-706`) + `handle_open_folder` (`708-739`): signature `(tab_id, leaf_id: string)`; `ts.active_leaf_id = leaf_id`; thread `leaf_id` into `import_many`; web path stashes `file_input_target_leaf = leaf_id`.
+- [ ] **Step 5.10:** rename `$state` `file_input_target_pane` → `file_input_target_leaf: string` (declaration + `handle_file_input`/`handle_folder_input` at `741-789`).
+- [ ] **Step 5.11:** `handle_database_import` (`791-806`): `const leaf = findLeafById(ts.root, modal.import_target_leaf); if (!leaf) return; const pane = leaf.content.pane;` mutate (clone). Rename `modal.import_target_pane`→`modal.import_target_leaf` (and the site that sets it).
+- [ ] **Step 5.12:** `apply_entry_to_pane` (`1003-1044`): signature `(tab_id, ts, leaf_id: string, e, remote_origin, local_file_path)`; `const leaf = findLeafById(ts.root, leaf_id); if (!leaf) return; const p = leaf.content.pane;` keep cube/traj/structure branches; `ts.active_leaf_id = leaf_id`. Update its 3 callers (5.13, 5.14, select_library_entry).
+- [ ] **Step 5.13:** `handle_load_trajectory_stream` (`211-241`): `const r = escalateForImport(ts.root, ts.active_leaf_id); let leaf_id; if (!r) { open_tab('structure'); const nts = tm.tab_states[tm.active_tab_id]; leaf_id = nts.active_leaf_id } else { ts.root = r.root; leaf_id = r.leafId }` then `apply_entry_to_pane(tab_id, ts, leaf_id, …)`.
+- [ ] **Step 5.14:** `process_file_content` (`1046-1069`): signature `(…, leaf_id: string, …)`; same `escalateForImport`-or-new-tab resolution; on new tab `return process_file_content(tm.active_tab_id, content, filename, nts.active_leaf_id, …)`.
+- [ ] **Step 5.15:** `import_many` (`1077-1114`): signature `(…, leaf_id: string)`; `ts.active_leaf_id = leaf_id`; rest unchanged.
+- [ ] **Step 5.16:** `select_library_entry` (`1116-1125`): `apply_entry_to_pane(tab_id, ts, ts.active_leaf_id, entry)`.
+- [ ] **Step 5.17:** `remove_library_entry` (`1128-1141`): `const leaf = findLeafById(ts.root, ts.active_leaf_id); if (leaf) Object.assign(leaf.content.pane, create_empty_pane())`.
+- [ ] **Step 5.18:** `create_on_file_drop` (`1151-1162`) + `create_on_file_load` (`1164-1226`): signature `(tab_id, leaf_id: string)`; `find_import_target_pane`→`escalateForImport`-or-new-tab; `new_ts.panes[0]`→`leaves(new_ts.root)[0].content.pane`; `ts.panes[target].*`→`targetLeaf.content.pane.*`; `ts.active_pane=target`→`ts.active_leaf_id=leaf.id`.
+- [ ] **Step 5.19:** keyboard dep wiring (`1330`): pass `ts.active_leaf_id` (Task 10 changes the dep signature).
+- [ ] **Step 5.20:** `show_lab_link` (`1341-1350`): `const first = leaves(ts.root)[0]; return !!first && !pane_has_content(first.content.pane)`.
+- [ ] **Step 5.21:** SSE injectors (`1369-1379`, `1427-1428`, `1501-1514`): `const first = leaves(ts.root)[0]; if (!first) return false; first.content.pane.structure = clone_structure(struct); …`. Guards `ts.panes?.[0]` → `!!leaves(ts.root)[0]`.
+- [ ] **Step 5.22:** `on_save_workflow` Sidebar prop (`1608-1611`): `const leaf = findLeafById(ts.root, ts.active_leaf_id); const pane = leaf?.content.pane; return pane?.mode==='workflow' ? (pane.workflow_id ?? null) : null`.
+
+- [ ] **Step 5.23: Commit (WIP)**
+
+```bash
+git add desktop/App.svelte
+git commit -m "refactor(app): migrate pane logic/effects/injectors to leaf ids (WIP)"
+```
+
+---
+
+## Task 6: `desktop/lib/resize-handlers.ts` — per-split ratio
+
+**Files:** Modify `desktop/lib/resize-handlers.ts` (whole file, 67 lines).
+
+- [ ] **Step 6.1:** Replace `ResizeDeps` and the two handlers with a single split-aware drag:
+
+```ts
+import type { StructureTabState } from '../pane-utils'
+import { findSplit, setRatio } from '../pane-tree'
+
+export interface ResizeDepsMin {
+  tab_states: Record<string, StructureTabState>
+  set_is_panel_resizing: (v: boolean) => void
+}
+
+export function on_split_drag(
+  deps: ResizeDepsMin, e: MouseEvent, split_id: string, dir: 'h' | 'v', tab_id: string,
+  on_start: () => void, on_end: () => void,
+) {
+  const ts = deps.tab_states[tab_id]
+  if (!ts) return
+  const node = findSplit(ts.root, split_id)
+  if (!node) return
+  const container = (e.target as HTMLElement).parentElement // the .split flex container
+  if (!container) return
+  e.preventDefault()
+  deps.set_is_panel_resizing(true)
+  on_start()
+  const start = dir === 'h' ? e.clientX : e.clientY
+  const start_ratio = node.ratio
+  function on_move(ev: MouseEvent) {
+    const rect = container!.getBoundingClientRect()
+    const total = dir === 'h' ? rect.width : rect.height
+    const delta = ((dir === 'h' ? ev.clientX : ev.clientY) - start) / total
+    ts!.root = setRatio(ts!.root, split_id, start_ratio + delta)
+  }
+  function on_up() {
+    window.removeEventListener('mousemove', on_move)
+    window.removeEventListener('mouseup', on_up)
+    deps.set_is_panel_resizing(false)
+    on_end()
+  }
+  window.addEventListener('mousemove', on_move)
+  window.addEventListener('mouseup', on_up)
+}
+```
+
+(`setRatio` already clamps 0.2..0.8. The quad center handle / `on_center_mousedown` is dropped — spec §6.5.)
+
+- [ ] **Step 6.2:** In App (`Step 4.7`) wire `start_split_resize` to call `on_split_drag` with a `resize_deps_min = { tab_states, set_is_panel_resizing: (v) => is_panel_resizing = v }`.
+
+- [ ] **Step 6.3: Commit (WIP)**
+
+```bash
+git add desktop/lib/resize-handlers.ts desktop/App.svelte
+git commit -m "refactor(resize): per-SplitNode ratio drag (drop quad center handle)"
+```
+
+---
+
+## Task 7: `desktop/lib/pane-manager.ts` — close lifecycle via `removeLeaf`
+
+**Files:** Modify `desktop/lib/pane-manager.ts`.
+
+- [ ] **Step 7.1:** Imports: from `../pane-utils` drop `LayoutType` + `layout_panel_count` (keep `create_empty_pane`, `pane_has_content`); add `import { leafCount, leaves, removeLeaf, findLeafById } from '../pane-tree'`.
+- [ ] **Step 7.2:** `handle_unload(deps, tab_id, leaf_id: string)` (`21-43`): `const leaf = findLeafById(ts.root, leaf_id); if (!leaf) return; const pane = leaf.content.pane;` workflow-unsaved or content → `ts.close_confirm_leaf_id = leaf_id; return`; else `close_panel(deps, tab_id, leaf_id)`.
+- [ ] **Step 7.3:** `close_panel(deps, tab_id, leaf_id: string)` (`45-84`): replace whole body:
+
+```ts
+const ts = deps.tab_states[tab_id]
+if (!ts) return
+ts.close_confirm_leaf_id = null
+if (leafCount(ts.root) <= 1) {
+  const leaf = findLeafById(ts.root, leaf_id)
+  if (leaf) Object.assign(leaf.content.pane, create_empty_pane())
+  deps.update_tab_label(tab_id)
+  return
+}
+ts.root = removeLeaf(ts.root, leaf_id)
+if (!findLeafById(ts.root, ts.active_leaf_id)) ts.active_leaf_id = leaves(ts.root)[0].id
+deps.update_tab_label(tab_id)
+```
+
+- [ ] **Step 7.4:** `save_and_close_panel(deps, tab_id, leaf_id: string)` (`101-…`): `const leaf = findLeafById(ts.root, leaf_id); const pane = leaf?.content.pane; if (!pane) return;` forward `leaf_id` to both `close_panel` calls; `exp.close_after = { tab_id, leaf_id }`; `ts.close_confirm_leaf_id = null`.
+- [ ] **Step 7.5:** `init_close_save_target` unchanged (takes a `PaneState`); caller passes the resolved `pane`.
+
+- [ ] **Step 7.6: Commit (WIP)**
+
+```bash
+git add desktop/lib/pane-manager.ts
+git commit -m "refactor(pane-manager): close/unload via removeLeaf + close_confirm_leaf_id"
+```
+
+---
+
+## Task 8: `desktop/lib/tab-manager.svelte.ts`
+
+**Files:** Modify `desktop/lib/tab-manager.svelte.ts`.
+
+- [ ] **Step 8.1:** Imports: drop `LayoutType`, `layout_panel_count`; add `import { leaves, matchesPreset, type PresetId } from '../pane-tree'` (and `create_empty_leaf` if used for resets — but resets reuse `create_tab_state().root`).
+- [ ] **Step 8.2:** `tabs_with_badges` (`46-56`): `const badge = leaves(ts.root).filter(l => pane_has_content(l.content.pane)).length`.
+- [ ] **Step 8.3:** `active_layout` (`58-63`): `return matchesPreset(ts.root)` (returns `PresetId | null`).
+- [ ] **Step 8.4:** `pending_layout_change` (`66`) + setter (`259-260`): retype `new_layout: LayoutType` → `new_layout: PresetId`.
+- [ ] **Step 8.5:** Extract `function reset_ts_to_empty(ts, tab) { const r = create_tab_state(); ts.root = r.root; ts.active_leaf_id = r.active_leaf_id; ts.close_confirm_leaf_id = null; ts.library = []; ts.active_library_id = null; tab.label = 'Structure' }`. Use it in both `request_close_tab` (`139-146`) and `close_tab` (`164-172`) reset branches; for the loaded-count guard use `leaves(ts.root).filter(l => pane_has_content(l.content.pane)).length`.
+- [ ] **Step 8.6:** `update_tab_label` (`208-233`): `const pane = leaves(ts.root).map(l => l.content.pane).find(p => p.structure)`; workflow check `leaves(ts.root).some(l => l.content.pane.mode==='workflow')`.
+- [ ] **Step 8.7:** Update the `tab_states` doc comment (`251-253`) example to `ts.root` / `findLeafById(...).content.pane`.
+
+- [ ] **Step 8.8: Commit (WIP)**
+
+```bash
+git add desktop/lib/tab-manager.svelte.ts
+git commit -m "refactor(tab-manager): badges/active_layout/reset/label over tree"
+```
+
+---
+
+## Task 9: `desktop/lib/layout-manager.ts` — preset applier
+
+**Files:** Modify `desktop/lib/layout-manager.ts`.
+
+- [ ] **Step 9.1:** Imports: drop `LayoutType`, `layout_panel_count`; add `import { buildPreset, leaves, matchesPreset, type PresetId } from '../pane-tree'`.
+- [ ] **Step 9.2:** `handle_layout_change(deps, preset: PresetId)`: early-return if `matchesPreset(ts.root) === preset`; compute `filled = leaves(ts.root).map(l => l.content.pane).filter(pane_has_content)` and target leaf count from the preset (single=1,splitH/V=2,quad=4). If `filled.length > target` → `deps.set_pending_layout_change({ tab_id, new_layout: preset, lost_count: filled.length - target }); return`. Else apply (Step 9.4).
+- [ ] **Step 9.3:** `confirm_layout_change`: read `preset` from pending; apply with truncation.
+- [ ] **Step 9.4:** Apply helper:
+
+```ts
+function apply_preset(ts, preset: PresetId, filled: PaneState[]) {
+  const root = buildPreset(preset)
+  const slots = leaves(root)
+  for (let i = 0; i < slots.length && i < filled.length; i++) slots[i].content.pane = filled[i]
+  ts.root = root
+  ts.active_leaf_id = slots[0].id
+  ts.close_confirm_leaf_id = null
+}
+```
+
+(Drops `col_split/row_split=50` — ratios default 0.5 in `buildPreset`. `active_pane` clamp → `active_leaf_id = slots[0].id`.)
+
+- [ ] **Step 9.5: Commit (WIP)**
+
+```bash
+git add desktop/lib/layout-manager.ts
+git commit -m "refactor(layout-manager): preset apply via buildPreset over tree"
+```
+
+---
+
+## Task 10: `desktop/lib/keyboard-shortcuts.ts`
+
+**Files:** Modify `desktop/lib/keyboard-shortcuts.ts`.
+
+- [ ] **Step 10.1:** Imports: drop `LayoutType`, `layout_panel_count`; add `import { leafCount, leaves } from '../pane-tree'`.
+- [ ] **Step 10.2:** `KeyboardShortcutDeps` (`18-24`): `handle_open_file`/`handle_unload` second param `pane_idx: number` → `leaf_id: string`; retype `get_pending_layout_change.new_layout` to `PresetId` (or delete if layout-manager keeps confirm).
+- [ ] **Step 10.3:** Ctrl+O (`72-75`): `deps.handle_open_file(active_tab_id, ts.active_leaf_id)`.
+- [ ] **Step 10.4:** Ctrl+W (`76-84`): `if (leafCount(ts.root) > 1) deps.handle_unload(active_tab_id, ts.active_leaf_id) else deps.request_close_tab(active_tab_id)`.
+- [ ] **Step 10.5:** Escape (`85-98`): `if (ts.close_confirm_leaf_id !== null) { ts.close_confirm_leaf_id = null; return }`.
+- [ ] **Step 10.6:** Digit 1-4 (`103-108`): `const ids = leaves(ts.root).map(l => l.id); if (idx < ids.length) ts.active_leaf_id = ids[idx]`.
+
+- [ ] **Step 10.7: Commit (WIP)**
+
+```bash
+git add desktop/lib/keyboard-shortcuts.ts
+git commit -m "refactor(keyboard): leaf-id active + leafCount/leaves"
+```
+
+---
+
+## Task 11: `desktop/lib/popout-manager.ts`
+
+**Files:** Modify `desktop/lib/popout-manager.ts`.
+
+- [ ] **Step 11.1:** Add `import { findLeafById, leaves } from '../pane-tree'`.
+- [ ] **Step 11.2:** `load_popout_structure` (`72-78`): `const leaf = findLeafById(ts.root, ts.active_leaf_id) ?? leaves(ts.root)[0]; if (!leaf) return; const pane = leaf.content.pane; pane.structure = structure; pane.source_filename = filename; pane.modified = false; update_tab_label(active_tab_id)`.
+- [ ] **Step 11.3:** `popout_pane(tab_id, leaf_id: string, tab_states, is_tauri)` (`85-94`): `const leaf = findLeafById(ts.root, leaf_id); if (!leaf) return; const pane = leaf.content.pane;` rest unchanged.
+
+- [ ] **Step 11.4: Commit (WIP)**
+
+```bash
+git add desktop/lib/popout-manager.ts
+git commit -m "refactor(popout): resolve leaf by id"
+```
+
+---
+
+## Task 12: `desktop/lib/drag-drop-handlers.ts`
+
+**Files:** Modify `desktop/lib/drag-drop-handlers.ts`.
+
+- [ ] **Step 12.1:** `DragDropDeps`: `process_file_content`/`import_many` 4th/3rd param → `leaf_id: string`; `get/set_drag_target_pane` → `string | null`.
+- [ ] **Step 12.2:** Add `import { findFirstEmptyLeaf } from '../pane-tree'`.
+- [ ] **Step 12.3:** `get_pane_from_event` (`63-71`) → returns `string`:
+
+```ts
+export function get_pane_from_event(deps: DragDropDeps, event: DragEvent): string {
+  const ts = deps.get_active_ts()
+  if (!ts) return ''
+  const el = (event.target as HTMLElement).closest('[data-leaf-id]')
+  if (el) return el.getAttribute('data-leaf-id') || ts.active_leaf_id
+  return findFirstEmptyLeaf(ts.root)?.id ?? ts.active_leaf_id
+}
+```
+
+- [ ] **Step 12.4:** `handle_dragover` (`90-99`): types propagate (no logic change).
+- [ ] **Step 12.5:** `handle_drop` (`105-138`, `168-179`): rename `pane_idx`→`target_leaf_id`; `ts.active_pane = pane_idx` → `ts.active_leaf_id = target_leaf_id` (all 4 sites); pass `target_leaf_id` to `process_file_content`/`import_many`.
+
+- [ ] **Step 12.6: Commit (WIP)**
+
+```bash
+git add desktop/lib/drag-drop-handlers.ts
+git commit -m "refactor(drag-drop): leaf-id targets + [data-leaf-id]"
+```
+
+---
+
+## Task 13: `desktop/lib/close-all-helper.ts` + `CloseAllEntry`
+
+**Files:** Modify `desktop/lib/close-all-helper.ts`, `desktop/state/modal-state.svelte` (CloseAllEntry).
+
+- [ ] **Step 13.1:** `CloseAllEntry` in `modal-state.svelte`: `pane_idx: number` → `leaf_id: string`.
+- [ ] **Step 13.2:** Imports: drop `layout_panel_count`; add `import { leaves } from '../pane-tree'`.
+- [ ] **Step 13.3:** `build_close_all_entries` (`30-32`): `for (const leaf of leaves(ts.root)) { const pane = leaf.content.pane; if (!pane_has_content(pane)) continue; … entries.push({ …, leaf_id: leaf.id, … }) }`.
+- [ ] **Step 13.4:** `execute_close_all_saves` (`68-73`): `const leaf = leaves(ts.root).find(l => l.id === entry.leaf_id); const pane = leaf?.content.pane; if (!pane) continue`.
+- [ ] **Step 13.5:** reset-to-empty (`108-120`): `const r = create_tab_state(); ts.root = r.root; ts.active_leaf_id = r.active_leaf_id; ts.close_confirm_leaf_id = null` (drop layout/active_pane/col_split/row_split). Import `create_tab_state` from `../pane-utils`.
+- [ ] **Step 13.6:** Update the close-all dialog UI that reads `entry.pane_idx` → `entry.leaf_id` (grep for `pane_idx` in `desktop/components/`).
+
+- [ ] **Step 13.7: Commit (WIP)**
+
+```bash
+git add desktop/lib/close-all-helper.ts desktop/state/modal-state.svelte desktop/components
+git commit -m "refactor(close-all): CloseAllEntry.leaf_id + leaves iteration"
+```
+
+---
+
+## Task 14: `export-handlers.ts` + `export-state` + `modal-state` field renames
+
+**Files:** Modify `desktop/lib/export-handlers.ts`, `desktop/state/export-state.svelte.ts`, `desktop/state/modal-state.svelte`.
+
+- [ ] **Step 14.1:** `export-state.svelte.ts`: `close_after` type `{ tab_id; pane_idx: number }` → `{ tab_id; leaf_id: string }`.
+- [ ] **Step 14.2:** `export-handlers.ts`: `ExportHandlerDeps.close_panel` param `pane_idx: number` → `leaf_id: string`; the deferred-close call (`85-89`) `deps.close_panel(exp.close_after.tab_id, exp.close_after.leaf_id)`.
+- [ ] **Step 14.3:** `modal-state.svelte`: `import_target_pane: number` → `import_target_leaf: string` (and any other UI reading it — grep `import_target_pane`).
+
+- [ ] **Step 14.4: Commit (WIP)**
+
+```bash
+git add desktop/lib/export-handlers.ts desktop/state/export-state.svelte.ts desktop/state/modal-state.svelte
+git commit -m "refactor(export/modal-state): close_after.leaf_id + import_target_leaf"
+```
+
+---
+
+## Task 15: `desktop/lib/sidebar-handlers.ts`
+
+**Files:** Modify `desktop/lib/sidebar-handlers.ts`.
+
+- [ ] **Step 15.1:** `process_file_content` dep (`18`): 4th param → `leaf_id: string`.
+- [ ] **Step 15.2:** Add `import { findFirstEmptyLeaf } from '../pane-tree'`.
+- [ ] **Step 15.3:** Both selection blocks (`34-41`, `79-83`): `const empty = findFirstEmptyLeaf(ts.root); const target = empty ? empty.id : ts.active_leaf_id;` pass `target` (string). Keep the terminal-tab early-returns. (Preserve the no-split fallback semantics — these handlers don't auto-split.)
+
+- [ ] **Step 15.4: Commit (WIP)**
+
+```bash
+git add desktop/lib/sidebar-handlers.ts
+git commit -m "refactor(sidebar-handlers): findFirstEmptyLeaf target"
+```
+
+---
+
+## Task 16: Verification gate + mobile safety + manual smoke (build goes GREEN)
+
+**Files:** none (verification + any residual fixes).
+
+- [ ] **Step 16.1:** Resolve all remaining type errors:
+
+Run: `pnpm check 2>&1 | tail -60`
+Expected: 0 errors. Fix any stragglers (grep the repo for leftover `\.panes\b`, `\.active_pane`, `\.col_split`, `\.row_split`, `close_confirm_pane`, `layout_panel_count`, `get_grid_style`, `get_pane_position`, `get_visible_panes`, `find_import_target_pane`, `[data-pane]`, `LayoutType` — all must be gone from `desktop/`).
+
+Run: `grep -rn "\.panes\b\|active_pane\|col_split\|row_split\|close_confirm_pane\|layout_panel_count\|get_grid_style\|get_pane_position\|get_visible_panes\|find_import_target_pane\|data-pane\b\|LayoutType" desktop`
+Expected: NO output.
+
+- [ ] **Step 16.2:** Unit tests:
+
+Run: `pnpm test`
+Expected: PASS, including `tests/desktop/pane-tree.test.ts`; no regressions vs the pre-refactor count.
+
+- [ ] **Step 16.3:** Mobile safety:
+
+Run: `git diff --name-only main...HEAD -- src/lib/mobile`
+Expected: NO output (zero mobile files touched — spec D8).
+
+Run: `pnpm check 2>&1 | grep -i mobile`
+Expected: NO new mobile errors.
+
+- [ ] **Step 16.4:** Manual smoke (desktop dev — `pnpm desktop:serve`, open http://127.0.0.1:3100/). Confirm each:
+  - Open one structure → single pane fills (landing → viewer).
+  - Open a 2nd file → splits left|right (splitH); 3rd → 3 leaves (left-1 / right-2, NO empty cell — §6.5); 4th → 4 leaves; 5th → new tab.
+  - Drag a divider → that split resizes; double-click → resets 50/50; independent quad dividers (§6.5) move separately.
+  - Click a pane → active highlight; digit keys 1-4 select leaves; close (X) on a pane → collapses, sibling fills; close last → returns to landing (tab survives).
+  - Pane popout button → opens a draggable window with that structure.
+  - Layout preset buttons (single/splitH/splitV/quad) still switch and highlight (`matchesPreset`).
+  - Tab badge shows populated-leaf count on inactive tabs.
+  - 3D canvas resizes correctly on split/resize (no zero-size/blank canvas) — the cross-tab `is_active` guard still holds (exactly one viewer active).
+
+- [ ] **Step 16.5:** Final review + commit:
+
+Run: `git diff --stat main...HEAD`
+
+```bash
+git add -A
+git commit -m "refactor(pane-tree): green — unified recursive pane tree replaces quad grid (subproject 1)"
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** model (§4) → Task 1; `StructureTabState` reshape (§6.1) → Task 2; recursive render + verbatim chrome (§5) → Tasks 3–4; parity checklist (§6.2: open-file escalation, popout, badge, close-collapse, divider, is_active, layout toggle, keyboard) → Tasks 5/7/8/9/10/12; two visible deltas (§6.5) → escalation in Task 1/5, independent dividers in Tasks 3/6 (center handle dropped); mobile (§3 D8) → Steps 2.1 + 16.3.
+- **`PaneState` unchanged** — only its container changes; all `pane.*` field names preserved.
+- **`clone_structure` on every structure assignment** preserved (memory: structure-must-clone-on-assign).
+- **`is_active` exactly-one-active invariant** preserved via `ts.active_leaf_id === leaf.id && tab.id === tm.active_tab_id` (memory: cross-tab bleed guard).
+- **Reactivity:** structural ops reassign `ts.root` (new object); leaf content edits mutate the live `$state` proxy node (`findLeafById(...).content.pane.X = …`), matching the existing deep-mutation pattern; old `ts.panes=[...]` nudges dropped.
+- **Build-red window** (Tasks 2–15) is inherent to an atomic model swap; `pane-tree.test.ts` stays green throughout; full green at Task 16.

--- a/docs/superpowers/specs/2026-06-16-unified-pane-tree-design.md
+++ b/docs/superpowers/specs/2026-06-16-unified-pane-tree-design.md
@@ -1,0 +1,234 @@
+# Unified Pane Tree — Design
+
+**Date:** 2026-06-16
+**Status:** Draft for review
+**Scope:** Desktop workspace layout. **Mobile is explicitly out of scope and must not change.**
+
+---
+
+## 1. Motivation
+
+Today the desktop workspace has two unrelated layout systems:
+
+1. **Structure panes** (`desktop/pane-utils.ts`): a fixed grid with four layout modes —
+   `single | splitH | splitV | quad` — capped at 4 panes, each holding one
+   structure / trajectory / cube / workflow. A single `col_split` + `row_split`
+   pair drives all dividers.
+2. **Terminal** (`src/lib/structure/TerminalPanel.svelte` as an in-viewer side panel,
+   plus a top-level "Terminal" tab and a separate `TerminalWindow.svelte` that has
+   multi-tab + a single binary split that is *not wired into the viewer*).
+
+Users want:
+
+- **R1.** A terminal that can cover the whole page instead of half-structure /
+  half-terminal.
+- **R2.** When opening a structure from the filesystem, a choice between taking a
+  split pane (current) or popping out a **draggable, multi-monitor** window.
+- **R3.** Terminal splitting — up to 4 terminals per tab, with multiple tabs.
+- **R4.** **User-defined** split layouts (e.g. "left column = 2 stacked, right = 1",
+  or "2×2"), not just the symmetric presets.
+- **R5.** A split cell may hold a **structure** (3D viewer), not only a terminal.
+
+The fixed `quad` grid cannot express R4 (it is always a symmetric 2×2; you cannot
+merge two cells into one). R5 means cells must be content-agnostic. Together these
+point to a single recursive layout primitive that both structures and terminals
+share.
+
+## 2. Decisions (locked with the user)
+
+| # | Decision |
+|---|----------|
+| D1 | One **recursive binary pane tree** is the single layout primitive; leaf content is `structure` **or** `terminal`. It **replaces** the `quad` grid. |
+| D2 | Execution is a **phased strangler**, not a big-bang rewrite. Ship a behavior-equivalent migration first, then add capability. |
+| D3 | "Maximize terminal" covers the **3D viewer only** (tab bar + sidebar stay; canvas kept warm). Generalizes later to "zoom any leaf". |
+| D4 | Open-file destination = a **global default setting + per-open override** (split pane vs new window). |
+| D5 | Multi-tab + split work in **both** the in-viewer terminal surface and the top-level Terminal tab, via a **shared component**. |
+| D6 | Leaf cap per tab = **4** (tunable). Covers the stated layouts (left-2-right-1 = 3, 2×2 = 4). |
+| D7 | Migrated `quad` dividers become **independent** (more powerful) rather than the old linked center cross. Reversible to linked if desired. |
+| **D8** | **Mobile must not change.** No behavioral or markup change to `src/lib/mobile/*`, `MobileWorkspace`, `MobileTerminal`, or any `TAURI_DEV_HOST`/mobile-gated branch. |
+
+## 3. Hard constraints
+
+- **Mobile untouched (D8).** The entire desktop pane system lives under `desktop/`
+  and mobile imports none of it (verified: `grep -rl pane-utils src/lib/mobile` is
+  empty). Subproject 1 is therefore mobile-safe by construction. `Structure.svelte`
+  is shared (mounted by `MobileWorkspace`); any edit to it must be desktop-gated and
+  verified not to alter mobile rendering. The design *reduces* shared surface by
+  lifting terminal-side-panel logic out of `Structure.svelte` into the desktop tree.
+- **iOS invariants preserved** (per `CLAUDE.md` / `deploy/ios/LOCAL-TESTING-PROGRESS.md`):
+  do not silently revert `Icon.svelte height:1em`, the keep-warm off-screen viewer
+  rule, etc.
+- **GPU envelope.** Each `structure` leaf is a live WebGL canvas. Cap (D6 = 4) keeps
+  us within today's `quad`-era envelope. Hidden/zoomed leaves stay warm off-screen
+  (never `display:none` a viewer canvas).
+- **No persistence change required.** Tab/pane state is in-memory; the model can be
+  rewritten without a migration format.
+
+## 4. Core model
+
+Per-tab layout is a binary tree:
+
+```ts
+type PaneNode = SplitNode | LeafNode
+
+interface SplitNode {
+  kind: 'split'
+  id: string
+  direction: 'h' | 'v'          // 'h' = side by side (vertical divider); 'v' = stacked (horizontal divider)
+  ratio: number                 // fraction (0..1) given to children[0]
+  children: [PaneNode, PaneNode] // strictly binary
+}
+
+interface LeafNode {
+  kind: 'leaf'
+  id: string
+  content: LeafContent
+}
+
+type LeafContent =
+  | { type: 'structure'; pane: PaneState } // wraps the EXISTING PaneState verbatim
+  | { type: 'terminal'; session: TerminalLeafState } // added in subproject 2
+  | { type: 'empty' }
+```
+
+Key point: a `structure` leaf **wraps the existing `PaneState`** unchanged, so it
+keeps every current content variant (`structure` / `trajectory` / `cube_file` /
+`workflow`) and all downstream logic (formula label, MCP `is_active`, popout
+serialization). Migration is lossless.
+
+### 4.1 Layouts as tree shapes
+
+| Layout | Tree |
+|--------|------|
+| single | `leaf` |
+| splitH (left\|right) | `split(h, [leaf, leaf])` |
+| splitV (top/bottom) | `split(v, [leaf, leaf])` |
+| quad | `split(h, [ split(v,[leaf,leaf]), split(v,[leaf,leaf]) ])` |
+| **left-2-right-1** | `split(h, [ split(v,[leaf,leaf]), leaf ])` |
+| **top-1-bottom-2** | `split(v, [ leaf, split(h,[leaf,leaf]) ])` |
+
+The four legacy presets are special cases, giving the migration exact anchors.
+
+### 4.2 Tree operations (pure functions, unit-testable)
+
+- `findFirstEmptyLeaf(root): id | null`
+- `splitLeaf(root, leafId, direction, newContent): root` — replaces the leaf with a
+  `split` of `[oldLeaf, newLeaf]`; refuses if `leafCount(root) >= CAP`.
+- `removeLeaf(root, leafId): root` — drops the leaf and **collapses** its parent
+  split so the sibling takes the parent's place (and ratio slot).
+- `setRatio(root, splitId, ratio): root`
+- `leafCount(root)`, `leaves(root)`, `setLeafContent(root, leafId, content)`.
+- `matchesPreset(root): 'single'|'splitH'|'splitV'|'quad'|'custom'` — drives the
+  layout-toggle UI's active state.
+
+All operations are immutable (return a new tree) for clean Svelte 5 `$state`
+reactivity and trivial testing.
+
+## 5. Rendering
+
+A recursive Svelte component `PaneTree.svelte`:
+
+- A `SplitNode` renders a flex container (`row` for `h`, `column` for `v`) with
+  child A, a 6px **divider**, child B; child A gets `flex-basis: ratio%`. Each split
+  owns its own divider + ratio (enables independent quad dividers, D7).
+- A `LeafNode` renders the leaf chrome (header: label, type switcher [subproj 3],
+  popout, maximize [subproj 4], close) plus its content.
+- Resize: pointer drag on a divider updates that split's `ratio` (clamped 0.15–0.85),
+  double-click resets to 0.5. Replaces the global `col_split`/`row_split` handlers.
+- **Canvas/xterm fit:** a `ResizeObserver` per leaf drives the viewer canvas resize
+  and xterm `FitAddon`, replacing the global `window.dispatchEvent('resize')` hack.
+  More robust and scoped (only the resized leaf reflows).
+
+## 6. Subproject 1 — Pane-tree core (behavior-equivalent migration)
+
+**Goal:** replace the `quad` grid with the tree, with **no user-visible behavior
+change** except the independent-quad-divider improvement (D7). Desktop-only.
+
+### 6.1 State change
+
+`desktop/pane-utils.ts` `StructureTabState`:
+
+- Remove: `panes: PaneState[4]`, `layout: LayoutType`, `active_pane: number`,
+  `col_split`, `row_split`.
+- Add: `root: PaneNode`, `active_leaf_id: string`.
+- Keep: `library`, `active_library_id`, `close_confirm_*` (keyed by leaf id now).
+
+### 6.2 Behaviors to preserve (parity checklist)
+
+| Current behavior | Tree implementation |
+|------------------|--------------------|
+| Open file → fill source pane, else first empty, else auto-upgrade `single→splitH→quad`, else new tab | `findFirstEmptyLeaf`; if none and `leafCount < CAP` → `splitLeaf(active, defaultDir)`; if `== CAP` → new tab. **Escalation differs (see §6.5):** the tree adds one leaf at a time (1→2→3→4, no empty cell) instead of legacy's jump to a 4-cell `quad` with an empty slot. |
+| Pane popout | popout the leaf's `PaneState` (unchanged serialization in `popout-manager.ts`). |
+| Inactive-tab badge = # populated panes | `leaves(root).filter(non-empty).length`. |
+| Close pane (confirm/save) → reduce layout | `removeLeaf` + parent collapse; reuse `pane-manager.ts` confirm flow keyed by leaf id. |
+| Divider drag / double-click reset | per-split `setRatio` in `resize-handlers.ts`. |
+| MCP `is_active` gating | active leaf id; only the active `structure` leaf syncs. |
+| Layout toggle buttons (single/splitH/splitV/quad) | build the corresponding preset tree; highlight via `matchesPreset`. |
+| Keyboard shortcuts (pane nav) | operate over `leaves(root)` order. |
+
+### 6.3 Touched files (desktop only)
+
+`pane-utils.ts` (model + ops), `App.svelte` (render `PaneTree` instead of the grid),
+`resize-handlers.ts`, `pane-manager.ts`, `tab-manager.svelte.ts`,
+`popout-manager.ts`, `keyboard-shortcuts.ts`, `layout-manager.ts`,
+`drag-drop-handlers.ts`, `close-all-helper.ts`, `export-handlers.ts`,
+`sidebar-handlers.ts`, `StructureLibrary.svelte`. New: `PaneTree.svelte`,
+`pane-tree.ts` (pure ops) + its test.
+
+### 6.4 Testing
+
+- Unit: pure tree ops (`splitLeaf`, `removeLeaf` + collapse, `setRatio`,
+  `findFirstEmptyLeaf`, `matchesPreset`, preset builders) — exhaustive, including
+  the cap boundary and collapse-to-sibling.
+- Parity: a table-driven test asserting the open-file escalation
+  (single→splitH→quad→new-tab) matches the legacy sequence.
+- `pnpm test` green; `pnpm check` clean.
+- **Mobile smoke:** confirm `MobileWorkspace` renders unchanged and no
+  `src/lib/mobile/*` file is touched (diff check).
+
+### 6.5 The two intended visible deltas
+
+Subproject 1 is "behavior-equivalent" with exactly two deliberate exceptions —
+called out so review does not flag them as regressions:
+
+1. **Independent quad dividers (D7).** The old linked center cross becomes two
+   independent dividers. Reversible to linked if undesired.
+2. **One-leaf-at-a-time escalation.** Opening a 3rd file from a 2-pane split adds a
+   3rd leaf (e.g. left-1 / right-2) rather than jumping to a 4-cell `quad` with one
+   empty slot. This removes the forced empty cell and is the natural behavior of the
+   free-split model the user asked for. *Alternative if strict parity is preferred:*
+   `splitLeaf` can target a full `quad` preset on the escalation step, keeping the
+   empty-cell behavior. **Recommendation: adopt one-at-a-time.**
+
+## 7. Subprojects 2–5 (sketch; each gets its own spec + plan)
+
+2. **Terminal leaf.** Add `LeafContent.terminal`; reuse `TerminalPanel.svelte` inside
+   a leaf. Lift the in-viewer terminal side panel out of the shared
+   `Structure.svelte` into a desktop tree leaf (shrinks shared surface, D8-positive).
+   Reconcile the top-level "Terminal" tab and `TerminalWindow.svelte` to use the same
+   `PaneTree`. Multi-tab terminals fall out of the existing app tab system.
+3. **Heterogeneous + type switch.** Leaf header dropdown to switch `terminal ⇄
+   structure`; "split and pick type". Delivers R5.
+4. **Leaf maximize / zoom.** Per-leaf maximize button; zoom one leaf to fill the tab,
+   others kept warm off-screen. Delivers R1 (and generalizes it).
+5. **Open-file destination.** Setting `open_target: 'split' | 'window'` + per-open
+   override (menu / modifier key). Reuses existing `popout_pane`. Delivers R2; mostly
+   independent — the `window` path can ship early since popout already exists.
+
+## 8. Risks & mitigations
+
+- **Wide blast radius in subproject 1** — ~14 desktop files reference `pane-utils`.
+  *Mitigation:* keep `PaneState` and the popout serialization unchanged; only the
+  container model changes. Pure tree ops are unit-tested before wiring. Behavior
+  parity table guards the escalation logic.
+- **Multiple WebGL canvases** — capped at 4 (D6), same as today's quad.
+- **Shared `Structure.svelte`** — subproject 1 does not touch it; later subprojects
+  gate edits behind desktop and verify mobile via diff + smoke.
+- **Two intended visible changes** in subproject 1 (D7 independent dividers +
+  one-at-a-time escalation) are enumerated in §6.5 so review doesn't flag them as
+  regressions.
+
+## 9. Out of scope
+
+- Mobile (any change). Persisted layouts across sessions. Drag-to-reorder leaves
+  (could be a later enhancement). More than 4 leaves per tab.

--- a/tests/desktop/pane-tree.test.ts
+++ b/tests/desktop/pane-tree.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { create_empty_pane } from '../../desktop/pane-utils'
+import {
+  CAP, buildPreset, create_empty_leaf, escalateForImport, findFirstEmptyLeaf,
+  findLeafById, findSplit, isEmptyLeaf, leafCount, leaves, matchesPreset,
+  removeLeaf, setRatio, splitLeaf,
+  type LeafNode, type PaneNode, type SplitNode,
+} from '../../desktop/pane-tree'
+
+const leaf = (id: string): LeafNode => ({ kind: 'leaf', id, content: { type: 'structure', pane: create_empty_pane() } })
+const split = (id: string, dir: 'h' | 'v', ratio: number, a: PaneNode, b: PaneNode): SplitNode => ({ kind: 'split', id, direction: dir, ratio, children: [a, b] })
+
+describe('leaves / leafCount / find', () => {
+  it('single leaf', () => {
+    const root = leaf('L1')
+    expect(leaves(root).map(l => l.id)).toEqual(['L1'])
+    expect(leafCount(root)).toBe(1)
+  })
+  it('nested tree returns leaves left-to-right', () => {
+    const root = split('S1', 'h', 0.5, split('S2', 'v', 0.5, leaf('A'), leaf('B')), leaf('C'))
+    expect(leaves(root).map(l => l.id)).toEqual(['A', 'B', 'C'])
+    expect(leafCount(root)).toBe(3)
+    expect(findLeafById(root, 'B')?.id).toBe('B')
+    expect(findLeafById(root, 'nope')).toBeNull()
+    expect(findSplit(root, 'S2')?.direction).toBe('v')
+    expect(findSplit(root, 'A')).toBeNull()
+  })
+})

--- a/tests/desktop/pane-tree.test.ts
+++ b/tests/desktop/pane-tree.test.ts
@@ -129,3 +129,16 @@ describe('buildPreset / matchesPreset', () => {
     expect(matchesPreset(custom)).toBeNull() // left-2-right-1
   })
 })
+
+describe('not-found ops are no-ops', () => {
+  it('splitLeaf returns null for a missing leaf id', () => {
+    const root = create_empty_leaf()
+    expect(splitLeaf(root, 'missing', 'h')).toBeNull()
+  })
+  it('removeLeaf returns the same root reference for a missing id', () => {
+    const a = create_empty_leaf()
+    const b = create_empty_leaf()
+    const root = split('S', 'h', 0.5, a, b)
+    expect(removeLeaf(root, 'missing')).toBe(root)
+  })
+})

--- a/tests/desktop/pane-tree.test.ts
+++ b/tests/desktop/pane-tree.test.ts
@@ -142,3 +142,14 @@ describe('not-found ops are no-ops', () => {
     expect(removeLeaf(root, 'missing')).toBe(root)
   })
 })
+
+import { create_tab_state } from '../../desktop/pane-utils'
+describe('create_tab_state', () => {
+  it('starts as one empty structure leaf, active = that leaf', () => {
+    const ts = create_tab_state()
+    expect(leafCount(ts.root)).toBe(1)
+    expect(ts.active_leaf_id).toBe((ts.root as LeafNode).id)
+    expect(isEmptyLeaf(ts.root as LeafNode)).toBe(true)
+    expect(ts.close_confirm_leaf_id).toBeNull()
+  })
+})

--- a/tests/desktop/pane-tree.test.ts
+++ b/tests/desktop/pane-tree.test.ts
@@ -26,3 +26,21 @@ describe('leaves / leafCount / find', () => {
     expect(findSplit(root, 'A')).toBeNull()
   })
 })
+
+describe('empty leaves', () => {
+  it('create_empty_leaf is an empty structure leaf with a unique id', () => {
+    const a = create_empty_leaf(); const b = create_empty_leaf()
+    expect(a.kind).toBe('leaf')
+    expect(a.content.type).toBe('structure')
+    expect(isEmptyLeaf(a)).toBe(true)
+    expect(a.id).not.toBe(b.id)
+  })
+  it('findFirstEmptyLeaf returns first content-free leaf or null', () => {
+    const filled = create_empty_leaf(); filled.content.pane.structure = { sites: [{}] } as never
+    const empty = create_empty_leaf()
+    const root = split('S', 'h', 0.5, filled, empty)
+    expect(findFirstEmptyLeaf(root)?.id).toBe(empty.id)
+    const full = split('S2', 'h', 0.5, filled, filled)
+    expect(findFirstEmptyLeaf(full)).toBeNull()
+  })
+})

--- a/tests/desktop/pane-tree.test.ts
+++ b/tests/desktop/pane-tree.test.ts
@@ -44,3 +44,36 @@ describe('empty leaves', () => {
     expect(findFirstEmptyLeaf(full)).toBeNull()
   })
 })
+
+describe('splitLeaf / removeLeaf', () => {
+  it('splitLeaf replaces a leaf with a split of [old, newEmpty]', () => {
+    const root0 = create_empty_leaf()
+    const { root, newLeafId } = splitLeaf(root0, root0.id, 'h')
+    expect(root.kind).toBe('split')
+    expect(leafCount(root)).toBe(2)
+    expect((root as SplitNode).direction).toBe('h')
+    expect((root as SplitNode).ratio).toBe(0.5)
+    expect(findLeafById(root, newLeafId)).not.toBeNull()
+    // original leaf id preserved as children[0]
+    expect(((root as SplitNode).children[0] as LeafNode).id).toBe(root0.id)
+  })
+  it('splitLeaf refuses at CAP leaves', () => {
+    let root: PaneNode = create_empty_leaf()
+    let active = (root as LeafNode).id
+    for (let i = 1; i < CAP; i++) { const r = splitLeaf(root, active, 'v'); root = r.root; active = r.newLeafId }
+    expect(leafCount(root)).toBe(CAP)
+    expect(splitLeaf(root, active, 'v')).toBeNull()
+  })
+  it('removeLeaf collapses parent split, sibling takes its place', () => {
+    const a = create_empty_leaf(); const b = create_empty_leaf(); const c = create_empty_leaf()
+    const root = split('S1', 'h', 0.4, split('S2', 'v', 0.5, a, b), c)
+    const next = removeLeaf(root, b.id) // S2 collapses -> a takes S2's slot
+    expect(leaves(next).map(l => l.id)).toEqual([a.id, c.id])
+    expect((next as SplitNode).id).toBe('S1')
+    expect(((next as SplitNode).children[0] as LeafNode).id).toBe(a.id)
+  })
+  it('removeLeaf of the only leaf returns the leaf unchanged (never empty tree)', () => {
+    const only = create_empty_leaf()
+    expect(removeLeaf(only, only.id)).toBe(only)
+  })
+})

--- a/tests/desktop/pane-tree.test.ts
+++ b/tests/desktop/pane-tree.test.ts
@@ -77,3 +77,55 @@ describe('splitLeaf / removeLeaf', () => {
     expect(removeLeaf(only, only.id)).toBe(only)
   })
 })
+
+describe('setRatio', () => {
+  it('sets a split ratio (pure) and clamps 0.2..0.8', () => {
+    const root = split('S', 'h', 0.5, create_empty_leaf(), create_empty_leaf())
+    expect((setRatio(root, 'S', 0.7) as SplitNode).ratio).toBe(0.7)
+    expect((setRatio(root, 'S', 0.01) as SplitNode).ratio).toBe(0.2)
+    expect((setRatio(root, 'S', 0.99) as SplitNode).ratio).toBe(0.8)
+    expect(setRatio(root, 'missing', 0.7)).toBe(root)
+  })
+})
+
+describe('escalateForImport (open-file target policy)', () => {
+  it('1->2->3->4 leaves one at a time, then null at CAP (open new tab)', () => {
+    let root: PaneNode = create_empty_leaf()
+    let active = (root as LeafNode).id
+    // fill the first leaf so it is no longer empty
+    ;(root as LeafNode).content.pane.structure = { sites: [{}] } as never
+    for (let n = 2; n <= CAP; n++) {
+      const r = escalateForImport(root, active)!
+      root = r.root; active = r.leafId
+      expect(leafCount(root)).toBe(n)
+      findLeafById(root, active)!.content.pane.structure = { sites: [{}] } as never
+    }
+    expect(escalateForImport(root, active)).toBeNull()
+  })
+  it('reuses an existing empty leaf instead of splitting', () => {
+    const filled = create_empty_leaf(); filled.content.pane.structure = { sites: [{}] } as never
+    const empty = create_empty_leaf()
+    const root = split('S', 'h', 0.5, filled, empty)
+    const r = escalateForImport(root, filled.id)!
+    expect(r.leafId).toBe(empty.id)
+    expect(leafCount(r.root)).toBe(2) // no new split
+  })
+})
+
+describe('buildPreset / matchesPreset', () => {
+  it('builds canonical preset trees', () => {
+    expect(leafCount(buildPreset('single'))).toBe(1)
+    expect(leafCount(buildPreset('splitH'))).toBe(2)
+    expect((buildPreset('splitH') as SplitNode).direction).toBe('h')
+    expect((buildPreset('splitV') as SplitNode).direction).toBe('v')
+    expect(leafCount(buildPreset('quad'))).toBe(4)
+  })
+  it('matchesPreset recognizes the canonical shapes, else null', () => {
+    expect(matchesPreset(buildPreset('single'))).toBe('single')
+    expect(matchesPreset(buildPreset('splitH'))).toBe('splitH')
+    expect(matchesPreset(buildPreset('splitV'))).toBe('splitV')
+    expect(matchesPreset(buildPreset('quad'))).toBe('quad')
+    const custom = split('S', 'h', 0.5, split('S2', 'v', 0.5, create_empty_leaf(), create_empty_leaf()), create_empty_leaf())
+    expect(matchesPreset(custom)).toBeNull() // left-2-right-1
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    include: ['tests/vitest/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
+    include: ['tests/vitest/**/*.test.ts', 'tests/desktop/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
     globals: false,
     // quickhull3d ships an ESM index.js that imports `./QuickHull` without
     // an extension. Node's ESM resolver rejects that — force Vite to


### PR DESCRIPTION
**Stack 1/5** — base: `main`. Commits 1–21 of the pane-tree epic.

Recursive pane-tree data model + behavior-equivalent migration of every consumer off the old quad-grid:
- Tree types & traversal (`leaves`/`leafCount`/`find`), `splitLeaf` (CAP) / `removeLeaf` (collapse to sibling), `setRatio`, `escalateForImport`, `buildPreset`/`matchesPreset`; HMR-safe id seed.
- Recursive `PaneTree.svelte` (flex splits + verbatim pane chrome via snippets); per-SplitNode ratio drag (drops the quad center handle).
- Migrate pane-manager / tab-manager / layout-manager / keyboard / popout / drag-drop / close-all / export / sidebar / App.svelte to leaf-ids.

Pure refactor — no user-facing behavior change yet (the later PRs build on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)