### PR TITLE
fix(desktop): CatBot pane Close/Popout buttons work

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -2177,8 +2177,25 @@
                 tab_id={tab.id}
                 is_pane={true}
                 on_close={() => { Object.assign(pane, create_empty_pane()); update_tab_label(tab.id) }}
-                on_popout={() => {
-                  window.open(`${location.origin}${location.pathname}#chat`, '_blank', 'width=520,height=760')
+                on_popout={async () => {
+                  // Tauri-aware popout (mirrors Structure.svelte popout_chat):
+                  // plain window.open does not create a window in a Tauri
+                  // WebView, so try the Tauri WebviewWindow API first and only
+                  // fall back to window.open in a real browser.
+                  const popout_tab_id = encodeURIComponent(tab.id ?? `default`)
+                  const url = `${location.origin}${location.pathname}#chat?tab_id=${popout_tab_id}`
+                  try {
+                    const { WebviewWindow } = await import(`@tauri-apps/api/webviewWindow`)
+                    const w = new WebviewWindow(`catgo-chat`, {
+                      title: `CatGo - AI Chat`,
+                      url, width: 500, height: 700, center: true, resizable: true, decorations: true,
+                    })
+                    w.once(`tauri://error`, () => {
+                      window.open(url, `catgo-chat`, `width=500,height=700,resizable=yes`)
+                    })
+                  } catch {
+                    window.open(url, `catgo-chat`, `width=500,height=700,resizable=yes`)
+                  }
                   Object.assign(pane, create_empty_pane())
                   update_tab_label(tab.id)
                 }}

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -97,7 +97,7 @@ export function get_pane_label(pane: PaneState): string {
 }
 
 export function create_empty_pane(): PaneState {
-  return { mode: 'structure', structure: undefined, saveable_structure: undefined, trajectory: null, is_trajectory_mode: false, cube_file: null, selected_sites: [], current_step_idx: 0, modified: false, initial_site_count: 0, initial_structure_ref: null, raw_traj_b64: '', raw_traj_format: '', remote_origin: null, local_file_path: null, source_filename: null, open_plugin_hub: 0 }
+  return { mode: 'structure', structure: undefined, saveable_structure: undefined, trajectory: null, is_trajectory_mode: false, cube_file: null, selected_sites: [], current_step_idx: 0, modified: false, initial_site_count: 0, initial_structure_ref: null, raw_traj_b64: '', raw_traj_format: '', remote_origin: null, local_file_path: null, source_filename: null, open_plugin_hub: 0, initial_panel: undefined }
 }
 
 export function pane_has_content(p: PaneState): boolean {


### PR DESCRIPTION
The standalone CatBot pane's **Close** and **Popout** buttons were unresponsive (found while testing CatBot in the desktop app).

1. **Close** — Close/Popout reset the pane via `Object.assign(pane, create_empty_pane())`, but `create_empty_pane()` omitted `initial_panel`. `Object.assign` only copies keys present in the source, so the existing `initial_panel: 'chat'` survived → the chat branch kept rendering → the click fired but nothing changed. Fix: `create_empty_pane()` returns `initial_panel: undefined`. Verified live (Chrome): Close → landing page.

2. **Popout** — used plain `window.open`, which doesn't create a window in a Tauri WebView (silently dead in the packaged app). Now tries the Tauri `WebviewWindow` API first (window.open fallback for the browser), mirroring `Structure.svelte`'s `popout_chat`, and tags the URL with `tab_id`.