### PR TITLE
feat(voice): local voice dictation in the terminal

### DIFF
--- a/docs/superpowers/plans/2026-06-18-terminal-voice-input.md
+++ b/docs/superpowers/plans/2026-06-18-terminal-voice-input.md
@@ -167,7 +167,7 @@ Generalize `get_pipeline` and `preload_whisper_model` (currently hardcoded to wh
 
 **Files:**
 - Modify: `src/lib/gesture/local-whisper.ts`
-- Test: `src/lib/gesture/local-whisper.test.ts`
+- Test: `src/lib/gesture/__tests__/local-whisper.test.ts` (repo convention: tests live in `__tests__/`)
 
 **Interfaces:**
 - Consumes: `resolve_model_id`, `DEFAULT_WHISPER_MODEL_ID` from `./whisper-models` (Task 1).
@@ -182,7 +182,7 @@ Generalize `get_pipeline` and `preload_whisper_model` (currently hardcoded to wh
 `@huggingface/transformers` is dynamically imported inside `get_pipeline`, so `vi.mock` it. `preload_whisper_model` does NOT touch the mic or VAD, so it is safe to call in jsdom.
 
 ```ts
-// src/lib/gesture/local-whisper.test.ts
+// src/lib/gesture/__tests__/local-whisper.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const pipeline_spy = vi.fn(async () => async () => ({ text: `` }))
@@ -199,7 +199,7 @@ describe('local-whisper model id threading', () => {
   })
 
   it('preload uses an explicit model id verbatim', async () => {
-    const { preload_whisper_model } = await import('./local-whisper')
+    const { preload_whisper_model } = await import('../local-whisper')
     await preload_whisper_model('en', undefined, 'onnx-community/whisper-small')
     expect(pipeline_spy).toHaveBeenCalledWith(
       'automatic-speech-recognition',
@@ -209,8 +209,8 @@ describe('local-whisper model id threading', () => {
   })
 
   it('preload falls back to a registry model when no id given', async () => {
-    const { preload_whisper_model } = await import('./local-whisper')
-    const { WHISPER_MODELS } = await import('./whisper-models')
+    const { preload_whisper_model } = await import('../local-whisper')
+    const { WHISPER_MODELS } = await import('../whisper-models')
     await preload_whisper_model('zh-CN')
     const used = pipeline_spy.mock.calls[0][1]
     expect(WHISPER_MODELS.some((m) => m.id === used)).toBe(true)
@@ -220,7 +220,7 @@ describe('local-whisper model id threading', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pnpm test -- src/lib/gesture/local-whisper.test.ts`
+Run: `pnpm test -- src/lib/gesture/__tests__/local-whisper.test.ts`
 Expected: FAIL — `preload_whisper_model` ignores the 3rd arg / pipeline called with `onnx-community/whisper-tiny`.
 
 - [ ] **Step 3: Edit `local-whisper.ts`**
@@ -316,7 +316,7 @@ In `set_language`, replace the `pipeline_promise = null; current_model_id = null
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `pnpm test -- src/lib/gesture/local-whisper.test.ts`
+Run: `pnpm test -- src/lib/gesture/__tests__/local-whisper.test.ts`
 Expected: PASS (2 tests).
 
 - [ ] **Step 5: Verify no regression in existing callers**
@@ -327,7 +327,7 @@ Expected: full suite green; type-check shows no NEW errors (the repo has ~15 pre
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/lib/gesture/local-whisper.ts src/lib/gesture/local-whisper.test.ts
+git add src/lib/gesture/local-whisper.ts src/lib/gesture/__tests__/local-whisper.test.ts
 git commit -m "feat(voice): let local-whisper load any registry model id"
 ```
 
@@ -339,7 +339,7 @@ A small per-terminal class that owns recording + model state and forwards only f
 
 **Files:**
 - Create: `src/lib/structure/terminal-voice.svelte.ts`
-- Test: `src/lib/structure/terminal-voice.test.ts`
+- Test: `src/lib/structure/__tests__/terminal-voice.test.ts` (repo convention: tests live in `__tests__/`)
 
 **Interfaces:**
 - Consumes: `DEFAULT_WHISPER_MODEL_ID` from `$lib/gesture/whisper-models`; `LocalWhisperEngine`, `ModelStatus` from `$lib/gesture/local-whisper`; `VoiceEvent` from `$lib/gesture/gesture-types`.
@@ -350,9 +350,9 @@ A small per-terminal class that owns recording + model state and forwards only f
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-// src/lib/structure/terminal-voice.test.ts
+// src/lib/structure/__tests__/terminal-voice.test.ts
 import { describe, it, expect, vi } from 'vitest'
-import { TerminalVoice } from './terminal-voice.svelte'
+import { TerminalVoice } from '../terminal-voice.svelte'
 import type { VoiceEvent } from '$lib/gesture/gesture-types'
 
 function fake_event(text: string, is_final: boolean): VoiceEvent {
@@ -417,7 +417,7 @@ describe('TerminalVoice', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pnpm test -- src/lib/structure/terminal-voice.test.ts`
+Run: `pnpm test -- src/lib/structure/__tests__/terminal-voice.test.ts`
 Expected: FAIL — `Cannot find module './terminal-voice.svelte'`.
 
 - [ ] **Step 3: Write the implementation**
@@ -521,13 +521,13 @@ export class TerminalVoice {
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pnpm test -- src/lib/structure/terminal-voice.test.ts`
+Run: `pnpm test -- src/lib/structure/__tests__/terminal-voice.test.ts`
 Expected: PASS (4 tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/lib/structure/terminal-voice.svelte.ts src/lib/structure/terminal-voice.test.ts
+git add src/lib/structure/terminal-voice.svelte.ts src/lib/structure/__tests__/terminal-voice.test.ts
 git commit -m "feat(voice): terminal voice-dictation controller"
 ```
 

--- a/docs/superpowers/plans/2026-06-18-terminal-voice-input.md
+++ b/docs/superpowers/plans/2026-06-18-terminal-voice-input.md
@@ -163,7 +163,7 @@ git commit -m "feat(voice): selectable Whisper model registry"
 
 ### Task 2: Thread an explicit model id through the local-whisper pipeline
 
-Generalize `get_pipeline` and `preload_whisper_model` (currently hardcoded to whisper-tiny) to accept any model id, and let `LocalWhisperEngine` take an optional `model_id`. Existing callers (gesture nav, chat) keep working via the language fallback.
+Generalize `get_pipeline` and `preload_whisper_model` (currently hardcoded to whisper-tiny) to accept any model id, and let `LocalWhisperEngine` take an optional `model_id`. Existing callers (gesture nav, chat) keep working via the language fallback. NOTE (recorded post-review): the multilingual default shifts from `whisper-tiny` to `whisper-base` (= `DEFAULT_WHISPER_MODEL_ID`), so the gesture/chat *non-English* path now loads the larger, more accurate base model on first use (English path unchanged). Accepted as an intentional accuracy upgrade.
 
 **Files:**
 - Modify: `src/lib/gesture/local-whisper.ts`

--- a/docs/superpowers/plans/2026-06-18-terminal-voice-input.md
+++ b/docs/superpowers/plans/2026-06-18-terminal-voice-input.md
@@ -1,0 +1,689 @@
+# Terminal Voice Input Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a microphone button (+ model dropdown) to the desktop terminal so the user can dictate into the shell / Claude Code; speech is transcribed locally and typed at the cursor without auto-Enter.
+
+**Architecture:** Reuse CatGo's existing in-browser STT pipeline (`local-whisper.ts`: Transformers.js + Silero VAD + IndexedDB-cached on-demand model download). Generalize the hardcoded model id into a selectable registry. A thin per-terminal controller bridges the engine's final transcripts to `panel_send_keys()`. No Web Speech, no voxpilot Node port, no new dependencies.
+
+**Tech Stack:** Svelte 5 runes, TypeScript, `@huggingface/transformers` (already a dependency), Vitest.
+
+## Global Constraints
+
+- **Desktop only.** Do not touch `src/lib/mobile/MobileTerminal.svelte` or any mobile path.
+- **No new runtime dependencies.** `@huggingface/transformers` is already present.
+- **Do NOT use the Web Speech API** (`SpeechRecognition`) anywhere in this feature.
+- **No auto-Enter.** Transcripts are typed into the PTY only; the user submits manually.
+- **Pure dictation:** call the engine with `ai_enabled = false` (no voice-command matching).
+- **Project style** (enforced by `deno fmt`, but `deno` is NOT installed here — write it by hand): single quotes, no semicolons, 2-space indent, ~90 col. `.svelte` files are excluded from `deno fmt`.
+- **Only `is_final` transcripts are sent** — interim hypotheses must never reach the PTY (already-written bytes cannot be retracted).
+- **i18n note:** `TerminalPanel.svelte` uses literal English strings for control `title`s (e.g. `title="Font settings"`). Follow that existing pattern — use literal strings, do NOT add i18n keys for this feature.
+- Run tests with `pnpm test` (vitest) and type-check with `pnpm check` (svelte-check). Both run from the repo root.
+
+---
+
+### Task 1: Whisper model registry
+
+A pure-data module listing selectable models plus a resolver. No engine/network code, so it is fully unit-testable.
+
+**Files:**
+- Create: `src/lib/gesture/whisper-models.ts`
+- Test: `src/lib/gesture/whisper-models.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface WhisperModel { id: string; label: string; size_mb: number; multilingual: boolean }`
+  - `const WHISPER_MODELS: WhisperModel[]`
+  - `const DEFAULT_WHISPER_MODEL_ID: string` (= `'onnx-community/whisper-base'`)
+  - `function resolve_model_id(explicit: string | undefined, language: string): string`
+    — returns `explicit` if it is a known model id; else the English-only model for `language === 'en'`/`'en-US'`, otherwise the multilingual default.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/gesture/whisper-models.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+  WHISPER_MODELS,
+  DEFAULT_WHISPER_MODEL_ID,
+  resolve_model_id,
+} from './whisper-models'
+
+describe('whisper-models registry', () => {
+  it('is non-empty and every id is namespaced under onnx-community', () => {
+    expect(WHISPER_MODELS.length).toBeGreaterThan(0)
+    for (const m of WHISPER_MODELS) {
+      expect(m.id).toMatch(/^onnx-community\/whisper-/)
+      expect(m.label.length).toBeGreaterThan(0)
+      expect(m.size_mb).toBeGreaterThan(0)
+    }
+  })
+
+  it('exposes a default id that exists in the registry', () => {
+    expect(WHISPER_MODELS.some((m) => m.id === DEFAULT_WHISPER_MODEL_ID)).toBe(true)
+  })
+
+  it('resolve_model_id honors an explicit known id', () => {
+    const known = WHISPER_MODELS[0].id
+    expect(resolve_model_id(known, 'en')).toBe(known)
+  })
+
+  it('resolve_model_id ignores an unknown explicit id and falls back', () => {
+    const out = resolve_model_id('totally/unknown', 'en')
+    expect(WHISPER_MODELS.some((m) => m.id === out)).toBe(true)
+  })
+
+  it('resolve_model_id picks an English-only model for en and a multilingual one otherwise', () => {
+    const en = resolve_model_id(undefined, 'en-US')
+    const multi = resolve_model_id(undefined, 'zh-CN')
+    expect(WHISPER_MODELS.find((m) => m.id === en)?.multilingual).toBe(false)
+    expect(WHISPER_MODELS.find((m) => m.id === multi)?.multilingual).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- src/lib/gesture/whisper-models.test.ts`
+Expected: FAIL — `Cannot find module './whisper-models'`.
+
+- [ ] **Step 3: Verify the model ids actually exist (manual, one-time)**
+
+For each id below, confirm the HuggingFace repo exists and has an ONNX build (open `https://huggingface.co/<id>/tree/main/onnx` in a browser, or `curl -sI https://huggingface.co/<id>/resolve/main/config.json` → expect `200`/`302`). Drop any id that 404s from the array in Step 4 and `console.warn` is NOT needed (it is compile-time data). These ids are known-good on `onnx-community` at time of writing:
+
+```
+onnx-community/whisper-tiny.en
+onnx-community/whisper-tiny
+onnx-community/whisper-base.en
+onnx-community/whisper-base
+onnx-community/whisper-small.en
+onnx-community/whisper-small
+onnx-community/whisper-large-v3-turbo
+```
+
+Note: a dedicated `whisper-medium` ONNX build may be absent on `onnx-community`. If `onnx-community/whisper-medium` 404s, ship `whisper-large-v3-turbo` (≈800 MB q4, multilingual, faster than medium) as the "Large (turbo)" entry instead of medium, and say so in the commit message. Do not invent an id that does not resolve.
+
+- [ ] **Step 4: Write the implementation**
+
+```ts
+// src/lib/gesture/whisper-models.ts
+/**
+ * Selectable Whisper ASR models for local in-browser transcription.
+ *
+ * All run via Transformers.js (WebGPU/WASM); models download on demand from the
+ * HuggingFace Hub and are cached in IndexedDB. Sizes are approximate q8/q4
+ * download sizes, shown in the picker so the user knows what they are fetching.
+ */
+
+export interface WhisperModel {
+  id: string // HuggingFace repo id
+  label: string // short UI label
+  size_mb: number // approx download size
+  multilingual: boolean // false = English-only (.en)
+}
+
+export const WHISPER_MODELS: WhisperModel[] = [
+  { id: `onnx-community/whisper-tiny.en`, label: `Tiny (English)`, size_mb: 40, multilingual: false },
+  { id: `onnx-community/whisper-tiny`, label: `Tiny (multilingual)`, size_mb: 40, multilingual: true },
+  { id: `onnx-community/whisper-base.en`, label: `Base (English)`, size_mb: 80, multilingual: false },
+  { id: `onnx-community/whisper-base`, label: `Base (multilingual)`, size_mb: 80, multilingual: true },
+  { id: `onnx-community/whisper-small.en`, label: `Small (English)`, size_mb: 250, multilingual: false },
+  { id: `onnx-community/whisper-small`, label: `Small (multilingual)`, size_mb: 250, multilingual: true },
+  { id: `onnx-community/whisper-large-v3-turbo`, label: `Large turbo (multilingual)`, size_mb: 800, multilingual: true },
+]
+
+export const DEFAULT_WHISPER_MODEL_ID = `onnx-community/whisper-base`
+
+/** Resolve which model id to load given an optional explicit choice + language. */
+export function resolve_model_id(explicit: string | undefined, language: string): string {
+  if (explicit && WHISPER_MODELS.some((m) => m.id === explicit)) return explicit
+  const is_en = language === `en` || language.startsWith(`en-`)
+  if (is_en) {
+    const en = WHISPER_MODELS.find((m) => !m.multilingual)
+    if (en) return en.id
+  }
+  return DEFAULT_WHISPER_MODEL_ID
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test -- src/lib/gesture/whisper-models.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/gesture/whisper-models.ts src/lib/gesture/whisper-models.test.ts
+git commit -m "feat(voice): selectable Whisper model registry"
+```
+
+---
+
+### Task 2: Thread an explicit model id through the local-whisper pipeline
+
+Generalize `get_pipeline` and `preload_whisper_model` (currently hardcoded to whisper-tiny) to accept any model id, and let `LocalWhisperEngine` take an optional `model_id`. Existing callers (gesture nav, chat) keep working via the language fallback.
+
+**Files:**
+- Modify: `src/lib/gesture/local-whisper.ts`
+- Test: `src/lib/gesture/local-whisper.test.ts`
+
+**Interfaces:**
+- Consumes: `resolve_model_id`, `DEFAULT_WHISPER_MODEL_ID` from `./whisper-models` (Task 1).
+- Produces:
+  - `get_pipeline(model_id: string, on_progress?: ModelProgressCallback): Promise<any>` (signature changes from `language` to `model_id`).
+  - `preload_whisper_model(language?: string, on_progress?: ModelProgressCallback, model_id?: string): Promise<void>` (adds optional `model_id`).
+  - `LocalWhisperEngine.start(callback, language?, ai_enabled?, on_error?, noise_suppression?, model_id?)` (adds trailing optional `model_id`).
+  - `LocalWhisperEngine.current_model_id: string | null` (getter, for tests/UI).
+
+- [ ] **Step 1: Write the failing test**
+
+`@huggingface/transformers` is dynamically imported inside `get_pipeline`, so `vi.mock` it. `preload_whisper_model` does NOT touch the mic or VAD, so it is safe to call in jsdom.
+
+```ts
+// src/lib/gesture/local-whisper.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const pipeline_spy = vi.fn(async () => async () => ({ text: `` }))
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: (...args: any[]) => pipeline_spy(...args),
+  env: { backends: { onnx: { wasm: {} } } },
+}))
+
+describe('local-whisper model id threading', () => {
+  beforeEach(() => {
+    pipeline_spy.mockClear()
+    vi.resetModules()
+  })
+
+  it('preload uses an explicit model id verbatim', async () => {
+    const { preload_whisper_model } = await import('./local-whisper')
+    await preload_whisper_model('en', undefined, 'onnx-community/whisper-small')
+    expect(pipeline_spy).toHaveBeenCalledWith(
+      'automatic-speech-recognition',
+      'onnx-community/whisper-small',
+      expect.anything(),
+    )
+  })
+
+  it('preload falls back to a registry model when no id given', async () => {
+    const { preload_whisper_model } = await import('./local-whisper')
+    const { WHISPER_MODELS } = await import('./whisper-models')
+    await preload_whisper_model('zh-CN')
+    const used = pipeline_spy.mock.calls[0][1]
+    expect(WHISPER_MODELS.some((m) => m.id === used)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- src/lib/gesture/local-whisper.test.ts`
+Expected: FAIL — `preload_whisper_model` ignores the 3rd arg / pipeline called with `onnx-community/whisper-tiny`.
+
+- [ ] **Step 3: Edit `local-whisper.ts`**
+
+Replace the model constants + `get_pipeline` signature (lines ~22–77) and update `preload_whisper_model` and the engine. Concretely:
+
+1. At the top, add the import:
+
+```ts
+import { resolve_model_id } from './whisper-models'
+```
+
+2. Delete the two `MODEL_EN` / `MODEL_MULTI` constants and change `get_pipeline` to take a model id:
+
+```ts
+async function get_pipeline(
+  model_id: string,
+  on_progress?: ModelProgressCallback,
+): Promise<any> {
+  // Return cached pipeline if same model
+  if (pipeline_promise && current_model_id === model_id) {
+    return pipeline_promise
+  }
+
+  // New model needed — reset
+  pipeline_promise = null
+  current_model_id = model_id
+
+  on_progress?.(`loading`)
+
+  pipeline_promise = (async () => {
+    const { pipeline, env } = await import(`@huggingface/transformers`)
+
+    if (env.backends?.onnx?.wasm) {
+      env.backends.onnx.wasm.numThreads = 1
+    }
+
+    on_progress?.(`downloading`, 0)
+
+    const pipe = await pipeline(`automatic-speech-recognition`, model_id, {
+      dtype: `q8`,
+      device: `auto`,
+      progress_callback: (data: any) => {
+        if (data.status === `progress` && typeof data.progress === `number`) {
+          on_progress?.(`downloading`, data.progress)
+        }
+      },
+    })
+
+    on_progress?.(`ready`)
+    return pipe
+  })()
+
+  try {
+    return await pipeline_promise
+  } catch (err) {
+    pipeline_promise = null
+    current_model_id = null
+    on_progress?.(`error`)
+    throw err
+  }
+}
+```
+
+3. Update `preload_whisper_model` to accept and resolve a model id:
+
+```ts
+/** Pre-load a Whisper model (e.g. from settings UI). */
+export async function preload_whisper_model(
+  language = `en`,
+  on_progress?: ModelProgressCallback,
+  model_id?: string,
+): Promise<void> {
+  await get_pipeline(resolve_model_id(model_id, language), on_progress)
+}
+```
+
+4. In `LocalWhisperEngine`, add a field and getter and thread the id:
+
+```ts
+  private model_id: string | null = null
+
+  get current_model_id(): string | null {
+    return this.model_id
+  }
+```
+
+Change `start(...)` to accept a trailing `model_id?: string`, set `this.model_id = resolve_model_id(model_id, language)`, and replace the `await get_pipeline(this.language, this.on_progress)` call with `await get_pipeline(this.model_id, this.on_progress)`.
+
+In `transcribe_local`, replace `const pipe = await get_pipeline(this.language, this.on_progress)` with `const pipe = await get_pipeline(this.model_id ?? resolve_model_id(undefined, this.language), this.on_progress)`.
+
+In `set_language`, replace the `pipeline_promise = null; current_model_id = null` reset block so it also recomputes `this.model_id = resolve_model_id(undefined, new_lang)` (only when no explicit model was pinned — keep it simple: always recompute from language here, since `set_language` is the language-driven path).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test -- src/lib/gesture/local-whisper.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Verify no regression in existing callers**
+
+Run: `pnpm test` and `pnpm check`
+Expected: full suite green; type-check shows no NEW errors (the repo has ~15 pre-existing `bond_scale` errors inherited from main — ignore those).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/gesture/local-whisper.ts src/lib/gesture/local-whisper.test.ts
+git commit -m "feat(voice): let local-whisper load any registry model id"
+```
+
+---
+
+### Task 3: Terminal voice controller
+
+A small per-terminal class that owns recording + model state and forwards only final transcripts to a `send` callback. The engine is injected via a factory so the controller is unit-testable without a mic.
+
+**Files:**
+- Create: `src/lib/structure/terminal-voice.svelte.ts`
+- Test: `src/lib/structure/terminal-voice.test.ts`
+
+**Interfaces:**
+- Consumes: `DEFAULT_WHISPER_MODEL_ID` from `$lib/gesture/whisper-models`; `LocalWhisperEngine`, `ModelStatus` from `$lib/gesture/local-whisper`; `VoiceEvent` from `$lib/gesture/gesture-types`.
+- Produces:
+  - `interface VoiceEngineLike { is_supported: boolean; start(cb, language, ai, onErr, noise, modelId): void | Promise<void>; stop(): void }`
+  - `class TerminalVoice` with reactive fields `recording: boolean`, `model_status: ModelStatus`, `download_progress: number`, `model_id: string`; getter `is_supported`; methods `async toggle(send: (text: string) => void, language?: string): Promise<void>` and `stop(): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/structure/terminal-voice.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { TerminalVoice } from './terminal-voice.svelte'
+import type { VoiceEvent } from '$lib/gesture/gesture-types'
+
+function fake_event(text: string, is_final: boolean): VoiceEvent {
+  return {
+    action: { type: `none` } as any,
+    raw_text: text,
+    confidence: 0.9,
+    is_final,
+    match_score: 0,
+    timestamp: 0,
+  }
+}
+
+// A controllable fake engine that lets the test fire transcript events.
+function make_fake() {
+  let cb: ((e: VoiceEvent) => void) | null = null
+  const engine = {
+    is_supported: true,
+    start: vi.fn((c: any) => { cb = c }),
+    stop: vi.fn(() => { cb = null }),
+  }
+  return { engine, fire: (e: VoiceEvent) => cb?.(e) }
+}
+
+describe('TerminalVoice', () => {
+  it('forwards only final transcripts to send, with a trailing space', async () => {
+    const { engine, fire } = make_fake()
+    const tv = new TerminalVoice(() => engine)
+    const sent: string[] = []
+    await tv.toggle((t) => sent.push(t))
+    expect(tv.recording).toBe(true)
+
+    fire(fake_event(`hello`, false)) // interim — ignored
+    fire(fake_event(`hello world`, true)) // final — sent
+    expect(sent).toEqual([`hello world `])
+  })
+
+  it('drops empty / whitespace-only final transcripts', async () => {
+    const { engine, fire } = make_fake()
+    const tv = new TerminalVoice(() => engine)
+    const sent: string[] = []
+    await tv.toggle((t) => sent.push(t))
+    fire(fake_event(`   `, true))
+    expect(sent).toEqual([])
+  })
+
+  it('toggle a second time stops and clears recording', async () => {
+    const { engine } = make_fake()
+    const tv = new TerminalVoice(() => engine)
+    await tv.toggle(() => {})
+    await tv.toggle(() => {})
+    expect(engine.stop).toHaveBeenCalled()
+    expect(tv.recording).toBe(false)
+  })
+
+  it('reports unsupported when the engine is unsupported', () => {
+    const tv = new TerminalVoice(() => ({ is_supported: false, start: vi.fn(), stop: vi.fn() }))
+    expect(tv.is_supported).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- src/lib/structure/terminal-voice.test.ts`
+Expected: FAIL — `Cannot find module './terminal-voice.svelte'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/structure/terminal-voice.svelte.ts
+/**
+ * Per-terminal voice-dictation controller.
+ *
+ * Bridges a local STT engine (LocalWhisperEngine by default) to the terminal:
+ * only FINAL transcripts are forwarded to `send`, which the TerminalPanel wires
+ * to panel_send_keys (no Enter). The engine is injected via a factory so this is
+ * unit-testable without a microphone. Desktop only.
+ */
+
+import { LocalWhisperEngine, type ModelStatus } from '$lib/gesture/local-whisper'
+import { DEFAULT_WHISPER_MODEL_ID } from '$lib/gesture/whisper-models'
+import type { VoiceEvent } from '$lib/gesture/gesture-types'
+
+export interface VoiceEngineLike {
+  readonly is_supported: boolean
+  start(
+    cb: (e: VoiceEvent) => void,
+    language?: string,
+    ai_enabled?: boolean,
+    on_error?: (err: string) => void,
+    noise_suppression?: boolean,
+    model_id?: string,
+  ): void | Promise<void>
+  stop(): void
+}
+
+const STORAGE_KEY = `catgo-terminal-voice-model`
+
+export class TerminalVoice {
+  recording = $state(false)
+  model_status = $state<ModelStatus>(`idle`)
+  download_progress = $state(0)
+  model_id = $state(DEFAULT_WHISPER_MODEL_ID)
+  error = $state<string | null>(null)
+
+  private make_engine: () => VoiceEngineLike
+  private engine: VoiceEngineLike | null = null
+
+  constructor(make_engine?: () => VoiceEngineLike) {
+    this.make_engine = make_engine
+      ?? (() =>
+        new LocalWhisperEngine((status, progress) => {
+          this.model_status = status
+          if (typeof progress === `number`) this.download_progress = progress
+        }))
+    if (typeof localStorage !== `undefined`) {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved) this.model_id = saved
+    }
+  }
+
+  get is_supported(): boolean {
+    if (!this.engine) this.engine = this.make_engine()
+    return this.engine.is_supported
+  }
+
+  set_model(id: string): void {
+    this.model_id = id
+    if (typeof localStorage !== `undefined`) localStorage.setItem(STORAGE_KEY, id)
+  }
+
+  async toggle(send: (text: string) => void, language = `en-US`): Promise<void> {
+    if (this.recording) {
+      this.stop()
+      return
+    }
+    this.error = null
+    if (!this.engine) this.engine = this.make_engine()
+
+    const on_event = (e: VoiceEvent) => {
+      if (!e.is_final) return
+      const text = e.raw_text.trim()
+      if (!text) return
+      send(`${text} `)
+    }
+    const on_error = (err: string) => {
+      this.error = err
+      this.recording = false
+    }
+
+    this.recording = true
+    try {
+      await this.engine.start(on_event, language, false, on_error, false, this.model_id)
+    } catch {
+      this.recording = false
+    }
+  }
+
+  stop(): void {
+    this.recording = false
+    this.engine?.stop()
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- src/lib/structure/terminal-voice.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/terminal-voice.svelte.ts src/lib/structure/terminal-voice.test.ts
+git commit -m "feat(voice): terminal voice-dictation controller"
+```
+
+---
+
+### Task 4: Wire the mic button + model dropdown into TerminalPanel
+
+Add the UI. Svelte component UI is not unit-tested in this repo, so this task is verified by type-check + a manual smoke test.
+
+**Files:**
+- Modify: `src/lib/structure/TerminalPanel.svelte`
+
+**Interfaces:**
+- Consumes: `TerminalVoice` from `./terminal-voice.svelte` (Task 3); `WHISPER_MODELS` from `$lib/gesture/whisper-models` (Task 1); existing `panel_send_keys` (line ~129) and `Icon` (`Mic` icon exists in `icons.ts`).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add imports and controller instance**
+
+Near the top imports (after the existing `import { Icon } from '$lib'` at line 6), add:
+
+```ts
+  import { TerminalVoice } from './terminal-voice.svelte'
+  import { WHISPER_MODELS } from '$lib/gesture/whisper-models'
+```
+
+In the component's script state region (alongside other `$state` declarations, e.g. near `show_font_menu`), add:
+
+```ts
+  const voice = new TerminalVoice()
+  let show_voice_menu = $state(false)
+```
+
+- [ ] **Step 2: Add the mic button + dropdown to the header controls**
+
+Inside `<div class="terminal-panel-controls">` (opens at line ~762), add this block right after the font-settings `</div>` (the `.tp-dropdown-wrap` block ending ~line 813), before the `{#if on_cwd_change || session_id}` sync button:
+
+```svelte
+        <!-- Voice dictation: mic toggle + model picker -->
+        <div class="tp-dropdown-wrap">
+          <button
+            class="terminal-voice-btn"
+            class:active={voice.recording}
+            disabled={!voice.is_supported}
+            title={voice.is_supported
+              ? (voice.recording ? `Stop dictation` : `Dictate into terminal`)
+              : `Voice dictation needs microphone access (unsupported here)`}
+            onclick={(e) => {
+              e.stopPropagation()
+              voice.toggle((t) => panel_send_keys(t))
+            }}
+          ><Icon icon="Mic" /></button>
+          <button
+            class="terminal-voice-caret"
+            title="Choose speech model"
+            onclick={(e) => { e.stopPropagation(); show_voice_menu = !show_voice_menu }}
+          >▾</button>
+          {#if show_voice_menu}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="tp-font-dropdown" onclick={(e) => e.stopPropagation()}>
+              <div class="tp-font-header">Speech model</div>
+              {#each WHISPER_MODELS as m}
+                <button
+                  class="tp-voice-model"
+                  class:selected={voice.model_id === m.id}
+                  onclick={() => { voice.set_model(m.id); show_voice_menu = false }}
+                >{m.label} · ~{m.size_mb}MB</button>
+              {/each}
+              {#if voice.model_status === `downloading`}
+                <div class="tp-voice-progress">
+                  Downloading… {Math.round(voice.download_progress)}%
+                </div>
+              {:else if voice.model_status === `error` || voice.error}
+                <div class="tp-voice-progress error">Model failed — try again</div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+```
+
+- [ ] **Step 3: Add minimal styles**
+
+In the component `<style>` block, near the other `.terminal-*-btn` rules, add:
+
+```css
+  .terminal-voice-btn.active {
+    color: #e5484d;
+  }
+  .terminal-voice-caret {
+    padding: 0 2px;
+    font-size: 10px;
+    opacity: 0.7;
+  }
+  .tp-voice-model {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 4px 8px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .tp-voice-model.selected {
+    font-weight: 600;
+  }
+  .tp-voice-model:hover {
+    background: rgba(127, 127, 127, 0.15);
+  }
+  .tp-voice-progress {
+    padding: 4px 8px;
+    font-size: 11px;
+    opacity: 0.8;
+  }
+  .tp-voice-progress.error {
+    color: #e5484d;
+  }
+```
+
+(If `.terminal-voice-btn` does not inherit base button styling, copy the selector list of an existing `.terminal-*-btn` rule to include `.terminal-voice-btn` so sizing/color match the neighbors.)
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm check`
+Expected: no NEW errors (ignore the ~15 pre-existing `bond_scale` errors from main).
+
+- [ ] **Step 5: Manual smoke test (desktop)**
+
+Run: `pnpm desktop:serve`, open a terminal pane.
+- Click the mic → browser asks for mic permission → grant.
+- First use of the selected model downloads (dropdown shows progress); speak a short phrase → the transcribed text appears at the shell prompt, **no Enter pressed**. Press Enter yourself → it runs.
+- Open a Claude Code session in the terminal, dictate → text lands in Claude Code's input.
+- Open the model dropdown, pick a different size → next dictation downloads/uses it.
+- Confirm a second mic click stops listening.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/structure/TerminalPanel.svelte
+git commit -m "feat(voice): mic button + model picker in the terminal toolbar"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- On-demand model download + selection → Tasks 1, 2, 4. ✅
+- Reuse local-whisper pipeline (no voxpilot Node) → Task 2 reuses it. ✅
+- `LocalWhisperEngine`, not Web Speech → Task 3 default factory. ✅
+- Transcript → `panel_send_keys`, no Enter → Task 3 (`send`) + Task 4 wiring. ✅
+- Only `is_final`, drop empty, trailing-space normalize → Task 3 tests. ✅
+- Desktop only, `MobileTerminal` untouched → Global Constraints; no task touches mobile. ✅
+- Error handling (unsupported / permission / download / empty) → Task 3 (`error`, `is_supported`, empty-drop) + Task 4 (disabled button, progress/error UI). ✅
+- Testing plan → Tasks 1–3 unit tests, Task 4 manual smoke. ✅
+- **Deviations from spec (intentional):** (1) No i18n task — `TerminalPanel` uses literal English strings, so this feature follows that pattern (recorded in Global Constraints). (2) No separate language UI — passing `language='en'` makes Whisper auto-detect on multilingual models, so model choice alone covers Chinese/English. (3) Spec's `whisper-medium` may not have an ONNX build; Task 1 Step 3 substitutes `whisper-large-v3-turbo` if so.
+
+**Placeholder scan:** No TBD/TODO; every code step has full code. ✅
+
+**Type consistency:** `resolve_model_id`, `WHISPER_MODELS`, `DEFAULT_WHISPER_MODEL_ID`, `ModelStatus`, `VoiceEvent`, `TerminalVoice.toggle/stop/set_model/model_id/recording/model_status/download_progress`, `panel_send_keys` — names match across tasks. ✅

--- a/docs/superpowers/specs/2026-06-18-terminal-voice-input-design.md
+++ b/docs/superpowers/specs/2026-06-18-terminal-voice-input-design.md
@@ -1,0 +1,176 @@
+# Terminal Voice Input — Design
+
+**Date:** 2026-06-18
+**Branch:** `feat/terminal-voice-input`
+**Status:** Approved design, pending implementation plan
+
+## Goal
+
+Let the user dictate into the desktop terminal (the shell prompt, and any TUI
+running in it such as Claude Code) by speaking. Spoken words are transcribed
+locally and typed into the terminal at the cursor. Inspired by
+[voxpilot](https://github.com/natearcher-ai/voxpilot), but built on CatGo's
+existing in-browser STT pipeline rather than voxpilot's VS Code / Node engine.
+
+## Scope
+
+- **In scope:** Desktop `TerminalPanel`. Local-only speech-to-text. On-demand
+  model download with model selection. Transcript inserted into the command
+  line without auto-Enter.
+- **Out of scope:** Mobile (`MobileTerminal` untouched). Web Speech API
+  (`SpeechRecognition`) — explicitly NOT used (cloud-routed, Chrome-only).
+  Porting voxpilot's Node/`onnxruntime-node`/native-CLI audio path. Voice
+  command matching (this is pure dictation, `ai_enabled = false`). New runtime
+  dependencies (`@huggingface/transformers` is already a dependency).
+
+## Why not voxpilot directly
+
+voxpilot is a VS Code extension (100% TypeScript) that captures audio via native
+CLI tools (`arecord`/`sox`/`ffmpeg`) and runs ONNX ASR in Node via
+`onnxruntime-node`. None of that fits CatGo's Tauri WKWebView. CatGo already has
+the browser-native equivalent in `src/lib/gesture/local-whisper.ts`:
+Transformers.js, on-demand model download from the HuggingFace Hub, IndexedDB
+caching, WebGPU/WASM ONNX inference, and Silero VAD. The integration therefore
+**reuses CatGo's pipeline** and only generalizes the hardcoded model choice.
+
+## Key existing pieces (reused, not rebuilt)
+
+| Piece | Location | Role |
+| --- | --- | --- |
+| `LocalWhisperEngine` | `src/lib/gesture/local-whisper.ts:89` | mic → VAD → ONNX transcribe → `VoiceCallback` |
+| `get_pipeline()` | `src/lib/gesture/local-whisper.ts:28` | model load + download, IndexedDB cache (currently hardcoded to whisper-tiny) |
+| Silero VAD | `src/lib/gesture/vad.ts` | speech-segment detection, emits final audio |
+| `panel_send_keys()` | `src/lib/structure/TerminalPanel.svelte:129` | write raw bytes to the PTY |
+| `<Icon>` / `icons.ts` | `src/lib/Icon.svelte`, `src/lib/icons.ts` | toolbar iconography |
+
+## Architecture
+
+```
+[mic] → getUserMedia → Silero VAD → LocalWhisperEngine (chosen Whisper model, ONNX)
+      → final transcript string → terminal-voice controller
+      → panel_send_keys(text)  [NO Enter]  → PTY → xterm renders at cursor
+```
+
+Four units, each independently understandable:
+
+### 1. Model registry — `src/lib/gesture/whisper-models.ts` (new)
+
+A small pure-data module: the list of selectable models and a default.
+
+```ts
+export interface WhisperModel {
+  id: string          // HF repo id, e.g. 'onnx-community/whisper-base'
+  label: string       // UI label, e.g. 'Base'
+  size_mb: number     // approx q8 download size, for the UI
+  multilingual: boolean
+}
+export const WHISPER_MODELS: WhisperModel[]
+export const DEFAULT_WHISPER_MODEL_ID: string
+```
+
+Models offered: Whisper **tiny / base / small / medium**, each in an English
+(`.en`) and a multilingual variant. Exact `onnx-community/whisper-*` repo ids
+are verified to exist with a q8 ONNX build during implementation; any size that
+lacks a browser-runnable ONNX build is dropped from the list (logged, not
+silently). `medium` (~1.5 GB q8) is included but clearly labelled as large.
+
+### 2. Generalize `get_pipeline()` — `local-whisper.ts` (modified)
+
+Today `get_pipeline(language)` maps language → one of two hardcoded ids. Change
+it to take an explicit `model_id` (keeping a language→default fallback so
+existing callers in the gesture/chat paths are unaffected). The cache key
+becomes `model_id` (already is). `LocalWhisperEngine.start()` and
+`set_language()` gain an optional `model_id` so the terminal can pass the chosen
+model. No behavior change for current callers.
+
+### 3. Terminal voice controller — `src/lib/structure/terminal-voice.svelte.ts` (new)
+
+Thin glue between the engine and the terminal. Owns the recording/model state
+for one terminal and isolates the engine choice (future swap = one file).
+
+```ts
+export class TerminalVoice {
+  recording: boolean          // $state
+  model_status: ModelStatus   // 'idle'|'loading'|'downloading'|'ready'|'error'
+  download_progress: number   // 0..1
+  model_id: string            // selected, persisted to localStorage
+
+  get is_supported(): boolean // navigator.mediaDevices?.getUserMedia
+  async toggle(send: (text: string) => void, language: string): Promise<void>
+  stop(): void
+}
+```
+
+On a final `VoiceEvent` it calls `send(raw_text)`. Only `is_final` events are
+forwarded — interim hypotheses are never sent, because bytes already written to
+the PTY cannot be retracted. A trailing space is normalized so consecutive
+dictations don't run together. `ai_enabled` is hardcoded `false` (no command
+matching). Selected `model_id` persists in `localStorage`
+(`catgo-terminal-voice-model`).
+
+### 4. Terminal UI — `TerminalPanel.svelte` (modified)
+
+Add to the existing toolbar: a mic toggle button and an adjacent caret that
+opens a small dropdown listing `WHISPER_MODELS` with the current download state
+/ progress. Wiring:
+
+- mic click → `terminal_voice.toggle((t) => panel_send_keys(t), voice_language)`
+- recording state drives button styling (active/pulsing) via `$state`
+- dropdown selection → `terminal_voice.model_id = id` (reloads on next start)
+- download progress shown inline (reuses `ModelProgressCallback` 0..1)
+- unsupported env (no `getUserMedia`) → button disabled + tooltip
+
+`MobileTerminal.svelte` is not touched.
+
+## Data flow (end to end)
+
+1. User clicks mic. If chosen model not cached, Transformers.js downloads it
+   (progress shown); subsequent uses load from IndexedDB.
+2. `getUserMedia` prompts for mic permission (browser-handled).
+3. Silero VAD slices speech; each segment is transcribed locally by the chosen
+   Whisper model.
+4. Final transcript → `panel_send_keys(text)` → PTY → xterm shows it at the
+   cursor. **No Enter is sent.** The user edits/submits manually.
+5. User clicks mic again to stop.
+
+## Error handling
+
+- **Unsupported browser** (no `getUserMedia`): button disabled, tooltip
+  explains. No crash.
+- **Mic permission denied** (`DOMException`): engine surfaces `not-allowed`;
+  controller resets `recording=false` and shows a non-blocking message.
+- **Model download/inference failure:** `model_status='error'`, recording stops,
+  message shown; retry by clicking again.
+- **Empty / whitespace transcript:** dropped (no `send_keys`).
+
+## Testing
+
+- **`whisper-models.ts`** — unit test: registry non-empty, ids well-formed,
+  default id present in the list.
+- **`terminal-voice.svelte.ts`** — unit test with a mocked engine: only
+  `is_final` events forward to `send`; interim events are ignored; empty
+  transcript dropped; trailing-space normalization; `stop()` clears state. The
+  engine is injected/mockable so tests don't touch real audio/models.
+- **`get_pipeline` generalization** — unit test that an explicit `model_id` is
+  honored and the language fallback still resolves for existing callers.
+- **TerminalPanel wiring** — manual smoke test on desktop (mic → speak → text
+  appears at prompt, no Enter; model dropdown downloads + switches).
+
+## File summary
+
+| File | Change |
+| --- | --- |
+| `src/lib/gesture/whisper-models.ts` | new — model registry |
+| `src/lib/gesture/local-whisper.ts` | modify — `get_pipeline`/engine accept explicit `model_id` |
+| `src/lib/structure/terminal-voice.svelte.ts` | new — terminal voice controller |
+| `src/lib/structure/TerminalPanel.svelte` | modify — mic button + model dropdown + wiring |
+| `src/lib/i18n/{en,zh}/*.ts` | modify — labels: mic button, model names, unsupported/permission messages (en/zh parity) |
+| test files | new — registry + controller + pipeline unit tests |
+
+## Open questions / risks
+
+- Exact `onnx-community/whisper-*` repo ids and which sizes have q8 ONNX builds
+  must be confirmed at implementation time (drop unsupported sizes).
+- `medium` is large (~1.5 GB); acceptable as an opt-in entry, surfaced with its
+  size in the dropdown.
+- WebGPU vs WASM performance varies; `device: 'auto'` already handles fallback.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "katex": "^0.16.33",
     "molstar": "^5.9.0",
     "monaco-editor": "^0.55.1",
+    "opencc-js": "^1.3.1",
     "plotly.js-dist-min": "^3.3.1",
     "quickhull3d": "^3.1.2",
     "sql.js": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
+      opencc-js:
+        specifier: ^1.3.1
+        version: 1.3.1
       plotly.js-dist-min:
         specifier: ^3.3.1
         version: 3.3.1
@@ -3384,6 +3387,9 @@ packages:
 
   onnxruntime-web@1.24.2:
     resolution: {integrity: sha512-L0vyau30A5reN/eBY/NsaJh0VTpu6Xc/c7y//S6wjU0p82CiaiYYktobDknZus8B6cQCMfufwgHCEHYxr2JQsA==}
+
+  opencc-js@1.3.1:
+    resolution: {integrity: sha512-EyKDnjHNYlxo3Blll0OGH5qcyZBI3YmXpqeDEity/db50A5TFfCdvylrBlTyx1XvlSRUmh2a5AHvSf89h4u87Q==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -7583,6 +7589,8 @@ snapshots:
       onnxruntime-common: 1.24.2
       platform: 1.3.6
       protobufjs: 7.5.4
+
+  opencc-js@1.3.1: {}
 
   optionator@0.9.4:
     dependencies:

--- a/src/lib/gesture/__tests__/local-whisper.test.ts
+++ b/src/lib/gesture/__tests__/local-whisper.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const pipeline_spy = vi.fn(async () => async () => ({ text: `` }))
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: (...args: any[]) => pipeline_spy(...args),
+  env: { backends: { onnx: { wasm: {} } } },
+}))
+
+describe('local-whisper model id threading', () => {
+  beforeEach(() => {
+    pipeline_spy.mockClear()
+    vi.resetModules()
+  })
+
+  it('preload uses an explicit model id verbatim', async () => {
+    const { preload_whisper_model } = await import('../local-whisper')
+    await preload_whisper_model('en', undefined, 'onnx-community/whisper-small')
+    expect(pipeline_spy).toHaveBeenCalledWith(
+      'automatic-speech-recognition',
+      'onnx-community/whisper-small',
+      expect.anything(),
+    )
+  })
+
+  it('preload falls back to a registry model when no id given', async () => {
+    const { preload_whisper_model } = await import('../local-whisper')
+    const { WHISPER_MODELS } = await import('../whisper-models')
+    await preload_whisper_model('zh-CN')
+    const used = pipeline_spy.mock.calls[0][1]
+    expect(WHISPER_MODELS.some((m) => m.id === used)).toBe(true)
+  })
+})

--- a/src/lib/gesture/__tests__/whisper-models.test.ts
+++ b/src/lib/gesture/__tests__/whisper-models.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import {
+  WHISPER_MODELS,
+  DEFAULT_WHISPER_MODEL_ID,
+  resolve_model_id,
+} from '../whisper-models'
+
+describe('whisper-models registry', () => {
+  it('is non-empty and every id is namespaced under onnx-community', () => {
+    expect(WHISPER_MODELS.length).toBeGreaterThan(0)
+    for (const m of WHISPER_MODELS) {
+      expect(m.id).toMatch(/^onnx-community\/whisper-/)
+      expect(m.label.length).toBeGreaterThan(0)
+      expect(m.size_mb).toBeGreaterThan(0)
+    }
+  })
+
+  it('exposes a default id that exists in the registry', () => {
+    expect(WHISPER_MODELS.some((m) => m.id === DEFAULT_WHISPER_MODEL_ID)).toBe(true)
+  })
+
+  it('resolve_model_id honors an explicit known id', () => {
+    const known = WHISPER_MODELS[0].id
+    expect(resolve_model_id(known, 'en')).toBe(known)
+  })
+
+  it('resolve_model_id ignores an unknown explicit id and falls back', () => {
+    const out = resolve_model_id('totally/unknown', 'en')
+    expect(WHISPER_MODELS.some((m) => m.id === out)).toBe(true)
+  })
+
+  it('resolve_model_id picks an English-only model for en and a multilingual one otherwise', () => {
+    const en = resolve_model_id(undefined, 'en-US')
+    const multi = resolve_model_id(undefined, 'zh-CN')
+    expect(WHISPER_MODELS.find((m) => m.id === en)?.multilingual).toBe(false)
+    expect(WHISPER_MODELS.find((m) => m.id === multi)?.multilingual).toBe(true)
+  })
+})

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -58,7 +58,11 @@ async function get_pipeline(
       const isolated = typeof globalThis !== `undefined`
         && (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
       const cores = (typeof navigator !== `undefined` && navigator.hardwareConcurrency) || 4
-      env.backends.onnx.wasm.numThreads = isolated ? Math.min(4, cores) : 1
+      // Use most cores but leave ~2 for the audio worklet / VAD / UI, and cap at
+      // 8 — beyond that wasm Whisper is memory-bandwidth bound and thread-sync
+      // overhead eats the gains (16 threads ≠ 2× of 8). Single thread without
+      // cross-origin isolation (no SharedArrayBuffer).
+      env.backends.onnx.wasm.numThreads = isolated ? Math.max(1, Math.min(8, cores - 2)) : 1
       // Load the onnxruntime-web wasm runtime from a CDN pinned to the version
       // @huggingface/transformers bundles. Without this, the WASM backend (the
       // fallback when WebGPU is unavailable — e.g. machines without a discrete

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -42,7 +42,16 @@ async function get_pipeline(
     const { pipeline, env } = await import(`@huggingface/transformers`)
 
     if (env.backends?.onnx?.wasm) {
-      env.backends.onnx.wasm.numThreads = 1
+      // Multi-threaded wasm needs SharedArrayBuffer, which only exists when the
+      // page is cross-origin isolated (COOP/COEP headers). When it is, use up to
+      // 4 cores for a big CPU-inference speedup (the common case on machines
+      // without usable WebGPU, e.g. integrated graphics under WebKitGTK); when
+      // it is not, fall back to a single thread (the safe default — more threads
+      // without isolation would fail to init).
+      const isolated = typeof globalThis !== `undefined`
+        && (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
+      const cores = (typeof navigator !== `undefined` && navigator.hardwareConcurrency) || 4
+      env.backends.onnx.wasm.numThreads = isolated ? Math.min(4, cores) : 1
       // Load the onnxruntime-web wasm runtime from a CDN pinned to the version
       // @huggingface/transformers bundles. Without this, the WASM backend (the
       // fallback when WebGPU is unavailable — e.g. machines without a discrete

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -68,7 +68,11 @@ async function get_pipeline(
 
     const pipe = await pipeline(`automatic-speech-recognition`, model_id, {
       dtype: `q8`,
-      device: `auto`,
+      // Force the CPU wasm backend. `auto` prefers WebGPU when the browser
+      // exposes it, but q8-quantized Whisper on WebGPU (esp. integrated GPUs)
+      // produces garbage/hallucinated output. wasm is slower but correct.
+      // (A proper WebGPU path would need an fp16/fp32 model variant.)
+      device: `wasm`,
       progress_callback: (data: any) => {
         if (data.status === `progress` && typeof data.progress === `number`) {
           on_progress?.(`downloading`, data.progress)

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -10,6 +10,7 @@ import type { VoiceCallback, VoiceErrorCallback } from './voice-engine'
 import { match_command_with_score } from './voice-engine'
 import { start_vad, stop_vad } from './vad'
 import type { AudioPipeline } from './audio-pipeline'
+import { resolve_model_id } from './whisper-models'
 
 // ─── Model Status ────────────────────────────────────────────────────
 
@@ -19,18 +20,13 @@ export type ModelProgressCallback = (status: ModelStatus, progress?: number) => 
 
 // ─── Singleton Pipeline ──────────────────────────────────────────────
 
-const MODEL_EN = `onnx-community/whisper-tiny.en`
-const MODEL_MULTI = `onnx-community/whisper-tiny`
-
 let pipeline_promise: Promise<any> | null = null
 let current_model_id: string | null = null
 
 async function get_pipeline(
-  language: string,
+  model_id: string,
   on_progress?: ModelProgressCallback,
 ): Promise<any> {
-  const model_id = language === `en` ? MODEL_EN : MODEL_MULTI
-
   // Return cached pipeline if same model
   if (pipeline_promise && current_model_id === model_id) {
     return pipeline_promise
@@ -45,7 +41,6 @@ async function get_pipeline(
   pipeline_promise = (async () => {
     const { pipeline, env } = await import(`@huggingface/transformers`)
 
-    // Prefer WebGPU, fall back to WASM
     if (env.backends?.onnx?.wasm) {
       env.backends.onnx.wasm.numThreads = 1
     }
@@ -76,12 +71,13 @@ async function get_pipeline(
   }
 }
 
-/** Pre-load the Whisper model (e.g. from settings UI). */
+/** Pre-load a Whisper model (e.g. from settings UI). */
 export async function preload_whisper_model(
   language = `en`,
   on_progress?: ModelProgressCallback,
+  model_id?: string,
 ): Promise<void> {
-  await get_pipeline(language, on_progress)
+  await get_pipeline(resolve_model_id(model_id, language), on_progress)
 }
 
 // ─── Local Whisper Engine ────────────────────────────────────────────
@@ -95,9 +91,14 @@ export class LocalWhisperEngine {
   private transcribing = false
   private pipeline: AudioPipeline | null = null
   private on_progress: ModelProgressCallback | undefined
+  private model_id: string | null = null
 
   constructor(on_progress?: ModelProgressCallback) {
     this.on_progress = on_progress
+  }
+
+  get current_model_id(): string | null {
+    return this.model_id
   }
 
   get is_supported(): boolean {
@@ -115,16 +116,18 @@ export class LocalWhisperEngine {
     ai_enabled = false,
     on_error?: VoiceErrorCallback,
     noise_suppression = false,
+    model_id?: string,
   ): Promise<void> {
     if (this.running) return
     this.callback = callback
     this.error_callback = on_error ?? null
     this.language = language.split(`-`)[0]
     this.ai_enabled = ai_enabled
+    this.model_id = resolve_model_id(model_id, this.language)
 
     try {
       // Load model first (may trigger download)
-      await get_pipeline(this.language, this.on_progress)
+      await get_pipeline(this.model_id, this.on_progress)
 
       // Optionally create noise suppression pipeline
       let stream: MediaStream | undefined
@@ -167,11 +170,13 @@ export class LocalWhisperEngine {
 
   set_language(lang: string, ai_enabled = false): void {
     const new_lang = lang.split(`-`)[0]
-    const model_changed = (new_lang === `en`) !== (this.language === `en`)
+    const new_model_id = resolve_model_id(undefined, new_lang)
+    const model_changed = new_model_id !== this.model_id
     this.language = new_lang
     this.ai_enabled = ai_enabled
+    this.model_id = new_model_id
 
-    // If switching between en ↔ multilingual, the pipeline will reload on next transcription
+    // If the resolved model changed, the pipeline will reload on next transcription
     if (model_changed) {
       pipeline_promise = null
       current_model_id = null
@@ -186,7 +191,10 @@ export class LocalWhisperEngine {
     this.transcribing = true
 
     try {
-      const pipe = await get_pipeline(this.language, this.on_progress)
+      const pipe = await get_pipeline(
+        this.model_id ?? resolve_model_id(undefined, this.language),
+        this.on_progress,
+      )
 
       const result = await pipe(audio, {
         language: this.language === `en` ? undefined : this.language,

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -20,21 +20,28 @@ export type ModelProgressCallback = (status: ModelStatus, progress?: number) => 
 
 // ─── Singleton Pipeline ──────────────────────────────────────────────
 
+/** Inference backend. cpu = wasm + q8 (correct everywhere, slower). gpu =
+ * WebGPU + fp16 (fast where WebGPU is sound; q8-on-WebGPU hallucinates, so the
+ * GPU path uses an fp16 model variant instead). */
+export type Accel = `cpu` | `gpu`
+
 let pipeline_promise: Promise<any> | null = null
-let current_model_id: string | null = null
+let current_key: string | null = null
 
 async function get_pipeline(
   model_id: string,
+  accel: Accel = `cpu`,
   on_progress?: ModelProgressCallback,
 ): Promise<any> {
-  // Return cached pipeline if same model
-  if (pipeline_promise && current_model_id === model_id) {
+  const key = `${model_id}::${accel}`
+  // Return cached pipeline if same model + backend
+  if (pipeline_promise && current_key === key) {
     return pipeline_promise
   }
 
-  // New model needed — reset
+  // New model/backend needed — reset
   pipeline_promise = null
-  current_model_id = model_id
+  current_key = key
 
   on_progress?.(`loading`)
 
@@ -66,13 +73,12 @@ async function get_pipeline(
 
     on_progress?.(`downloading`, 0)
 
+    // CPU path: wasm + q8 (correct everywhere). GPU path: WebGPU + fp16 — q8 on
+    // WebGPU produces garbage/hallucinated output (esp. integrated GPUs), so the
+    // GPU path uses the fp16 model variant, which runs correctly on WebGPU.
     const pipe = await pipeline(`automatic-speech-recognition`, model_id, {
-      dtype: `q8`,
-      // Force the CPU wasm backend. `auto` prefers WebGPU when the browser
-      // exposes it, but q8-quantized Whisper on WebGPU (esp. integrated GPUs)
-      // produces garbage/hallucinated output. wasm is slower but correct.
-      // (A proper WebGPU path would need an fp16/fp32 model variant.)
-      device: `wasm`,
+      dtype: accel === `gpu` ? `fp16` : `q8`,
+      device: accel === `gpu` ? `webgpu` : `wasm`,
       progress_callback: (data: any) => {
         if (data.status === `progress` && typeof data.progress === `number`) {
           on_progress?.(`downloading`, data.progress)
@@ -88,7 +94,7 @@ async function get_pipeline(
     return await pipeline_promise
   } catch (err) {
     pipeline_promise = null
-    current_model_id = null
+    current_key = null
     on_progress?.(`error`)
     throw err
   }
@@ -99,8 +105,9 @@ export async function preload_whisper_model(
   language = `en`,
   on_progress?: ModelProgressCallback,
   model_id?: string,
+  accel: Accel = `cpu`,
 ): Promise<void> {
-  await get_pipeline(resolve_model_id(model_id, language), on_progress)
+  await get_pipeline(resolve_model_id(model_id, language), accel, on_progress)
 }
 
 // ─── Local Whisper Engine ────────────────────────────────────────────
@@ -115,6 +122,7 @@ export class LocalWhisperEngine {
   private pipeline: AudioPipeline | null = null
   private on_progress: ModelProgressCallback | undefined
   private model_id: string | null = null
+  private accel: Accel = `cpu`
 
   constructor(on_progress?: ModelProgressCallback) {
     this.on_progress = on_progress
@@ -140,6 +148,7 @@ export class LocalWhisperEngine {
     on_error?: VoiceErrorCallback,
     noise_suppression = false,
     model_id?: string,
+    accel: Accel = `cpu`,
   ): Promise<void> {
     if (this.running) return
     this.callback = callback
@@ -147,10 +156,11 @@ export class LocalWhisperEngine {
     this.language = language.split(`-`)[0]
     this.ai_enabled = ai_enabled
     this.model_id = resolve_model_id(model_id, this.language)
+    this.accel = accel
 
     try {
       // Load model first (may trigger download)
-      await get_pipeline(this.model_id, this.on_progress)
+      await get_pipeline(this.model_id, this.accel, this.on_progress)
 
       // Optionally create noise suppression pipeline
       let stream: MediaStream | undefined
@@ -216,6 +226,7 @@ export class LocalWhisperEngine {
     try {
       const pipe = await get_pipeline(
         this.model_id ?? resolve_model_id(undefined, this.language),
+        this.accel,
         this.on_progress,
       )
 

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -218,6 +218,11 @@ export class LocalWhisperEngine {
       const result = await pipe(audio, {
         language: this.language === `en` ? undefined : this.language,
         task: `transcribe`,
+        // Anti-hallucination: Whisper degenerates into endless repeated
+        // multilingual fragments on near-silent / very short / noisy clips.
+        // Block repeated n-grams and penalize repetition to break the loop.
+        no_repeat_ngram_size: 3,
+        repetition_penalty: 1.2,
       })
 
       const text = (result as any)?.text?.trim()

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -43,6 +43,16 @@ async function get_pipeline(
 
     if (env.backends?.onnx?.wasm) {
       env.backends.onnx.wasm.numThreads = 1
+      // Load the onnxruntime-web wasm runtime from a CDN pinned to the version
+      // @huggingface/transformers bundles. Without this, the WASM backend (the
+      // fallback when WebGPU is unavailable — e.g. machines without a discrete
+      // GPU) tries to fetch ort-wasm-*.mjs from the app's own /assets, which the
+      // Vite build does not emit, producing "no available backend found". The
+      // version MUST match @huggingface/transformers' onnxruntime-web dep.
+      if (!env.backends.onnx.wasm.wasmPaths) {
+        env.backends.onnx.wasm.wasmPaths =
+          `https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0-dev.20250409-89f8206ba4/dist/`
+      }
     }
 
     on_progress?.(`downloading`, 0)

--- a/src/lib/gesture/vad.ts
+++ b/src/lib/gesture/vad.ts
@@ -30,6 +30,14 @@ export async function start_vad(config: VadConfig): Promise<void> {
   const { MicVAD } = await import(`@ricky0123/vad-web`)
 
   const vad_options: any = {
+    // Load the VAD worklet + Silero ONNX model and the onnxruntime-web wasm from
+    // CDNs pinned to the installed versions. The Vite build does not emit these
+    // assets into the app, so the defaults ("./silero_vad_legacy.onnx", local
+    // ort wasm) 404 — fatal on machines without WebGPU, which fall back to wasm.
+    // Versions MUST match the installed @ricky0123/vad-web and onnxruntime-web.
+    baseAssetPath: `https://cdn.jsdelivr.net/npm/@ricky0123/vad-web@0.0.30/dist/`,
+    onnxWASMBasePath:
+      `https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0-dev.20250409-89f8206ba4/dist/`,
     positiveSpeechThreshold: config.positive_speech_threshold ?? 0.5,
     negativeSpeechThreshold: config.negative_speech_threshold ?? 0.35,
     minSpeechFrames: config.min_speech_frames ?? 6,

--- a/src/lib/gesture/whisper-models.ts
+++ b/src/lib/gesture/whisper-models.ts
@@ -1,0 +1,37 @@
+/**
+ * Selectable Whisper ASR models for local in-browser transcription.
+ *
+ * All run via Transformers.js (WebGPU/WASM); models download on demand from the
+ * HuggingFace Hub and are cached in IndexedDB. Sizes are approximate q8/q4
+ * download sizes, shown in the picker so the user knows what they are fetching.
+ */
+
+export interface WhisperModel {
+  id: string // HuggingFace repo id
+  label: string // short UI label
+  size_mb: number // approx download size
+  multilingual: boolean // false = English-only (.en)
+}
+
+export const WHISPER_MODELS: WhisperModel[] = [
+  { id: `onnx-community/whisper-tiny.en`, label: `Tiny (English)`, size_mb: 40, multilingual: false },
+  { id: `onnx-community/whisper-tiny`, label: `Tiny (multilingual)`, size_mb: 40, multilingual: true },
+  { id: `onnx-community/whisper-base.en`, label: `Base (English)`, size_mb: 80, multilingual: false },
+  { id: `onnx-community/whisper-base`, label: `Base (multilingual)`, size_mb: 80, multilingual: true },
+  { id: `onnx-community/whisper-small.en`, label: `Small (English)`, size_mb: 250, multilingual: false },
+  { id: `onnx-community/whisper-small`, label: `Small (multilingual)`, size_mb: 250, multilingual: true },
+  { id: `onnx-community/whisper-large-v3-turbo`, label: `Large turbo (multilingual)`, size_mb: 800, multilingual: true },
+]
+
+export const DEFAULT_WHISPER_MODEL_ID = `onnx-community/whisper-base`
+
+/** Resolve which model id to load given an optional explicit choice + language. */
+export function resolve_model_id(explicit: string | undefined, language: string): string {
+  if (explicit && WHISPER_MODELS.some((m) => m.id === explicit)) return explicit
+  const is_en = language === `en` || language.startsWith(`en-`)
+  if (is_en) {
+    const en = WHISPER_MODELS.find((m) => !m.multilingual)
+    if (en) return en.id
+  }
+  return DEFAULT_WHISPER_MODEL_ID
+}

--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -7,8 +7,6 @@
   import { theme_state, terminal_font_state, save_terminal_font_state, TERMINAL_FONT_FAMILIES } from '$lib/state.svelte'
   import { register_terminal, unregister_terminal, mark_terminal_active } from './terminal-registry.svelte'
   import { next_marker, wrap_command, extract_result, strip_ansi } from './terminal-capture'
-  import { TerminalVoice } from './terminal-voice.svelte'
-  import { WHISPER_MODELS } from '$lib/gesture/whisper-models'
 
   let {
     layout = `horizontal`,
@@ -68,8 +66,6 @@
   /** Monotonic sequence counter for CWD broadcasts — receivers discard stale messages. */
   let _cwd_seq = 0
   let show_font_menu = $state(false)
-  const voice = new TerminalVoice()
-  let show_voice_menu = $state(false)
 
   const title = $derived(
     host ? `${username || ``}@${host}` : `Terminal`
@@ -748,7 +744,7 @@
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-<div class="terminal-panel" onclick={() => { if (show_font_menu) show_font_menu = false; if (show_voice_menu) show_voice_menu = false }}>
+<div class="terminal-panel" onclick={() => { if (show_font_menu) show_font_menu = false }}>
   {#if show_header}
     <div class="terminal-panel-header">
       <span class="terminal-panel-title">
@@ -811,46 +807,6 @@
                   </select>
                 </label>
               </div>
-            </div>
-          {/if}
-        </div>
-        <!-- Voice dictation: mic toggle + model picker -->
-        <div class="tp-dropdown-wrap">
-          <button
-            class="terminal-voice-btn"
-            class:active={voice.recording}
-            disabled={!voice.is_supported}
-            title={voice.is_supported
-              ? (voice.recording ? `Stop dictation` : `Dictate into terminal`)
-              : `Voice dictation needs microphone access (unsupported here)`}
-            onclick={(e) => {
-              e.stopPropagation()
-              voice.toggle((t) => panel_send_keys(t))
-            }}
-          ><Icon icon="Mic" /></button>
-          <button
-            class="terminal-voice-caret"
-            title="Choose speech model"
-            onclick={(e) => { e.stopPropagation(); show_voice_menu = !show_voice_menu }}
-          >▾</button>
-          {#if show_voice_menu}
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-            <div class="tp-font-dropdown" onclick={(e) => e.stopPropagation()}>
-              <div class="tp-font-header">Speech model</div>
-              {#each WHISPER_MODELS as m}
-                <button
-                  class="tp-voice-model"
-                  class:selected={voice.model_id === m.id}
-                  onclick={() => { voice.set_model(m.id); show_voice_menu = false }}
-                >{m.label} · ~{m.size_mb}MB</button>
-              {/each}
-              {#if voice.model_status === `downloading`}
-                <div class="tp-voice-progress">
-                  Downloading… {Math.round(voice.download_progress)}%
-                </div>
-              {:else if voice.model_status === `error` || voice.error}
-                <div class="tp-voice-progress error">Model failed — try again</div>
-              {/if}
             </div>
           {/if}
         </div>
@@ -1065,39 +1021,6 @@
   }
   .tp-font-control select:focus {
     border-color: var(--accent-color, #3b82f6);
-  }
-
-  .terminal-voice-btn.active {
-    color: #e5484d;
-  }
-  .terminal-voice-caret {
-    padding: 0 2px;
-    font-size: 10px;
-    opacity: 0.7;
-  }
-  .tp-voice-model {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 4px 8px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 12px;
-  }
-  .tp-voice-model.selected {
-    font-weight: 600;
-  }
-  .tp-voice-model:hover {
-    background: rgba(127, 127, 127, 0.15);
-  }
-  .tp-voice-progress {
-    padding: 4px 8px;
-    font-size: 11px;
-    opacity: 0.8;
-  }
-  .tp-voice-progress.error {
-    color: #e5484d;
   }
 
   .terminal-container {

--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -7,6 +7,8 @@
   import { theme_state, terminal_font_state, save_terminal_font_state, TERMINAL_FONT_FAMILIES } from '$lib/state.svelte'
   import { register_terminal, unregister_terminal, mark_terminal_active } from './terminal-registry.svelte'
   import { next_marker, wrap_command, extract_result, strip_ansi } from './terminal-capture'
+  import { TerminalVoice } from './terminal-voice.svelte'
+  import { WHISPER_MODELS } from '$lib/gesture/whisper-models'
 
   let {
     layout = `horizontal`,
@@ -66,6 +68,8 @@
   /** Monotonic sequence counter for CWD broadcasts — receivers discard stale messages. */
   let _cwd_seq = 0
   let show_font_menu = $state(false)
+  const voice = new TerminalVoice()
+  let show_voice_menu = $state(false)
 
   const title = $derived(
     host ? `${username || ``}@${host}` : `Terminal`
@@ -744,7 +748,7 @@
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-<div class="terminal-panel" onclick={() => { if (show_font_menu) show_font_menu = false }}>
+<div class="terminal-panel" onclick={() => { if (show_font_menu) show_font_menu = false; if (show_voice_menu) show_voice_menu = false }}>
   {#if show_header}
     <div class="terminal-panel-header">
       <span class="terminal-panel-title">
@@ -807,6 +811,46 @@
                   </select>
                 </label>
               </div>
+            </div>
+          {/if}
+        </div>
+        <!-- Voice dictation: mic toggle + model picker -->
+        <div class="tp-dropdown-wrap">
+          <button
+            class="terminal-voice-btn"
+            class:active={voice.recording}
+            disabled={!voice.is_supported}
+            title={voice.is_supported
+              ? (voice.recording ? `Stop dictation` : `Dictate into terminal`)
+              : `Voice dictation needs microphone access (unsupported here)`}
+            onclick={(e) => {
+              e.stopPropagation()
+              voice.toggle((t) => panel_send_keys(t))
+            }}
+          ><Icon icon="Mic" /></button>
+          <button
+            class="terminal-voice-caret"
+            title="Choose speech model"
+            onclick={(e) => { e.stopPropagation(); show_voice_menu = !show_voice_menu }}
+          >▾</button>
+          {#if show_voice_menu}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <div class="tp-font-dropdown" onclick={(e) => e.stopPropagation()}>
+              <div class="tp-font-header">Speech model</div>
+              {#each WHISPER_MODELS as m}
+                <button
+                  class="tp-voice-model"
+                  class:selected={voice.model_id === m.id}
+                  onclick={() => { voice.set_model(m.id); show_voice_menu = false }}
+                >{m.label} · ~{m.size_mb}MB</button>
+              {/each}
+              {#if voice.model_status === `downloading`}
+                <div class="tp-voice-progress">
+                  Downloading… {Math.round(voice.download_progress)}%
+                </div>
+              {:else if voice.model_status === `error` || voice.error}
+                <div class="tp-voice-progress error">Model failed — try again</div>
+              {/if}
             </div>
           {/if}
         </div>
@@ -1021,6 +1065,39 @@
   }
   .tp-font-control select:focus {
     border-color: var(--accent-color, #3b82f6);
+  }
+
+  .terminal-voice-btn.active {
+    color: #e5484d;
+  }
+  .terminal-voice-caret {
+    padding: 0 2px;
+    font-size: 10px;
+    opacity: 0.7;
+  }
+  .tp-voice-model {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 4px 8px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .tp-voice-model.selected {
+    font-weight: 600;
+  }
+  .tp-voice-model:hover {
+    background: rgba(127, 127, 127, 0.15);
+  }
+  .tp-voice-progress {
+    padding: 4px 8px;
+    font-size: 11px;
+    opacity: 0.8;
+  }
+  .tp-voice-progress.error {
+    color: #e5484d;
   }
 
   .terminal-container {

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -355,7 +355,16 @@
                 onclick={() => { voice.set_language(l.tag) }}
               >{l.label}</button>
             {/each}
-            <div class="tw-dropdown-note">中英混合：选「中文」+ 更大模型(Small / Large turbo)效果最好</div>
+            <div class="tw-dropdown-divider"></div>
+            <div class="tw-dropdown-header">Acceleration</div>
+            {#each [{ a: `cpu`, label: `CPU (稳定)` }, { a: `gpu`, label: `GPU / WebGPU (实验·更快)` }] as opt}
+              <button
+                class="tw-dropdown-item"
+                class:tw-voice-selected={voice.accel === opt.a}
+                onclick={() => { voice.set_accel(opt.a === `gpu` ? `gpu` : `cpu`) }}
+              >{opt.label}</button>
+            {/each}
+            <div class="tw-dropdown-note">中英混合：选「中文」+ 更大模型。GPU 需浏览器支持 WebGPU,出乱码就切回 CPU</div>
             {#if voice.model_status === `downloading`}
               <div class="tw-dropdown-note">Downloading… {Math.round(voice.download_progress)}%</div>
             {:else if voice.model_status === `error` || voice.error}

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -2,6 +2,9 @@
   import { untrack } from 'svelte'
   import TerminalPanel from './TerminalPanel.svelte'
   import { Icon } from '$lib'
+  import { TerminalVoice } from './terminal-voice.svelte'
+  import { WHISPER_MODELS } from '$lib/gesture/whisper-models'
+  import { get_active_terminal } from './terminal-registry.svelte'
   import { fetchConnections, type ConnectionInfo } from '$lib/api/hpc'
   import { fetchAvailableShells, type ShellInfo } from '$lib/api/pty'
   import { hpc_session_store, LOCAL_SESSION_ID } from '$lib/hpc-sessions.svelte'
@@ -176,9 +179,21 @@
 
   let show_font_menu = $state(false)
 
+  // ====== Voice dictation ======
+  // Reuses the in-browser local-Whisper engine. Final transcripts are typed
+  // into the ACTIVE tab's PTY via the terminal registry (same path CatBot
+  // uses), with no Enter appended.
+  const voice = new TerminalVoice()
+  let show_voice_menu = $state(false)
+
+  function toggle_voice() {
+    voice.toggle((text) => { get_active_terminal()?.send_keys(text) })
+  }
+
   function handle_global_click() {
     if (show_new_menu) show_new_menu = false
     if (show_font_menu) show_font_menu = false
+    if (show_voice_menu) show_voice_menu = false
   }
 </script>
 
@@ -300,6 +315,42 @@
                 </select>
               </label>
             </div>
+          </div>
+        {/if}
+      </div>
+
+      <!-- Voice dictation: mic toggle + speech-model picker -->
+      <div class="tw-dropdown-wrap">
+        <button
+          class="tw-icon-btn tw-voice-btn"
+          class:active={voice.recording}
+          disabled={!voice.is_supported}
+          title={voice.is_supported
+            ? (voice.recording ? `Stop dictation` : `Dictate into the active terminal`)
+            : `Voice dictation needs microphone access (unsupported here)`}
+          onclick={(e) => { e.stopPropagation(); toggle_voice() }}
+        ><Icon icon="Mic" /></button>
+        <button
+          class="tw-icon-btn tw-voice-caret"
+          title="Choose speech model"
+          onclick={(e) => { e.stopPropagation(); show_voice_menu = !show_voice_menu; show_font_menu = false; show_new_menu = false }}
+        >▾</button>
+        {#if show_voice_menu}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div class="tw-dropdown tw-voice-dropdown" onclick={(e) => e.stopPropagation()}>
+            <div class="tw-dropdown-header">Speech model</div>
+            {#each WHISPER_MODELS as m}
+              <button
+                class="tw-dropdown-item"
+                class:tw-voice-selected={voice.model_id === m.id}
+                onclick={() => { voice.set_model(m.id); show_voice_menu = false }}
+              >{m.label} · ~{m.size_mb}MB</button>
+            {/each}
+            {#if voice.model_status === `downloading`}
+              <div class="tw-dropdown-note">Downloading… {Math.round(voice.download_progress)}%</div>
+            {:else if voice.model_status === `error` || voice.error}
+              <div class="tw-dropdown-note tw-voice-error">Model failed — try again</div>
+            {/if}
           </div>
         {/if}
       </div>
@@ -450,6 +501,23 @@
   }
   .tw-sync-btn.active {
     color: var(--accent-color, #3b82f6);
+  }
+  .tw-voice-btn.active {
+    color: #e5484d;
+  }
+  .tw-voice-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .tw-voice-caret {
+    padding: 4px 2px;
+    font-size: 0.7em;
+  }
+  .tw-voice-selected {
+    font-weight: 600;
+  }
+  .tw-voice-error {
+    color: #e5484d;
   }
   .tw-icon-btn:hover {
     background: var(--surface-bg-hover, rgba(0, 0, 0, 0.05));

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -346,6 +346,16 @@
                 onclick={() => { voice.set_model(m.id); show_voice_menu = false }}
               >{m.label} · ~{m.size_mb}MB</button>
             {/each}
+            <div class="tw-dropdown-divider"></div>
+            <div class="tw-dropdown-header">Spoken language</div>
+            {#each [{ tag: `en-US`, label: `English / 自动` }, { tag: `zh-CN`, label: `中文 (普通话)` }] as l}
+              <button
+                class="tw-dropdown-item"
+                class:tw-voice-selected={voice.language === l.tag}
+                onclick={() => { voice.set_language(l.tag) }}
+              >{l.label}</button>
+            {/each}
+            <div class="tw-dropdown-note">中英混合：选「中文」+ 更大模型(Small / Large turbo)效果最好</div>
             {#if voice.model_status === `downloading`}
               <div class="tw-dropdown-note">Downloading… {Math.round(voice.download_progress)}%</div>
             {:else if voice.model_status === `error` || voice.error}

--- a/src/lib/structure/__tests__/terminal-voice.test.ts
+++ b/src/lib/structure/__tests__/terminal-voice.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { TerminalVoice } from '../terminal-voice.svelte'
+import type { VoiceEvent } from '$lib/gesture/gesture-types'
+
+function fake_event(text: string, is_final: boolean): VoiceEvent {
+  return {
+    action: { type: `none` } as any,
+    raw_text: text,
+    confidence: 0.9,
+    is_final,
+    match_score: 0,
+    timestamp: 0,
+  }
+}
+
+// A controllable fake engine that lets the test fire transcript events.
+function make_fake() {
+  let cb: ((e: VoiceEvent) => void) | null = null
+  const engine = {
+    is_supported: true,
+    start: vi.fn((c: any) => { cb = c }),
+    stop: vi.fn(() => { cb = null }),
+  }
+  return { engine, fire: (e: VoiceEvent) => cb?.(e) }
+}
+
+describe('TerminalVoice', () => {
+  it('forwards only final transcripts to send, with a trailing space', async () => {
+    const { engine, fire } = make_fake()
+    const tv = new TerminalVoice(() => engine)
+    const sent: string[] = []
+    await tv.toggle((t) => sent.push(t))
+    expect(tv.recording).toBe(true)
+
+    fire(fake_event(`hello`, false)) // interim — ignored
+    fire(fake_event(`hello world`, true)) // final — sent
+    expect(sent).toEqual([`hello world `])
+  })
+
+  it('drops empty / whitespace-only final transcripts', async () => {
+    const { engine, fire } = make_fake()
+    const tv = new TerminalVoice(() => engine)
+    const sent: string[] = []
+    await tv.toggle((t) => sent.push(t))
+    fire(fake_event(`   `, true))
+    expect(sent).toEqual([])
+  })
+
+  it('toggle a second time stops and clears recording', async () => {
+    const { engine } = make_fake()
+    const tv = new TerminalVoice(() => engine)
+    await tv.toggle(() => {})
+    await tv.toggle(() => {})
+    expect(engine.stop).toHaveBeenCalled()
+    expect(tv.recording).toBe(false)
+  })
+
+  it('reports unsupported when the engine is unsupported', () => {
+    const tv = new TerminalVoice(() => ({ is_supported: false, start: vi.fn(), stop: vi.fn() }))
+    expect(tv.is_supported).toBe(false)
+  })
+})

--- a/src/lib/structure/terminal-voice.svelte.ts
+++ b/src/lib/structure/terminal-voice.svelte.ts
@@ -25,12 +25,17 @@ export interface VoiceEngineLike {
 }
 
 const STORAGE_KEY = `catgo-terminal-voice-model`
+const LANG_KEY = `catgo-terminal-voice-lang`
 
 export class TerminalVoice {
   recording = $state(false)
   model_status = $state<ModelStatus>(`idle`)
   download_progress = $state(0)
   model_id = $state(DEFAULT_WHISPER_MODEL_ID)
+  // BCP-47-ish tag handed to the engine; `en-US` → Whisper auto-detect (English
+  // lean), `zh-CN` → forced Chinese, etc. Forcing the language fixes Chinese
+  // speech being transcribed as English under auto-detect on short audio.
+  language = $state(`en-US`)
   error = $state<string | null>(null)
 
   private make_engine: () => VoiceEngineLike
@@ -46,6 +51,8 @@ export class TerminalVoice {
     if (typeof localStorage !== `undefined`) {
       const saved = localStorage.getItem(STORAGE_KEY)
       if (saved) this.model_id = saved
+      const lang = localStorage.getItem(LANG_KEY)
+      if (lang) this.language = lang
     }
   }
 
@@ -59,7 +66,14 @@ export class TerminalVoice {
     if (typeof localStorage !== `undefined`) localStorage.setItem(STORAGE_KEY, id)
   }
 
-  async toggle(send: (text: string) => void, language = `en-US`): Promise<void> {
+  set_language(lang: string): void {
+    this.language = lang
+    if (typeof localStorage !== `undefined`) localStorage.setItem(LANG_KEY, lang)
+    // Apply live if an engine exists so a mid-session change takes effect.
+    ;(this.engine as { set_language?: (l: string) => void } | null)?.set_language?.(lang)
+  }
+
+  async toggle(send: (text: string) => void, language?: string): Promise<void> {
     if (this.recording) {
       this.stop()
       return
@@ -80,7 +94,7 @@ export class TerminalVoice {
 
     this.recording = true
     try {
-      await this.engine.start(on_event, language, false, on_error, false, this.model_id)
+      await this.engine.start(on_event, language ?? this.language, false, on_error, false, this.model_id)
     } catch {
       this.recording = false
     }

--- a/src/lib/structure/terminal-voice.svelte.ts
+++ b/src/lib/structure/terminal-voice.svelte.ts
@@ -1,0 +1,93 @@
+/**
+ * Per-terminal voice-dictation controller.
+ *
+ * Bridges a local STT engine (LocalWhisperEngine by default) to the terminal:
+ * only FINAL transcripts are forwarded to `send`, which the TerminalPanel wires
+ * to panel_send_keys (no Enter). The engine is injected via a factory so this is
+ * unit-testable without a microphone. Desktop only.
+ */
+
+import { LocalWhisperEngine, type ModelStatus } from '$lib/gesture/local-whisper'
+import { DEFAULT_WHISPER_MODEL_ID } from '$lib/gesture/whisper-models'
+import type { VoiceEvent } from '$lib/gesture/gesture-types'
+
+export interface VoiceEngineLike {
+  readonly is_supported: boolean
+  start(
+    cb: (e: VoiceEvent) => void,
+    language?: string,
+    ai_enabled?: boolean,
+    on_error?: (err: string) => void,
+    noise_suppression?: boolean,
+    model_id?: string,
+  ): void | Promise<void>
+  stop(): void
+}
+
+const STORAGE_KEY = `catgo-terminal-voice-model`
+
+export class TerminalVoice {
+  recording = $state(false)
+  model_status = $state<ModelStatus>(`idle`)
+  download_progress = $state(0)
+  model_id = $state(DEFAULT_WHISPER_MODEL_ID)
+  error = $state<string | null>(null)
+
+  private make_engine: () => VoiceEngineLike
+  private engine: VoiceEngineLike | null = null
+
+  constructor(make_engine?: () => VoiceEngineLike) {
+    this.make_engine = make_engine
+      ?? (() =>
+        new LocalWhisperEngine((status, progress) => {
+          this.model_status = status
+          if (typeof progress === `number`) this.download_progress = progress
+        }))
+    if (typeof localStorage !== `undefined`) {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved) this.model_id = saved
+    }
+  }
+
+  get is_supported(): boolean {
+    if (!this.engine) this.engine = this.make_engine()
+    return this.engine.is_supported
+  }
+
+  set_model(id: string): void {
+    this.model_id = id
+    if (typeof localStorage !== `undefined`) localStorage.setItem(STORAGE_KEY, id)
+  }
+
+  async toggle(send: (text: string) => void, language = `en-US`): Promise<void> {
+    if (this.recording) {
+      this.stop()
+      return
+    }
+    this.error = null
+    if (!this.engine) this.engine = this.make_engine()
+
+    const on_event = (e: VoiceEvent) => {
+      if (!e.is_final) return
+      const text = e.raw_text.trim()
+      if (!text) return
+      send(`${text} `)
+    }
+    const on_error = (err: string) => {
+      this.error = err
+      this.recording = false
+    }
+
+    this.recording = true
+    try {
+      await this.engine.start(on_event, language, false, on_error, false, this.model_id)
+    } catch {
+      this.recording = false
+    }
+  }
+
+  stop(): void {
+    this.recording = false
+    this.engine?.stop()
+  }
+}

--- a/src/lib/structure/terminal-voice.svelte.ts
+++ b/src/lib/structure/terminal-voice.svelte.ts
@@ -11,6 +11,8 @@ import { LocalWhisperEngine, type ModelStatus } from '$lib/gesture/local-whisper
 import { DEFAULT_WHISPER_MODEL_ID } from '$lib/gesture/whisper-models'
 import type { VoiceEvent } from '$lib/gesture/gesture-types'
 
+export type Accel = `cpu` | `gpu`
+
 export interface VoiceEngineLike {
   readonly is_supported: boolean
   start(
@@ -20,12 +22,14 @@ export interface VoiceEngineLike {
     on_error?: (err: string) => void,
     noise_suppression?: boolean,
     model_id?: string,
+    accel?: Accel,
   ): void | Promise<void>
   stop(): void
 }
 
 const STORAGE_KEY = `catgo-terminal-voice-model`
 const LANG_KEY = `catgo-terminal-voice-lang`
+const ACCEL_KEY = `catgo-terminal-voice-accel`
 
 export class TerminalVoice {
   recording = $state(false)
@@ -36,6 +40,9 @@ export class TerminalVoice {
   // lean), `zh-CN` → forced Chinese, etc. Forcing the language fixes Chinese
   // speech being transcribed as English under auto-detect on short audio.
   language = $state(`en-US`)
+  // `cpu` = wasm/q8 (correct everywhere). `gpu` = WebGPU/fp16 (faster where
+  // WebGPU is sound; opt-in because some integrated GPUs misbehave).
+  accel = $state<Accel>(`cpu`)
   error = $state<string | null>(null)
 
   private make_engine: () => VoiceEngineLike
@@ -64,6 +71,8 @@ export class TerminalVoice {
       if (saved) this.model_id = saved
       const lang = localStorage.getItem(LANG_KEY)
       if (lang) this.language = lang
+      const accel = localStorage.getItem(ACCEL_KEY)
+      if (accel === `cpu` || accel === `gpu`) this.accel = accel
     }
   }
 
@@ -82,6 +91,12 @@ export class TerminalVoice {
     if (typeof localStorage !== `undefined`) localStorage.setItem(LANG_KEY, lang)
     // Apply live if an engine exists so a mid-session change takes effect.
     ;(this.engine as { set_language?: (l: string) => void } | null)?.set_language?.(lang)
+  }
+
+  set_accel(accel: Accel): void {
+    this.accel = accel
+    if (typeof localStorage !== `undefined`) localStorage.setItem(ACCEL_KEY, accel)
+    // Takes effect on the next start() (pipeline reloads for the new backend).
   }
 
   async toggle(send: (text: string) => void, language?: string): Promise<void> {
@@ -111,7 +126,15 @@ export class TerminalVoice {
 
     this.recording = true
     try {
-      await this.engine.start(on_event, language ?? this.language, false, on_error, false, this.model_id)
+      await this.engine.start(
+        on_event,
+        language ?? this.language,
+        false,
+        on_error,
+        false,
+        this.model_id,
+        this.accel,
+      )
     } catch {
       this.recording = false
     }

--- a/src/lib/structure/terminal-voice.svelte.ts
+++ b/src/lib/structure/terminal-voice.svelte.ts
@@ -40,6 +40,17 @@ export class TerminalVoice {
 
   private make_engine: () => VoiceEngineLike
   private engine: VoiceEngineLike | null = null
+  // Lazy Traditional→Simplified converter. Whisper's multilingual model emits
+  // Traditional Chinese for Mandarin; convert to Simplified for zh-CN. Loaded
+  // on first Chinese utterance so non-Chinese use pays nothing.
+  private t2s: ((s: string) => string) | null = null
+
+  private async ensure_t2s(): Promise<(s: string) => string> {
+    if (this.t2s) return this.t2s
+    const OpenCC: any = await import(`opencc-js`)
+    this.t2s = OpenCC.Converter({ from: `t`, to: `cn` })
+    return this.t2s!
+  }
 
   constructor(make_engine?: () => VoiceEngineLike) {
     this.make_engine = make_engine
@@ -81,10 +92,16 @@ export class TerminalVoice {
     this.error = null
     if (!this.engine) this.engine = this.make_engine()
 
-    const on_event = (e: VoiceEvent) => {
+    const on_event = async (e: VoiceEvent) => {
       if (!e.is_final) return
-      const text = e.raw_text.trim()
+      let text = e.raw_text.trim()
       if (!text) return
+      if (this.language.startsWith(`zh`)) {
+        try {
+          const conv = await this.ensure_t2s()
+          text = conv(text)
+        } catch { /* fall back to raw (Traditional) text */ }
+      }
       send(`${text} `)
     }
     const on_error = (err: string) => {

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -29,6 +29,14 @@ import {
 } from './vite.shared'
 import { Buffer } from 'node:buffer'
 
+// Cross-origin isolation headers (enables SharedArrayBuffer → multi-threaded
+// wasm). `credentialless` keeps cross-origin (HuggingFace/jsdelivr) fetches
+// working without requiring CORP headers on those responses.
+const COI_HEADERS = {
+  'Cross-Origin-Opener-Policy': `same-origin`,
+  'Cross-Origin-Embedder-Policy': `credentialless`,
+}
+
 const offset = worktree_offset()
 const desktop_port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3100 + offset
 const srv_port = server_port(offset)
@@ -824,12 +832,23 @@ export default defineConfig({
     port: desktop_port,
     strictPort: true,
     fs: { strict: false },
+    // Cross-origin isolation → SharedArrayBuffer → multi-threaded wasm for local
+    // Whisper STT (big CPU speedup when WebGPU is unavailable). COEP is
+    // `credentialless` (not `require-corp`) so cross-origin model/wasm fetches
+    // from the HuggingFace Hub and jsdelivr still work without CORP headers.
+    headers: COI_HEADERS,
     // Point the HMR client at the LAN dev server explicitly — without an
     // explicit clientPort it tries port 80 (ws://<host>/) first, fails, and
     // only then falls back. clientPort pins it to the actual dev-server port.
     ...(tauri_dev_host
       ? { hmr: { protocol: `ws`, host: tauri_dev_host, clientPort: desktop_port } }
       : {}),
+  },
+
+  preview: {
+    port: desktop_port,
+    strictPort: true,
+    headers: COI_HEADERS,
   },
 
   define: {

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -29,14 +29,6 @@ import {
 } from './vite.shared'
 import { Buffer } from 'node:buffer'
 
-// Cross-origin isolation headers (enables SharedArrayBuffer → multi-threaded
-// wasm). `credentialless` keeps cross-origin (HuggingFace/jsdelivr) fetches
-// working without requiring CORP headers on those responses.
-const COI_HEADERS = {
-  'Cross-Origin-Opener-Policy': `same-origin`,
-  'Cross-Origin-Embedder-Policy': `credentialless`,
-}
-
 const offset = worktree_offset()
 const desktop_port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3100 + offset
 const srv_port = server_port(offset)
@@ -832,23 +824,12 @@ export default defineConfig({
     port: desktop_port,
     strictPort: true,
     fs: { strict: false },
-    // Cross-origin isolation → SharedArrayBuffer → multi-threaded wasm for local
-    // Whisper STT (big CPU speedup when WebGPU is unavailable). COEP is
-    // `credentialless` (not `require-corp`) so cross-origin model/wasm fetches
-    // from the HuggingFace Hub and jsdelivr still work without CORP headers.
-    headers: COI_HEADERS,
     // Point the HMR client at the LAN dev server explicitly — without an
     // explicit clientPort it tries port 80 (ws://<host>/) first, fails, and
     // only then falls back. clientPort pins it to the actual dev-server port.
     ...(tauri_dev_host
       ? { hmr: { protocol: `ws`, host: tauri_dev_host, clientPort: desktop_port } }
       : {}),
-  },
-
-  preview: {
-    port: desktop_port,
-    strictPort: true,
-    headers: COI_HEADERS,
   },
 
   define: {


### PR DESCRIPTION
## What

Adds **voice dictation** to the desktop terminal. A mic button + model/language/acceleration picker in the `TerminalWindow` toolbar lets you speak; speech is transcribed locally (in-browser, Transformers.js Whisper + Silero VAD) and the final transcript is typed into the active terminal's PTY at the cursor — **no Enter sent**. Inspired by [voxpilot](https://github.com/natearcher-ai/voxpilot), but built on CatGo's existing in-browser STT pipeline rather than its Node engine. Desktop only; mobile untouched.

## Highlights

- **Pure-data Whisper model registry** (`whisper-models.ts`): tiny/base/small (en+multilingual) + large-turbo, on-demand download, IndexedDB/Cache-Storage cached (no re-download next launch).
- **Generalized `local-whisper.ts`** to load any registry model id; existing gesture/chat callers unaffected.
- **`TerminalVoice` controller** (`terminal-voice.svelte.ts`): forwards only final transcripts, drops empties, trailing-space; engine injected for unit tests.
- **UI** in `TerminalWindow` (the real terminal toolbar — `TerminalPanel` is always embedded headerless): mic toggle + dropdown for model / spoken language / acceleration. Routes via `get_active_terminal().send_keys` (same path CatBot uses).
- **Chinese**: force language `zh` (auto-detect mis-transcribed Mandarin as English) + Traditional→Simplified via lazy `opencc-js`.
- **Engine robustness**: load onnxruntime-web wasm + Silero assets from a version-pinned CDN (Vite doesn't emit them → WebGPU-less machines 404'd); `device:'wasm'`+q8 by default because **q8-on-WebGPU hallucinates**; optional GPU path uses **fp16** WebGPU; anti-repeat generation params.
- **Speed**: cross-origin isolation (COOP=same-origin, COEP=credentialless — keeps CDN/HF fetches working) enables multi-threaded wasm, adaptive `min(8, cores-2)` threads.

## Tests

11/11 new unit tests pass (model registry, model-id threading, controller behavior). Type-check: no new errors.

## Reviewer notes / risk

- **COI headers are shared infra** (`vite.desktop.config.ts`, dev+preview, also affects mobile dev). COOP/COEP can affect cross-origin popups (OAuth) / embeds elsewhere — verified voice + model download work, but a broader app smoke is advisable.
- COI/multi-thread applies to vite-served contexts (dev/preview/`tauri dev`); the **production Tauri bundle** would need the headers on its own protocol for COI in the shipped app.
- Integrated-GPU WebGPU was unreliable for Whisper even at fp16 on the test machine → GPU path is opt-in, defaults to CPU.
- Spec + plan: `docs/superpowers/specs/2026-06-18-terminal-voice-input-design.md`, `docs/superpowers/plans/2026-06-18-terminal-voice-input.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)