### PR TITLE
Pane tree (3/5): CatBot terminal control + flat keyed render (no remount on split)

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -2094,6 +2094,16 @@
               show_controls={true}
               style="--struct-height: 100%; --struct-width: 100%; border-radius: 0;"
             />
+          {:else if pane.initial_panel === `chat`}
+            <!-- Standalone CatBot pane (e.g. "Ask CatBot" from a terminal): no
+                 structure needed — the chat drives the active terminal via the
+                 global terminal registry. -->
+            <div class="pane-chat-fill">
+              <ChatPane
+                tab_id={tab.id}
+                on_close={() => { Object.assign(pane, create_empty_pane()); update_tab_label(tab.id) }}
+              />
+            </div>
           {:else}
             {@const is_primary = leaf.id === leaves(ts.root)[0].id}
             <div class="landing-page" class:secondary-pane={!is_primary} class:compact={leafCount(ts.root) > 1}>
@@ -2245,10 +2255,9 @@
                 <!-- AI Chat: shown in STATIC_ONLY too — CatBot runs client-direct
                      in-browser (no backend) and can fetch/build structures from empty state. -->
                 <button class="import-card chat-card" onclick={() => {
-                  console.log(`[CatGo:UI] Welcome card clicked: AI Chat → loading structure + opening Chat panel`)
-                  pane.structure = clone_structure(water as unknown as AnyStructure)
-                  pane.initial_site_count = (water as any).sites?.length ?? 0
-                  pane.initial_structure_ref = water as unknown as AnyStructure
+                  // Open a full CatBot pane (no forced structure). CatBot runs
+                  // client-direct and can fetch/build structures from empty state
+                  // if asked; the standalone-chat leaf_body branch renders it.
                   pane.initial_panel = `chat`
                   ts.active_leaf_id = leaf.id
                   update_tab_label(tab.id)
@@ -2992,6 +3001,14 @@
 
   /* .pane.dragover glow + add-own-card highlight live in PaneTree.svelte
      (.pane is rendered there; cards render in App's scope via :global). */
+
+  /* Standalone CatBot pane (full-pane chat, no structure viewer) */
+  .pane-chat-fill {
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
 
   /* Original horizontal layout (restored) */
   .landing-page {

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1852,7 +1852,7 @@
           />
         {/if}
         <PaneTree
-          node={ts.root}
+          root={ts.root}
           multi={leafCount(ts.root) > 1}
           active_leaf_id={ts.active_leaf_id}
           drag_target_leaf={tab.id === tm.active_tab_id ? drag_target_leaf : null}

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -395,6 +395,21 @@
     }
     update_tab_label(tab_id)
   }
+  function open_chat_beside(leaf: LeafNode) {
+    const ts = get_active_ts()
+    if (!ts) return
+    const r = escalateForImport(ts.root, leaf.id)
+    if (!r) {
+      // At CAP: fall back to the chat popout window.
+      window.open(`${location.origin}${location.pathname}#chat`, '_blank', 'width=520,height=760')
+      return
+    }
+    ts.root = r.root
+    const new_leaf = findLeafById(ts.root, r.leafId)
+    const pane = new_leaf ? structurePane(new_leaf) : null
+    if (pane) pane.initial_panel = `chat`
+    ts.active_leaf_id = r.leafId
+  }
   function handle_unload(tab_id: string, leaf_id: string) { _handle_unload(pane_deps, tab_id, leaf_id) }
   function close_panel(tab_id: string, leaf_id: string) { _close_panel(pane_deps, tab_id, leaf_id) }
   function save_and_close_panel(tab_id: string, leaf_id: string) { return _save_and_close_panel(pane_deps, tab_id, leaf_id) }
@@ -2335,6 +2350,7 @@
               onpopout={() => popout_terminal_leaf(tab.id, leaf.id)}
               onclose={() => close_terminal_leaf(tab.id, leaf.id)}
               on_open_file={(p) => handle_terminal_leaf_open_file(p, term)}
+              on_ask_catbot={() => open_chat_beside(leaf)}
             />
           {/if}
         {/snippet}

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -65,6 +65,7 @@
   // Deep-clone structures on assignment into a pane so panes/tabs never alias
   // the same object (module-level samples, library entries, reused DB imports).
   import { clone_structure } from '$lib/structure/clone'
+  import { set_terminal_opener, get_active_terminal, type TerminalHandle } from '$lib/structure/terminal-registry.svelte'
   // Extracted tab manager (factory — must be called in component context)
   import { create_tab_manager } from './lib/tab-manager.svelte'
   // Extracted close-all helpers (pure functions)
@@ -348,6 +349,27 @@
     const close = () => { type_menu_leaf_id = null }
     window.addEventListener('click', close)
     return () => window.removeEventListener('click', close)
+  })
+
+  // Register the terminal opener for CatBot: when no terminal is active,
+  // this spawns a local terminal leaf in the active tab and waits for its PTY.
+  $effect(() => {
+    set_terminal_opener(async (): Promise<TerminalHandle | null> => {
+      const ts = get_active_ts()
+      if (!ts) return null
+      const r = escalateForImport(ts.root, ts.active_leaf_id)
+      if (!r) return null
+      ts.root = setLeafContent(r.root, r.leafId, { type: `terminal`, term: { sync_cwd: false } })
+      ts.active_leaf_id = r.leafId
+      // Wait (bounded) for the new TerminalPanel to spawn its PTY and register.
+      for (let i = 0; i < 60; i++) {
+        await new Promise((res) => setTimeout(res, 100))
+        const h = get_active_terminal()
+        if (h) return h
+      }
+      return null
+    })
+    return () => set_terminal_opener(null)
   })
 
   // Pop a terminal leaf out into its own window, then drop it from the source tree.

--- a/desktop/PaneTree.svelte
+++ b/desktop/PaneTree.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
-  import type { PaneNode, LeafNode, SplitNode } from './pane-tree'
-  import { subtreeContains } from './pane-tree'
+  import type { PaneNode, LeafNode } from './pane-tree'
+  import { compute_pane_layout } from './pane-layout'
   import type { Snippet } from 'svelte'
 
   interface Props {
-    // May transiently be undefined: when a split collapses (close-leaf), a child
-    // <svelte:self>'s `node={s.children[0]}` getter can re-run against a parent
-    // whose node is now a leaf (no .children) before the {#if} tears it down.
-    node: PaneNode | undefined
+    root: PaneNode | undefined
     multi: boolean // leafCount(root) > 1 — gates per-leaf header chrome
     active_leaf_id: string
     drag_target_leaf: string | null
     close_confirm_leaf_id: string | null
     active_split_id: string | null
-    maximized_leaf_id: string | null // when set, only the subtree holding it is visible (others stay warm at 0 size)
+    maximized_leaf_id: string | null
     leaf_body: Snippet<[LeafNode]>     // App renders the viewer/landing for a structure leaf
     terminal_body: Snippet<[LeafNode]> // App renders the TerminalPanel for a terminal leaf
     header: Snippet<[LeafNode]>        // App renders the dot+label+popout+close buttons
@@ -22,82 +19,76 @@
     on_split_mousedown: (e: MouseEvent, split_id: string, dir: 'h' | 'v') => void
     on_split_dblclick: (split_id: string) => void
   }
-  let { node, multi, active_leaf_id, drag_target_leaf, close_confirm_leaf_id, active_split_id, maximized_leaf_id, leaf_body, terminal_body, header, banner, on_activate, on_split_mousedown, on_split_dblclick }: Props = $props()
+  let { root, multi, active_leaf_id, drag_target_leaf, close_confirm_leaf_id, active_split_id, maximized_leaf_id, leaf_body, terminal_body, header, banner, on_activate, on_split_mousedown, on_split_dblclick }: Props = $props()
+
+  // Flat layout: every leaf is one keyed slot positioned by a computed rect.
+  // Keyed by leaf.id, so a leaf keeps its component instance when the tree
+  // restructures (split / collapse / resize / maximize) — no remount, so a
+  // terminal's PTY and a viewer's WebGL state survive layout changes.
+  let layout = $derived(compute_pane_layout(root, maximized_leaf_id))
 </script>
 
