### PR TITLE
fix(bonds): correct all four bonding strategies + tunable scales + trajectory rule tracking

### DIFF
--- a/extensions/rust/src/bonding.rs
+++ b/extensions/rust/src/bonding.rs
@@ -400,6 +400,12 @@ pub struct SolidAngleOptions {
     /// Minimum bond strength to include (default: 0.05)
     #[serde(default = "default_sa_strength_threshold")]
     pub strength_threshold: f64,
+    /// Distance sanity: drop a Voronoi contact whose length exceeds this
+    /// multiple of the covalent-radii sum (default: 1.5). Suppresses
+    /// anion-anion polyhedra edges (e.g. O-O) while keeping M-O and metal
+    /// bonds. Set very large to keep pure radius-free Voronoi behaviour.
+    #[serde(default = "default_sa_max_ratio")]
+    pub max_distance_ratio: f64,
 }
 
 fn default_min_solid_angle() -> f64 {
@@ -411,6 +417,9 @@ fn default_min_face_area() -> f64 {
 fn default_sa_strength_threshold() -> f64 {
     0.05
 }
+fn default_sa_max_ratio() -> f64 {
+    1.5
+}
 
 impl Default for SolidAngleOptions {
     fn default() -> Self {
@@ -420,6 +429,7 @@ impl Default for SolidAngleOptions {
             max_distance: default_max_dist(),
             min_bond_dist: default_min_dist(),
             strength_threshold: default_sa_strength_threshold(),
+            max_distance_ratio: default_sa_max_ratio(),
         }
     }
 }
@@ -449,6 +459,13 @@ pub fn detect_bonds_solid_angle(structure: &Structure, options: &SolidAngleOptio
     // home cell and tessellate that: correct for ANY lattice, and each image
     // atom carries its exact Cartesian position → exact distance + jimage. A
     // slab's vacuum side simply yields unbounded (boundary) faces → no bond.
+    // Covalent radii for the distance sanity that trims anion-anion edges.
+    let radii: Vec<f64> = structure
+        .species()
+        .iter()
+        .map(|sp| sp.element.covalent_radius().unwrap_or(1.5))
+        .collect();
+
     let cart = structure.cart_coords();
     let m = structure.lattice.matrix();
     let avec = nalgebra::Vector3::new(m[(0, 0)], m[(0, 1)], m[(0, 2)]);
@@ -535,6 +552,11 @@ pub fn detect_bonds_solid_angle(structure: &Structure, options: &SolidAngleOptio
 
             let dist = (sc_pos[raw] - center).length();
             if dist < min_dist {
+                continue;
+            }
+            // Distance sanity: a shared Voronoi face that is far longer than the
+            // covalent-radii sum is a polyhedra edge (anion-anion), not a bond.
+            if dist > options.max_distance_ratio * (radii[i] + radii[j]) {
                 continue;
             }
             // Solid-angle fraction Ω/4π ≈ A / (4π r²).
@@ -1011,6 +1033,22 @@ mod tests {
             "longest electroneg bond should be 1st-shell (~2.56 Å), got {max_len:.3} Å \
              (2nd shell at 3.615 Å leaked in — closest-neighbor penalty missing)"
         );
+    }
+
+    #[test]
+    fn test_solid_angle_drops_anion_edge() {
+        // Two O atoms 2.6 Å apart share a Voronoi face, but 2.6 > 1.5·Σr(O,O)
+        // (≈1.98 Å), so the distance sanity must drop this O-O polyhedra edge.
+        let lattice = Lattice::cubic(12.0);
+        let species = vec![Species::neutral(Element::O), Species::neutral(Element::O)];
+        let frac_coords = vec![
+            Vector3::new(0.4, 0.5, 0.5),
+            Vector3::new(0.4 + 2.6 / 12.0, 0.5, 0.5),
+        ];
+        let structure = Structure::new(lattice, species, frac_coords);
+
+        let bonds = detect_bonds_solid_angle(&structure, &SolidAngleOptions::default());
+        assert!(bonds.is_empty(), "O-O at 2.6 Å exceeds 1.5·Σr; must not bond");
     }
 
     #[test]

--- a/extensions/rust/src/bonding.rs
+++ b/extensions/rust/src/bonding.rs
@@ -267,8 +267,37 @@ pub fn detect_bonds_electroneg(structure: &Structure, options: &ElectronegOption
     let mut bonds = Vec::new();
     let min_dist_sq = options.min_bond_dist * options.min_bond_dist;
 
-    // Track closest bond for each atom (for strength normalization)
-    let mut closest: HashMap<usize, f64> = HashMap::new();
+    // Pass 1: per-atom minimum NORMALIZED neighbour distance (dist / Σr) over
+    // every geometric candidate (both directions, no pair dedup). Used below to
+    // damp bonds that are long *relative to the atom's tightest contact* — this
+    // is what stops a dense metal from bonding to its 2nd/3rd shell (matterviz's
+    // closest-neighbour penalty). Precomputed so it is order-independent (the
+    // neighbour list is not distance-sorted).
+    let mut closest_norm: HashMap<usize, f64> = HashMap::new();
+    for idx in 0..center_indices.len() {
+        let dist = distances[idx];
+        if dist * dist < min_dist_sq {
+            continue;
+        }
+        let ci = center_indices[idx];
+        let ni = neighbor_indices[idx];
+        let sum_radii = props[ci].covalent_radius + props[ni].covalent_radius;
+        if dist > sum_radii * options.max_distance_ratio {
+            continue;
+        }
+        // Only count BONDABLE neighbours (same en filter as the bond loop), so
+        // an atom's "closest contact" is its nearest *bond*, not a nearer pair
+        // that electronegativity rejects (e.g. Na-Cl while bonding Na-Na).
+        let en_diff = (props[ci].electronegativity - props[ni].electronegativity).abs();
+        if en_diff > options.electronegativity_threshold {
+            continue;
+        }
+        let norm = dist / sum_radii;
+        closest_norm
+            .entry(ci)
+            .and_modify(|d| *d = d.min(norm))
+            .or_insert(norm);
+    }
 
     for idx in 0..center_indices.len() {
         let center_idx = center_indices[idx];
@@ -340,15 +369,18 @@ pub fn detect_bonds_electroneg(structure: &Structure, options: &ElectronegOption
             strength *= options.same_species_penalty;
         }
 
-        // Track closest distances
-        closest
-            .entry(center_idx)
-            .and_modify(|d| *d = d.min(dist))
-            .or_insert(dist);
-        closest
-            .entry(neighbor_idx)
-            .and_modify(|d| *d = d.min(dist))
-            .or_insert(dist);
+        // Closest-neighbour penalty: damp bonds that are long relative to each
+        // endpoint's tightest contact. A bond at an atom's own minimum has
+        // ratio 1 (no penalty); longer ones decay as exp(-(ratio-1)/0.5),
+        // pushing 2nd-shell metallic contacts below the strength threshold so
+        // the viewer shows the coordination shell, not a hedgehog.
+        for atom in [center_idx, neighbor_idx] {
+            if let Some(&c) = closest_norm.get(&atom) {
+                if c > 0.0 && dist_ratio > c {
+                    strength *= (-(dist_ratio / c - 1.0) / 0.5).exp();
+                }
+            }
+        }
 
         if strength >= options.strength_threshold {
             bonds.push(Bond {
@@ -875,5 +907,34 @@ mod tests {
 
         let bonds = detect_bonds_atom_radii(&structure, &AtomRadiiOptions::default());
         assert!(bonds.is_empty(), "Cu-Cu at 3.30 Å exceeds 1.2*(r1+r2); must not bond");
+    }
+
+    fn fcc_cu() -> Structure {
+        // Conventional FCC Cu cell (a = 3.615 Å): 1st shell at a/√2 = 2.556 Å,
+        // 2nd shell at a = 3.615 Å.
+        let lattice = Lattice::cubic(3.615);
+        let species = vec![Species::neutral(Element::Cu); 4];
+        let frac_coords = vec![
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.5, 0.5, 0.0),
+            Vector3::new(0.5, 0.0, 0.5),
+            Vector3::new(0.0, 0.5, 0.5),
+        ];
+        Structure::new(lattice, species, frac_coords)
+    }
+
+    #[test]
+    fn test_electroneg_no_second_shell_in_metal() {
+        // electroneg must not paint a hedgehog: with the closest-neighbor
+        // penalty, only the 1st coordination shell (~2.56 Å) survives; the
+        // 2nd shell at 3.615 Å is suppressed below the strength threshold.
+        let bonds = detect_bonds_electroneg(&fcc_cu(), &ElectronegOptions::default());
+        assert!(!bonds.is_empty(), "FCC Cu must have 1st-shell metallic bonds");
+        let max_len = bonds.iter().map(|b| b.bond_length).fold(0.0_f64, f64::max);
+        assert!(
+            max_len < 3.0,
+            "longest electroneg bond should be 1st-shell (~2.56 Å), got {max_len:.3} Å \
+             (2nd shell at 3.615 Å leaked in — closest-neighbor penalty missing)"
+        );
     }
 }

--- a/extensions/rust/src/bonding.rs
+++ b/extensions/rust/src/bonding.rs
@@ -430,74 +430,144 @@ impl Default for SolidAngleOptions {
 /// the solid angle subtended by the atom pair and a Gaussian distance penalty.
 /// This is a geometry-only algorithm (no chemical preferences).
 pub fn detect_bonds_solid_angle(structure: &Structure, options: &SolidAngleOptions) -> Vec<Bond> {
+    use glam::DVec3;
+    use meshless_voronoi::{Dimensionality, Voronoi};
+    use std::collections::HashSet;
+
     let num_sites = structure.num_sites();
     if num_sites < 2 {
         return Vec::new();
     }
 
-    let species = structure.species();
-    let props: Vec<ElementProps> = species
-        .iter()
-        .map(|sp| ElementProps::from_element(sp.element))
-        .collect();
+    // A bonded pair shares a Voronoi face. This is radius-free geometry, so it
+    // gets octahedra (6) / tetrahedra (4) right and naturally excludes
+    // cation-cation pairs an anion sits between (no shared face).
+    //
+    // meshless_voronoi's periodic box is axis-aligned, so it is only correct
+    // for orthogonal cells (hexagonal/triclinic would tessellate wrongly).
+    // Instead build a NON-periodic supercell of explicit image atoms around the
+    // home cell and tessellate that: correct for ANY lattice, and each image
+    // atom carries its exact Cartesian position → exact distance + jimage. A
+    // slab's vacuum side simply yields unbounded (boundary) faces → no bond.
+    let cart = structure.cart_coords();
+    let m = structure.lattice.matrix();
+    let avec = nalgebra::Vector3::new(m[(0, 0)], m[(0, 1)], m[(0, 2)]);
+    let bvec = nalgebra::Vector3::new(m[(1, 0)], m[(1, 1)], m[(1, 2)]);
+    let cvec = nalgebra::Vector3::new(m[(2, 0)], m[(2, 1)], m[(2, 2)]);
 
-    let cutoff = options.max_distance;
-    let (center_indices, neighbor_indices, image_offsets, distances) =
-        structure.get_neighbor_list(cutoff, 1e-8, true);
+    // Replicate far enough that every home-cell atom is fully enclosed (≥ one
+    // image past the search radius along each axis).
+    let reps = |v: &nalgebra::Vector3<f64>| -> i32 {
+        let len = v.norm();
+        if len < 1e-6 {
+            1
+        } else {
+            (options.max_distance / len).ceil().max(1.0) as i32
+        }
+    };
+    let (na, nb, nc) = (reps(&avec), reps(&bvec), reps(&cvec));
 
+    // A tiny deterministic jitter (≪ bond-length resolution) breaks the exact
+    // coplanar/collinear degeneracies of symmetric crystals that otherwise make
+    // meshless_voronoi's plane-intersection panic. Deterministic so results are
+    // reproducible (no RNG, which is unavailable on wasm anyway).
+    let jitter = |seed: u64| -> f64 {
+        (seed.wrapping_mul(2_654_435_761) % 4001) as f64 / 4000.0 * 2e-6 - 1e-6
+    };
+    let mut sc_pos: Vec<DVec3> = Vec::new();
+    let mut sc_map: Vec<(usize, [i32; 3])> = Vec::new(); // supercell idx -> (home idx, image)
+    let mut central: Vec<usize> = Vec::new(); // supercell indices of the home (image 0) atoms
+    for da in -na..=na {
+        for db in -nb..=nb {
+            for dc in -nc..=nc {
+                let shift = avec * (da as f64) + bvec * (db as f64) + cvec * (dc as f64);
+                for k in 0..num_sites {
+                    if da == 0 && db == 0 && dc == 0 {
+                        central.push(sc_pos.len());
+                    }
+                    let p = cart[k] + shift;
+                    let s = sc_pos.len() as u64;
+                    sc_map.push((k, [da, db, dc]));
+                    sc_pos.push(DVec3::new(
+                        p.x + jitter(3 * s),
+                        p.y + jitter(3 * s + 1),
+                        p.z + jitter(3 * s + 2),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Bounding box for the non-periodic tessellation.
+    let mut lo = sc_pos[0];
+    let mut hi = sc_pos[0];
+    for p in &sc_pos {
+        lo = lo.min(*p);
+        hi = hi.max(*p);
+    }
+    let margin = DVec3::splat(1.0);
+    let anchor = lo - margin;
+    let extent = (hi - lo) + margin * 2.0;
+    let voronoi = Voronoi::build(&sc_pos, anchor, extent, Dimensionality::ThreeD, false);
+
+    let min_dist = options.min_bond_dist;
     let mut bonds = Vec::new();
-    let min_dist_sq = options.min_bond_dist * options.min_bond_dist;
+    let mut seen: HashSet<(usize, usize, [i32; 3])> = HashSet::new();
 
-    for idx in 0..center_indices.len() {
-        let center_idx = center_indices[idx];
-        let neighbor_idx = neighbor_indices[idx];
-        let image = image_offsets[idx];
-        let dist = distances[idx];
-
-        // Pair-level dedup with PBC awareness (see detect_bonds_atom_radii).
-        if center_idx == neighbor_idx {
-            if image[0] < 0
-                || (image[0] == 0 && image[1] < 0)
-                || (image[0] == 0 && image[1] == 0 && image[2] <= 0)
-            {
+    for &sc_i in &central {
+        let (i, _) = sc_map[sc_i];
+        let center = sc_pos[sc_i];
+        for face in voronoi.cells()[sc_i].faces(&voronoi) {
+            let area = face.area();
+            if area < 1e-9 {
                 continue;
             }
-        } else if center_idx > neighbor_idx {
-            continue;
-        }
+            // Boundary faces (cluster surface / vacuum) have no neighbour.
+            let raw = if face.left() == sc_i {
+                match face.right() {
+                    Some(r) => r,
+                    None => continue,
+                }
+            } else {
+                face.left()
+            };
+            let (j, image) = sc_map[raw];
 
+            let dist = (sc_pos[raw] - center).length();
+            if dist < min_dist {
+                continue;
+            }
+            // Solid-angle fraction Ω/4π ≈ A / (4π r²).
+            let saf = area / (4.0 * std::f64::consts::PI * dist * dist);
+            if saf < options.min_solid_angle {
+                continue;
+            }
 
-        let dist_sq = dist * dist;
-        if dist_sq < min_dist_sq {
-            continue;
-        }
+            // Canonicalise (min, max, image-relative-to-min) so the same face
+            // seen from both atoms dedupes to one bond.
+            let key = if i < j {
+                (i, j, image)
+            } else if i > j {
+                (j, i, [-image[0], -image[1], -image[2]])
+            } else {
+                if image[0] < 0
+                    || (image[0] == 0 && image[1] < 0)
+                    || (image[0] == 0 && image[1] == 0 && image[2] <= 0)
+                {
+                    continue;
+                }
+                (i, j, image)
+            };
+            if !seen.insert(key) {
+                continue;
+            }
 
-        let r1 = props[center_idx].covalent_radius;
-        let r2 = props[neighbor_idx].covalent_radius;
-        let avg_r = (r1 + r2) / 2.0;
-        let face_area = std::f64::consts::PI * avg_r * avg_r;
-        let solid_angle = face_area / dist_sq;
-
-        if solid_angle < options.min_solid_angle || face_area < options.min_face_area {
-            continue;
-        }
-
-        // Gaussian distance penalty centered at ideal bond length (sum of covalent radii)
-        let sum_radii = r1 + r2;
-        let ratio = dist / sum_radii;
-        let dist_penalty = (-((ratio - 1.0).powi(2)) / 0.4).exp();
-
-        // Normalize solid angle by full sphere (4π steradians)
-        let angle_strength = (solid_angle / (4.0 * std::f64::consts::PI)).min(1.0);
-        let strength = angle_strength * dist_penalty;
-
-        if strength > options.strength_threshold {
             bonds.push(Bond {
-                site_idx_1: center_idx,
-                site_idx_2: neighbor_idx,
+                site_idx_1: key.0,
+                site_idx_2: key.1,
                 bond_length: dist,
-                strength,
-                image,
+                strength: saf.min(1.0),
+                image: key.2,
             });
         }
     }
@@ -823,7 +893,17 @@ mod tests {
         for bond in &bonds {
             assert!(bond.bond_length > 0.4);
             assert!(bond.strength > 0.0);
+            // Voronoi coordination: rock-salt cells are cubes → 6 faces toward
+            // the opposite species only. No same-species (Na-Na / Cl-Cl) bonds.
+            let cross = (bond.site_idx_1 < 4) != (bond.site_idx_2 < 4);
+            assert!(
+                cross,
+                "solid_angle must not bond same species in NaCl: {}-{}",
+                bond.site_idx_1, bond.site_idx_2
+            );
         }
+        // 6-fold coordination: 4 Na × 6 Cl = 24 unique Na-Cl bonds.
+        assert_eq!(bonds.len(), 24, "rock-salt is 6-coordinate");
     }
 
     #[test]
@@ -930,6 +1010,28 @@ mod tests {
             max_len < 3.0,
             "longest electroneg bond should be 1st-shell (~2.56 Å), got {max_len:.3} Å \
              (2nd shell at 3.615 Å leaked in — closest-neighbor penalty missing)"
+        );
+    }
+
+    #[test]
+    fn test_solid_angle_hcp_non_orthogonal() {
+        // HCP (γ = 120°, non-orthogonal): every atom is 12-coordinate. An
+        // axis-aligned periodic Voronoi gets this wrong (6); the non-periodic
+        // supercell tessellation must recover the full 12.
+        let lattice = Lattice::hexagonal(3.21, 5.21);
+        let species = vec![Species::neutral(Element::Mg); 2];
+        let frac_coords = vec![
+            Vector3::new(1.0 / 3.0, 2.0 / 3.0, 0.25),
+            Vector3::new(2.0 / 3.0, 1.0 / 3.0, 0.75),
+        ];
+        let structure = Structure::new(lattice, species, frac_coords);
+
+        let bonds = detect_bonds_solid_angle(&structure, &SolidAngleOptions::default());
+        // coordination = 2 * bonds / atoms
+        let coordination = 2 * bonds.len() / 2;
+        assert_eq!(
+            coordination, 12,
+            "HCP must be 12-coordinate via supercell Voronoi, got {coordination}"
         );
     }
 

--- a/extensions/rust/src/bonding.rs
+++ b/extensions/rust/src/bonding.rs
@@ -74,9 +74,6 @@ impl Default for AtomRadiiOptions {
 /// Options for electroneg_ratio bonding algorithm.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ElectronegOptions {
-    /// Maximum electronegativity difference for bonding (default: 1.7)
-    #[serde(default = "default_en_threshold")]
-    pub electronegativity_threshold: f64,
     /// Max distance as multiple of sum of covalent radii (default: 2.0)
     #[serde(default = "default_max_ratio")]
     pub max_distance_ratio: f64,
@@ -100,9 +97,6 @@ pub struct ElectronegOptions {
     pub strength_threshold: f64,
 }
 
-fn default_en_threshold() -> f64 {
-    1.7
-}
 fn default_max_ratio() -> f64 {
     2.0
 }
@@ -125,7 +119,6 @@ fn default_strength_threshold() -> f64 {
 impl Default for ElectronegOptions {
     fn default() -> Self {
         Self {
-            electronegativity_threshold: default_en_threshold(),
             max_distance_ratio: default_max_ratio(),
             min_bond_dist: default_min_dist(),
             metal_metal_penalty: default_mm_penalty(),
@@ -285,13 +278,6 @@ pub fn detect_bonds_electroneg(structure: &Structure, options: &ElectronegOption
         if dist > sum_radii * options.max_distance_ratio {
             continue;
         }
-        // Only count BONDABLE neighbours (same en filter as the bond loop), so
-        // an atom's "closest contact" is its nearest *bond*, not a nearer pair
-        // that electronegativity rejects (e.g. Na-Cl while bonding Na-Na).
-        let en_diff = (props[ci].electronegativity - props[ni].electronegativity).abs();
-        if en_diff > options.electronegativity_threshold {
-            continue;
-        }
         let norm = dist / sum_radii;
         closest_norm
             .entry(ci)
@@ -332,11 +318,11 @@ pub fn detect_bonds_electroneg(structure: &Structure, options: &ElectronegOption
             continue;
         }
 
-        // Check electronegativity constraint
+        // Electronegativity difference modulates strength (below) but never
+        // rejects a bond: a large ΔEN is a strong ionic bond (Li-O, Na-Cl),
+        // not a non-bond. (Earlier a hard `en_diff > threshold` cutoff here
+        // dropped every ionic bond — chemically backwards.)
         let en_diff = (p1.electronegativity - p2.electronegativity).abs();
-        if en_diff > options.electronegativity_threshold {
-            continue;
-        }
 
         // Calculate base strength from distance
         let dist_ratio = dist / sum_radii;
@@ -798,12 +784,21 @@ mod tests {
         let options = ElectronegOptions::default();
         let bonds = detect_bonds_electroneg(&structure, &options);
 
-        // Should detect ionic Na-Cl bonds
         assert!(!bonds.is_empty(), "Should detect Na-Cl bonds");
 
-        // Metal-nonmetal bonus should boost strength
-        for bond in &bonds {
-            assert!(bond.strength > 0.3);
+        // The ionic Na-Cl bonds (idx 0-3 = Na, 4-7 = Cl) must be present and
+        // strong — a large ΔEN is an ionic bond, not a rejected pair. The
+        // metal-nonmetal bonus boosts them well above any same-species contact.
+        let na_cl: Vec<_> = bonds
+            .iter()
+            .filter(|b| (b.site_idx_1 < 4) != (b.site_idx_2 < 4))
+            .collect();
+        assert!(
+            !na_cl.is_empty(),
+            "Should detect ionic Na-Cl bonds (large ΔEN must not be rejected)"
+        );
+        for b in &na_cl {
+            assert!(b.strength > 0.5, "Na-Cl ionic bond should be strong, got {}", b.strength);
         }
     }
 
@@ -935,6 +930,27 @@ mod tests {
             max_len < 3.0,
             "longest electroneg bond should be 1st-shell (~2.56 Å), got {max_len:.3} Å \
              (2nd shell at 3.615 Å leaked in — closest-neighbor penalty missing)"
+        );
+    }
+
+    #[test]
+    fn test_electroneg_bonds_ionic_lio() {
+        // Li-O is a strong ionic bond (ΔEN ≈ 2.5). electroneg must NOT drop it
+        // just because the electronegativity difference is large — a big ΔEN is
+        // an ionic bond, not a non-bond.
+        let lattice = Lattice::cubic(15.0);
+        let species = vec![Species::neutral(Element::Li), Species::neutral(Element::O)];
+        let frac_coords = vec![
+            Vector3::new(0.3, 0.3, 0.3),
+            Vector3::new(0.3 + 2.0 / 15.0, 0.3, 0.3),
+        ];
+        let structure = Structure::new(lattice, species, frac_coords);
+
+        let bonds = detect_bonds_electroneg(&structure, &ElectronegOptions::default());
+        assert_eq!(
+            bonds.len(),
+            1,
+            "Li-O at 2.0 Å is a real ionic bond; electroneg must detect it"
         );
     }
 }

--- a/extensions/rust/src/bonding.rs
+++ b/extensions/rust/src/bonding.rs
@@ -32,10 +32,12 @@ pub struct Bond {
 /// Options for atom_radii bonding algorithm.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AtomRadiiOptions {
-    /// Absolute tolerance in Angstroms added to covalent radii sum (default: 0.3)
-    /// Bond if: (r1 + r2) - tolerance <= distance <= (r1 + r2) + tolerance
-    #[serde(default = "default_tolerance")]
-    pub tolerance: f64,
+    /// Multiplicative cutoff on the covalent radii sum (default: 1.2).
+    /// Bond if: min_bond_dist <= distance <= scale * (r1 + r2).
+    /// A proportional cutoff scales with atom size, unlike a fixed absolute
+    /// pad which is too tight for large atoms / stretched metallic contacts.
+    #[serde(default = "default_scale")]
+    pub scale: f64,
     /// Minimum bond distance in Angstroms (default: 0.4)
     #[serde(default = "default_min_dist")]
     pub min_bond_dist: f64,
@@ -48,8 +50,8 @@ pub struct AtomRadiiOptions {
     pub include_periodic_images: bool,
 }
 
-fn default_tolerance() -> f64 {
-    0.3
+fn default_scale() -> f64 {
+    1.2
 }
 fn default_min_dist() -> f64 {
     0.4
@@ -61,7 +63,7 @@ fn default_max_dist() -> f64 {
 impl Default for AtomRadiiOptions {
     fn default() -> Self {
         Self {
-            tolerance: default_tolerance(),
+            scale: default_scale(),
             min_bond_dist: default_min_dist(),
             max_bond_dist: default_max_dist(),
             include_periodic_images: false,
@@ -157,8 +159,8 @@ impl ElementProps {
 
 /// Detect bonds using covalent radii sum.
 ///
-/// A bond is detected if the distance between two atoms is less than
-/// the sum of their covalent radii times (1 + tolerance).
+/// A bond is detected if the distance between two atoms is at most
+/// `scale` times the sum of their covalent radii.
 ///
 /// This is the fastest algorithm, suitable for quick visualization.
 pub fn detect_bonds_atom_radii(structure: &Structure, options: &AtomRadiiOptions) -> Vec<Bond> {
@@ -215,8 +217,7 @@ pub fn detect_bonds_atom_radii(structure: &Structure, options: &AtomRadiiOptions
 
         let r1 = props[center_idx].covalent_radius;
         let r2 = props[neighbor_idx].covalent_radius;
-        let expected = r1 + r2;
-        let upper_bound = expected + options.tolerance;
+        let upper_bound = (r1 + r2) * options.scale;
 
         // Only check upper bound: coordination bonds (M-O, M-N) are often
         // significantly shorter than the covalent radii sum. The lower bound
@@ -838,5 +839,41 @@ mod tests {
             assert!(hb.da_distance < 3.5, "D···A distance should be < 3.5 Å");
             assert!(hb.strength > 0.0);
         }
+    }
+
+    #[test]
+    fn test_atom_radii_metal_scale() {
+        // Two Cu atoms 3.05 Å apart. The covalent-radii sum is 2.64 Å, so the
+        // legacy absolute window (sum + 0.3 = 2.94 Å) drops this real metallic
+        // contact. A multiplicative cutoff (1.2 * sum = 3.17 Å) keeps it.
+        let lattice = Lattice::cubic(20.0);
+        let species = vec![Species::neutral(Element::Cu), Species::neutral(Element::Cu)];
+        let frac_coords = vec![
+            Vector3::new(0.25, 0.25, 0.25),
+            Vector3::new(0.25 + 3.05 / 20.0, 0.25, 0.25),
+        ];
+        let structure = Structure::new(lattice, species, frac_coords);
+
+        let bonds = detect_bonds_atom_radii(&structure, &AtomRadiiOptions::default());
+        assert_eq!(
+            bonds.len(),
+            1,
+            "Cu-Cu at 3.05 Å is a metallic contact within 1.2*(r1+r2); must bond"
+        );
+    }
+
+    #[test]
+    fn test_atom_radii_scale_rejects_far() {
+        // Two Cu atoms 3.30 Å apart sit beyond 1.2 * sum (3.17 Å) — no bond.
+        let lattice = Lattice::cubic(20.0);
+        let species = vec![Species::neutral(Element::Cu), Species::neutral(Element::Cu)];
+        let frac_coords = vec![
+            Vector3::new(0.25, 0.25, 0.25),
+            Vector3::new(0.25 + 3.30 / 20.0, 0.25, 0.25),
+        ];
+        let structure = Structure::new(lattice, species, frac_coords);
+
+        let bonds = detect_bonds_atom_radii(&structure, &AtomRadiiOptions::default());
+        assert!(bonds.is_empty(), "Cu-Cu at 3.30 Å exceeds 1.2*(r1+r2); must not bond");
     }
 }

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -48,6 +48,7 @@ const structure: Record<string, string> = {
   orthographic: `Orthographic`,
   strategy: `Strategy`,
   thickness: `Thickness`,
+  bond_scale: `Bond scale`,
   cell_edge_stub_bonds: `Cell-edge stub bonds`,
   stub_length: `Stub Length`,
   clipping: `Clipping`,

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -57,6 +57,7 @@ const structure: Record<string, string> = {
   outside_opacity: `Outside Opacity`,
   polyhedra: `Polyhedra`,
   show_polyhedra: `Show Polyhedra`,
+  polyhedra_bond_scale: `Bond scale`,
   polyhedra_centers: `Centers`,
   polyhedra_centers_auto: `Auto`,
   min_coordination: `Min Coordination`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -57,6 +57,7 @@ const structure: Record<string, string> = {
   outside_opacity: `外部不透明度`,
   polyhedra: `多面体`,
   show_polyhedra: `显示多面体`,
+  polyhedra_bond_scale: `键长系数`,
   polyhedra_centers: `中心元素`,
   polyhedra_centers_auto: `自动`,
   min_coordination: `最小配位数`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -48,6 +48,7 @@ const structure: Record<string, string> = {
   orthographic: `正交`,
   strategy: `策略`,
   thickness: `粗细`,
+  bond_scale: `键长系数`,
   cell_edge_stub_bonds: `晶胞边缘短键`,
   stub_length: `短键长度`,
   clipping: `裁剪`,

--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -144,6 +144,14 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       value: {},
       description: `Additional parameters for the bonding strategy`,
     },
+    bond_scale: {
+      value: 1.15,
+      description:
+        `Atom Radii strategy: bond when distance ≤ scale × (sum of covalent radii). ` +
+        `Lower = fewer, tighter bonds; higher = catches longer/stretched contacts.`,
+      minimum: 1.0,
+      maximum: 1.4,
+    },
     show_hydrogen_bonds: {
       value: false,
       description: `Show hydrogen bonds as dashed lines`,

--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -510,6 +510,16 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       minimum: 4,
       maximum: 16,
     },
+    polyhedra_bond_scale: {
+      value: 1.15,
+      description:
+        `Bond cutoff for the atom_radii bonds that build polyhedra: connect when ` +
+        `distance ≤ scale × (sum of covalent radii). Tune independently of the ` +
+        `displayed bonds — lower for tighter coordination shells, higher to close ` +
+        `polyhedra with longer metal-ligand bonds.`,
+      minimum: 1.0,
+      maximum: 1.4,
+    },
     polyhedra_metals_only: {
       value: true,
       description:

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -1105,6 +1105,7 @@
       polyhedra_color_mode: scene_props.polyhedra_color_mode,
       polyhedra_show_edges: scene_props.polyhedra_show_edges,
       polyhedra_max_neighbors: scene_props.polyhedra_max_neighbors,
+      polyhedra_bond_scale: scene_props.polyhedra_bond_scale,
       polyhedra_edge_color: scene_props.polyhedra_edge_color,
       hide_polyhedra_center_atoms: scene_props.hide_polyhedra_center_atoms,
       hide_polyhedra_internal_bonds: scene_props.hide_polyhedra_internal_bonds,
@@ -1114,6 +1115,7 @@
       scene_props.polyhedra_center_elements = DEFAULTS.structure.polyhedra_center_elements
       scene_props.polyhedra_min_coordination = DEFAULTS.structure.polyhedra_min_coordination
       scene_props.polyhedra_max_neighbors = DEFAULTS.structure.polyhedra_max_neighbors
+      scene_props.polyhedra_bond_scale = DEFAULTS.structure.polyhedra_bond_scale
       scene_props.polyhedra_color_mode = DEFAULTS.structure.polyhedra_color_mode
       scene_props.polyhedra_color = DEFAULTS.structure.polyhedra_color
       scene_props.polyhedra_show_edges = DEFAULTS.structure.polyhedra_show_edges
@@ -1183,6 +1185,27 @@
           max="16"
           step="1"
           bind:value={scene_props.polyhedra_max_neighbors}
+        />
+      </label>
+      <label
+        {@attach tooltip({
+          content: SETTINGS_CONFIG.structure.polyhedra_bond_scale.description,
+        })}
+      >
+        {t(`structure.polyhedra_bond_scale`)}
+        <input
+          type="number"
+          min={SETTINGS_CONFIG.structure.polyhedra_bond_scale.minimum}
+          max={SETTINGS_CONFIG.structure.polyhedra_bond_scale.maximum}
+          step={0.05}
+          bind:value={scene_props.polyhedra_bond_scale}
+        />
+        <input
+          type="range"
+          min={SETTINGS_CONFIG.structure.polyhedra_bond_scale.minimum}
+          max={SETTINGS_CONFIG.structure.polyhedra_bond_scale.maximum}
+          step={0.05}
+          bind:value={scene_props.polyhedra_bond_scale}
         />
       </label>
       <label>

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -943,6 +943,7 @@
         bonding_strategy: scene_props.bonding_strategy,
         bond_color: scene_props.bond_color,
         bond_thickness: scene_props.bond_thickness,
+        bond_scale: scene_props.bond_scale,
         incomplete_periodic_edge_mode: scene_props.incomplete_periodic_edge_mode,
         incomplete_edge_length_scale: scene_props.incomplete_edge_length_scale,
       }}
@@ -950,6 +951,7 @@
         scene_props.bonding_strategy = DEFAULTS.structure.bonding_strategy
         scene_props.bond_color = DEFAULTS.structure.bond_color
         scene_props.bond_thickness = DEFAULTS.structure.bond_thickness
+        scene_props.bond_scale = DEFAULTS.structure.bond_scale
         scene_props.incomplete_periodic_edge_mode = DEFAULTS.structure.incomplete_periodic_edge_mode
         scene_props.incomplete_edge_length_scale = DEFAULTS.structure.incomplete_edge_length_scale
       }}
@@ -966,6 +968,29 @@
           {/each}
         </select>
       </label>
+      {#if scene_props.bonding_strategy === `atom_radii`}
+        <label
+          {@attach tooltip({
+            content: SETTINGS_CONFIG.structure.bond_scale.description,
+          })}
+        >
+          {t('structure.bond_scale')}
+          <input
+            type="number"
+            min={SETTINGS_CONFIG.structure.bond_scale.minimum}
+            max={SETTINGS_CONFIG.structure.bond_scale.maximum}
+            step={0.05}
+            bind:value={scene_props.bond_scale}
+          />
+          <input
+            type="range"
+            min={SETTINGS_CONFIG.structure.bond_scale.minimum}
+            max={SETTINGS_CONFIG.structure.bond_scale.maximum}
+            step={0.05}
+            bind:value={scene_props.bond_scale}
+          />
+        </label>
+      {/if}
       <label>
         {t('structure.color')} <input type="color" bind:value={scene_props.bond_color} />
       </label>

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -618,6 +618,7 @@
     polyhedra_center_elements = [] as string[],
     polyhedra_min_coordination = 3,
     polyhedra_max_neighbors = 8,
+    polyhedra_bond_scale = DEFAULTS.structure.polyhedra_bond_scale,
     polyhedra_metals_only = true,
     polyhedra_color_mode = `vertex` as import('$lib/settings').PolyhedraColorMode,
     polyhedra_color = `#4a90d9`,
@@ -871,6 +872,7 @@
     polyhedra_center_elements?: string[]
     polyhedra_min_coordination?: number
     polyhedra_max_neighbors?: number
+    polyhedra_bond_scale?: number
     polyhedra_metals_only?: boolean
     polyhedra_color_mode?: import('$lib/settings').PolyhedraColorMode
     polyhedra_color?: string
@@ -2616,10 +2618,11 @@
           : structure
       // Polyhedra need coordination-complete bonds, independent of the user's
       // render bond mode (solid_angle under-coordinates octahedra). Compute
-      // atom_radii bonds (PBC-aware via WASM) just for polyhedra; fall back to
-      // the rendered bonds if the sync path is unavailable (large cell / no WASM).
+      // atom_radii bonds (PBC-aware via WASM) just for polyhedra, with their own
+      // scale knob; fall back to the rendered bonds if the sync path is
+      // unavailable (large cell / no WASM).
       const poly_bonds_raw =
-        compute_bonds_sync(base_structure, `atom_radii`, { scale: bond_scale }) ??
+        compute_bonds_sync(base_structure, `atom_radii`, { scale: polyhedra_bond_scale }) ??
         visible_bond_pairs
       // Honour per-pair distance rules in polyhedra too, so a ruled pair's
       // coordination shell matches the rendered bonds (generate + filter).

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -2934,8 +2934,12 @@
     const lat_matrix = (Array.isArray(lat_m) && lat_m.length === 3)
       ? lat_m as [Vec3, Vec3, Vec3]
       : null
+    // During trajectory playback `bond_struct.sites[].xyz` are the loaded
+    // frame, not the one on screen. Pass the animated frame positions so ruled
+    // bonds track the trajectory instead of freezing at frame 0.
     const ruled_bonds = apply_bond_distance_rules(
       bond_struct, lat_matrix, bond_pairs, bond_distance_rules ?? [],
+      trajectory_frame_positions ?? null,
     )
 
     const is_site_visible = (site_idx: number) => {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -458,6 +458,7 @@
     show_image_atoms = false,
     bonding_strategy = DEFAULTS.structure.bonding_strategy,
     bonding_options = {},
+    bond_scale = DEFAULTS.structure.bond_scale,
     show_hydrogen_bonds = DEFAULTS.structure.show_hydrogen_bonds,
     hbond_distance_cutoff = DEFAULTS.structure.hbond_distance_cutoff,
     hbond_angle_cutoff = DEFAULTS.structure.hbond_angle_cutoff,
@@ -709,6 +710,7 @@
     bond_color?: string
     bonding_strategy?: BondingStrategy
     bonding_options?: Record<string, unknown>
+    bond_scale?: number
     show_hydrogen_bonds?: boolean
     hbond_distance_cutoff?: number
     hbond_angle_cutoff?: number
@@ -2040,11 +2042,17 @@
   // cross-cell bonds with `image` populated; the renderer paints two
   // halves anchored at the original atoms.
   let bond_input = $derived(bond_input_structure ?? structure)
+  // Merge the user-tunable `bond_scale` into the strategy options. atom_radii
+  // reads `scale` (bond iff dist ≤ scale·Σr); electroneg/solid_angle ignore it.
+  let bonding_options_eff = $derived({
+    ...(bonding_options as Record<string, unknown>),
+    scale: bond_scale,
+  })
   $effect.pre(() => {
     compute_bond_connectivity(
       bond_state, (pairs) => { bond_pairs = pairs },
       bond_input, show_bonds, lattice, bonding_strategy,
-      bonding_options, external_dragging,
+      bonding_options_eff, external_dragging,
     )
   })
 
@@ -2059,7 +2067,7 @@
     compute_bond_connectivity(
       bond_state, (pairs) => { bond_pairs = pairs },
       bond_input, show_bonds, lattice, bonding_strategy,
-      bonding_options, external_dragging,
+      bonding_options_eff, external_dragging,
     )
   })))
 
@@ -2610,7 +2618,8 @@
       // render bond mode (solid_angle under-coordinates octahedra). Compute
       // atom_radii bonds (PBC-aware via WASM) just for polyhedra; fall back to
       // the rendered bonds if the sync path is unavailable (large cell / no WASM).
-      const poly_bonds_raw = compute_bonds_sync(base_structure, `atom_radii`, {}) ??
+      const poly_bonds_raw =
+        compute_bonds_sync(base_structure, `atom_radii`, { scale: bond_scale }) ??
         visible_bond_pairs
       // Honour per-pair distance rules in polyhedra too, so a ruled pair's
       // coordination shell matches the rendered bonds (generate + filter).
@@ -3659,7 +3668,7 @@
         // behavior as flag-off), which is still correct but slower.
         const ok = apply_atom_add_incremental(
           bond_state, added, bond_manager, new_sites as Site[],
-          structure, bonding_strategy, bonding_options as Record<string, unknown>,
+          structure, bonding_strategy, bonding_options_eff,
         )
         if (import.meta.env?.DEV) {
           // eslint-disable-next-line no-console
@@ -3691,7 +3700,7 @@
         // element change — covalent radius shifts).
         const ok = apply_atom_replace_incremental(
           bond_state, replacements, bond_manager, new_sites as Site[],
-          structure, bonding_strategy, bonding_options as Record<string, unknown>,
+          structure, bonding_strategy, bonding_options_eff,
         )
         if (import.meta.env?.DEV) {
           // eslint-disable-next-line no-console
@@ -3716,7 +3725,7 @@
         // apply_atom_move_incremental about the drag fast-path.
         const ok = apply_atom_move_incremental(
           bond_state, moved, bond_manager, new_sites as Site[],
-          structure, bonding_strategy, bonding_options as Record<string, unknown>,
+          structure, bonding_strategy, bonding_options_eff,
         )
         if (import.meta.env?.DEV) {
           // eslint-disable-next-line no-console
@@ -5355,7 +5364,7 @@
           {cutting_slab_preview}
           {cutting_show_bonds}
           {bonding_strategy}
-          {bonding_options}
+          bonding_options={bonding_options_eff}
           {bond_thickness}
           {bond_color}
           {ambient_light}

--- a/src/lib/structure/bond-distance-rules.ts
+++ b/src/lib/structure/bond-distance-rules.ts
@@ -57,9 +57,21 @@ export function apply_bond_distance_rules(
   lattice: [Vec3, Vec3, Vec3] | null,
   bonds: readonly BondPair[],
   rules: readonly BondDistanceRuleLike[],
+  // Optional current-frame Cartesian positions (flat xyz). During trajectory
+  // playback the structure's `sites[].xyz` are the loaded frame, not the one
+  // on screen — pass the animated positions so ruled bonds track the frame
+  // instead of freezing at frame 0. Ignored unless its length matches sites.
+  frame_positions?: Float32Array | null,
 ): BondPair[] {
   if (!rules.length) return [...bonds]
   if (!structure?.sites?.length) return [...bonds]
+
+  const use_frame = !!frame_positions
+    && frame_positions.length === structure.sites.length * 3
+  const pos_of = (idx: number): Vec3 =>
+    use_frame
+      ? [frame_positions![idx * 3], frame_positions![idx * 3 + 1], frame_positions![idx * 3 + 2]]
+      : (structure.sites[idx].xyz as Vec3)
 
   const ruled = new Map<string, { min: number; max: number }>()
   for (const r of rules) {
@@ -87,12 +99,12 @@ export function apply_bond_distance_rules(
   for (let i = 0; i < sites.length; i++) {
     const ei = site_element(structure, i)
     if (!ei) continue
-    const pi = sites[i].xyz as Vec3
+    const pi = pos_of(i)
     for (let j = i; j < sites.length; j++) {
       const ej = site_element(structure, j)
       const rule = ruled.get(pair_key(ei, ej))
       if (!rule) continue
-      const pj = sites[j].xyz as Vec3
+      const pj = pos_of(j)
       for (let a = -ra; a <= ra; a++) {
         for (let b = -rb; b <= rb; b++) {
           for (let c = -rc; c <= rc; c++) {

--- a/tests/vitest/structure/bond-distance-rules.test.ts
+++ b/tests/vitest/structure/bond-distance-rules.test.ts
@@ -40,6 +40,23 @@ describe(`apply_bond_distance_rules`, () => {
     expect(out).toHaveLength(1) // P-O untouched (no P-O rule)
   })
 
+  it(`uses current-frame positions (trajectory) instead of static xyz`, () => {
+    // Static geometry: Fe-O at 2.5 Å, outside [0, 2.3] → no bond.
+    // The trajectory's current frame moved O to 2.0 Å → the rule must
+    // regenerate the bond from the FRAME position, not the static one.
+    const s = struct([site(`Fe`, [0, 0, 0]), site(`O`, [2.5, 0, 0])])
+    const frame = new Float32Array([0, 0, 0, 2.0, 0, 0])
+    const out = apply_bond_distance_rules(
+      s,
+      null,
+      [],
+      [{ element_1: `Fe`, element_2: `O`, min_dist: 0, max_dist: 2.3 }],
+      frame,
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].bond_length).toBeCloseTo(2.0, 3)
+  })
+
   it(`removes a ruled-pair bond that is longer than max`, () => {
     // Fe-O at 2.5 Å, rule max 2.3 -> dropped, and not regenerated (out of range)
     const s = struct([site(`Fe`, [0, 0, 0]), site(`O`, [2.5, 0, 0])])


### PR DESCRIPTION
Fixes all four bonding strategies (live path = ferrox-wasm Rust) plus two UX/correctness gaps. Each commit is an independent, TDD'd fix; verified on the live wasm artifact (LiFePO4 / HCP / NaCl) and 11/11 cargo + 1209 structure vitest.

## Strategies
- **atom_radii**: absolute `Σr+0.3` window was too tight for metals → multiplicative `dist ≤ scale·Σr` (default 1.2), plus a user **Bond scale** slider (default 1.15).
- **electroneg**: (1) applied the missing matterviz closest-neighbour penalty — killed the 2nd/3rd-shell "hedgehog" over-bonding; (2) dropped the `ΔEN > 1.7 → reject` gate that silently discarded every ionic bond (Li-O, Na-Cl).
- **solid_angle**: replaced the radius-weighted sphere-cap (under-coordinated octahedra) with a real Voronoi tessellation via a non-periodic supercell — correct for ANY lattice (orthogonal + hexagonal/triclinic), exact jimage, deterministic jitter to avoid meshless_voronoi degeneracy panics; plus a covalent-radii distance sanity to trim anion-anion (O-O) polyhedra edges.

LiFePO4 now resolves to exactly Fe-O 24 / Li-O 24 / P-O 16, zero spurious; HCP 12-coordinate; NaCl 6-fold Na-Cl.

## UX / correctness
- Separate **polyhedra Bond scale** (polyhedra are built from a dedicated atom_radii pass).
- **Bond distance rules now track the trajectory frame** — ruled pairs were frozen at frame 0 while atoms animated; rules now use the current-frame positions.

Note: meshless_voronoi (already a dep) compiles AND runs under wasm; the `#[cfg(not(wasm32))]` gate in coordination.rs was conservative.