### PR TITLE
fix(chat): adaptive agent-bridge port + lab link only on landing

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1611,19 +1611,6 @@
 
   // Drag/drop, resize handlers are in ./lib/drag-drop-handlers.ts and ./lib/resize-handlers.ts
 
-  let show_lab_link = $derived.by(() => {
-    // Show only on the landing state of the *currently active* structure
-    // tab. Using the first tab let the link bleed through to other tabs
-    // that already had a structure loaded.
-    const t = tm.active_tab
-    if (!t || t.type !== `structure`) return false
-    const ts = tab_states[t.id]
-    if (!ts) return false
-    const first = leaves(ts.root)[0]
-    const pane = first ? structurePane(first) : null
-    return !!pane && !pane_has_content(pane)
-  })
-
   // Global SSE listener for the External/MCP "default" panel.
   //
   // Lab claude (and any MCP client without an X-CatGo-Tab-Id header)
@@ -2217,6 +2204,18 @@
                     <path d="M12 17.27l5.18 3.13-1.37-5.9 4.59-3.97-6.04-.52L12 4.5 9.64 10l-6.04.52 4.59 3.97-1.37 5.9z"/>
                   </svg>
                 </a>
+                <!-- Lab link — same mode as the GitHub link above: an
+                     absolutely-positioned pill inside the landing block (top-left,
+                     mirroring GitHub at top-right). Landing-only by construction. -->
+                <a
+                  href="https://wanlulilab.ucsd.edu"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="lab-link"
+                  title="Dr. Wanlu Li Lab @ UCSD"
+                >
+                  Dr. Wanlu Li @UCSD
+                </a>
                 <div class="samples-grid">
                   {#each sample_structures as sample}
                     <button
@@ -2516,19 +2515,6 @@
       </div>
     </div>
   </div>
-{/if}
-
-<!-- Lab link -->
-{#if show_lab_link}
-  <a
-    href="https://wanlulilab.ucsd.edu"
-    target="_blank"
-    rel="noopener noreferrer"
-    class="lab-link"
-    title="Dr. Wanlu Li Lab @ UCSD"
-  >
-    Dr. Wanlu Li @UCSD
-  </a>
 {/if}
 
 <!-- Database search modal (needs backend proxy) -->
@@ -3435,25 +3421,34 @@
   */
   }
 
+  /* Same mode as .github-star: an absolutely-positioned pill in the landing
+     corner (top-left, mirroring GitHub at top-right) — not a fixed badge. */
   .lab-link {
-    position: fixed;
-    bottom: 12px;
-    right: 12px;
+    position: absolute;
+    top: 14px;
+    left: 16px;
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     padding: 6px 12px;
-    background: var(--surface-bg, rgba(30, 41, 59, 0.8));
-    border: 1px solid var(--text-color-muted, rgba(71, 85, 105, 0.4));
-    border-radius: 6px;
-    color: var(--text-color-muted, rgba(148, 163, 184, 0.9));
-    font-size: 11px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
     text-decoration: none;
-    z-index: 100;
-    transition: all 0.2s ease;
+    color: var(--text-color-muted, #9ca3af);
+    background: var(--surface-bg, rgba(255, 255, 255, 0.05));
+    border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+    border-radius: 8px;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s, border-color 0.15s, transform 0.15s;
   }
 
   .lab-link:hover {
-    background: rgba(30, 41, 59, 0.95);
-    border-color: rgba(59, 130, 246, 0.5);
-    color: #60a5fa;
+    color: var(--text-color, #f3f4f6);
+    background: var(--surface-bg-hover, rgba(255, 255, 255, 0.1));
+    border-color: var(--accent-color, cornflowerblue);
+    transform: translateY(-1px);
   }
 
   .loading {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -505,15 +505,63 @@ pub fn run() {
             // (`claude`, `codex`, `gemini`). Desktop launchers strip PATH, so
             // we re-augment it here with the usual user-bin locations or the
             // CLIs won't be found in production.
-            let agent_port = std::env::var("CATGO_AGENT_PORT").unwrap_or_else(|_| "8001".to_string());
-            let agent_already_running = {
+            // Identity-aware probe: only treat the port as "agent already running"
+            // when /health carries our `catgo-agent` marker — so an unrelated
+            // process squatting the port (common on shared boxes / random Windows
+            // apps) is NOT mistaken for us.
+            fn probe_catgo_agent(port: u16) -> bool {
+                use std::io::{Read, Write};
                 use std::net::TcpStream;
-                let addr = format!("127.0.0.1:{}", agent_port);
-                TcpStream::connect_timeout(
-                    &addr.parse().unwrap(),
-                    std::time::Duration::from_millis(500),
-                ).is_ok()
+                use std::time::Duration;
+                let Ok(addr) = format!("127.0.0.1:{port}").parse() else {
+                    return false;
+                };
+                let Ok(mut s) = TcpStream::connect_timeout(&addr, Duration::from_millis(400))
+                else {
+                    return false;
+                };
+                let _ = s.set_read_timeout(Some(Duration::from_millis(700)));
+                if s
+                    .write_all(b"GET /health HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+                    .is_err()
+                {
+                    return false;
+                }
+                let mut buf = String::new();
+                let _ = s.read_to_string(&mut buf);
+                buf.contains("catgo-agent")
+            }
+            fn port_is_free(port: u16) -> bool {
+                std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+            }
+
+            let preferred_port: u16 = std::env::var("CATGO_AGENT_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(8001);
+            let agent_already_running = probe_catgo_agent(preferred_port);
+
+            // Port to spawn the agent on (used only when one isn't already
+            // running): the preferred port if free, else the next free port so a
+            // squatter on the preferred port can't stop the agent from starting.
+            let agent_port = if agent_already_running || port_is_free(preferred_port) {
+                preferred_port.to_string()
+            } else {
+                log::warn!(
+                    "[CatGo] agent port {} is taken by another process — picking a free port",
+                    preferred_port
+                );
+                (preferred_port + 1..preferred_port + 50)
+                    .find(|p| port_is_free(*p))
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|| preferred_port.to_string())
             };
+
+            // Set once we actually have a reachable agent. Left false (e.g. dev
+            // builds with no bundled sidecar, or a spawn failure), the webview is
+            // NOT given a port and falls back to the relative /api/agent/* URL —
+            // i.e. the dev vite-plugin-agent-bridge.
+            let mut agent_available = agent_already_running;
 
             if agent_already_running {
                 log::info!(
@@ -554,6 +602,7 @@ pub fn run() {
                         match cmd.spawn() {
                             Ok((mut rx, child)) => {
                                 log::info!("[CatGo] Agent bridge started (sidecar) on port {}", agent_port);
+                                agent_available = true;
                                 if let Ok(mut state) = app.state::<Mutex<AgentState>>().lock() {
                                     state.child = Some(child);
                                     state.spawned_by_us = true;
@@ -597,12 +646,17 @@ pub fn run() {
                 }
             }
 
-            // Expose the agent port to the webview so `sdk-stream.ts` can
-            // build the absolute URL (otherwise it would try `/api/agent/stream`
-            // against the webview's own origin, which 404s in production).
-            if let Some(win) = app.get_webview_window("main") {
-                let init = format!("window.__CATGO_AGENT_PORT__ = {};", agent_port);
-                let _ = win.eval(&init);
+            // Expose the agent port to the webview so `sdk-stream.ts` can build
+            // the absolute URL. Only when we actually have a reachable agent —
+            // otherwise leave it unset so the FE uses the relative /api/agent/*
+            // URL (served by vite-plugin-agent-bridge in dev). Pointing the
+            // webview at a port with no agent (or a foreign process) is what
+            // caused CatBot's "Not Found".
+            if agent_available {
+                if let Some(win) = app.get_webview_window("main") {
+                    let init = format!("window.__CATGO_AGENT_PORT__ = {};", agent_port);
+                    let _ = win.eval(&init);
+                }
             }
             } // end #[cfg(desktop)] sidecar block
 

--- a/src/lib/server/agent-bridge/server.ts
+++ b/src/lib/server/agent-bridge/server.ts
@@ -217,7 +217,10 @@ const server = createServer(async (req, res) => {
       return
     }
     if (url.pathname === '/health' && req.method === 'GET') {
-      jsonResponse(res, 200, { ok: true, port: AGENT_PORT })
+      // `service` is an identity marker: the desktop shell probes /health and
+      // only treats a port as "the agent already running" when it sees this,
+      // so a foreign process squatting the port is not mistaken for us.
+      jsonResponse(res, 200, { ok: true, service: 'catgo-agent', port: AGENT_PORT })
       return
     }
 


### PR DESCRIPTION
Two independent fixes found while testing CatBot in the Tauri desktop app.

## 1. Adaptive agent-bridge port (fixes CatBot on shared boxes / shipped installs)
The shell decided "agent already running, skip" from a bare TCP connect to :8001 and always pointed the webview there. ANY process holding :8001 (another user, or a random app on a Windows install) → real agent never starts → CatBot `Agent stream failed: Not Found`.

- `/health` gains a `service: "catgo-agent"` identity marker.
- Shell probes `/health` (not just TCP); reuses :8001 only when the marker is present.
- If :8001 is taken by a non-agent, spawn the agent on the next free port.
- Inject `window.__CATGO_AGENT_PORT__` only when an agent is reachable; else the FE uses the relative `/api/agent/*` URL (dev vite plugin). Dev unchanged.

Verified live: with another user squatting :8001, the shell logs "port 8001 is taken … picking a free port" and CatBot connects.

## 2. Lab link only on the landing page
The "Dr. Wanlu Li @UCSD" `position:fixed` badge bled into the workbench. Moved into the landing-page block next to "Star on GitHub" (same visibility) and restyled to match `.github-star` (absolute pill, top-left).