-{#if node && node.kind === 'split' && node.children}
-  {@const s = node as SplitNode}
-  {@const max0 = maximized_leaf_id && s.children ? subtreeContains(s.children[0], maximized_leaf_id) : null}
-  {@const max1 = maximized_leaf_id && s.children ? subtreeContains(s.children[1], maximized_leaf_id) : null}
-  {@const basis0 = maximized_leaf_id ? (max0 ? '100%' : '0%') : `calc(${s.ratio * 100}% - 3px)`}
-  {@const basis1 = maximized_leaf_id ? (max1 ? '100%' : '0%') : `calc(${(1 - s.ratio) * 100}% - 3px)`}
-  <div class="split {s.direction === 'h' ? 'h' : 'v'}" class:maximizing={!!maximized_leaf_id}>
-    <div class="split-child" style={`flex-basis:${basis0}`}>
-      <svelte:self node={s.children?.[0]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {maximized_leaf_id} {leaf_body} {terminal_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
-    </div>
-    {#if !maximized_leaf_id}
-      <div
-        class="grid-divider {s.direction === 'h' ? 'grid-divider-col' : 'grid-divider-row'}"
-        class:active={active_split_id === s.id}
-        onmousedown={(e) => on_split_mousedown(e, s.id, s.direction)}
-        ondblclick={() => on_split_dblclick(s.id)}
-        role="separator"
-        aria-orientation={s.direction === 'h' ? 'vertical' : 'horizontal'}
-      ></div>
-    {/if}
-    <div class="split-child" style={`flex-basis:${basis1}`}>
-      <svelte:self node={s.children?.[1]} {multi} {active_leaf_id} {drag_target_leaf} {close_confirm_leaf_id} {active_split_id} {maximized_leaf_id} {leaf_body} {terminal_body} {header} {banner} {on_activate} {on_split_mousedown} {on_split_dblclick} />
-    </div>
-  </div>
-{:else if node && node.kind === 'leaf'}
-  {@const leaf = node as LeafNode}
-  <div
-    class="pane"
-    class:active={active_leaf_id === leaf.id}
-    class:dragover={drag_target_leaf === leaf.id}
-    class:warn-glow={close_confirm_leaf_id === leaf.id}
-    data-leaf-id={leaf.id}
-    role="button"
-    tabindex="0"
-    onclick={() => on_activate(leaf.id)}
-    onkeydown={(e) => { if (e.key === 'Enter') on_activate(leaf.id) }}
-  >
-    {#if multi || leaf.content.type === 'terminal'}
-      <!-- A lone terminal leaf still needs its header (Directory Sync / popout /
-           close); a lone structure leaf has its own in-viewer toolbar instead. -->
-      <div class="panel-header">{@render header(leaf)}</div>
-    {/if}
-    {@render banner(leaf)}
-    <div class="panel-content">
-      {#if leaf.content.type === 'terminal'}
-        {@render terminal_body(leaf)}
-      {:else}
-        {@render leaf_body(leaf)}
+<div class="pane-tree-root">
+  {#each layout.leaves as { leaf, rect } (leaf.id)}
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <div
+      class="pane"
+      class:active={active_leaf_id === leaf.id}
+      class:dragover={drag_target_leaf === leaf.id}
+      class:warn-glow={close_confirm_leaf_id === leaf.id}
+      class:maximized-hidden={!!maximized_leaf_id && rect.w === 0}
+      data-leaf-id={leaf.id}
+      style={`left:${rect.x}%; top:${rect.y}%; width:${rect.w}%; height:${rect.h}%`}
+      role="button"
+      tabindex="0"
+      onclick={() => on_activate(leaf.id)}
+      onkeydown={(e) => { if (e.key === 'Enter') on_activate(leaf.id) }}
+    >
+      {#if multi || leaf.content.type === 'terminal'}
+        <!-- A lone terminal leaf still needs its header (Directory Sync / popout /
+             close); a lone structure leaf has its own in-viewer toolbar instead. -->
+        <div class="panel-header">{@render header(leaf)}</div>
       {/if}
+      {@render banner(leaf)}
+      <div class="panel-content">
+        {#if leaf.content.type === 'terminal'}
+          {@render terminal_body(leaf)}
+        {:else}
+          {@render leaf_body(leaf)}
+        {/if}
+      </div>
     </div>
-  </div>
-{/if}
+  {/each}
+
+  {#if !maximized_leaf_id}
+    {#each layout.dividers as d (d.split_id)}
+      <div
+        class="grid-divider {d.dir === 'h' ? 'grid-divider-col' : 'grid-divider-row'}"
+        class:active={active_split_id === d.split_id}
+        data-split-span={d.span}
+        style={`left:${d.rect.x}%; top:${d.rect.y}%; ${d.dir === 'h' ? `height:${d.rect.h}%` : `width:${d.rect.w}%`}`}
+        onmousedown={(e) => on_split_mousedown(e, d.split_id, d.dir)}
+        ondblclick={() => on_split_dblclick(d.split_id)}
+        role="separator"
+        aria-orientation={d.dir === 'h' ? 'vertical' : 'horizontal'}
+      ></div>
+    {/each}
+  {/if}
+</div>
 
 <style>
-  /* Split container geometry — moves grid-container -> flex splits */
-  .split { display: flex; width: 100%; height: 100%; min-width: 0; min-height: 0; }
-  .split.h { flex-direction: row; }
-  .split.v { flex-direction: column; }
-  .split-child { position: relative; min-width: 0; min-height: 0; overflow: hidden; flex: 0 0 auto; }
+  .pane-tree-root { position: relative; width: 100%; height: 100%; min-width: 0; min-height: 0; overflow: hidden; }
 
-  /* Resize dividers — var names match App.svelte exactly */
-  .grid-divider { background: var(--border-color, rgba(128, 128, 128, 0.2)); transition: background 0.15s; z-index: 1; flex: 0 0 auto; }
-  .grid-divider-col { width: 6px; cursor: col-resize; }
-  .grid-divider-row { height: 6px; cursor: row-resize; }
-  .grid-divider:hover, .grid-divider.active { background: var(--accent-color, #3b82f6); }
-
-  /* Pane wrapper — var names match App.svelte exactly */
-  .pane { position: relative; overflow: hidden; background: var(--surface-bg, var(--page-bg)); cursor: pointer; display: flex; flex-direction: column; width: 100%; height: 100%; }
+  /* Absolutely-positioned leaf slots (left/top/width/height set inline as %).
+     Keyed by leaf.id in the {#each}, so they never remount on restructure. */
+  .pane { position: absolute; overflow: hidden; background: var(--surface-bg, var(--page-bg)); cursor: pointer; display: flex; flex-direction: column; }
   .pane.warn-glow { box-shadow: inset 0 0 0 2px rgba(245, 158, 11, 0.5); }
+  /* Keep-warm while maximized: hide but stay mounted (NOT display:none). */
+  .pane.maximized-hidden { visibility: hidden; pointer-events: none; }
 
   /* Pane state visuals that cross the App<->PaneTree scope boundary: .pane lives
      here, but its header buttons / import cards render via App-defined snippets,
-     so the descendant parts need :global(). (moved verbatim from App.svelte) */
+     so the descendant parts need :global(). */
   .pane:hover :global(.panel-popout-btn),
   .pane:hover :global(.panel-maximize-btn),
   .pane:hover :global(.panel-close-btn),
@@ -117,8 +108,14 @@
   }
   .pane.dragover :global(.import-card.add-own-card .import-title) { color: #22c55e; }
 
+  /* Absolutely-positioned dividers, centered on the split seam via negative margin. */
+  .grid-divider { position: absolute; background: var(--border-color, rgba(128, 128, 128, 0.2)); transition: background 0.15s; z-index: 2; }
+  .grid-divider-col { width: 6px; margin-left: -3px; cursor: col-resize; }
+  .grid-divider-row { height: 6px; margin-top: -3px; cursor: row-resize; }
+  .grid-divider:hover, .grid-divider.active { background: var(--accent-color, #3b82f6); }
+
   /* Panel header flex container (its dot/label/buttons render via App snippets,
-     styled by App's scoped CSS). Moved verbatim from App.svelte. */
+     styled by App's scoped CSS). */
   .panel-header {
     display: flex;
     align-items: center;
@@ -129,13 +126,13 @@
     border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.15));
     font-size: 11px;
     user-select: none;
+    flex: 0 0 auto;
   }
 
-  /* Content area — height:0 is load-bearing for the WebGL canvas */
+  /* Content area — height:0 / flex:1 is load-bearing for the WebGL canvas */
   .panel-content { flex: 1; min-height: 0; position: relative; overflow: hidden; height: 0; }
 
-  /* NOTE: .panel-header/.panel-dot/.panel-label/.panel-*-btn/.panel-close-banner/.banner-*
-     rules are supplied by App.svelte's global <style> (the header/banner snippets render
-     in App's scope); keep them in App.svelte. Only split/pane/divider/content geometry
-     lives here. */
+  /* NOTE: .panel-dot/.panel-label/.panel-*-btn/.panel-close-banner/.banner-*
+     rules are supplied by App.svelte's global <style> (the header/banner snippets
+     render in App's scope); keep them in App.svelte. */
 </style>

--- a/desktop/lib/layout-manager.ts
+++ b/desktop/lib/layout-manager.ts
@@ -10,7 +10,7 @@ import type { StructureTabState } from '../pane-utils'
 import { pane_has_content } from '../pane-utils'
 import {
   buildPreset, leaves, matchesPreset, isTerminalLeaf, structurePane,
-  type LeafContent, type PresetId,
+  type LeafNode, type PresetId,
 } from '../pane-tree'
 
 export interface LayoutManagerDeps {
@@ -30,25 +30,30 @@ function preset_leaf_count(preset: PresetId): number {
 }
 
 /**
- * Leaf contents worth carrying across a preset switch: terminal leaves (always)
- * plus structure leaves that hold renderable content. Terminals survive a
- * preset change with their session intact (we carry the whole `content`).
+ * Leaf nodes worth carrying across a preset switch: terminal leaves (always)
+ * plus structure leaves that hold renderable content. We carry the whole leaf
+ * (id + content), not just the content — preserving the id is what lets the flat
+ * keyed renderer keep the component instance (terminal PTY / viewer WebGL) alive
+ * across the layout change instead of remounting it.
  */
-function filled_contents(ts: StructureTabState): LeafContent[] {
-  return leaves(ts.root)
-    .filter(l => {
-      if (isTerminalLeaf(l)) return true
-      const pane = structurePane(l)
-      return !!pane && pane_has_content(pane)
-    })
-    .map(l => l.content)
+function filled_leaves(ts: StructureTabState): LeafNode[] {
+  return leaves(ts.root).filter(l => {
+    if (isTerminalLeaf(l)) return true
+    const pane = structurePane(l)
+    return !!pane && pane_has_content(pane)
+  })
 }
 
-/** Rebuild the tab's tree from a preset, dropping populated contents into its leaves. */
-function apply_preset(ts: StructureTabState, preset: PresetId, filled: LeafContent[]) {
+/** Rebuild the tab's tree from a preset, migrating populated leaves into its slots. */
+function apply_preset(ts: StructureTabState, preset: PresetId, filled: LeafNode[]) {
   const root = buildPreset(preset)
   const slots = leaves(root)
-  for (let i = 0; i < slots.length && i < filled.length; i++) slots[i].content = filled[i]
+  for (let i = 0; i < slots.length && i < filled.length; i++) {
+    // Preserve the existing leaf's identity (id), not just its content, so the
+    // keyed pane render reuses the same component instance — no remount.
+    slots[i].id = filled[i].id
+    slots[i].content = filled[i].content
+  }
   ts.root = root
   ts.active_leaf_id = slots[0].id
   ts.close_confirm_leaf_id = null
@@ -59,7 +64,7 @@ export function handle_layout_change(deps: LayoutManagerDeps, preset: PresetId) 
   if (!ts) return
   if (matchesPreset(ts.root) === preset) return
 
-  const filled = filled_contents(ts)
+  const filled = filled_leaves(ts)
   const target = preset_leaf_count(preset)
 
   if (filled.length > target) {
@@ -80,7 +85,7 @@ export function confirm_layout_change(deps: LayoutManagerDeps) {
 
   // Truncate: keep only as many populated panes as the preset has leaves.
   const target = preset_leaf_count(new_layout)
-  const filled = filled_contents(ts).slice(0, target)
+  const filled = filled_leaves(ts).slice(0, target)
 
   apply_preset(ts, new_layout, filled)
   deps.set_pending_layout_change(null)

--- a/desktop/lib/resize-handlers.ts
+++ b/desktop/lib/resize-handlers.ts
@@ -26,17 +26,21 @@ export function on_split_drag(
   if (!ts) return
   const node = findSplit(ts.root, split_id)
   if (!node) return
-  const container = (e.target as HTMLElement).parentElement // the .split flex container
-  if (!container) return
+  const root_el = (e.target as HTMLElement).parentElement // .pane-tree-root
+  if (!root_el) return
+  // The divider carries its split's % extent along the drag axis (data-split-span)
+  // so nested-split drags convert px → ratio against the split's own size, not
+  // the whole tree.
+  const span_pct = parseFloat((e.target as HTMLElement).dataset.splitSpan ?? '100') || 100
   e.preventDefault()
   deps.set_is_panel_resizing(true)
   on_start()
   const start = dir === 'h' ? e.clientX : e.clientY
   const start_ratio = node.ratio
   function on_move(ev: MouseEvent) {
-    const rect = container!.getBoundingClientRect()
-    const total = dir === 'h' ? rect.width : rect.height
-    const delta = ((dir === 'h' ? ev.clientX : ev.clientY) - start) / total
+    const rect = root_el!.getBoundingClientRect()
+    const total = (dir === 'h' ? rect.width : rect.height) * (span_pct / 100)
+    const delta = total > 0 ? ((dir === 'h' ? ev.clientX : ev.clientY) - start) / total : 0
     ts!.root = setRatio(ts!.root, split_id, start_ratio + delta)
   }
   function on_up() {

--- a/desktop/pane-layout.ts
+++ b/desktop/pane-layout.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure geometry for the flat pane renderer: turns the pane tree into a flat list
+ * of absolutely-positioned leaf boxes + divider boxes (all in % of the
+ * container). No DOM. Lets PaneTree render leaves as one keyed list so they
+ * never remount when the tree restructures.
+ */
+import type { PaneNode } from './pane-tree'
+import type { LeafNode } from './pane-tree'
+
+export interface Rect { x: number; y: number; w: number; h: number }
+export interface LeafBox { leaf: LeafNode; rect: Rect }
+/** `span` = the split's own extent (%) along the drag axis (width for 'h',
+ *  height for 'v') — the resize handler needs it to convert px → ratio. */
+export interface DividerBox { split_id: string; dir: 'h' | 'v'; rect: Rect; span: number }
+export interface PaneLayout { leaves: LeafBox[]; dividers: DividerBox[] }
+
+function leaf_ids(node: PaneNode | undefined): string[] {
+  if (!node) return []
+  if (node.kind === 'leaf') return [node.id]
+  if (!node.children) return []
+  return [...leaf_ids(node.children[0]), ...leaf_ids(node.children[1])]
+}
+
+export function compute_pane_layout(
+  root: PaneNode | undefined,
+  maximized_leaf_id: string | null,
+): PaneLayout {
+  const leaves: LeafBox[] = []
+  const dividers: DividerBox[] = []
+
+  function walk(node: PaneNode | undefined, rect: Rect): void {
+    if (!node) return
+    if (node.kind === 'leaf') {
+      leaves.push({ leaf: node, rect })
+      return
+    }
+    if (!node.children) return
+    const [c0, c1] = node.children
+    if (maximized_leaf_id) {
+      // The child subtree holding the maximized leaf takes the full rect; the
+      // other collapses to zero size but its leaves stay mounted (keep-warm).
+      const zero = { ...rect, w: 0, h: 0 }
+      if (leaf_ids(c0).includes(maximized_leaf_id)) { walk(c0, rect); walk(c1, zero) }
+      else if (leaf_ids(c1).includes(maximized_leaf_id)) { walk(c0, zero); walk(c1, rect) }
+      else { walk(c0, zero); walk(c1, zero) }
+      return
+    }
+    if (node.direction === 'h') {
+      const w0 = rect.w * node.ratio
+      walk(c0, { x: rect.x, y: rect.y, w: w0, h: rect.h })
+      walk(c1, { x: rect.x + w0, y: rect.y, w: rect.w - w0, h: rect.h })
+      dividers.push({ split_id: node.id, dir: 'h', rect: { x: rect.x + w0, y: rect.y, w: 0, h: rect.h }, span: rect.w })
+    } else {
+      const h0 = rect.h * node.ratio
+      walk(c0, { x: rect.x, y: rect.y, w: rect.w, h: h0 })
+      walk(c1, { x: rect.x, y: rect.y + h0, w: rect.w, h: rect.h - h0 })
+      dividers.push({ split_id: node.id, dir: 'v', rect: { x: rect.x, y: rect.y + h0, w: rect.w, h: 0 }, span: rect.h })
+    }
+  }
+
+  walk(root, { x: 0, y: 0, w: 100, h: 100 })
+  return { leaves, dividers }
+}

--- a/docs/superpowers/plans/2026-06-16-catbot-terminal-control.md
+++ b/docs/superpowers/plans/2026-06-16-catbot-terminal-control.md
@@ -1,0 +1,914 @@
+# CatBot Terminal Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let CatBot (in-app AI Chat) read and operate the visible terminal pane — `read_terminal`, `run_command`, `send_keys`, `interrupt_terminal` — with per-command approval, for local + HPC terminals, plus an "Ask CatBot" button in the terminal header.
+
+**Architecture:** An in-process **terminal registry** bridges chat ↔ the visible PTY. `TerminalPanel` gains `run_command` (inline `BEGIN…END_<exit>` marker capture over `pty.onData`), `send_keys`, `interrupt`, `read_buffer`, and registers a handle. Four CLIENT_TOOLS call the active handle; `kind:'mutate'` reuses the existing PermissionCard gate. "Ask CatBot" splits the terminal leaf and opens a chat panel (`initial_panel='chat'`).
+
+**Tech Stack:** SvelteKit 2 / Svelte 5 runes, TypeScript, xterm.js, vitest, Playwright. Project style: single quotes, **no semicolons**, 2-space indent (write by hand; never run `deno fmt`).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-catbot-terminal-control-design.md`
+
+**Confirmed APIs (do not re-derive):**
+- `PtySession` (`src/lib/api/pty.ts`): `write(data: string): Promise<void>`, `onData(cb: (data: Uint8Array) => void): () => void`, `onExit`, `kill`, `resize`.
+- Tool registry (`src/lib/chat/structure-tools.ts`): `register(def: ClientTool, run: (input) => Promise<unknown>)`; `execute_tool` routes via REGISTRY; `tool_kind` reads `def.kind`. `ClientTool = { name, description, kind: 'read'|'mutate', input_schema }` (`src/lib/chat/types.ts`).
+- Approval: `tool-loop.ts:160` — `kind === 'mutate'` → `permission_request` → `request_permission`. ChatPane already renders `PermissionCard` from `slice.active_permission_blocks.entries`. `skip_permission` flag exists per chat slice. **No tool-loop changes needed.**
+- Spawn terminal leaf (App.svelte:2249): `ts.root = setLeafContent(ts.root, leaf.id, { type: 'terminal', term: { sync_cwd: false } })`; get a target leaf via `escalateForImport(ts.root, ts.active_leaf_id)`.
+- Open chat panel (App.svelte:2215): `pane.initial_panel = 'chat'`.
+
+---
+
+## Task 1: Pure capture helpers (`terminal-capture.ts`)
+
+**Files:**
+- Create: `src/lib/structure/terminal-capture.ts`
+- Test: `tests/vitest/terminal-capture.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/vitest/terminal-capture.test.ts
+import { describe, it, expect } from 'vitest'
+import { strip_ansi, next_marker, wrap_command, extract_result, KEY_MAP, resolve_keys } from '../../src/lib/structure/terminal-capture'
+
+describe('strip_ansi', () => {
+  it('removes CSI color codes', () => {
+    expect(strip_ansi('\x1b[31mred\x1b[0m')).toBe('red')
+  })
+  it('removes OSC sequences (e.g. OSC 7 cwd)', () => {
+    expect(strip_ansi('a\x1b]7;file://h/p\x07b')).toBe('ab')
+  })
+  it('keeps plain text and newlines', () => {
+    expect(strip_ansi('line1\nline2')).toBe('line1\nline2')
+  })
+})
+
+describe('next_marker', () => {
+  it('is unique per call and matches the expected shape', () => {
+    const a = next_marker(); const b = next_marker()
+    expect(a).not.toBe(b)
+    expect(a).toMatch(/^__CATGO_\d+_[a-z0-9]+__$/)
+  })
+})
+
+describe('wrap_command / extract_result', () => {
+  it('round-trips output and exit code (simulating shell echo + run)', () => {
+    const marker = '__CATGO_1_abc__'
+    const wrapped = wrap_command('echo hi', marker)
+    // The shell echoes the wrapped command (contains %s_BEGIN, marker in quotes),
+    // then prints the real BEGIN/output/END.
+    const raw = wrapped + `\r\n` +
+      `\n${marker}_BEGIN\n` + `hi\n` + `\n${marker}_END_0\n` + `(base) $ `
+    const res = extract_result(strip_ansi(raw), marker)
+    expect(res).toEqual({ output: 'hi', exit_code: 0 })
+  })
+  it('returns null until END marker is present', () => {
+    const marker = '__CATGO_2_def__'
+    const raw = `\n${marker}_BEGIN\n` + 'partial output'
+    expect(extract_result(raw, marker)).toBeNull()
+  })
+  it('captures a non-zero exit code', () => {
+    const marker = '__CATGO_3_ghi__'
+    const raw = `\n${marker}_BEGIN\n` + 'nope\n' + `\n${marker}_END_2\n`
+    expect(extract_result(raw, marker)).toEqual({ output: 'nope', exit_code: 2 })
+  })
+  it('is not fooled by the echoed command (literal %s_BEGIN, quoted marker)', () => {
+    const marker = '__CATGO_4_jkl__'
+    const echo = `{ printf '\\n%s_BEGIN\\n' '${marker}'\necho hi\nprintf '\\n%s_END_%d\\n' '${marker}' "$?"\n}`
+    const raw = echo + `\n${marker}_BEGIN\n` + 'hi\n' + `\n${marker}_END_0\n`
+    expect(extract_result(raw, marker)).toEqual({ output: 'hi', exit_code: 0 })
+  })
+})
+
+describe('resolve_keys', () => {
+  it('maps named keys to control bytes and passes literal text through', () => {
+    expect(resolve_keys('y<enter>')).toBe('y\r')
+    expect(resolve_keys('<c-c>')).toBe('\x03')
+    expect(resolve_keys('<up><tab><esc>')).toBe('\x1b[A\t\x1b')
+    expect(resolve_keys('plain')).toBe('plain')
+  })
+  it('exposes the key table', () => {
+    expect(KEY_MAP['<enter>']).toBe('\r')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vitest/terminal-capture.test.ts`
+Expected: FAIL — "Failed to resolve import ... terminal-capture" / functions undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/structure/terminal-capture.ts
+/**
+ * Pure helpers for CatBot terminal control: ANSI stripping, command-output
+ * markers (BEGIN..END_<exit>), and named-key resolution. No DOM / no PTY here —
+ * keeps the logic unit-testable in isolation.
+ */
+
+/** Strip ANSI/VT control sequences (CSI, OSC, and stray C0 controls except \n\t). */
+export function strip_ansi(s: string): string {
+  return s
+    // OSC: ESC ] ... BEL  or  ESC ] ... ST(ESC \)
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    // CSI: ESC [ ... final byte
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')
+    // Other ESC-prefixed singles / 2-char
+    .replace(/\x1b[@-Z\\-_]/g, '')
+    // Lone carriage returns (xterm line discipline) and remaining C0 except \n \t
+    .replace(/\r/g, '')
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, '')
+}
+
+let _seq = 0
+/** Unique per-call marker token. */
+export function next_marker(): string {
+  _seq += 1
+  const rand = Math.random().toString(36).slice(2, 10)
+  return `__CATGO_${_seq}_${rand}__`
+}
+
+/**
+ * Wrap a user command in a brace group that prints BEGIN before and
+ * END_<exit-code> after. Newlines (not `;`) separate the parts so multi-word /
+ * piped commands pass through verbatim; `$?` is the user command's exit code.
+ */
+export function wrap_command(cmd: string, marker: string): string {
+  return `{ printf '\\n%s_BEGIN\\n' '${marker}'\n${cmd}\nprintf '\\n%s_END_%d\\n' '${marker}' "$?"\n}\r`
+}
+
+function escape_re(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Find the captured output between `MARKER_BEGIN` and `MARKER_END_<code>` in the
+ * accumulated (ANSI-stripped) PTY text. Returns null until the END marker lands.
+ * The echoed command can't false-match: its literal text is `%s_BEGIN` and the
+ * marker there is quote-wrapped, never `MARKER_BEGIN` / `MARKER_END_<digits>`.
+ */
+export function extract_result(raw: string, marker: string): { output: string; exit_code: number | null } | null {
+  const begin = `${marker}_BEGIN`
+  const bi = raw.indexOf(begin)
+  if (bi < 0) return null
+  const after = raw.slice(bi + begin.length)
+  const m = after.match(new RegExp(`${escape_re(marker)}_END_(\\d+)`))
+  if (!m || m.index === undefined) return null
+  const output = after.slice(0, m.index).replace(/^\n+/, '').replace(/\n+$/, '')
+  return { output, exit_code: parseInt(m[1], 10) }
+}
+
+/** Named-key tokens → control bytes. Literal text passes through unchanged. */
+export const KEY_MAP: Record<string, string> = {
+  '<enter>': '\r',
+  '<tab>': '\t',
+  '<esc>': '\x1b',
+  '<backspace>': '\x7f',
+  '<space>': ' ',
+  '<up>': '\x1b[A',
+  '<down>': '\x1b[B',
+  '<right>': '\x1b[C',
+  '<left>': '\x1b[D',
+  '<c-c>': '\x03',
+  '<c-d>': '\x04',
+  '<c-z>': '\x1a',
+}
+
+/** Replace `<...>` tokens with their bytes; everything else is literal. */
+export function resolve_keys(keys: string): string {
+  return keys.replace(/<[a-z-]+>/gi, (tok) => KEY_MAP[tok.toLowerCase()] ?? tok)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vitest/terminal-capture.test.ts`
+Expected: PASS (all assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/terminal-capture.ts tests/vitest/terminal-capture.test.ts
+git commit -m "feat(terminal-tools): pure capture helpers (markers, ansi strip, key map)"
+```
+
+---
+
+## Task 2: Terminal registry (`terminal-registry.svelte.ts`)
+
+**Files:**
+- Create: `src/lib/structure/terminal-registry.svelte.ts`
+- Test: `tests/vitest/terminal-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/vitest/terminal-registry.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  register_terminal, unregister_terminal, mark_terminal_active,
+  get_active_terminal, has_active_terminal, _reset_registry_for_test,
+  type TerminalHandle,
+} from '../../src/lib/structure/terminal-registry.svelte'
+
+function fake(id: string): TerminalHandle {
+  return {
+    id, session_id: '', is_remote: false,
+    run_command: async () => ({ output: '', exit_code: 0, running: false }),
+    send_keys: async () => {}, interrupt: async () => {}, read_buffer: () => '',
+  }
+}
+
+describe('terminal-registry', () => {
+  beforeEach(() => _reset_registry_for_test())
+
+  it('reports no active terminal when empty', () => {
+    expect(has_active_terminal()).toBe(false)
+    expect(get_active_terminal()).toBeNull()
+  })
+  it('returns the explicitly-activated handle', () => {
+    register_terminal(fake('a')); register_terminal(fake('b'))
+    mark_terminal_active('b')
+    expect(get_active_terminal()?.id).toBe('b')
+  })
+  it('falls back to the most-recently registered when active id is stale', () => {
+    register_terminal(fake('a')); register_terminal(fake('b'))
+    mark_terminal_active('b')
+    unregister_terminal('b')
+    expect(get_active_terminal()?.id).toBe('a')
+  })
+  it('unregister of a non-active handle keeps the active one', () => {
+    register_terminal(fake('a')); register_terminal(fake('b'))
+    mark_terminal_active('a')
+    unregister_terminal('b')
+    expect(get_active_terminal()?.id).toBe('a')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vitest/terminal-registry.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/structure/terminal-registry.svelte.ts
+/**
+ * In-process registry bridging CatBot tools <-> the visible terminal PTYs.
+ * Each TerminalPanel registers a handle on mount and marks itself active on
+ * focus; CatBot tools call get_active_terminal(). Renderer-global singleton —
+ * in a popout window it is that window's own registry (window-local, like the
+ * CWD-sync rule). No Svelte $state needed: callers read at call time, not in a
+ * reactive context.
+ */
+
+export interface TerminalHandle {
+  id: string
+  session_id: string // '' for local, HPC session id for remote
+  host?: string
+  username?: string
+  is_remote: boolean
+  run_command: (cmd: string, opts?: { timeout_ms?: number }) =>
+    Promise<{ output: string; exit_code: number | null; running: boolean }>
+  send_keys: (data: string) => Promise<void>
+  interrupt: () => Promise<void>
+  read_buffer: (lines?: number) => string
+}
+
+const _handles = new Map<string, TerminalHandle>()
+const _order: string[] = [] // registration order; last = most recent
+let _active_id: string | null = null
+
+export function register_terminal(h: TerminalHandle): void {
+  _handles.set(h.id, h)
+  const i = _order.indexOf(h.id)
+  if (i >= 0) _order.splice(i, 1)
+  _order.push(h.id)
+}
+
+export function unregister_terminal(id: string): void {
+  _handles.delete(id)
+  const i = _order.indexOf(id)
+  if (i >= 0) _order.splice(i, 1)
+  if (_active_id === id) _active_id = null
+}
+
+export function mark_terminal_active(id: string): void {
+  if (_handles.has(id)) _active_id = id
+}
+
+export function get_active_terminal(): TerminalHandle | null {
+  if (_active_id && _handles.has(_active_id)) return _handles.get(_active_id)!
+  for (let i = _order.length - 1; i >= 0; i--) {
+    const h = _handles.get(_order[i])
+    if (h) return h
+  }
+  return null
+}
+
+export function has_active_terminal(): boolean {
+  return get_active_terminal() !== null
+}
+
+/**
+ * App registers an opener so the tools can auto-spawn a local terminal when none
+ * exists. Returns the new handle once it has registered.
+ */
+let _opener: (() => Promise<TerminalHandle | null>) | null = null
+export function set_terminal_opener(fn: (() => Promise<TerminalHandle | null>) | null): void {
+  _opener = fn
+}
+export async function ensure_active_terminal(): Promise<TerminalHandle | null> {
+  const existing = get_active_terminal()
+  if (existing) return existing
+  if (_opener) return await _opener()
+  return null
+}
+
+/** Test-only: clear all state. */
+export function _reset_registry_for_test(): void {
+  _handles.clear()
+  _order.length = 0
+  _active_id = null
+  _opener = null
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vitest/terminal-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/terminal-registry.svelte.ts tests/vitest/terminal-registry.test.ts
+git commit -m "feat(terminal-tools): in-process terminal registry + auto-spawn opener hook"
+```
+
+---
+
+## Task 3: TerminalPanel methods + registration
+
+**Files:**
+- Modify: `src/lib/structure/TerminalPanel.svelte` (script: add methods; register in the existing pty effect; unregister on cleanup)
+
+Context: `pty_ref` (a `$state<PtySession | null>`) is set after `spawnPty` (~line 523); the OSC 7 injection effect at ~line 78 gates on `pty_ref`. `session_id`, `host`, `username` are props. `container_el`/xterm `term` are created in the main effect; capture `term` into a module ref for `read_buffer`.
+
+- [ ] **Step 1: Add imports + a term ref**
+
+At the top of `<script>` (with the other imports):
+
+```ts
+  import { register_terminal, unregister_terminal, mark_terminal_active } from './terminal-registry.svelte'
+  import { next_marker, wrap_command, extract_result, strip_ansi } from './terminal-capture'
+```
+
+Find the existing `let term_ref: any = null` (already present per the file). If absent, add it near `let pty_ref`.
+
+- [ ] **Step 2: Add the four methods + a busy guard**
+
+Add inside `<script>` (after `pty_ref` is declared):
+
+```ts
+  let _run_busy = false
+
+  async function panel_run_command(
+    cmd: string,
+    opts?: { timeout_ms?: number },
+  ): Promise<{ output: string; exit_code: number | null; running: boolean }> {
+    const pty = pty_ref
+    if (!pty) return { output: 'Terminal not ready.', exit_code: null, running: false }
+    if (_run_busy) return { output: 'Terminal is busy running another command.', exit_code: null, running: false }
+    _run_busy = true
+    const marker = next_marker()
+    const decoder = new TextDecoder()
+    let acc = ''
+    let off: (() => void) | null = null
+    try {
+      const done = new Promise<{ output: string; exit_code: number | null; running: boolean }>((resolve) => {
+        const timeout = setTimeout(() => {
+          resolve({ output: strip_ansi(acc).slice(-4000), exit_code: null, running: true })
+        }, opts?.timeout_ms ?? 15000)
+        off = pty.onData((bytes) => {
+          acc += decoder.decode(bytes, { stream: true })
+          const res = extract_result(strip_ansi(acc), marker)
+          if (res) {
+            clearTimeout(timeout)
+            resolve({ output: res.output.slice(-8000), exit_code: res.exit_code, running: false })
+          }
+        })
+      })
+      await pty.write(wrap_command(cmd, marker))
+      return await done
+    } finally {
+      if (off) off()
+      _run_busy = false
+    }
+  }
+
+  async function panel_send_keys(data: string): Promise<void> {
+    if (pty_ref) await pty_ref.write(data)
+  }
+
+  async function panel_interrupt(): Promise<void> {
+    if (pty_ref) await pty_ref.write('\x03')
+  }
+
+  function panel_read_buffer(lines = 40): string {
+    const term = term_ref
+    if (!term?.buffer?.active) return ''
+    const buf = term.buffer.active
+    const end = buf.baseY + buf.cursorY
+    const start = Math.max(0, end - lines)
+    const out: string[] = []
+    for (let y = start; y <= end; y++) {
+      const line = buf.getLine(y)
+      if (line) out.push(line.translateToString(true))
+    }
+    return out.join('\n').replace(/\n+$/, '')
+  }
+```
+
+- [ ] **Step 3: Register the handle in the pty effect; mark active on focus; unregister on cleanup**
+
+In the existing OSC-7 `$effect` (the one guarded by `if (!pty_ref) { ... return }`), after confirming `pty_ref` exists, register once. Add a module flag `let _registered = false` near `let _osc7_injected = false`, then inside that effect's `if (!pty_ref)` reset branch also do `if (_registered) { unregister_terminal(panel_id); _registered = false }`, and after the OSC7 injection setup add:
+
+```ts
+    if (!_registered) {
+      _registered = true
+      register_terminal({
+        id: panel_id,
+        session_id: session_id ?? '',
+        host, username,
+        is_remote: !!session_id,
+        run_command: panel_run_command,
+        send_keys: panel_send_keys,
+        interrupt: panel_interrupt,
+        read_buffer: panel_read_buffer,
+      })
+    }
+```
+
+Add a stable `panel_id` near the top of `<script>`:
+
+```ts
+  let _pid_seq = 0
+  const panel_id = `term-panel-${++_pid_seq}-${Math.random().toString(36).slice(2, 8)}`
+```
+
+In the MAIN xterm effect, after `term.open(...)` (where `term` is created), add a focus listener to mark active:
+
+```ts
+    term.textarea?.addEventListener('focus', () => mark_terminal_active(panel_id))
+```
+
+And in that main effect's cleanup (the returned function / `disposed` path), add:
+
+```ts
+    unregister_terminal(panel_id)
+    _registered = false
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm check 2>&1 | tail -3`
+Expected: `0 errors` (304 pre-existing warnings unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/TerminalPanel.svelte
+git commit -m "feat(terminal-tools): TerminalPanel exposes run_command/send_keys/interrupt/read_buffer + registers handle"
+```
+
+---
+
+## Task 4: CatBot terminal tools (`terminal-tools.ts`) + registration
+
+**Files:**
+- Create: `src/lib/chat/terminal-tools.ts`
+- Modify: `src/lib/chat/structure-tools.ts` (register `TERMINAL_TOOLS` at the bottom, beside `VIEWER_TOOLS`)
+- Test: `tests/vitest/terminal-tools.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/vitest/terminal-tools.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { TERMINAL_TOOLS } from '../../src/lib/chat/terminal-tools'
+import {
+  register_terminal, _reset_registry_for_test, mark_terminal_active,
+  type TerminalHandle,
+} from '../../src/lib/structure/terminal-registry.svelte'
+
+function find(name: string) {
+  const t = TERMINAL_TOOLS.find((x) => x.def.name === name)
+  if (!t) throw new Error(`missing tool ${name}`)
+  return t
+}
+
+const calls: string[] = []
+function handle(): TerminalHandle {
+  return {
+    id: 'h', session_id: '', is_remote: false,
+    run_command: async (cmd) => { calls.push('run:' + cmd); return { output: 'OUT', exit_code: 0, running: false } },
+    send_keys: async (d) => { calls.push('keys:' + d) },
+    interrupt: async () => { calls.push('interrupt') },
+    read_buffer: () => 'BUFFER',
+  }
+}
+
+describe('terminal tools', () => {
+  beforeEach(() => { _reset_registry_for_test(); calls.length = 0; register_terminal(handle()); mark_terminal_active('h') })
+
+  it('exposes the four tools with correct kinds', () => {
+    expect(find('read_terminal').def.kind).toBe('read')
+    expect(find('run_command').def.kind).toBe('mutate')
+    expect(find('send_keys').def.kind).toBe('mutate')
+    expect(find('interrupt_terminal').def.kind).toBe('mutate')
+  })
+  it('read_terminal returns the buffer', async () => {
+    const r = await find('read_terminal').run({}) as { output: string }
+    expect(r.output).toBe('BUFFER')
+  })
+  it('run_command forwards the command and returns output + exit_code', async () => {
+    const r = await find('run_command').run({ command: 'pwd' }) as { output: string; exit_code: number }
+    expect(calls).toContain('run:pwd')
+    expect(r).toMatchObject({ output: 'OUT', exit_code: 0 })
+  })
+  it('send_keys resolves named keys before writing', async () => {
+    await find('send_keys').run({ keys: 'y<enter>' })
+    expect(calls).toContain('keys:y\r')
+  })
+  it('interrupt_terminal sends Ctrl-C', async () => {
+    await find('interrupt_terminal').run({})
+    expect(calls).toContain('interrupt')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vitest/terminal-tools.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/chat/terminal-tools.ts
+/**
+ * CatBot tools that read/operate the visible terminal pane. Each `run` resolves
+ * the active terminal handle (auto-spawning a local one if none) and calls into
+ * it. Registered into CLIENT_TOOLS by structure-tools.ts. Mutating tools are
+ * gated by the existing PermissionCard flow (kind: 'mutate').
+ */
+import type { ClientTool } from './types'
+import { ensure_active_terminal } from '../structure/terminal-registry.svelte'
+import { resolve_keys } from '../structure/terminal-capture'
+
+export interface TerminalToolEntry {
+  def: ClientTool
+  run: (input: Record<string, unknown>) => Promise<unknown>
+}
+
+async function active() {
+  const h = await ensure_active_terminal()
+  if (!h) throw new Error('No terminal is open and one could not be started.')
+  return h
+}
+
+function info(h: { session_id: string; host?: string; is_remote: boolean }) {
+  return { target: h.is_remote ? `remote (${h.host ?? h.session_id})` : 'local shell' }
+}
+
+export const TERMINAL_TOOLS: TerminalToolEntry[] = [
+  {
+    def: {
+      name: 'read_terminal',
+      kind: 'read',
+      description: 'Read the current visible text of the active terminal pane (last N lines). Use to inspect output, prompts, or state before acting.',
+      input_schema: {
+        type: 'object',
+        properties: { lines: { type: 'number', description: 'How many trailing lines to read (default 40).' } },
+      },
+    },
+    run: async (input) => {
+      const h = await active()
+      const lines = typeof input.lines === 'number' ? input.lines : 40
+      return { output: h.read_buffer(lines), ...info(h) }
+    },
+  },
+  {
+    def: {
+      name: 'run_command',
+      kind: 'mutate',
+      description: 'Run a non-interactive shell command in the active terminal pane and return its output + exit code. If output shows a prompt or `running` is true, the command may be waiting for input — use send_keys. Works for local and HPC terminals.',
+      input_schema: {
+        type: 'object',
+        properties: { command: { type: 'string', description: 'The shell command to run.' } },
+        required: ['command'],
+      },
+    },
+    run: async (input) => {
+      const h = await active()
+      const r = await h.run_command(String(input.command ?? ''))
+      return { ...r, ...info(h) }
+    },
+  },
+  {
+    def: {
+      name: 'send_keys',
+      kind: 'mutate',
+      description: 'Send keystrokes to the active terminal (for interactive prompts/TUIs). Literal text plus named keys: <enter> <tab> <esc> <backspace> <space> <up> <down> <left> <right> <c-c> <c-d> <c-z>. Example: "y<enter>".',
+      input_schema: {
+        type: 'object',
+        properties: { keys: { type: 'string', description: 'Keys to send, e.g. "y<enter>" or "<c-c>".' } },
+        required: ['keys'],
+      },
+    },
+    run: async (input) => {
+      const h = await active()
+      await h.send_keys(resolve_keys(String(input.keys ?? '')))
+      await new Promise((r) => setTimeout(r, 200))
+      return { output: h.read_buffer(40), ...info(h) }
+    },
+  },
+  {
+    def: {
+      name: 'interrupt_terminal',
+      kind: 'mutate',
+      description: 'Send Ctrl-C to the active terminal to interrupt the running command.',
+      input_schema: { type: 'object', properties: {} },
+    },
+    run: async (_input) => {
+      const h = await active()
+      await h.interrupt()
+      await new Promise((r) => setTimeout(r, 200))
+      return { output: h.read_buffer(40), ...info(h) }
+    },
+  },
+]
+```
+
+- [ ] **Step 4: Register into the tool registry**
+
+In `src/lib/chat/structure-tools.ts`, near the top imports add:
+
+```ts
+import { TERMINAL_TOOLS } from './terminal-tools'
+```
+
+At the very bottom, beside `for (const { def, run } of VIEWER_TOOLS) register(def, run)`, add:
+
+```ts
+for (const { def, run } of TERMINAL_TOOLS) register(def, run)
+```
+
+- [ ] **Step 5: Run tests + type-check**
+
+Run: `pnpm vitest run tests/vitest/terminal-tools.test.ts && pnpm check 2>&1 | tail -3`
+Expected: tools test PASS; `0 errors`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/chat/terminal-tools.ts src/lib/chat/structure-tools.ts tests/vitest/terminal-tools.test.ts
+git commit -m "feat(terminal-tools): read_terminal/run_command/send_keys/interrupt_terminal CatBot tools"
+```
+
+---
+
+## Task 5: Auto-spawn opener (App provides a local terminal when none active)
+
+**Files:**
+- Modify: `desktop/App.svelte` (register a `set_terminal_opener` that creates a local terminal leaf and waits for its handle)
+
+Context: App holds `tab_states`, the active `ts` (StructureTabState), `escalateForImport`, `setLeafContent`. A terminal leaf renders `TerminalWindow` → `TerminalPanel`, which registers asynchronously after `spawnPty`. The opener must create the leaf, then poll `get_active_terminal()` until a handle appears (bounded).
+
+- [ ] **Step 1: Add imports**
+
+With App's other imports from `'./pane-tree'` / registry:
+
+```ts
+  import { set_terminal_opener, get_active_terminal, type TerminalHandle } from '$lib/structure/terminal-registry.svelte'
+```
+
+- [ ] **Step 2: Register the opener in an onMount/$effect**
+
+Add (inside an existing `$effect(() => { ... })` that runs once on mount, or a new one):
+
+```ts
+  $effect(() => {
+    set_terminal_opener(async (): Promise<TerminalHandle | null> => {
+      const ts = get_active_ts()
+      if (!ts) return null
+      const r = escalateForImport(ts.root, ts.active_leaf_id)
+      if (!r) return null
+      ts.root = setLeafContent(r.root, r.leafId, { type: `terminal`, term: { sync_cwd: false } })
+      ts.active_leaf_id = r.leafId
+      // Wait (bounded) for the new TerminalPanel to spawn its PTY and register.
+      for (let i = 0; i < 60; i++) {
+        await new Promise((res) => setTimeout(res, 100))
+        const h = get_active_terminal()
+        if (h) return h
+      }
+      return null
+    })
+    return () => set_terminal_opener(null)
+  })
+```
+
+`get_active_ts` is already destructured from `tm` in App.svelte:135 (`const { tab_states, get_active_ts, ... } = tm`).
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm check 2>&1 | tail -3`
+Expected: `0 errors`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add desktop/App.svelte
+git commit -m "feat(terminal-tools): auto-spawn a local terminal when CatBot has no active terminal"
+```
+
+---
+
+## Task 6: "Ask CatBot" button (TerminalWindow header → chat split)
+
+**Files:**
+- Modify: `src/lib/structure/TerminalWindow.svelte` (add `🤖` button + `on_ask_catbot?` prop)
+- Modify: `desktop/App.svelte` (pass `on_ask_catbot` into the terminal leaf body; implement split → `initial_panel='chat'`)
+
+- [ ] **Step 1: Add the prop + button to TerminalWindow**
+
+In `TerminalWindow.svelte` `Props`/`$props()` (where `onpopout`, `onclose` are), add `on_ask_catbot?: () => void`. In the destructure: `on_ask_catbot`.
+
+In the `tw-toolbar-right` div, before the popout `↗` button, add:
+
+```svelte
+      {#if on_ask_catbot}
+        <button class="tw-icon-btn" title={t('app.ask_catbot')} onclick={on_ask_catbot}>
+          <Icon icon="Chat" />
+        </button>
+      {/if}
+```
+
+(`Chat` is a confirmed icon in `src/lib/icons.ts`. `Icon` and `t` are already imported in TerminalWindow.svelte.)
+
+- [ ] **Step 2: Wire App to pass on_ask_catbot into the terminal body**
+
+In `App.svelte`, find where the `terminal_body` snippet renders `<TerminalWindow ... />` (the one with `initial_session_id`, `onclose`, `onpopout`). Add:
+
+```svelte
+            on_ask_catbot={() => open_chat_beside(leaf)}
+```
+
+Add the helper near the other pane helpers:
+
+```ts
+  function open_chat_beside(leaf: LeafNode) {
+    const ts = active_ts()
+    if (!ts) return
+    const r = escalateForImport(ts.root, leaf.id)
+    if (!r) {
+      // At CAP: fall back to the chat popout window.
+      window.open(`${location.origin}${location.pathname}#chat`, '_blank', 'width=520,height=760')
+      return
+    }
+    ts.root = r.root
+    const new_leaf = findLeafById(ts.root, r.leafId)
+    const pane = new_leaf ? structurePane(new_leaf) : null
+    if (pane) pane.initial_panel = `chat`
+    ts.active_leaf_id = r.leafId
+  }
+```
+
+`get_active_ts`, `escalateForImport`, `structurePane` are already in App. Add `findLeafById` and the `LeafNode` type to App's `'./pane-tree'` import if not already present (App.svelte:62 imports several pane-tree symbols).
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm check 2>&1 | tail -3`
+Expected: `0 errors`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/structure/TerminalWindow.svelte desktop/App.svelte
+git commit -m "feat(terminal-tools): Ask CatBot button opens a chat panel beside the terminal"
+```
+
+---
+
+## Task 7: i18n keys (en + zh parity)
+
+**Files:**
+- Modify: `src/lib/i18n/en/app.ts`
+- Modify: `src/lib/i18n/zh/app.ts`
+
+- [ ] **Step 1: Add the key to en**
+
+In `src/lib/i18n/en/app.ts`, in the Panel section (near `dir_sync_on`):
+
+```ts
+  ask_catbot: `Ask CatBot about this terminal`,
+```
+
+- [ ] **Step 2: Add the matching key to zh**
+
+In `src/lib/i18n/zh/app.ts`, same section:
+
+```ts
+  ask_catbot: `让 CatBot 处理此终端`,
+```
+
+- [ ] **Step 3: Verify i18n parity + full suite**
+
+Run: `pnpm vitest run 2>&1 | tail -5`
+Expected: PASS, including any i18n key-parity test. (`pnpm check` also `0 errors`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/i18n/en/app.ts src/lib/i18n/zh/app.ts
+git commit -m "i18n(terminal-tools): ask_catbot key (en+zh)"
+```
+
+---
+
+## Task 8: Playwright integration test
+
+**Files:**
+- Create: `tests/e2e/catbot-terminal.spec.ts` (match the repo's existing Playwright test dir/naming — verify with `ls tests/e2e 2>/dev/null || grep -rl "@playwright/test" tests`)
+
+Note: CatBot needs a configured provider to run the full tool-loop. If the e2e harness has no LLM key, assert the **tool layer** directly via `page.evaluate` against the registry + tools (deterministic, no model), which still exercises the real PTY + capture path.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+// tests/e2e/catbot-terminal.spec.ts
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.CATGO_E2E_URL ?? 'http://localhost:3186'
+
+test('run_command captures real terminal output via the registry', async ({ page }) => {
+  await page.goto(BASE)
+  // Open a local terminal from the landing grid.
+  await page.evaluate(() => {
+    const b = [...document.querySelectorAll('button')].find((x) =>
+      x.textContent?.includes('Terminal') && x.textContent?.includes('Local shell'))
+    ;(b as HTMLButtonElement)?.click()
+  })
+  // Wait for a terminal handle to register.
+  await page.waitForFunction(async () => {
+    const m = await import('/@fs' + (window as any).__catgo_repo + '/src/lib/structure/terminal-registry.svelte.ts').catch(() => null)
+    return !!m && m.has_active_terminal && m.has_active_terminal()
+  }, { timeout: 15000 }).catch(() => {})
+
+  // Drive the tool directly (deterministic, no LLM): import the registry and run a command.
+  const out = await page.evaluate(async () => {
+    const reg: any = await import('/src/lib/structure/terminal-registry.svelte.ts')
+    const h = reg.get_active_terminal()
+    if (!h) return 'NO_HANDLE'
+    const r = await h.run_command('echo catgo_marker_123')
+    return r.output
+  })
+  expect(out).toContain('catgo_marker_123')
+})
+```
+
+If the dynamic `import('/src/...')` path differs under the dev server, resolve the served module URL the way `bond-wasm` verification did (`/@fs/<abs path>/...`); the assertion (output contains the echoed token) is unchanged.
+
+- [ ] **Step 2: Run it against the dev server**
+
+Run (dev stack already on :3186): `pnpm exec playwright test tests/e2e/catbot-terminal.spec.ts`
+Expected: PASS — `out` contains `catgo_marker_123` (proves marker capture over a real local PTY).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/catbot-terminal.spec.ts
+git commit -m "test(terminal-tools): e2e run_command captures real PTY output"
+```
+
+---
+
+## Final verification
+
+- [ ] `pnpm check` → `0 errors`.
+- [ ] `pnpm vitest run` → all pass (capture, registry, tools, i18n parity).
+- [ ] Manual smoke (browser :3186): open terminal → in CatBot ask "run pwd in my terminal" → approve the card → output returned; "Ask CatBot" button opens a chat panel beside the terminal; with no terminal open, a run_command auto-spawns one.
+- [ ] Merge to `feat/pane-tree-core` (fast-forward from the worktree branch).
+
+## Notes / invariants
+
+- **No `src/lib/mobile/*` edits** (D8). `TerminalPanel` gains methods (shared), but the Ask-CatBot button is desktop-only and mobile makes no tool calls.
+- **No backend changes** — all execution flows through the visible PTY.
+- Project style by hand (single quote, no semicolon, 2-space). Never run `deno fmt`.
+- **Approval / auto-run already exist**: `kind:'mutate'` triggers the PermissionCard (tool-loop.ts:160 → ChatPane `active_permission_blocks`), and the per-chat auto-run toggle is the existing `slice.skip_permission` (set_skip_permission/get_skip_permission, hint `chat.skip_permission_on`). No new approval UI for v1.

--- a/docs/superpowers/plans/2026-06-16-pane-tree-flat-keyed-render.md
+++ b/docs/superpowers/plans/2026-06-16-pane-tree-flat-keyed-render.md
@@ -1,0 +1,401 @@
+# Pane-Tree Flat Keyed Render Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make pane splits / layout changes stop remounting leaf content, so a split no longer restarts the terminal (or resets 3D viewers).
+
+**Architecture:** Replace `PaneTree.svelte`'s recursive `<svelte:self>` with one flat, `leaf.id`-keyed list of absolutely-positioned slots whose rects are computed from the tree by a pure `compute_pane_layout`. Keyed slots keep the same component instance across restructures — only the CSS rect changes — so no unmount → no `pty_session.kill()` → no restart.
+
+**Tech Stack:** SvelteKit 2 / Svelte 5 runes, TypeScript, vitest. Style by hand: single quotes, **no semicolons**, 2-space indent. **Never run `deno fmt`.**
+
+**Spec:** `docs/superpowers/specs/2026-06-16-pane-tree-flat-keyed-render-design.md`
+
+**Confirmed current code (do not re-derive):**
+- `PaneTree.svelte` props today: `node: PaneNode | undefined` + `multi, active_leaf_id, drag_target_leaf, close_confirm_leaf_id, active_split_id, maximized_leaf_id, leaf_body, terminal_body, header, banner, on_activate, on_split_mousedown(e,split_id,dir), on_split_dblclick(split_id)`.
+- App renders it (App.svelte ~1854): `<PaneTree node={ts.root} {multi} {active_leaf_id} ... maximized_leaf_id={ts.maximized_leaf_id} {active_split_id} ... on_split_mousedown={(e, sid, dir) => start_split_resize(e, sid, dir, tab.id)} on_split_dblclick={...} />`.
+- `pane-tree.ts` types: `LeafNode = { kind:'leaf', id, content }`, `SplitNode = { kind:'split', id, direction:'h'|'v', ratio, children:[PaneNode,PaneNode] }`, `PaneNode = SplitNode|LeafNode`.
+- `pane-utils.ts` exports `create_empty_pane()` (a valid `PaneState`).
+- `resize-handlers.ts` `on_split_drag` converts px delta → ratio using `(e.target).parentElement` as the container and `setRatio(ts.root, split_id, start_ratio + delta)`.
+
+---
+
+## Task 1: Pure layout function (`pane-layout.ts`)
+
+**Files:**
+- Create: `desktop/pane-layout.ts`
+- Test: `tests/vitest/pane-layout.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/vitest/pane-layout.test.ts
+import { describe, it, expect } from 'vitest'
+import { compute_pane_layout } from '../../desktop/pane-layout'
+import type { LeafNode, SplitNode, PaneNode } from '../../desktop/pane-tree'
+import { create_empty_pane } from '../../desktop/pane-utils'
+
+function leaf(id: string): LeafNode {
+  return { kind: 'leaf', id, content: { type: 'structure', pane: create_empty_pane() } }
+}
+function split(id: string, direction: 'h' | 'v', ratio: number, a: PaneNode, b: PaneNode): SplitNode {
+  return { kind: 'split', id, direction, ratio, children: [a, b] }
+}
+function box(layout: ReturnType<typeof compute_pane_layout>, id: string) {
+  return layout.leaves.find((l) => l.leaf.id === id)?.rect
+}
+
+describe('compute_pane_layout', () => {
+  it('single leaf fills the whole area, no dividers', () => {
+    const l = compute_pane_layout(leaf('a'), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 100, h: 100 })
+    expect(l.dividers).toEqual([])
+  })
+
+  it('splitH at 0.5 → side-by-side halves + one vertical divider with span 100', () => {
+    const l = compute_pane_layout(split('s', 'h', 0.5, leaf('a'), leaf('b')), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 50, h: 100 })
+    expect(box(l, 'b')).toEqual({ x: 50, y: 0, w: 50, h: 100 })
+    expect(l.dividers).toEqual([{ split_id: 's', dir: 'h', rect: { x: 50, y: 0, w: 0, h: 100 }, span: 100 }])
+  })
+
+  it('splitV at 0.5 → stacked halves + one horizontal divider', () => {
+    const l = compute_pane_layout(split('s', 'v', 0.5, leaf('a'), leaf('b')), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 100, h: 50 })
+    expect(box(l, 'b')).toEqual({ x: 0, y: 50, w: 100, h: 50 })
+    expect(l.dividers).toEqual([{ split_id: 's', dir: 'v', rect: { x: 0, y: 50, w: 100, h: 0 }, span: 100 }])
+  })
+
+  it('asymmetric splitH respects the ratio', () => {
+    const l = compute_pane_layout(split('s', 'h', 0.3, leaf('a'), leaf('b')), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 30, h: 100 })
+    expect(box(l, 'b')).toEqual({ x: 30, y: 0, w: 70, h: 100 })
+  })
+
+  it('quad (h-split of two v-splits) → 4 quadrants + 3 dividers', () => {
+    const col0 = split('c0', 'v', 0.5, leaf('a'), leaf('b'))
+    const col1 = split('c1', 'v', 0.5, leaf('c'), leaf('d'))
+    const l = compute_pane_layout(split('root', 'h', 0.5, col0, col1), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 50, h: 50 })
+    expect(box(l, 'b')).toEqual({ x: 0, y: 50, w: 50, h: 50 })
+    expect(box(l, 'c')).toEqual({ x: 50, y: 0, w: 50, h: 50 })
+    expect(box(l, 'd')).toEqual({ x: 50, y: 50, w: 50, h: 50 })
+    expect(l.dividers).toContainEqual({ split_id: 'root', dir: 'h', rect: { x: 50, y: 0, w: 0, h: 100 }, span: 100 })
+    expect(l.dividers).toContainEqual({ split_id: 'c0', dir: 'v', rect: { x: 0, y: 50, w: 50, h: 0 }, span: 50 })
+    expect(l.dividers).toContainEqual({ split_id: 'c1', dir: 'v', rect: { x: 50, y: 50, w: 50, h: 0 }, span: 50 })
+    expect(l.dividers).toHaveLength(3)
+  })
+
+  it('maximize → maximized leaf fills, sibling collapses to 0, no dividers', () => {
+    const l = compute_pane_layout(split('s', 'h', 0.5, leaf('a'), leaf('b')), 'a')
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 100, h: 100 })
+    expect(box(l, 'b')).toEqual({ x: 0, y: 0, w: 0, h: 0 })
+    expect(l.dividers).toEqual([])
+  })
+
+  it('undefined root → empty layout', () => {
+    expect(compute_pane_layout(undefined, null)).toEqual({ leaves: [], dividers: [] })
+  })
+})
+```
+
+- [ ] **Step 2: Run it, confirm FAIL** — `pnpm vitest run tests/vitest/pane-layout.test.ts` (module not found).
+
+- [ ] **Step 3: Implement `desktop/pane-layout.ts`** exactly:
+
+```ts
+/**
+ * Pure geometry for the flat pane renderer: turns the pane tree into a flat list
+ * of absolutely-positioned leaf boxes + divider boxes (all in % of the
+ * container). No DOM. Lets PaneTree render leaves as one keyed list so they
+ * never remount when the tree restructures.
+ */
+import type { PaneNode } from './pane-tree'
+import type { LeafNode } from './pane-tree'
+
+export interface Rect { x: number; y: number; w: number; h: number }
+export interface LeafBox { leaf: LeafNode; rect: Rect }
+/** `span` = the split's own extent (%) along the drag axis (width for 'h',
+ *  height for 'v') — the resize handler needs it to convert px → ratio. */
+export interface DividerBox { split_id: string; dir: 'h' | 'v'; rect: Rect; span: number }
+export interface PaneLayout { leaves: LeafBox[]; dividers: DividerBox[] }
+
+function leaf_ids(node: PaneNode | undefined): string[] {
+  if (!node) return []
+  if (node.kind === 'leaf') return [node.id]
+  if (!node.children) return []
+  return [...leaf_ids(node.children[0]), ...leaf_ids(node.children[1])]
+}
+
+export function compute_pane_layout(
+  root: PaneNode | undefined,
+  maximized_leaf_id: string | null,
+): PaneLayout {
+  const leaves: LeafBox[] = []
+  const dividers: DividerBox[] = []
+
+  function walk(node: PaneNode | undefined, rect: Rect): void {
+    if (!node) return
+    if (node.kind === 'leaf') {
+      leaves.push({ leaf: node, rect })
+      return
+    }
+    if (!node.children) return
+    const [c0, c1] = node.children
+    if (maximized_leaf_id) {
+      // The child subtree holding the maximized leaf takes the full rect; the
+      // other collapses to zero size but its leaves stay mounted (keep-warm).
+      const zero = { ...rect, w: 0, h: 0 }
+      if (leaf_ids(c0).includes(maximized_leaf_id)) { walk(c0, rect); walk(c1, zero) }
+      else if (leaf_ids(c1).includes(maximized_leaf_id)) { walk(c0, zero); walk(c1, rect) }
+      else { walk(c0, zero); walk(c1, zero) }
+      return
+    }
+    if (node.direction === 'h') {
+      const w0 = rect.w * node.ratio
+      walk(c0, { x: rect.x, y: rect.y, w: w0, h: rect.h })
+      walk(c1, { x: rect.x + w0, y: rect.y, w: rect.w - w0, h: rect.h })
+      dividers.push({ split_id: node.id, dir: 'h', rect: { x: rect.x + w0, y: rect.y, w: 0, h: rect.h }, span: rect.w })
+    } else {
+      const h0 = rect.h * node.ratio
+      walk(c0, { x: rect.x, y: rect.y, w: rect.w, h: h0 })
+      walk(c1, { x: rect.x, y: rect.y + h0, w: rect.w, h: rect.h - h0 })
+      dividers.push({ split_id: node.id, dir: 'v', rect: { x: rect.x, y: rect.y + h0, w: rect.w, h: 0 }, span: rect.h })
+    }
+  }
+
+  walk(root, { x: 0, y: 0, w: 100, h: 100 })
+  return { leaves, dividers }
+}
+```
+
+- [ ] **Step 4: Run it, confirm PASS** — `pnpm vitest run tests/vitest/pane-layout.test.ts` (7 passed). Fix the implementation (not the tests) if any fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop/pane-layout.ts tests/vitest/pane-layout.test.ts
+git commit -m "feat(pane-tree): pure compute_pane_layout for flat keyed render"
+```
+
+---
+
+## Task 2: Flat-render `PaneTree.svelte` + App prop rename
+
+**Files:**
+- Modify (rewrite): `desktop/PaneTree.svelte`
+- Modify: `desktop/App.svelte` (the `<PaneTree node={ts.root} ...>` call site → `root={ts.root}`)
+
+These change together (the prop rename is a compile gate). Acceptance = `pnpm check` 0 errors.
+
+- [ ] **Step 1: Rewrite `desktop/PaneTree.svelte`** to exactly this:
+
+```svelte
+<script lang="ts">
+  import type { PaneNode, LeafNode } from './pane-tree'
+  import { compute_pane_layout } from './pane-layout'
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    root: PaneNode | undefined
+    multi: boolean // leafCount(root) > 1 — gates per-leaf header chrome
+    active_leaf_id: string
+    drag_target_leaf: string | null
+    close_confirm_leaf_id: string | null
+    active_split_id: string | null
+    maximized_leaf_id: string | null
+    leaf_body: Snippet<[LeafNode]>
+    terminal_body: Snippet<[LeafNode]>
+    header: Snippet<[LeafNode]>
+    banner: Snippet<[LeafNode]>
+    on_activate: (leaf_id: string) => void
+    on_split_mousedown: (e: MouseEvent, split_id: string, dir: 'h' | 'v') => void
+    on_split_dblclick: (split_id: string) => void
+  }
+  let { root, multi, active_leaf_id, drag_target_leaf, close_confirm_leaf_id, active_split_id, maximized_leaf_id, leaf_body, terminal_body, header, banner, on_activate, on_split_mousedown, on_split_dblclick }: Props = $props()
+
+  let layout = $derived(compute_pane_layout(root, maximized_leaf_id))
+</script>
+
+<div class="pane-tree-root">
+  {#each layout.leaves as { leaf, rect } (leaf.id)}
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <div
+      class="pane"
+      class:active={active_leaf_id === leaf.id}
+      class:dragover={drag_target_leaf === leaf.id}
+      class:warn-glow={close_confirm_leaf_id === leaf.id}
+      class:maximized-hidden={!!maximized_leaf_id && rect.w === 0}
+      data-leaf-id={leaf.id}
+      style={`left:${rect.x}%; top:${rect.y}%; width:${rect.w}%; height:${rect.h}%`}
+      role="button"
+      tabindex="0"
+      onclick={() => on_activate(leaf.id)}
+      onkeydown={(e) => { if (e.key === 'Enter') on_activate(leaf.id) }}
+    >
+      {#if multi || leaf.content.type === 'terminal'}
+        <!-- A lone terminal leaf still needs its header (Directory Sync / popout /
+             close); a lone structure leaf has its own in-viewer toolbar instead. -->
+        <div class="panel-header">{@render header(leaf)}</div>
+      {/if}
+      {@render banner(leaf)}
+      <div class="panel-content">
+        {#if leaf.content.type === 'terminal'}
+          {@render terminal_body(leaf)}
+        {:else}
+          {@render leaf_body(leaf)}
+        {/if}
+      </div>
+    </div>
+  {/each}
+
+  {#if !maximized_leaf_id}
+    {#each layout.dividers as d (d.split_id)}
+      <div
+        class="grid-divider {d.dir === 'h' ? 'grid-divider-col' : 'grid-divider-row'}"
+        class:active={active_split_id === d.split_id}
+        data-split-span={d.span}
+        style={`left:${d.rect.x}%; top:${d.rect.y}%; ${d.dir === 'h' ? `height:${d.rect.h}%` : `width:${d.rect.w}%`}`}
+        onmousedown={(e) => on_split_mousedown(e, d.split_id, d.dir)}
+        ondblclick={() => on_split_dblclick(d.split_id)}
+        role="separator"
+        aria-orientation={d.dir === 'h' ? 'vertical' : 'horizontal'}
+      ></div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .pane-tree-root { position: relative; width: 100%; height: 100%; min-width: 0; min-height: 0; overflow: hidden; }
+
+  /* Absolutely-positioned leaf slots (left/top/width/height set inline as %).
+     Keyed by leaf.id in the {#each}, so they never remount on restructure. */
+  .pane { position: absolute; overflow: hidden; background: var(--surface-bg, var(--page-bg)); cursor: pointer; display: flex; flex-direction: column; }
+  .pane.warn-glow { box-shadow: inset 0 0 0 2px rgba(245, 158, 11, 0.5); }
+  /* Keep-warm while maximized: hide but stay mounted (NOT display:none). */
+  .pane.maximized-hidden { visibility: hidden; pointer-events: none; }
+
+  .pane:hover :global(.panel-popout-btn),
+  .pane:hover :global(.panel-maximize-btn),
+  .pane:hover :global(.panel-close-btn),
+  .pane:hover :global(.panel-type-btn) { opacity: 1; }
+  .pane.dragover::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 100000005;
+    box-shadow: inset 0 0 0 3px #22c55e;
+  }
+  .pane.dragover :global(.import-card.add-own-card) {
+    border-color: #22c55e;
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+  }
+  .pane.dragover :global(.import-card.add-own-card .import-title) { color: #22c55e; }
+
+  /* Absolutely-positioned dividers, centered on the split seam via negative margin. */
+  .grid-divider { position: absolute; background: var(--border-color, rgba(128, 128, 128, 0.2)); transition: background 0.15s; z-index: 2; }
+  .grid-divider-col { width: 6px; margin-left: -3px; cursor: col-resize; }
+  .grid-divider-row { height: 6px; margin-top: -3px; cursor: row-resize; }
+  .grid-divider:hover, .grid-divider.active { background: var(--accent-color, #3b82f6); }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    min-height: 28px;
+    background: var(--page-bg, #0f1520);
+    border-bottom: 1px solid var(--border-color, rgba(128, 128, 128, 0.15));
+    font-size: 11px;
+    user-select: none;
+    flex: 0 0 auto;
+  }
+
+  /* Content area — height:0 / flex:1 is load-bearing for the WebGL canvas */
+  .panel-content { flex: 1; min-height: 0; position: relative; overflow: hidden; height: 0; }
+</style>
+```
+
+- [ ] **Step 2: Update the App call site.** In `desktop/App.svelte` find `<PaneTree` (~line 1854). Change the first prop `node={ts.root}` to `root={ts.root}`. Leave every other prop unchanged.
+
+- [ ] **Step 3: Type-check** — `pnpm check 2>&1 | tail -3` → **0 errors** (304 warnings expected). The only expected error if mis-edited is "Object literal may only specify known properties" on `node`/`root` — fix by ensuring App passes `root=` and PaneTree declares `root`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add desktop/PaneTree.svelte desktop/App.svelte
+git commit -m "refactor(pane-tree): flat keyed render — leaves never remount on split"
+```
+
+---
+
+## Task 3: Correct nested-split resize (`resize-handlers.ts`)
+
+**Files:**
+- Modify: `desktop/lib/resize-handlers.ts`
+
+Context: the divider is now an absolute child of `.pane-tree-root` (not a `.split` flex container), so `parentElement.getBoundingClientRect()` is the **whole tree**. Use the divider's `data-split-span` (% extent of the split along the drag axis, set in Task 2) to convert px → ratio correctly for nested splits.
+
+- [ ] **Step 1: Edit `on_split_drag`.** Replace the body from `const container = ...` through the end of `on_move` with:
+
+```ts
+  const root_el = (e.target as HTMLElement).parentElement // .pane-tree-root
+  if (!root_el) return
+  const span_pct = parseFloat((e.target as HTMLElement).dataset.splitSpan ?? '100') || 100
+  e.preventDefault()
+  deps.set_is_panel_resizing(true)
+  on_start()
+  const start = dir === 'h' ? e.clientX : e.clientY
+  const start_ratio = node.ratio
+  function on_move(ev: MouseEvent) {
+    const rect = root_el!.getBoundingClientRect()
+    // The split occupies `span_pct`% of the root along the drag axis.
+    const total = (dir === 'h' ? rect.width : rect.height) * (span_pct / 100)
+    const delta = total > 0 ? ((dir === 'h' ? ev.clientX : ev.clientY) - start) / total : 0
+    ts!.root = setRatio(ts!.root, split_id, start_ratio + delta)
+  }
+```
+
+(The `on_up` listener teardown and the `window.addEventListener` lines stay unchanged.)
+
+- [ ] **Step 2: Type-check** — `pnpm check 2>&1 | tail -3` → **0 errors**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add desktop/lib/resize-handlers.ts
+git commit -m "fix(pane-tree): divider drag uses split span for correct nested resize"
+```
+
+---
+
+## Task 4: Acceptance — terminal survives a split (browser, live stack)
+
+**Files:** none (verification).
+
+Dev stack must be running (`pnpm desktop:serve`, :3186). Drive it (Playwright MCP or manual):
+
+- [ ] **Step 1:** Open a Terminal (landing "Terminal" card). Wait for the prompt.
+- [ ] **Step 2:** Run a command that leaves visible scrollback, e.g. type `echo SPLIT_SURVIVES_MARKER` + Enter.
+- [ ] **Step 3:** Split via the tab-bar layout button → "Side by Side".
+- [ ] **Step 4: Assert no remount** — the terminal pane still shows the **same** prompt and `SPLIT_SURVIVES_MARKER` in its scrollback (not a fresh shell), and the cwd is unchanged. Programmatic check (page.evaluate): the `.xterm-rows` text still contains `SPLIT_SURVIVES_MARKER` after the split.
+- [ ] **Step 5:** Maximize the terminal leaf and restore — still the same scrollback (no remount). Collapse the sibling (close it) — terminal unchanged.
+- [ ] **Step 6:** Confirm `pnpm check` is 0 errors and `pnpm vitest run tests/vitest/pane-layout.test.ts` passes.
+
+If the marker is gone after the split, the leaf remounted — investigate the `{#each ... (leaf.id)}` keying (the leaf id must be stable across the split; `splitLeaf` keeps the original leaf's id, so the key must match).
+
+---
+
+## Final verification
+
+- [ ] `pnpm check` → 0 errors.
+- [ ] `pnpm vitest run` → all pass (the 2 pre-existing XRD/RDF numerical failures are unrelated and may flake).
+- [ ] Merge to `feat/pane-tree-core` (fast-forward from the worktree branch).
+
+## Notes / invariants
+
+- Keep-warm uses `visibility:hidden`, never `display:none`.
+- No `src/lib/mobile/*` edits.
+- The `:global(.panel-*)` and `.panel-header`/`.panel-content` CSS must stay (header/banner snippets render in App's scope and rely on them).
+- Removed CSS: `.split`, `.split.h`, `.split.v`, `.split-child`, and the old flex-`.grid-divider` rules — replaced by absolute positioning above.

--- a/docs/superpowers/specs/2026-06-16-catbot-terminal-control-design.md
+++ b/docs/superpowers/specs/2026-06-16-catbot-terminal-control-design.md
@@ -1,0 +1,175 @@
+# CatBot Terminal Control — Design Spec
+
+**Date:** 2026-06-16
+**Status:** Approved (design); ready for implementation plan
+**Branch target:** `feat/pane-tree-core` (terminal leaves already live here)
+
+## Goal
+
+Let the in-app AI Chat (**CatBot**) read the content of the user's visible terminal pane and operate in it — run commands, send keystrokes, interrupt — Cursor-agent style, with per-command approval. Works for both **local** shells and **HPC** (remote SSH) terminals. Also surface CatBot from a terminal via an **"Ask CatBot"** button.
+
+## Non-goals (YAGNI)
+
+- Multi-terminal management by the agent (pick/list/route among many terminals). v1 targets the single *active* terminal.
+- Full real-time TUI streaming / a virtual screen for the model. v1 is run-and-capture + discrete keystroke sends + buffer snapshots.
+- Shell-integration OSC injection (VS Code OSC 633 style). v1 uses inline output markers.
+- Backend command execution. All execution flows through the **visible** PTY so shell state (cwd, env, conda/venv) is preserved.
+
+## Decisions (locked during brainstorming)
+
+| Question | Decision |
+|---|---|
+| Approval | **Approve each command** via the existing client-tool gate; passive reads need no approval. Per-chat **"auto-run"** toggle (reuses `skip_permission`). |
+| Target terminal | The **active** terminal leaf/tab. **Auto-spawn** a local terminal if none is active. |
+| Interaction scope | Read buffer + run-and-capture + **interactive keystrokes** (`send_keys`) + Ctrl-C (`interrupt`). |
+| CatBot surfacing | **"Ask CatBot" button** in the terminal header → opens a chat panel in an adjacent split, targeting that terminal. |
+| Capture mechanism | **In-process registry + inline output markers** (Approach A). |
+
+## Architecture overview
+
+```
+ChatPane (CLIENT_TOOLS tool-loop)
+   │  run_command / send_keys / interrupt / read_terminal
+   ▼
+terminal-tools.ts  ──register name+schema+kind──▶ CLIENT_TOOLS / execute_tool / tool_kind
+   │  (execute → resolve active handle)
+   ▼
+terminal-registry.svelte.ts   ── active_id, handles ──
+   ▲ register/unregister/markActive
+   │
+TerminalPanel.svelte  ── run_command()/send_keys()/interrupt()/read_buffer() over its PTY
+```
+
+Both CatBot and the terminal live in the same window (chat is a panel in a sibling pane). The registry is the in-process bridge; no `window` CustomEvent or backend hop needed.
+
+## Components
+
+### 1. Terminal registry — `src/lib/structure/terminal-registry.svelte.ts` (new, ~80 lines)
+
+Module-level `$state` registry mapping a stable id → handle.
+
+```ts
+export interface TerminalHandle {
+  id: string                 // unique per TerminalPanel instance
+  session_id: string         // '' for local, HPC session id for remote
+  host?: string
+  username?: string
+  is_remote: boolean
+  run_command: (cmd: string, opts?: { timeout_ms?: number }) =>
+    Promise<{ output: string; exit_code: number | null; running: boolean }>
+  send_keys: (data: string) => Promise<void>
+  interrupt: () => Promise<void>
+  read_buffer: (lines?: number) => string
+}
+
+export function register_terminal(h: TerminalHandle): void
+export function unregister_terminal(id: string): void
+export function mark_terminal_active(id: string): void
+export function get_active_terminal(): TerminalHandle | null
+export function has_active_terminal(): boolean
+```
+
+- `active_id` is set by `mark_terminal_active`, called from `TerminalPanel` on xterm `focus` and when it becomes visible/active.
+- `get_active_terminal()` returns the active handle, or falls back to the most-recently-registered if `active_id` is stale (handle gone).
+- Registry is renderer-global (module singleton). In a popout window it is that window's own registry — chat in a popout drives that popout's terminals (consistent with the window-local CWD-sync rule).
+
+### 2. Capture protocol — `TerminalPanel.svelte` additions
+
+Add four methods, wired into the registry via `register_terminal` in an existing `$effect` (after `pty_ref` is set), `unregister_terminal` on cleanup.
+
+**`run_command(cmd, { timeout_ms = 15000 })`:**
+- Generate a per-call unique `marker = __CATGO_<n>_<rand>__` (module counter `n` + a random token; ordinary browser `Math.random`/`Date.now` are fine here — the workflow-script ban on them does not apply to app code).
+- Write to PTY: `{ printf '\n%s_BEGIN\n' "<marker>"; <cmd>; printf '\n%s_END_%d\n' "<marker>" "$?"; }\r`
+  (brace group so `$?` is the user command's exit code; leading `\n` isolates the BEGIN line.)
+- Attach a temporary `pty.onData` accumulator; strip ANSI; scan for `<marker>_BEGIN` … `<marker>_END_<code>`.
+- Resolve `{ output, exit_code, running:false }` when END seen. On timeout, detach and resolve `{ output: <partial>, exit_code:null, running:true }` (command may be long or awaiting input).
+- Guard: one in-flight `run_command` per panel; a second call rejects with a clear "terminal busy" error.
+- ANSI strip + marker-line removal shared with a small helper (`strip_ansi`, `extract_between_markers`) — unit-testable, lives in `terminal-capture.ts`.
+
+**`send_keys(data)`:** `pty.write(data)` raw. Caller passes already-resolved bytes (see tool schema key map). Returns after a short settle so a follow-up `read_buffer` reflects the result.
+
+**`interrupt()`:** `pty.write('\x03')` (Ctrl-C).
+
+**`read_buffer(lines = 40)`:** read the xterm buffer (`term.buffer.active`) bottom `lines` rows, join, right-trim. Returns plain text (already de-ANSI'd by xterm's buffer API).
+
+### 3. CatBot tools — `src/lib/chat/terminal-tools.ts` (new) + register into `structure-tools.ts`
+
+Register four tools into `CLIENT_TOOLS`, classify in `tool_kind`, dispatch in `execute_tool` (or a `terminal-tool-executor.ts` the dispatcher calls, mirroring the workflow-tool-executor split).
+
+| Tool | Input | Approval | Returns |
+|---|---|---|---|
+| `read_terminal` | `{ lines?: number }` | none (passive) | current buffer text + `{session, host}` |
+| `run_command` | `{ command: string }` | **yes** | `{ output, exit_code, running }` |
+| `send_keys` | `{ keys: string }` — text and/or named keys (`<enter>`, `<up>`, `<tab>`, `<esc>`, `<c-c>`, `<c-d>`) | **yes** | buffer snapshot after settle |
+| `interrupt_terminal` | `{}` | **yes** | buffer snapshot after settle |
+
+- `send_keys` maps named tokens → control bytes via a small table in `terminal-tools.ts` (`<enter>`→`\r`, `<c-c>`→`\x03`, arrows→CSI, etc.); literal text passes through.
+- **Auto-spawn:** if `get_active_terminal()` is null when `run_command`/`send_keys`/`interrupt`/`read_terminal` is called, the executor opens a local terminal leaf first (via the same path the "Terminal" landing card uses), waits for it to register, then proceeds. Surfaced to the model as a note ("opened a local terminal").
+- Tool descriptions tell the model: prefer `run_command` for non-interactive commands; when output shows a prompt or `running:true`, use `send_keys`/`interrupt`; call `read_terminal` to inspect current state.
+
+### 4. Approval — reuse the existing client-tool gate
+
+- `run_command`, `send_keys`, `interrupt_terminal` are marked **mutating** in `tool_kind` so the existing in-browser gating (chat-state `run_tool_loop`, the mutating-CLIENT_TOOLS path) shows a confirm/PermissionCard before execution.
+- The card shows the tool + the exact command/keys. Allow / Deny.
+- Per-chat **"auto-run"** uses the existing `skip_permission` slice flag (a toggle in the chat header); when on, the gate is bypassed for that chat only, never persisted.
+- Denied → tool returns a `denied` result string; the model adapts.
+
+### 5. "Ask CatBot" button — `TerminalWindow.svelte` header + `App.svelte`
+
+- Add a `🤖 Ask CatBot` `tw-icon-btn` to TerminalWindow's right toolbar.
+- onclick → callback prop `on_ask_catbot` (App provides it). App: `splitLeaf` the current terminal leaf (direction `h`), set the new leaf's pane `initial_panel = 'chat'` (the existing AI-Chat panel mechanism), and `mark_terminal_active` for the source terminal so the chat targets it.
+- If at CAP (4 leaves), fall back to opening the chat popout (`#chat`) instead of splitting.
+- Mobile: **do not** add this button to mobile terminal UI (`src/lib/mobile/*` untouched — D8). The shared `TerminalPanel` registry methods are harmless on mobile (no tools call them there).
+
+## Data flow — run a command
+
+1. Model emits `run_command({command:"pwd"})`.
+2. tool-loop → mutating gate → PermissionCard → user **Allow**.
+3. `execute_tool` → `get_active_terminal()` (auto-spawn if none) → `handle.run_command("pwd")`.
+4. TerminalPanel writes the marker-wrapped command to its PTY; `onData` accumulates until `<marker>_END_<code>`.
+5. Returns `{ output:"/home/james/...", exit_code:0, running:false }` to the model.
+6. Model reads the result and continues (e.g. on a `[y/N]` prompt, calls `send_keys({keys:"y<enter>"})`).
+
+## Error handling / edge cases
+
+- **No active terminal:** auto-spawn local, then proceed.
+- **Capture timeout:** return partial output + `running:true`; model uses `read_terminal`/`send_keys`/`interrupt`.
+- **Terminal busy** (overlapping `run_command`): reject with a clear message; model waits or interrupts.
+- **HPC terminal:** identical path; markers travel over the SSH PTY. (HPC login banners/MOTD already settle before OSC 7 injection, so markers are not confused with banner text.)
+- **Marker collision** with command output: marker includes a per-call random token; END requires the exact token + numeric code.
+- **Panel unmount mid-run:** `unregister_terminal` + in-flight promise rejects ("terminal closed").
+- **Popout window:** chat targets that window's own terminals (window-local registry).
+
+## Testing
+
+- **Unit (vitest):**
+  - `terminal-capture.ts`: `strip_ansi`, `extract_between_markers` (BEGIN/END, exit-code parse, partial/no-END, marker not in output).
+  - `terminal-registry`: register → active → get → unregister → fallback-to-recent.
+  - `terminal-tools` key map: `<enter>`/`<c-c>`/arrows → bytes; literal passthrough.
+- **Integration (Playwright):**
+  - Open terminal → CatBot `run_command pwd` → approve → assert output contains cwd.
+  - `run_command` of a command that prompts (`read -p`) → `send_keys` answers it → assert effect.
+  - No-terminal-open → `run_command` auto-spawns then runs.
+  - "Ask CatBot" button → opens a chat panel split next to the terminal.
+
+## File summary
+
+| File | Change |
+|---|---|
+| `src/lib/structure/terminal-registry.svelte.ts` | **new** — registry + active tracking |
+| `src/lib/structure/terminal-capture.ts` | **new** — marker wrap/parse, ANSI strip (pure, tested) |
+| `src/lib/structure/TerminalPanel.svelte` | add `run_command`/`send_keys`/`interrupt`/`read_buffer`; register/unregister |
+| `src/lib/chat/terminal-tools.ts` | **new** — 4 tool schemas + key map |
+| `src/lib/chat/terminal-tool-executor.ts` | **new** — dispatch + auto-spawn |
+| `src/lib/chat/structure-tools.ts` | register terminal tools into `CLIENT_TOOLS`/`tool_kind`/`execute_tool` |
+| `src/lib/structure/TerminalWindow.svelte` | `Ask CatBot` header button + `on_ask_catbot` prop |
+| `desktop/App.svelte` | provide `on_ask_catbot` → split + `initial_panel='chat'`; auto-spawn helper |
+| `src/lib/i18n/{en,zh}/*.ts` | keys: `ask_catbot`, approval card labels, auto-run toggle |
+| `*/__tests__/*` | unit + Playwright tests above |
+
+## Invariants honored
+
+- No `src/lib/mobile/*` edits (D8); shared `TerminalPanel` gains methods but mobile adds no Ask-CatBot button and makes no tool calls.
+- All command execution flows through the visible PTY (no hidden backend shell).
+- Mutating tools always gated unless the user opts into per-chat auto-run.
+- Project style by hand (single-quote, no-semicolon, 2-space); never run `deno fmt`.

--- a/docs/superpowers/specs/2026-06-16-pane-tree-flat-keyed-render-design.md
+++ b/docs/superpowers/specs/2026-06-16-pane-tree-flat-keyed-render-design.md
@@ -1,0 +1,144 @@
+# Pane-Tree Flat Keyed Render — Design Spec
+
+**Date:** 2026-06-16
+**Status:** Approved (design); ready for implementation plan
+**Branch target:** `feat/pane-tree-core`
+
+## Goal
+
+Stop pane splits / layout changes from **remounting** leaf content. Today, splitting a terminal restarts its shell (the PTY is killed on unmount); 3D viewers similarly lose state. Make every leaf's component instance **survive** any tree restructure (split, collapse, resize, maximize) so terminals keep running (scrollback + shell) and viewers keep their WebGL state.
+
+## Root cause (current)
+
+`desktop/PaneTree.svelte` renders the tree **recursively** via nested `<svelte:self node={s.children[i]}>`. When the tree restructures (e.g. a single terminal leaf becomes `split(terminalLeaf, emptyLeaf)`), that leaf moves from being rendered at the root to being rendered by a *different* child `<svelte:self>` instance at a new DOM position. Svelte destroys the old subtree and creates a new one → `TerminalPanel`'s cleanup runs `pty_session.kill()` (`TerminalPanel.svelte:687-689`) → the shell dies → the new instance spawns a fresh PTY. Net effect: the terminal "restarts".
+
+## Approach
+
+Render all leaves as **one flat keyed list** of absolutely-positioned slots, with each slot's rect computed from the tree. Keyed by `leaf.id`, so Svelte preserves the **same component instance** across restructures — only the slot's CSS rect updates. No remount → no `kill()` → no restart. This is the keep-warm architecture the pane-tree always intended.
+
+## Components
+
+### 1. `desktop/pane-layout.ts` (new, pure, unit-tested)
+
+```ts
+import type { PaneNode } from './pane-tree'
+import type { LeafNode } from './pane-tree'
+
+export interface Rect { x: number; y: number; w: number; h: number } // percentages 0..100
+export interface LeafBox { leaf: LeafNode; rect: Rect }
+export interface DividerBox { split_id: string; dir: 'h' | 'v'; rect: Rect }
+export interface PaneLayout { leaves: LeafBox[]; dividers: DividerBox[] }
+
+/** Panes are sized by exact ratio percentages; a divider is emitted at each
+ *  split boundary and given a fixed 6px thickness in CSS, centered on the seam
+ *  via a negative margin (-3px). So the divider overlays the boundary without
+ *  any %-gap subtraction — no container-size dependence in the layout math. */
+export function compute_pane_layout(
+  root: PaneNode | undefined,
+  maximized_leaf_id: string | null,
+): PaneLayout
+```
+
+Algorithm:
+- Recurse with an accumulating `Rect` starting at `{0,0,100,100}`.
+- **Leaf:** push `{ leaf, rect }`.
+- **Split (dir 'h' = side-by-side):** child0 = `{x, y, w*ratio, h}`, child1 = `{x + w*ratio, y, w*(1-ratio), h}`; emit a divider at the boundary `{ x: x + w*ratio, y, w: 0, h }` tagged `dir:'h'` (CSS gives it a fixed px width, centered on the boundary). `dir 'v' = stacked`: split along `h` analogously.
+- **Maximize:** if `maximized_leaf_id` is set, the box containing it gets the **full** parent rect and the sibling subtree collapses to `w:0`/`h:0` (its leaves still emitted, at 0 size, so they stay mounted = keep-warm). Dividers are omitted while maximized.
+- Guard `!root` → empty layout. Guard `!node.children` (transient) → treat as no-op.
+
+### 2. `desktop/PaneTree.svelte` (rewrite)
+
+Props change: `node: PaneNode` → **`root: PaneNode | undefined`** (App passes the whole tree). All other props unchanged (`multi`, `active_leaf_id`, `drag_target_leaf`, `close_confirm_leaf_id`, `active_split_id`, `maximized_leaf_id`, the four snippets, `on_activate`, `on_split_mousedown`, `on_split_dblclick`).
+
+```svelte
+{@const layout = compute_pane_layout(root, maximized_leaf_id)}
+<div class="pane-tree-root">
+  {#each layout.leaves as { leaf, rect } (leaf.id)}
+    <div
+      class="pane"
+      class:active={active_leaf_id === leaf.id}
+      class:dragover={drag_target_leaf === leaf.id}
+      class:warn-glow={close_confirm_leaf_id === leaf.id}
+      class:maximized-hidden={!!maximized_leaf_id && rect.w === 0}
+      data-leaf-id={leaf.id}
+      style="left:{rect.x}%; top:{rect.y}%; width:{rect.w}%; height:{rect.h}%"
+      role="button" tabindex="0"
+      onclick={() => on_activate(leaf.id)}
+      onkeydown={(e) => { if (e.key === 'Enter') on_activate(leaf.id) }}
+    >
+      {#if multi || leaf.content.type === 'terminal'}
+        <div class="panel-header">{@render header(leaf)}</div>
+      {/if}
+      {@render banner(leaf)}
+      <div class="panel-content">
+        {#if leaf.content.type === 'terminal'}{@render terminal_body(leaf)}
+        {:else}{@render leaf_body(leaf)}{/if}
+      </div>
+    </div>
+  {/each}
+  {#if !maximized_leaf_id}
+    {#each layout.dividers as d (d.split_id)}
+      <div
+        class="grid-divider {d.dir === 'h' ? 'grid-divider-col' : 'grid-divider-row'}"
+        class:active={active_split_id === d.split_id}
+        style="left:{d.rect.x}%; top:{d.rect.y}%; {d.dir === 'h' ? `height:${d.rect.h}%` : `width:${d.rect.w}%`}"
+        onmousedown={(e) => on_split_mousedown(e, d.split_id, d.dir)}
+        ondblclick={() => on_split_dblclick(d.split_id)}
+        role="separator" aria-orientation={d.dir === 'h' ? 'vertical' : 'horizontal'}
+      ></div>
+    {/each}
+  {/if}
+</div>
+```
+
+CSS: `.pane-tree-root { position:relative; width:100%; height:100% }`. `.pane { position:absolute; overflow:hidden; … }` (move from the old `.split-child`/`.pane` rules). `.grid-divider-col { position:absolute; width:6px; margin-left:-3px; cursor:col-resize }` (centered on the boundary via the negative margin), `.grid-divider-row { position:absolute; height:6px; margin-top:-3px; cursor:row-resize }`. `.maximized-hidden { visibility:hidden }` (keep-warm — NOT `display:none`). Keep the existing `:global(.panel-*)` hover rules.
+
+### 3. `desktop/lib/resize-handlers.ts`
+
+The divider drag converts px-delta → ratio. Today it divides by the whole container size (`total`), which is slightly off for nested splits. Concrete change: inside `on_split_drag`, after reading the `.pane-tree-root` rect, recompute `compute_pane_layout(ts.root, null)`, find the divider with this `split_id`, and take its split extent along the drag axis: `split_extent_px = (dir === 'h' ? rect.width * split_w/100 : rect.height * split_h/100)` where `split_w/h` come from the split's own bounding rect (the union of its two child boxes). Then `delta = (px moved) / split_extent_px`. (`setRatio(ts.root, split_id, start_ratio + delta)` is unchanged.)
+
+### 4. `desktop/App.svelte`
+
+`<PaneTree root={ts.root} … />` (was `node={ts.root}`). No other change — snippets, handlers, and `maximized_leaf_id` flow through unchanged.
+
+## Invariants preserved
+
+- Keep-warm uses `visibility:hidden`, never `display:none` (WebGL/PTY stay live).
+- `is_active` exactly-one-leaf-active unchanged (App owns `active_leaf_id`).
+- `clone_structure` on assignment unchanged (App owns pane content).
+- No `src/lib/mobile/*` edits (mobile doesn't use the desktop PaneTree).
+- Project style by hand (single-quote, no-semicolon, 2-space); never run `deno fmt`.
+
+## Error handling / edge cases
+
+- `root` undefined or transient childless split → empty/partial layout, no crash (the prior null-deref guards become moot since there's no `<svelte:self>` re-eval, but `compute_pane_layout` still guards).
+- Maximize toggles only change rects → no remount.
+- A leaf removed (close) → it drops out of the keyed `{#each}` → its component unmounts normally (TerminalPanel `kill()` fires — correct, the shell really is closed). Splitting/collapsing that keeps the leaf → component persists.
+- CAP (≤4 leaves) unchanged (App enforces).
+
+## Testing
+
+- **Unit (vitest)** `tests/vitest/pane-layout.test.ts`: `compute_pane_layout` for
+  - single leaf → one box `{0,0,100,100}`, no dividers;
+  - splitH ratio 0.5 → two boxes `{0,0,50,100}` / `{50,0,50,100}` + one `dir:'h'` divider at x=50;
+  - splitV → stacked boxes + `dir:'v'` divider;
+  - quad (h-split of two v-splits) → 4 boxes + 3 dividers;
+  - nested asymmetric ratios → exact rects;
+  - maximize → maximized leaf full rect, siblings `w:0`/`h:0`, no dividers.
+- **Acceptance (browser, live stack)**: open terminal → `echo MARKER` (scrollback) → split (Side by Side) → assert the terminal pane's **same** xterm/PTY persists: prompt + `MARKER` still visible, shell alive (run another command). Then collapse the sibling and maximize → still no remount.
+
+## File summary
+
+| File | Change |
+|---|---|
+| `desktop/pane-layout.ts` | **new** — pure `compute_pane_layout` (+ types) |
+| `desktop/PaneTree.svelte` | **rewrite** — flat keyed render, `root` prop, absolute slots + dividers |
+| `desktop/lib/resize-handlers.ts` | divider drag uses the split's sub-rect size |
+| `desktop/App.svelte` | `<PaneTree root={ts.root} …>` (was `node=`) |
+| `tests/vitest/pane-layout.test.ts` | **new** — layout unit tests |
+
+## Out of scope
+
+- Animated transitions between layouts (rects snap; can add CSS transitions later).
+- Drag-to-reorder leaves between slots (separate feature).
+- Mobile pane system (untouched).

--- a/src/lib/api/pty.ts
+++ b/src/lib/api/pty.ts
@@ -95,19 +95,31 @@ async function spawnTauriPty(cols: number, rows: number, cwd?: string): Promise<
     async kill() { await invoke(`pty_kill`, { id }) },
 
     onData(cb: (data: Uint8Array) => void): () => void {
+      // `cancelled` guards the case where the caller unsubscribes BEFORE the
+      // async listen() resolves (rapid subscribe/unsubscribe, e.g. one per
+      // run_command): without it the listener would register after off() and
+      // leak for the PTY's lifetime.
       let unlisten: (() => void) | null = null
+      let cancelled = false
       listen<{ id: number; data: string }>(`pty-output`, (event) => {
         if (event.payload.id === id) cb(b64ToBytes(event.payload.data))
-      }).then((fn) => { unlisten = fn; unlisteners.push(fn) })
-      return () => unlisten?.()
+      }).then((fn) => {
+        if (cancelled) { fn(); return }
+        unlisten = fn; unlisteners.push(fn)
+      })
+      return () => { cancelled = true; unlisten?.() }
     },
 
     onExit(cb: () => void): () => void {
       let unlisten: (() => void) | null = null
+      let cancelled = false
       listen<{ id: number; success: boolean }>(`pty-exit`, (event) => {
         if (event.payload.id === id) cb()
-      }).then((fn) => { unlisten = fn; unlisteners.push(fn) })
-      return () => unlisten?.()
+      }).then((fn) => {
+        if (cancelled) { fn(); return }
+        unlisten = fn; unlisteners.push(fn)
+      })
+      return () => { cancelled = true; unlisten?.() }
     },
 
     dispose() {

--- a/src/lib/chat/structure-tools.ts
+++ b/src/lib/chat/structure-tools.ts
@@ -50,6 +50,7 @@ import { get_run_status, run_workflow as api_run_workflow } from '$lib/api/workf
 import { load_run_config } from '$lib/workflow/run-config-store'
 import { iter_workflow_slices } from '$lib/workflow/workflow-state.svelte'
 import { VIEWER_TOOLS } from './viewer-tools'
+import { TERMINAL_TOOLS } from './terminal-tools'
 
 /** Minimal pymatgen-site shape the mutate executors read/write. */
 interface MutSite {
@@ -1461,6 +1462,7 @@ export async function execute_tool(
 // the CLIENT_TOOLS const exist) rather than via a side-effect `import` in
 // viewer-tools, which would hit a const temporal-dead-zone during circular init.
 for (const { def, run } of VIEWER_TOOLS) register(def, run)
+for (const { def, run } of TERMINAL_TOOLS) register(def, run)
 
 // Re-export so later tasks can register mutating tools that write structures back.
 export { register, set_current_structure }

--- a/src/lib/chat/terminal-tools.ts
+++ b/src/lib/chat/terminal-tools.ts
@@ -1,0 +1,92 @@
+/**
+ * CatBot tools that read/operate the visible terminal pane. Each `run` resolves
+ * the active terminal handle (auto-spawning a local one if none) and calls into
+ * it. Registered into CLIENT_TOOLS by structure-tools.ts. Mutating tools are
+ * gated by the existing PermissionCard flow (kind: 'mutate').
+ */
+import type { ClientTool } from './types'
+import { ensure_active_terminal } from '../structure/terminal-registry.svelte'
+import { resolve_keys } from '../structure/terminal-capture'
+
+export interface TerminalToolEntry {
+  def: ClientTool
+  run: (input: Record<string, unknown>) => Promise<unknown>
+}
+
+async function active() {
+  const h = await ensure_active_terminal()
+  if (!h) throw new Error('No terminal is open and one could not be started.')
+  return h
+}
+
+function info(h: { session_id: string; host?: string; is_remote: boolean }) {
+  return { target: h.is_remote ? `remote (${h.host ?? h.session_id})` : 'local shell' }
+}
+
+export const TERMINAL_TOOLS: TerminalToolEntry[] = [
+  {
+    def: {
+      name: 'read_terminal',
+      kind: 'read',
+      description: 'Read the current visible text of the active terminal pane (last N lines). Use to inspect output, prompts, or state before acting.',
+      input_schema: {
+        type: 'object',
+        properties: { lines: { type: 'number', description: 'How many trailing lines to read (default 40).' } },
+      },
+    },
+    run: async (input) => {
+      const h = await active()
+      const lines = typeof input.lines === 'number' ? input.lines : 40
+      return { output: h.read_buffer(lines), ...info(h) }
+    },
+  },
+  {
+    def: {
+      name: 'run_command',
+      kind: 'mutate',
+      description: 'Run a non-interactive shell command in the active terminal pane and return its output + exit code. If output shows a prompt or `running` is true, the command may be waiting for input — use send_keys. Works for local and HPC terminals.',
+      input_schema: {
+        type: 'object',
+        properties: { command: { type: 'string', description: 'The shell command to run.' } },
+        required: ['command'],
+      },
+    },
+    run: async (input) => {
+      const h = await active()
+      const r = await h.run_command(String(input.command ?? ''))
+      return { ...r, ...info(h) }
+    },
+  },
+  {
+    def: {
+      name: 'send_keys',
+      kind: 'mutate',
+      description: 'Send keystrokes to the active terminal (for interactive prompts/TUIs). Literal text plus named keys: <enter> <tab> <esc> <backspace> <space> <up> <down> <left> <right> <c-c> <c-d> <c-z>. Example: "y<enter>".',
+      input_schema: {
+        type: 'object',
+        properties: { keys: { type: 'string', description: 'Keys to send, e.g. "y<enter>" or "<c-c>".' } },
+        required: ['keys'],
+      },
+    },
+    run: async (input) => {
+      const h = await active()
+      await h.send_keys(resolve_keys(String(input.keys ?? '')))
+      await new Promise((r) => setTimeout(r, 200))
+      return { output: h.read_buffer(40), ...info(h) }
+    },
+  },
+  {
+    def: {
+      name: 'interrupt_terminal',
+      kind: 'mutate',
+      description: 'Send Ctrl-C to the active terminal to interrupt the running command.',
+      input_schema: { type: 'object', properties: {} },
+    },
+    run: async (_input) => {
+      const h = await active()
+      await h.interrupt()
+      await new Promise((r) => setTimeout(r, 200))
+      return { output: h.read_buffer(40), ...info(h) }
+    },
+  },
+]

--- a/src/lib/i18n/en/app.ts
+++ b/src/lib/i18n/en/app.ts
@@ -23,6 +23,7 @@ const app: Record<string, string> = {
   dir_sync_on: `Directory sync ON — Files panel follows terminal CWD`,
   dir_sync_off: `Directory sync OFF — click to follow terminal CWD`,
   ask_catbot: `Ask CatBot about this terminal`,
+  connect_new_cluster: `Connect new cluster…`,
   workflow_will_be_closed: `Workflow will be closed.`,
   local: `Local`,
   hpc: `HPC`,

--- a/src/lib/i18n/en/app.ts
+++ b/src/lib/i18n/en/app.ts
@@ -22,6 +22,7 @@ const app: Record<string, string> = {
   type_empty: `Empty`,
   dir_sync_on: `Directory sync ON — Files panel follows terminal CWD`,
   dir_sync_off: `Directory sync OFF — click to follow terminal CWD`,
+  ask_catbot: `Ask CatBot about this terminal`,
   workflow_will_be_closed: `Workflow will be closed.`,
   local: `Local`,
   hpc: `HPC`,

--- a/src/lib/i18n/zh/app.ts
+++ b/src/lib/i18n/zh/app.ts
@@ -23,6 +23,7 @@ const app: Record<string, string> = {
   dir_sync_on: `目录同步 开 — 文件面板跟随终端目录`,
   dir_sync_off: `目录同步 关 — 点击开启跟随终端目录`,
   ask_catbot: `让 CatBot 处理此终端`,
+  connect_new_cluster: `连接新集群…`,
   workflow_will_be_closed: `工作流将被关闭。`,
   local: `本地`,
   hpc: `HPC`,

--- a/src/lib/i18n/zh/app.ts
+++ b/src/lib/i18n/zh/app.ts
@@ -22,6 +22,7 @@ const app: Record<string, string> = {
   type_empty: `清空`,
   dir_sync_on: `目录同步 开 — 文件面板跟随终端目录`,
   dir_sync_off: `目录同步 关 — 点击开启跟随终端目录`,
+  ask_catbot: `让 CatBot 处理此终端`,
   workflow_will_be_closed: `工作流将被关闭。`,
   local: `本地`,
   hpc: `HPC`,

--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -5,6 +5,8 @@
   import { spawnPty, type PtySession } from '$lib/api/pty'
   import { Icon } from '$lib'
   import { theme_state, terminal_font_state, save_terminal_font_state, TERMINAL_FONT_FAMILIES } from '$lib/state.svelte'
+  import { register_terminal, unregister_terminal, mark_terminal_active } from './terminal-registry.svelte'
+  import { next_marker, wrap_command, extract_result, strip_ansi } from './terminal-capture'
 
   let {
     layout = `horizontal`,
@@ -74,15 +76,93 @@
   // need it just as much as remote: a plain bash emits no OSC 7 on its own, so without this
   // the local Files panel never follows the terminal's cwd. sync_cwd only controls whether
   // CWD changes are broadcast to the file browser.
+  const panel_id = `term-panel-${Math.random().toString(36).slice(2, 10)}`
+  let _run_busy = false
+  let _registered = false
+
+  async function panel_run_command(
+    cmd: string,
+    opts?: { timeout_ms?: number },
+  ): Promise<{ output: string; exit_code: number | null; running: boolean }> {
+    const pty = pty_ref
+    if (!pty) return { output: 'Terminal not ready.', exit_code: null, running: false }
+    if (_run_busy) return { output: 'Terminal is busy running another command.', exit_code: null, running: false }
+    _run_busy = true
+    const marker = next_marker()
+    const decoder = new TextDecoder()
+    let acc = ''
+    let settle: ((v: { output: string; exit_code: number | null; running: boolean }) => void) | null = null
+    let timeout_handle: ReturnType<typeof setTimeout> | null = null
+    const done = new Promise<{ output: string; exit_code: number | null; running: boolean }>((resolve) => {
+      settle = resolve
+    })
+    const off = pty.onData((bytes) => {
+      acc += decoder.decode(bytes, { stream: true })
+      const res = extract_result(strip_ansi(acc), marker)
+      if (res) {
+        if (timeout_handle) clearTimeout(timeout_handle)
+        settle?.({ output: res.output.slice(-8000), exit_code: res.exit_code, running: false })
+      }
+    })
+    timeout_handle = setTimeout(() => {
+      settle?.({ output: strip_ansi(acc).slice(-4000), exit_code: null, running: true })
+    }, opts?.timeout_ms ?? 15000)
+    try {
+      await pty.write(wrap_command(cmd, marker))
+      return await done
+    } finally {
+      off()
+      if (timeout_handle) clearTimeout(timeout_handle)
+      _run_busy = false
+    }
+  }
+
+  async function panel_send_keys(data: string): Promise<void> {
+    if (pty_ref) await pty_ref.write(data)
+  }
+
+  async function panel_interrupt(): Promise<void> {
+    if (pty_ref) await pty_ref.write('\x03')
+  }
+
+  function panel_read_buffer(lines = 40): string {
+    const term = term_ref
+    if (!term?.buffer?.active) return ''
+    const buf = term.buffer.active
+    const end = buf.baseY + buf.cursorY
+    const start = Math.max(0, end - lines)
+    const out: string[] = []
+    for (let y = start; y <= end; y++) {
+      const line = buf.getLine(y)
+      if (line) out.push(line.translateToString(true))
+    }
+    return out.join('\n').replace(/\n+$/, '')
+  }
+
   let _osc7_injected = false
   let _osc7_quiescence_timer: ReturnType<typeof setTimeout> | null = null
   let _osc7_data_listener: (() => void) | null = null
   $effect(() => {
     if (!pty_ref) {
+      if (_registered) { unregister_terminal(panel_id); _registered = false }
       _osc7_injected = false
       if (_osc7_quiescence_timer) clearTimeout(_osc7_quiescence_timer)
       if (_osc7_data_listener) { _osc7_data_listener(); _osc7_data_listener = null }
       return
+    }
+    if (!_registered) {
+      _registered = true
+      register_terminal({
+        id: panel_id,
+        session_id: session_id ?? '',
+        host,
+        username,
+        is_remote: !!session_id,
+        run_command: panel_run_command,
+        send_keys: panel_send_keys,
+        interrupt: panel_interrupt,
+        read_buffer: panel_read_buffer,
+      })
     }
     if (!_osc7_injected) {
       _osc7_injected = true
@@ -309,6 +389,7 @@
 
         terminal = term
         term_ref = term
+        term.textarea?.addEventListener('focus', () => mark_terminal_active(panel_id))
         fit_addon = fit
         fit_ref = fit
 
@@ -594,6 +675,8 @@
 
     return () => {
       disposed = true
+      unregister_terminal(panel_id)
+      _registered = false
       observer?.disconnect()
       vis_observer?.disconnect()
       unlisten_data?.()

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -7,6 +7,7 @@
   import { hpc_session_store, LOCAL_SESSION_ID } from '$lib/hpc-sessions.svelte'
   import { terminal_font_state, save_terminal_font_state, TERMINAL_FONT_FAMILIES } from '$lib/state.svelte'
   import { t } from '$lib/i18n/index.svelte'
+  import ConnectDialog from '$lib/ConnectDialog.svelte'
 
   let {
     initial_session_id,
@@ -151,6 +152,7 @@
   // ====== New tab dropdown ======
 
   let show_new_menu = $state(false)
+  let show_connect_dialog = $state(false)
 
   function add_tab(server?: ServerOption) {
     const tab = make_tab(server)
@@ -237,6 +239,11 @@
           {#if servers_loading}
             <div class="tw-dropdown-note">Loading...</div>
           {/if}
+          <div class="tw-dropdown-divider"></div>
+          <button class="tw-dropdown-item" onclick={(e) => { e.stopPropagation(); show_connect_dialog = true; show_new_menu = false }}>
+            <span class="tw-dropdown-icon">🔗</span>
+            {t('app.connect_new_cluster')}
+          </button>
           <button class="tw-dropdown-item tw-dropdown-refresh" onclick={(e) => { e.stopPropagation(); refresh_servers() }}>
             ↻ Refresh
           </button>
@@ -345,6 +352,10 @@
     {/each}
   </div>
 </div>
+
+<!-- Connect-new-cluster modal: on success it adds the session to the shared
+     hpc store, which the $effect above picks up to refresh the "+" Remote list. -->
+<ConnectDialog bind:show={show_connect_dialog} />
 
 <style>
   .tw {

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -6,6 +6,7 @@
   import { fetchAvailableShells, type ShellInfo } from '$lib/api/pty'
   import { hpc_session_store, LOCAL_SESSION_ID } from '$lib/hpc-sessions.svelte'
   import { terminal_font_state, save_terminal_font_state, TERMINAL_FONT_FAMILIES } from '$lib/state.svelte'
+  import { t } from '$lib/i18n/index.svelte'
 
   let {
     initial_session_id,
@@ -14,6 +15,7 @@
     initial_sync_cwd = false,
     onclose,
     onpopout,
+    on_ask_catbot,
     on_open_file,
   }: {
     /** Pre-fill the first tab with a remote session. */
@@ -24,6 +26,7 @@
     initial_sync_cwd?: boolean
     onclose?: () => void
     onpopout?: () => void
+    on_ask_catbot?: () => void
     /** Callback when user Ctrl+clicks a file path in the terminal output. */
     on_open_file?: (file_path: string) => void
   } = $props()
@@ -302,6 +305,11 @@
           onclick={() => { if (active_tab) active_tab.sync_cwd = !active_tab.sync_cwd; tabs = [...tabs] }}
         >
           <Icon icon="Link" />
+        </button>
+      {/if}
+      {#if on_ask_catbot}
+        <button class="tw-icon-btn" title={t('app.ask_catbot')} onclick={on_ask_catbot}>
+          <Icon icon="Chat" />
         </button>
       {/if}
       {#if onpopout}

--- a/src/lib/structure/terminal-capture.ts
+++ b/src/lib/structure/terminal-capture.ts
@@ -40,13 +40,16 @@ function escape_re(s: string): string {
  * accumulated (ANSI-stripped) PTY text. Returns null until the END marker lands.
  * The echoed command can't false-match: its literal text is `%s_BEGIN` and the
  * marker there is quote-wrapped, never `MARKER_BEGIN` / `MARKER_END_<digits>`.
+ * The END match is newline-anchored (the real marker prints as `\n…_END_…`), so
+ * a command whose own output contains the token mid-line can't truncate capture.
+ * The per-call random marker makes deliberate collision near-impossible anyway.
  */
 export function extract_result(raw: string, marker: string): { output: string; exit_code: number | null } | null {
   const begin = `${marker}_BEGIN`
   const bi = raw.indexOf(begin)
   if (bi < 0) return null
   const after = raw.slice(bi + begin.length)
-  const m = after.match(new RegExp(`${escape_re(marker)}_END_(\\d+)`))
+  const m = after.match(new RegExp(`(?:^|\\n)${escape_re(marker)}_END_(\\d+)`))
   if (!m || m.index === undefined) return null
   const output = after.slice(0, m.index).replace(/^\n+/, '').replace(/\n+$/, '')
   return { output, exit_code: parseInt(m[1], 10) }

--- a/src/lib/structure/terminal-capture.ts
+++ b/src/lib/structure/terminal-capture.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers for CatBot terminal control: ANSI stripping, command-output
+ * markers (BEGIN..END_<exit>), and named-key resolution. No DOM / no PTY here —
+ * keeps the logic unit-testable in isolation.
+ */
+
+/** Strip ANSI/VT control sequences (CSI, OSC, and stray C0 controls except \n\t). */
+export function strip_ansi(s: string): string {
+  return s
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b[@-Z\\-_]/g, '')
+    .replace(/\r/g, '')
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, '')
+}
+
+let _seq = 0
+/** Unique per-call marker token. */
+export function next_marker(): string {
+  _seq += 1
+  const rand = Math.random().toString(36).slice(2, 10)
+  return `__CATGO_${_seq}_${rand}__`
+}
+
+/**
+ * Wrap a user command in a brace group that prints BEGIN before and
+ * END_<exit-code> after. Newlines (not `;`) separate the parts so multi-word /
+ * piped commands pass through verbatim; `$?` is the user command's exit code.
+ */
+export function wrap_command(cmd: string, marker: string): string {
+  return `{ printf '\\n%s_BEGIN\\n' '${marker}'\n${cmd}\nprintf '\\n%s_END_%d\\n' '${marker}' "$?"\n}\r`
+}
+
+function escape_re(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Find the captured output between `MARKER_BEGIN` and `MARKER_END_<code>` in the
+ * accumulated (ANSI-stripped) PTY text. Returns null until the END marker lands.
+ * The echoed command can't false-match: its literal text is `%s_BEGIN` and the
+ * marker there is quote-wrapped, never `MARKER_BEGIN` / `MARKER_END_<digits>`.
+ */
+export function extract_result(raw: string, marker: string): { output: string; exit_code: number | null } | null {
+  const begin = `${marker}_BEGIN`
+  const bi = raw.indexOf(begin)
+  if (bi < 0) return null
+  const after = raw.slice(bi + begin.length)
+  const m = after.match(new RegExp(`${escape_re(marker)}_END_(\\d+)`))
+  if (!m || m.index === undefined) return null
+  const output = after.slice(0, m.index).replace(/^\n+/, '').replace(/\n+$/, '')
+  return { output, exit_code: parseInt(m[1], 10) }
+}
+
+/** Named-key tokens → control bytes. Literal text passes through unchanged. */
+export const KEY_MAP: Record<string, string> = {
+  '<enter>': '\r',
+  '<tab>': '\t',
+  '<esc>': '\x1b',
+  '<backspace>': '\x7f',
+  '<space>': ' ',
+  '<up>': '\x1b[A',
+  '<down>': '\x1b[B',
+  '<right>': '\x1b[C',
+  '<left>': '\x1b[D',
+  '<c-c>': '\x03',
+  '<c-d>': '\x04',
+  '<c-z>': '\x1a',
+}
+
+/** Replace `<...>` tokens with their bytes; everything else is literal. */
+export function resolve_keys(keys: string): string {
+  return keys.replace(/<[a-z-]+>/gi, (tok) => KEY_MAP[tok.toLowerCase()] ?? tok)
+}

--- a/src/lib/structure/terminal-registry.svelte.ts
+++ b/src/lib/structure/terminal-registry.svelte.ts
@@ -1,0 +1,79 @@
+/**
+ * In-process registry bridging CatBot tools <-> the visible terminal PTYs.
+ * Each TerminalPanel registers a handle on mount and marks itself active on
+ * focus; CatBot tools call get_active_terminal(). Renderer-global singleton —
+ * in a popout window it is that window's own registry (window-local, like the
+ * CWD-sync rule). No Svelte $state needed: callers read at call time, not in a
+ * reactive context.
+ */
+
+export interface TerminalHandle {
+  id: string
+  session_id: string // '' for local, HPC session id for remote
+  host?: string
+  username?: string
+  is_remote: boolean
+  run_command: (cmd: string, opts?: { timeout_ms?: number }) =>
+    Promise<{ output: string; exit_code: number | null; running: boolean }>
+  send_keys: (data: string) => Promise<void>
+  interrupt: () => Promise<void>
+  read_buffer: (lines?: number) => string
+}
+
+const _handles = new Map<string, TerminalHandle>()
+const _order: string[] = [] // registration order; last = most recent
+let _active_id: string | null = null
+
+export function register_terminal(h: TerminalHandle): void {
+  _handles.set(h.id, h)
+  const i = _order.indexOf(h.id)
+  if (i >= 0) _order.splice(i, 1)
+  _order.push(h.id)
+}
+
+export function unregister_terminal(id: string): void {
+  _handles.delete(id)
+  const i = _order.indexOf(id)
+  if (i >= 0) _order.splice(i, 1)
+  if (_active_id === id) _active_id = null
+}
+
+export function mark_terminal_active(id: string): void {
+  if (_handles.has(id)) _active_id = id
+}
+
+export function get_active_terminal(): TerminalHandle | null {
+  if (_active_id && _handles.has(_active_id)) return _handles.get(_active_id)!
+  for (let i = _order.length - 1; i >= 0; i--) {
+    const h = _handles.get(_order[i])
+    if (h) return h
+  }
+  return null
+}
+
+export function has_active_terminal(): boolean {
+  return get_active_terminal() !== null
+}
+
+/**
+ * App registers an opener so the tools can auto-spawn a local terminal when none
+ * exists. Returns the new handle once it has registered.
+ */
+let _opener: (() => Promise<TerminalHandle | null>) | null = null
+export function set_terminal_opener(fn: (() => Promise<TerminalHandle | null>) | null): void {
+  _opener = fn
+}
+export async function ensure_active_terminal(): Promise<TerminalHandle | null> {
+  const existing = get_active_terminal()
+  if (existing) return existing
+  if (_opener) return await _opener()
+  return null
+}
+
+/** Test-only: clear all state. */
+export function _reset_registry_for_test(): void {
+  _handles.clear()
+  _order.length = 0
+  _active_id = null
+  _opener = null
+}

--- a/tests/e2e/catbot-terminal.spec.ts
+++ b/tests/e2e/catbot-terminal.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Integration test for CatBot terminal control.
+ *
+ * Exercises the real chain: TerminalPanel registers a handle → run_command wraps
+ * the command with BEGIN/END markers, writes it to the PTY, and captures the
+ * output. This needs the FULL dev stack (vite + Python backend, so the PTY can
+ * spawn) — set CATGO_E2E_URL to it (default http://localhost:3186, the
+ * `pnpm desktop:serve` port). The CatBot tool layer itself is unit-tested in
+ * tests/vitest/terminal-tools.test.ts; here we prove the PTY capture end to end.
+ *
+ * If no terminal registers within the timeout (e.g. running against a
+ * frontend-only server with no backend), the test skips rather than failing.
+ */
+const BASE = process.env.CATGO_E2E_URL ?? 'http://localhost:3186'
+const REGISTRY_URL = '/src/lib/structure/terminal-registry.svelte.ts'
+
+test('run_command captures real terminal output via the registry', async ({ page }) => {
+  await page.goto(BASE)
+
+  // Open a local terminal from the landing grid.
+  await page.evaluate(() => {
+    const b = [...document.querySelectorAll('button')].find((x) =>
+      x.textContent?.includes('Terminal') && x.textContent?.includes('Local shell'))
+    ;(b as HTMLButtonElement | undefined)?.click()
+  })
+
+  // Wait (bounded) for a terminal handle to register; skip if the backend/PTY
+  // isn't available in this environment.
+  const registered = await page.evaluate(async (url) => {
+    for (let i = 0; i < 80; i++) {
+      try {
+        const reg: any = await import(/* @vite-ignore */ url)
+        if (reg.has_active_terminal && reg.has_active_terminal()) return true
+      } catch { /* module not served yet */ }
+      await new Promise((r) => setTimeout(r, 250))
+    }
+    return false
+  }, REGISTRY_URL)
+
+  test.skip(!registered, 'No PTY-backed terminal registered (frontend-only server?)')
+
+  const result = await page.evaluate(async (url) => {
+    const reg: any = await import(/* @vite-ignore */ url)
+    const h = reg.get_active_terminal()
+    const token = 'catgo_e2e_' + Math.floor(Math.random() * 1e6)
+    const r = await h.run_command('echo ' + token)
+    return { token, output: r.output as string, exit_code: r.exit_code as number | null, running: r.running as boolean }
+  }, REGISTRY_URL)
+
+  expect(result.output).toContain(result.token)
+  expect(result.exit_code).toBe(0)
+  expect(result.running).toBe(false)
+})

--- a/tests/vitest/pane-layout.test.ts
+++ b/tests/vitest/pane-layout.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { compute_pane_layout } from '../../desktop/pane-layout'
+import type { LeafNode, SplitNode, PaneNode } from '../../desktop/pane-tree'
+import { create_empty_pane } from '../../desktop/pane-utils'
+
+function leaf(id: string): LeafNode {
+  return { kind: 'leaf', id, content: { type: 'structure', pane: create_empty_pane() } }
+}
+function split(id: string, direction: 'h' | 'v', ratio: number, a: PaneNode, b: PaneNode): SplitNode {
+  return { kind: 'split', id, direction, ratio, children: [a, b] }
+}
+function box(layout: ReturnType<typeof compute_pane_layout>, id: string) {
+  return layout.leaves.find((l) => l.leaf.id === id)?.rect
+}
+
+describe('compute_pane_layout', () => {
+  it('single leaf fills the whole area, no dividers', () => {
+    const l = compute_pane_layout(leaf('a'), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 100, h: 100 })
+    expect(l.dividers).toEqual([])
+  })
+
+  it('splitH at 0.5 → side-by-side halves + one vertical divider with span 100', () => {
+    const l = compute_pane_layout(split('s', 'h', 0.5, leaf('a'), leaf('b')), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 50, h: 100 })
+    expect(box(l, 'b')).toEqual({ x: 50, y: 0, w: 50, h: 100 })
+    expect(l.dividers).toEqual([{ split_id: 's', dir: 'h', rect: { x: 50, y: 0, w: 0, h: 100 }, span: 100 }])
+  })
+
+  it('splitV at 0.5 → stacked halves + one horizontal divider', () => {
+    const l = compute_pane_layout(split('s', 'v', 0.5, leaf('a'), leaf('b')), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 100, h: 50 })
+    expect(box(l, 'b')).toEqual({ x: 0, y: 50, w: 100, h: 50 })
+    expect(l.dividers).toEqual([{ split_id: 's', dir: 'v', rect: { x: 0, y: 50, w: 100, h: 0 }, span: 100 }])
+  })
+
+  it('asymmetric splitH respects the ratio', () => {
+    const l = compute_pane_layout(split('s', 'h', 0.3, leaf('a'), leaf('b')), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 30, h: 100 })
+    expect(box(l, 'b')).toEqual({ x: 30, y: 0, w: 70, h: 100 })
+  })
+
+  it('quad (h-split of two v-splits) → 4 quadrants + 3 dividers', () => {
+    const col0 = split('c0', 'v', 0.5, leaf('a'), leaf('b'))
+    const col1 = split('c1', 'v', 0.5, leaf('c'), leaf('d'))
+    const l = compute_pane_layout(split('root', 'h', 0.5, col0, col1), null)
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 50, h: 50 })
+    expect(box(l, 'b')).toEqual({ x: 0, y: 50, w: 50, h: 50 })
+    expect(box(l, 'c')).toEqual({ x: 50, y: 0, w: 50, h: 50 })
+    expect(box(l, 'd')).toEqual({ x: 50, y: 50, w: 50, h: 50 })
+    expect(l.dividers).toContainEqual({ split_id: 'root', dir: 'h', rect: { x: 50, y: 0, w: 0, h: 100 }, span: 100 })
+    expect(l.dividers).toContainEqual({ split_id: 'c0', dir: 'v', rect: { x: 0, y: 50, w: 50, h: 0 }, span: 100 })
+    expect(l.dividers).toContainEqual({ split_id: 'c1', dir: 'v', rect: { x: 50, y: 50, w: 50, h: 0 }, span: 100 })
+    expect(l.dividers).toHaveLength(3)
+  })
+
+  it('maximize → maximized leaf fills, sibling collapses to 0, no dividers', () => {
+    const l = compute_pane_layout(split('s', 'h', 0.5, leaf('a'), leaf('b')), 'a')
+    expect(box(l, 'a')).toEqual({ x: 0, y: 0, w: 100, h: 100 })
+    expect(box(l, 'b')).toEqual({ x: 0, y: 0, w: 0, h: 0 })
+    expect(l.dividers).toEqual([])
+  })
+
+  it('undefined root → empty layout', () => {
+    expect(compute_pane_layout(undefined, null)).toEqual({ leaves: [], dividers: [] })
+  })
+})

--- a/tests/vitest/terminal-capture.test.ts
+++ b/tests/vitest/terminal-capture.test.ts
@@ -46,6 +46,11 @@ describe('wrap_command / extract_result', () => {
     const raw = echo + `\n${marker}_BEGIN\n` + 'hi\n' + `\n${marker}_END_0\n`
     expect(extract_result(raw, marker)).toEqual({ output: 'hi', exit_code: 0 })
   })
+  it('ignores an END token that appears mid-line in command output', () => {
+    const marker = '__CATGO_5_mno__'
+    const raw = `\n${marker}_BEGIN\n` + `prefix ${marker}_END_9 still going\n` + `\n${marker}_END_0\n`
+    expect(extract_result(raw, marker)).toEqual({ output: `prefix ${marker}_END_9 still going`, exit_code: 0 })
+  })
 })
 
 describe('resolve_keys', () => {

--- a/tests/vitest/terminal-capture.test.ts
+++ b/tests/vitest/terminal-capture.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { strip_ansi, next_marker, wrap_command, extract_result, KEY_MAP, resolve_keys } from '../../src/lib/structure/terminal-capture'
+
+describe('strip_ansi', () => {
+  it('removes CSI color codes', () => {
+    expect(strip_ansi('\x1b[31mred\x1b[0m')).toBe('red')
+  })
+  it('removes OSC sequences (e.g. OSC 7 cwd)', () => {
+    expect(strip_ansi('a\x1b]7;file://h/p\x07b')).toBe('ab')
+  })
+  it('keeps plain text and newlines', () => {
+    expect(strip_ansi('line1\nline2')).toBe('line1\nline2')
+  })
+})
+
+describe('next_marker', () => {
+  it('is unique per call and matches the expected shape', () => {
+    const a = next_marker(); const b = next_marker()
+    expect(a).not.toBe(b)
+    expect(a).toMatch(/^__CATGO_\d+_[a-z0-9]+__$/)
+  })
+})
+
+describe('wrap_command / extract_result', () => {
+  it('round-trips output and exit code (simulating shell echo + run)', () => {
+    const marker = '__CATGO_1_abc__'
+    const wrapped = wrap_command('echo hi', marker)
+    const raw = wrapped + `\r\n` +
+      `\n${marker}_BEGIN\n` + `hi\n` + `\n${marker}_END_0\n` + `(base) $ `
+    const res = extract_result(strip_ansi(raw), marker)
+    expect(res).toEqual({ output: 'hi', exit_code: 0 })
+  })
+  it('returns null until END marker is present', () => {
+    const marker = '__CATGO_2_def__'
+    const raw = `\n${marker}_BEGIN\n` + 'partial output'
+    expect(extract_result(raw, marker)).toBeNull()
+  })
+  it('captures a non-zero exit code', () => {
+    const marker = '__CATGO_3_ghi__'
+    const raw = `\n${marker}_BEGIN\n` + 'nope\n' + `\n${marker}_END_2\n`
+    expect(extract_result(raw, marker)).toEqual({ output: 'nope', exit_code: 2 })
+  })
+  it('is not fooled by the echoed command (literal %s_BEGIN, quoted marker)', () => {
+    const marker = '__CATGO_4_jkl__'
+    const echo = `{ printf '\\n%s_BEGIN\\n' '${marker}'\necho hi\nprintf '\\n%s_END_%d\\n' '${marker}' "$?"\n}`
+    const raw = echo + `\n${marker}_BEGIN\n` + 'hi\n' + `\n${marker}_END_0\n`
+    expect(extract_result(raw, marker)).toEqual({ output: 'hi', exit_code: 0 })
+  })
+})
+
+describe('resolve_keys', () => {
+  it('maps named keys to control bytes and passes literal text through', () => {
+    expect(resolve_keys('y<enter>')).toBe('y\r')
+    expect(resolve_keys('<c-c>')).toBe('\x03')
+    expect(resolve_keys('<up><tab><esc>')).toBe('\x1b[A\t\x1b')
+    expect(resolve_keys('plain')).toBe('plain')
+  })
+  it('exposes the key table', () => {
+    expect(KEY_MAP['<enter>']).toBe('\r')
+  })
+})

--- a/tests/vitest/terminal-registry.test.ts
+++ b/tests/vitest/terminal-registry.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  register_terminal, unregister_terminal, mark_terminal_active,
+  get_active_terminal, has_active_terminal, _reset_registry_for_test,
+  type TerminalHandle,
+} from '../../src/lib/structure/terminal-registry.svelte'
+
+function fake(id: string): TerminalHandle {
+  return {
+    id, session_id: '', is_remote: false,
+    run_command: async () => ({ output: '', exit_code: 0, running: false }),
+    send_keys: async () => {}, interrupt: async () => {}, read_buffer: () => '',
+  }
+}
+
+describe('terminal-registry', () => {
+  beforeEach(() => _reset_registry_for_test())
+
+  it('reports no active terminal when empty', () => {
+    expect(has_active_terminal()).toBe(false)
+    expect(get_active_terminal()).toBeNull()
+  })
+  it('returns the explicitly-activated handle', () => {
+    register_terminal(fake('a')); register_terminal(fake('b'))
+    mark_terminal_active('b')
+    expect(get_active_terminal()?.id).toBe('b')
+  })
+  it('falls back to the most-recently registered when active id is stale', () => {
+    register_terminal(fake('a')); register_terminal(fake('b'))
+    mark_terminal_active('b')
+    unregister_terminal('b')
+    expect(get_active_terminal()?.id).toBe('a')
+  })
+  it('unregister of a non-active handle keeps the active one', () => {
+    register_terminal(fake('a')); register_terminal(fake('b'))
+    mark_terminal_active('a')
+    unregister_terminal('b')
+    expect(get_active_terminal()?.id).toBe('a')
+  })
+})

--- a/tests/vitest/terminal-tools.test.ts
+++ b/tests/vitest/terminal-tools.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { TERMINAL_TOOLS } from '../../src/lib/chat/terminal-tools'
+import {
+  register_terminal, _reset_registry_for_test, mark_terminal_active,
+  type TerminalHandle,
+} from '../../src/lib/structure/terminal-registry.svelte'
+
+function find(name: string) {
+  const t = TERMINAL_TOOLS.find((x) => x.def.name === name)
+  if (!t) throw new Error(`missing tool ${name}`)
+  return t
+}
+
+const calls: string[] = []
+function handle(): TerminalHandle {
+  return {
+    id: 'h', session_id: '', is_remote: false,
+    run_command: async (cmd) => { calls.push('run:' + cmd); return { output: 'OUT', exit_code: 0, running: false } },
+    send_keys: async (d) => { calls.push('keys:' + d) },
+    interrupt: async () => { calls.push('interrupt') },
+    read_buffer: () => 'BUFFER',
+  }
+}
+
+describe('terminal tools', () => {
+  beforeEach(() => { _reset_registry_for_test(); calls.length = 0; register_terminal(handle()); mark_terminal_active('h') })
+
+  it('exposes the four tools with correct kinds', () => {
+    expect(find('read_terminal').def.kind).toBe('read')
+    expect(find('run_command').def.kind).toBe('mutate')
+    expect(find('send_keys').def.kind).toBe('mutate')
+    expect(find('interrupt_terminal').def.kind).toBe('mutate')
+  })
+  it('read_terminal returns the buffer', async () => {
+    const r = await find('read_terminal').run({}) as { output: string }
+    expect(r.output).toBe('BUFFER')
+  })
+  it('run_command forwards the command and returns output + exit_code', async () => {
+    const r = await find('run_command').run({ command: 'pwd' }) as { output: string; exit_code: number }
+    expect(calls).toContain('run:pwd')
+    expect(r).toMatchObject({ output: 'OUT', exit_code: 0 })
+  })
+  it('send_keys resolves named keys before writing', async () => {
+    await find('send_keys').run({ keys: 'y<enter>' })
+    expect(calls).toContain('keys:y\r')
+  })
+  it('interrupt_terminal sends Ctrl-C', async () => {
+    await find('interrupt_terminal').run({})
+    expect(calls).toContain('interrupt')
+  })
+})


### PR DESCRIPTION
**Stack 3/5** — base: `pr/02-terminal-leaves`. Commits 55–73.

- **CatBot drives the visible terminal** (client-direct): in-process terminal registry + capture helpers (markers/ANSI/keys); `TerminalPanel` exposes run_command/send_keys/interrupt/read_buffer + registers a handle; 4 CatBot tools (mutating ones gated by the PermissionCard); **Ask CatBot** button; auto-spawn a local terminal when none is active.
- **Flat keyed render**: `compute_pane_layout` → absolute keyed `{#each leaves (leaf.id)}` slots replace recursive `svelte:self` — **splitting/maximizing no longer remounts the terminal**. Requires `apply_preset` to preserve `leaf.id`. Divider drag uses split span for nested resize.
- Full-pane CatBot for Ask-CatBot / AI-Chat card; "Connect new cluster" in the `+` menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)