### PR TITLE
fix(chat): stop CatBot reading a phantom/stale structure

### DIFF
--- a/server/catgo/routers/view_capture.py
+++ b/server/catgo/routers/view_capture.py
@@ -361,15 +361,21 @@ def get_current_structure(
     """
     struct = _panel_structures.get(panel_id, {})
     if not struct:
-        for pid, candidate in _panel_structures.items():
-            if pid == panel_id:
-                continue
-            if candidate:
-                logger.debug(
-                    "get_current_structure: panel '%s' empty, falling back to '%s'",
-                    panel_id, pid,
-                )
-                return candidate
+        # Only the "default" sentinel may borrow another panel's structure —
+        # that's the value tool callers pass when they don't know the real
+        # frontend panel id. An EXPLICIT panel that happens to be empty must
+        # NOT inherit a different panel's (possibly stale) structure: doing so
+        # made CatBot report a phantom structure the user couldn't find.
+        if panel_id == "default":
+            for pid, candidate in _panel_structures.items():
+                if pid == panel_id:
+                    continue
+                if candidate:
+                    logger.debug(
+                        "get_current_structure: panel '%s' empty, falling back to '%s'",
+                        panel_id, pid,
+                    )
+                    return candidate
         raise HTTPException(
             status_code=404,
             detail=f"No structure available for panel '{panel_id}'. "

--- a/server/tests/test_view_current_fallback.py
+++ b/server/tests/test_view_current_fallback.py
@@ -1,0 +1,46 @@
+"""get_current_structure must not surface another panel's structure for an
+explicit panel id (that caused CatBot to read a phantom/stale structure).
+
+Fallback is only for the "default" sentinel (callers that don't know the real
+frontend panel id).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_server_dir = str(Path(__file__).resolve().parent.parent)
+if _server_dir not in sys.path:
+    sys.path.insert(0, _server_dir)
+
+from fastapi import HTTPException  # noqa: E402
+
+from catgo.routers import view_capture  # noqa: E402
+
+
+def _reset():
+    view_capture._panel_structures.clear()
+
+
+def test_explicit_empty_panel_does_not_borrow_another():
+    _reset()
+    view_capture._panel_structures["structure-2"] = {"sites": [1, 2, 3]}
+    # An explicit, empty panel must NOT return structure-2's data.
+    with pytest.raises(HTTPException) as ei:
+        view_capture.get_current_structure(panel_id="structure-1")
+    assert ei.value.status_code == 404
+
+
+def test_default_empty_panel_falls_back():
+    _reset()
+    view_capture._panel_structures["structure-1"] = {"sites": [1, 2, 3]}
+    # The "default" sentinel may borrow the real viewer panel.
+    assert view_capture.get_current_structure(panel_id="default") == {"sites": [1, 2, 3]}
+
+
+def test_populated_panel_returns_own():
+    _reset()
+    view_capture._panel_structures["structure-1"] = {"sites": ["own"]}
+    view_capture._panel_structures["structure-2"] = {"sites": ["other"]}
+    assert view_capture.get_current_structure(panel_id="structure-1") == {"sites": ["own"]}

--- a/src/lib/structure/controllers/tool-handler.ts
+++ b/src/lib/structure/controllers/tool-handler.ts
@@ -254,6 +254,14 @@ export function start_mcp_bridge(deps: McpBridgeDeps): {
     cleanup: () => {
       stopped = true
       close_sse?.()
+      // Clear this panel's backend structure on unmount. The backend store can
+      // outlive the tab; without this, a closed/replaced structure tab leaves a
+      // stale structure that CatBot (bound to the same panel_id) later reads as
+      // a phantom the user can't find in any open view.
+      if (!STATIC_ONLY) {
+        fetch(`${API_BASE}/view/reset?panel_id=${deps.panel_id}`, { method: `POST` })
+          .catch(() => {})
+      }
     },
     request_push,
   }


### PR DESCRIPTION
CatBot's `get_state` read the backend panel store (`/view/structure/current?panel_id=<tab>`) and returned a structure the user couldn't find in any open view (a 580-atom IrO2/TiO2 slab, lattice:null).

**Root cause (two parts):**
1. The MCP bridge reset the backend panel on *start* but never on *cleanup*. When a structure tab closed or became a chat pane, its pushed structure lingered in the backend forever — and CatBot, bound to that `panel_id`, read the ghost.
2. `GET /view/structure/current` fell back to **any** other populated panel when the requested one was empty, so an explicit panel could inherit another panel's stale structure.

**Fixes:**
- **FE** (`tool-handler.ts`): bridge cleanup POSTs `/view/reset?panel_id` so a closed/replaced tab clears its backend structure (mirrors the reset on start).
- **Backend** (`view_capture.py`): only the `"default"` sentinel may borrow another panel's structure; an explicit empty panel returns 404 instead of a phantom. New pytest covers all 3 cases (3 passed).

The live backend's stale panels were also cleared via `/view/reset`. Note: the backend code change takes effect on the next `:8000` restart.