### PR TITLE
fix(structure): normalize ortho pan speed to camera distance

### DIFF
--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -4450,6 +4450,18 @@
     }
   })
 
+  // Orthographic pan-speed normalization (applied per-drag in `onstart` below).
+  // TrackballControls._panCamera scales on-screen pan by `_eye.length()` (the
+  // camera→target distance). With ortho, the 1/zoom term cancels against the
+  // projection's ×zoom, but eye.length has NO such cancellation — so the same drag
+  // pans little when the camera sits close (small molecule) and a lot when it sits
+  // far (large cell). We can't use structure_size as a proxy: compute_structure_size
+  // returns a flat 10 for non-periodic systems (no lattice), so it doesn't track the
+  // real distance. Instead we read the true eye length at drag start and set panSpeed
+  // = pan_speed × PAN_REF_EYE / eye, which makes on-screen pan ∝ pan_speed for every
+  // structure. PAN_REF_EYE is the eye length at which the user's pan_speed is left
+  // unchanged. Perspective pan already tracks the cursor 1:1, so it's left alone.
+  const PAN_REF_EYE = 50
   let trackball_controls_props = $derived.by(() => ({
     rotateSpeed: rotate_speed,
     zoomSpeed: camera_projection === `orthographic` ? zoom_speed * 2 : zoom_speed,
@@ -4476,6 +4488,12 @@
     // The target is managed programmatically in the $effect blocks above.
     onstart: () => {
       camera_is_moving = true
+      // Normalize ortho pan to the true camera→target distance so a drag pans the
+      // same on-screen amount regardless of structure size (see PAN_REF_EYE note).
+      if (camera && orbit_controls?.target && camera_projection === `orthographic`) {
+        const eye = (camera as any).position.distanceTo(orbit_controls.target)
+        ;(orbit_controls as any).panSpeed = pan_speed * PAN_REF_EYE / Math.max(0.001, eye)
+      }
       capture_trackball_view_state()
       if (!trackball_is_rotating()) clear_trackball_rotation_inertia()
       // Don't clear hovered_idx here - let it stay so rotation stays disabled on atoms.


### PR DESCRIPTION
## Problem
Panning a non-periodic system (small molecule) felt much slower than a periodic cell for the same mouse drag — a sensitivity issue, not fps.

## Root cause
`TrackballControls._panCamera` scales on-screen pan by `_eye.length()` (camera→target distance). For the ortho camera the `1/zoom` term cancels against the projection's `×zoom`, but `_eye.length()` has **no** such cancellation. CatGo places the ortho camera at a distance that scales with structure size, so molecules (close camera) panned slowly and cells (far camera) fast. Rotate uses `_rotateCamera` (pixel-angle only) and was never affected.

`compute_structure_size` can't serve as a proxy — it returns a flat `10` for lattice-less (non-periodic) systems, so it doesn't track the real distance.

## Fix
Read the true eye length at drag start (`onstart`) and set `panSpeed = pan_speed × PAN_REF_EYE / eye`, making on-screen pan ∝ `pan_speed` for every structure. Perspective pan already tracks the cursor 1:1, so it's left alone. (+18 lines, one file.)

## Test
Verified by hand on a small molecule vs a large crystal — pan now feels identical. `pnpm check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)