### PR TITLE
fix(mcp): address the mounted MCP endpoint with a trailing slash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -263,7 +263,7 @@ You ─ chat ─▶ CatBot pane                         (src/lib/chat/*)
               ▼
         provider adapter                          (for Claude: @anthropic-ai/claude-agent-sdk query())
               │
-              │  MCP server URL: http://localhost:<port>/api/mcp
+              │  MCP server URL: http://localhost:<port>/api/mcp/
               │  plus X-CatGo-Tab-Id so tool results return to the active viewer tab
               ▼
         server/catgo/routers/mcp_http.py

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -257,7 +257,7 @@ catbot-plugin 使用的那套 stdio MCP server。
               ▼
         provider adapter                        (Claude 路径: @anthropic-ai/claude-agent-sdk query())
               │
-              │  MCP server URL: http://localhost:<port>/api/mcp
+              │  MCP server URL: http://localhost:<port>/api/mcp/
               │  加 X-CatGo-Tab-Id，让工具结果回到当前查看器 tab
               ▼
         server/catgo/routers/mcp_http.py

--- a/server/catgo/routers/hpc.py
+++ b/server/catgo/routers/hpc.py
@@ -1828,7 +1828,9 @@ PYEOF
         "PY_CLAUDEMD_EOF\n"
     )
 
-    mcp_url = f"http://localhost:{remote_port}/api/mcp"
+    # Starlette mounts the MCP ASGI app below this prefix, so HTTP clients
+    # must address the mounted root with a trailing slash.
+    mcp_url = f"http://localhost:{remote_port}/api/mcp/"
 
     try:
         # Register MCP server via `claude mcp add` (idempotent — overwrites if exists).

--- a/server/catgo/routers/mcp_http.py
+++ b/server/catgo/routers/mcp_http.py
@@ -4,7 +4,7 @@ Embeds the MCP server directly in the FastAPI backend so Claude Code
 can connect with just a URL (no Python or source code needed on the client):
 
     ~/.claude/mcp.json:
-    {"mcpServers": {"catgo": {"type": "http", "url": "http://localhost:8000/api/mcp"}}}
+    {"mcpServers": {"catgo": {"type": "http", "url": "http://localhost:8000/api/mcp/"}}}
 
 DEADLOCK PREVENTION:
 

--- a/server/catgo/setup_claude.py
+++ b/server/catgo/setup_claude.py
@@ -15,9 +15,9 @@ idempotent (safe to run on every launch), cross-platform (``pathlib`` only) and
 never raises to the caller — failures are collected and returned so a broken
 skills copy can't take down server startup.
 
-The bundled server mounts an HTTP MCP at ``/api/mcp`` (see
+The bundled server mounts an HTTP MCP at ``/api/mcp/`` (see
 ``main.py``: ``app.mount("/api/mcp", mcp_asgi_app)``), so registration uses the
-HTTP transport (``{"type": "http", "url": ".../api/mcp"}``) — no Python on the
+HTTP transport (``{"type": "http", "url": ".../api/mcp/"}``) — no Python on the
 client side is required.
 """
 
@@ -80,7 +80,11 @@ def register_mcp_http(api_base: str) -> str:
     """Register the catgo HTTP MCP server in ``~/.claude.json``.
 
     ``api_base`` is the API root, e.g. ``http://127.0.0.1:8000/api``; the MCP
-    URL is ``<api_base>/mcp`` (→ ``http://127.0.0.1:8000/api/mcp``).
+    URL is ``<api_base>/mcp/`` (→ ``http://127.0.0.1:8000/api/mcp/``).
+
+    The trailing slash is required by Starlette's mounted ASGI route. Without
+    it, POST requests can fall through to a later GET-only route and return
+    HTTP 405 before reaching the MCP session manager.
 
     Loads the existing config (or ``{}`` if missing / corrupt), sets only the
     ``mcpServers.catgo`` entry — preserving every other ``mcpServers`` entry and
@@ -88,7 +92,7 @@ def register_mcp_http(api_base: str) -> str:
 
     Returns the registered MCP URL.
     """
-    url = api_base.rstrip("/") + "/mcp"
+    url = api_base.rstrip("/") + "/mcp/"
     path = _claude_json_path()
 
     cfg: dict = {}

--- a/server/main.py
+++ b/server/main.py
@@ -254,7 +254,7 @@ def _sync_setup_claude_integration() -> None:
     Runs ONLY in the bundled (frozen) desktop app. Installer users have no
     `catgo` CLI on PATH, so the server self-registers on startup: it writes the
     HTTP MCP entry to ``~/.claude.json`` (the file Claude Code actually reads —
-    NOT ``~/.claude/mcp.json``) pointing at this server's own ``/api/mcp``, and
+    NOT ``~/.claude/mcp.json``) pointing at this server's own ``/api/mcp/``, and
     copies the campaign skills into ``~/.claude/skills``.
 
     Gated on ``sys.frozen`` and an env opt-out so dev runs are untouched. Fully
@@ -595,7 +595,7 @@ app.include_router(tools_router, prefix="/api")
 try:
     from catgo.routers.mcp_http import mcp_asgi_app
     app.mount("/api/mcp", mcp_asgi_app)
-    print("[Server] MCP HTTP endpoint available at /api/mcp")
+    print("[Server] MCP HTTP endpoint available at /api/mcp/")
 except Exception as e:
     print(f"[Server] MCP HTTP setup failed (non-fatal): {e}")
 

--- a/server/tests/test_setup_claude.py
+++ b/server/tests/test_setup_claude.py
@@ -46,20 +46,20 @@ def _make_skills_src(root: Path) -> Path:
 
 def test_register_mcp_http_writes_correct_shape(fake_home):
     url = setup_claude.register_mcp_http("http://127.0.0.1:8000/api")
-    assert url == "http://127.0.0.1:8000/api/mcp"
+    assert url == "http://127.0.0.1:8000/api/mcp/"
 
     claude_json = fake_home / ".claude.json"
     assert claude_json.exists()
     cfg = json.loads(claude_json.read_text())
     assert cfg["mcpServers"]["catgo"] == {
         "type": "http",
-        "url": "http://127.0.0.1:8000/api/mcp",
+        "url": "http://127.0.0.1:8000/api/mcp/",
     }
 
 
 def test_register_mcp_http_strips_trailing_slash(fake_home):
     url = setup_claude.register_mcp_http("http://127.0.0.1:8000/api/")
-    assert url == "http://127.0.0.1:8000/api/mcp"
+    assert url == "http://127.0.0.1:8000/api/mcp/"
 
 
 def test_register_mcp_http_preserves_other_keys(fake_home):
@@ -85,7 +85,7 @@ def test_register_mcp_http_preserves_other_keys(fake_home):
     # Pre-existing unrelated MCP server preserved.
     assert cfg["mcpServers"]["other-server"] == {"type": "stdio", "command": "foo"}
     # catgo entry added.
-    assert cfg["mcpServers"]["catgo"]["url"] == "http://127.0.0.1:8000/api/mcp"
+    assert cfg["mcpServers"]["catgo"]["url"] == "http://127.0.0.1:8000/api/mcp/"
 
 
 def test_register_mcp_http_idempotent(fake_home):
@@ -97,7 +97,7 @@ def test_register_mcp_http_idempotent(fake_home):
     assert list(cfg["mcpServers"].keys()) == ["catgo"]
     assert cfg["mcpServers"]["catgo"] == {
         "type": "http",
-        "url": "http://127.0.0.1:8000/api/mcp",
+        "url": "http://127.0.0.1:8000/api/mcp/",
     }
 
 
@@ -108,7 +108,7 @@ def test_register_mcp_http_recovers_from_corrupt_file(fake_home):
     url = setup_claude.register_mcp_http("http://127.0.0.1:8000/api")
 
     cfg = json.loads(claude_json.read_text())
-    assert url == "http://127.0.0.1:8000/api/mcp"
+    assert url == "http://127.0.0.1:8000/api/mcp/"
     assert cfg["mcpServers"]["catgo"]["url"] == url
 
 
@@ -192,7 +192,7 @@ def test_ensure_claude_integration_happy_path(fake_home, tmp_path):
         skills_src=src,
     )
 
-    assert result["mcp_url"] == "http://127.0.0.1:8000/api/mcp"
+    assert result["mcp_url"] == "http://127.0.0.1:8000/api/mcp/"
     assert sorted(result["skills"]) == ["catgo-campaign", "catgo-gibbs-pipeline"]
     assert result["claude_json"] == str(fake_home / ".claude.json")
     assert "errors" not in result
@@ -214,7 +214,7 @@ def test_ensure_claude_integration_collects_errors_without_raising(
         skills_src=src,
     )
 
-    assert result["mcp_url"] == "http://127.0.0.1:8000/api/mcp"
+    assert result["mcp_url"] == "http://127.0.0.1:8000/api/mcp/"
     assert result["skills"] == []
     assert "skills" in result["errors"]
     assert "PermissionError" in result["errors"]["skills"]


### PR DESCRIPTION
## Problem
The backend mounts the HTTP MCP app under `/api/mcp` via `app.mount("/api/mcp", mcp_asgi_app)`. Starlette mounted ASGI sub-apps must be addressed at their mounted root **with a trailing slash** — clients hitting `http://…/api/mcp` (no slash) miss the mount and the MCP endpoint fails to register/respond.

## Fix
Use `/api/mcp/` (trailing slash) everywhere the MCP URL is emitted or documented:
- `server/catgo/routers/mcp_http.py`, `server/catgo/setup_claude.py`, `server/main.py`, `server/catgo/routers/hpc.py` (remote registration)
- `readme.md` / `readme.zh.md` diagrams
- `server/tests/test_setup_claude.py` updated to assert the trailing-slash URL (12/12 pass)

Self-contained; unrelated to the load-into-viewer feature (extracted from that branch into its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
