### PR TITLE
fix(slab): orthogonalize c by default so the surface plane is ab

### DIFF
--- a/server/catgo/routers/structure_ops.py
+++ b/server/catgo/routers/structure_ops.py
@@ -127,9 +127,10 @@ class GenerateSlabRequest(BaseModel):
         "Higher values find more accurate normals but are slower.",
     )
     orthogonalize_c: bool = Field(
-        False,
-        description="If True, orthogonalize the c-vector of the slab "
-        "so it is perpendicular to the surface plane.",
+        True,
+        description="If True (default), orthogonalize the c-vector of the slab "
+        "so it is perpendicular to the ab surface plane (vacuum cleanly along c "
+        "— what surface DFT expects). Set False to keep pymatgen's oriented cell.",
     )
 
 

--- a/server/catgo/workflow/builtins_impl.py
+++ b/server/catgo/workflow/builtins_impl.py
@@ -189,7 +189,10 @@ def run_slab_gen(
         slabs = gen.get_slabs()
         if not slabs:
             raise RuntimeError(f"SlabGenerator returned no slabs for miller=({h},{k},{l})")
-        slab = slabs[0]
+        # Orthogonalize c so it is perpendicular to the ab surface plane (vacuum
+        # cleanly along c) — matches the interactive /structure-ops slab path and
+        # the ferrox primary path; the raw oriented cell has a tilted c.
+        slab = slabs[0].get_orthogonal_c_slab()
 
     # --- Supercell (applies to BOTH paths) ---
     sa = int(params.get("supercell_a", 1) or 1)

--- a/server/tests/test_slab_orthogonalize.py
+++ b/server/tests/test_slab_orthogonalize.py
@@ -1,0 +1,51 @@
+"""Slab generation must return a cell whose c-vector is perpendicular to the
+ab surface plane (vacuum cleanly along c). Regression: the interactive/MCP
+slab tool used to default orthogonalize_c=False, yielding an oriented cell with
+a tilted c that is unusable for surface DFT.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_d = str(Path(__file__).resolve().parent.parent)
+if _d not in sys.path:
+    sys.path.insert(0, _d)
+
+from pymatgen.core import Lattice, Structure  # noqa: E402
+
+from catgo.routers.structure_ops import GenerateSlabRequest, generate_slab  # noqa: E402
+
+
+def _fcc_cu() -> dict:
+    lat = Lattice.cubic(3.61)
+    coords = [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]]
+    return Structure(lat, ["Cu"] * 4, coords).as_dict()
+
+
+def _c_perp_ab(slab_dict: dict) -> bool:
+    m = np.array(slab_dict["lattice"]["matrix"], dtype=float)
+    a, b, c = m[0], m[1], m[2]
+    cos_ca = abs(np.dot(c, a)) / (np.linalg.norm(c) * np.linalg.norm(a))
+    cos_cb = abs(np.dot(c, b)) / (np.linalg.norm(c) * np.linalg.norm(b))
+    return cos_ca < 1e-6 and cos_cb < 1e-6
+
+
+def test_default_slab_has_c_perpendicular_to_ab():
+    # FCC(111): the oriented (non-orthogonalized) cell has a tilted c — this
+    # is exactly the case that must be orthogonalized by default.
+    res = generate_slab(
+        GenerateSlabRequest(structure=_fcc_cu(), miller_index=[1, 1, 1])
+    )
+    assert res.num_slabs >= 1
+    assert _c_perp_ab(res.slabs[0]), "default slab c-vector is not perpendicular to ab"
+
+
+def test_orthogonalize_c_can_be_disabled():
+    # The flag still works: explicitly False keeps the oriented (tilted-c) cell.
+    res = generate_slab(
+        GenerateSlabRequest(
+            structure=_fcc_cu(), miller_index=[1, 1, 1], orthogonalize_c=False
+        )
+    )
+    assert not _c_perp_ab(res.slabs[0]), "FCC(111) oriented cell should have a tilted c"


### PR DESCRIPTION
## Problem
The interactive / MCP slab tool (`POST /structure-ops/generate-slab`, used by `catgo_structure action="slab"` and the CLI) defaulted `orthogonalize_c=False`. pymatgen's `SlabGenerator` then returns the **oriented** cell, whose **c-vector is tilted** (not perpendicular to the ab surface plane) for non-orthogonal cuts (e.g. FCC(111)). That slab is unusable for surface DFT — vacuum is not cleanly along c.

This only affected the **pymatgen** path. The frontend WASM cutter and the ferrox primary path already produce c⊥ab.

## Fix
- `GenerateSlabRequest.orthogonalize_c` now defaults to **True** (`structure_ops.py`) → `get_orthogonal_c_slab()` runs by default. `orthogonalize_c=False` still available to keep pymatgen's oriented cell.
- The workflow `slab_gen` **pymatgen fallback** (`builtins_impl.py`) now also orthogonalizes c, matching the ferrox primary path.

## Test / verification
- New `server/tests/test_slab_orthogonalize.py` (2/2): default FCC(111) slab has c⊥ab; the flag still works when explicitly disabled.
- Live: `curl POST /api/structure-ops/generate-slab` FCC(111) → `cos(c,a)=cos(c,b)≈1.6e-16` (c⊥ab).
- Regression: isolated run of the broader slab/structure/workflow set matches pristine `main` (the 6 failing there are pre-existing — `test_claude_code_mcp` registry drift, `test_expanse_e2e`, `test_workflow_engine*` — and `test_lateral_hetero_mcp` is import-order flaky, all unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
