### PR TITLE
fix(electronic): plot polish — axis titles, Arial font, theme colors, sizes, line styles; band gap; button greys

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.87",
     "@catgo/ferrox-wasm": "link:extensions/rust-wasm",
+    "@fontsource/arimo": "^5.2.8",
     "@huggingface/transformers": "^3.8.1",
     "@mediapipe/tasks-vision": "^0.10.32",
     "@openai/codex-sdk": "0.132.0-alpha.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@catgo/ferrox-wasm':
         specifier: link:extensions/rust-wasm
         version: link:extensions/rust-wasm
+      '@fontsource/arimo':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@huggingface/transformers':
         specifier: ^3.8.1
         version: 3.8.1
@@ -812,6 +815,9 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fontsource/arimo@5.2.8':
+    resolution: {integrity: sha512-EGB/l4PhYsxJbskePrgFQKM3Ob+x3Xr+VZDuSMR2XNVQYhx8t5zIfiMxCLLbgBPkY2qeXGfbyrXeAOEGl1lOSA==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -4809,6 +4815,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@fontsource/arimo@5.2.8': {}
 
   '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -785,12 +785,16 @@
   .draggable-pane :global(input::-webkit-inner-spin-button) {
     display: none;
   }
-  .draggable-pane :global(button) {
+  /* Default chrome for bare pane buttons. Wrapped in :where() so the whole
+     selector has ZERO specificity — it acts as a fallback that any button which
+     sets its own background (e.g. .btn-primary / .btn-compute accent buttons)
+     overrides, instead of this global rule winning and graying them out. */
+  :where(.draggable-pane) :global(:where(button)) {
     width: max-content;
     border-radius: 6px;
     background-color: var(--pane-btn-bg, var(--btn-bg));
   }
-  .draggable-pane :global(button:hover) {
+  :where(.draggable-pane) :global(:where(button:hover)) {
     background-color: var(--pane-btn-bg-hover, var(--btn-bg-hover));
   }
   .draggable-pane :global(select) {

--- a/src/lib/dialog-shared.css
+++ b/src/lib/dialog-shared.css
@@ -91,7 +91,9 @@
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
-  color: var(--text-color-muted, light-dark(#6b7280, #9ca3af));
+  /* Readable inactive-tab text — the muted #6b7280 read as disabled-gray on
+     light dialogs. Still clearly distinct from the accent active tab below. */
+  color: light-dark(#4b5563, #cbd5e1);
   cursor: pointer;
   font-size: 12px;
   padding: 8px 12px;

--- a/src/lib/electronic/BandAnalysisPane.svelte
+++ b/src/lib/electronic/BandAnalysisPane.svelte
@@ -445,6 +445,51 @@
           <input type="checkbox" bind:checked={band_state.show_axis_lines} />
           {t('structure.dos_show_axis_lines')}
         </label>
+        <div class="range-row">
+          <span>{t('structure.dos_axis_width')}</span>
+          <input
+            type="number"
+            bind:value={band_state.axis_line_width}
+            min="0.5" max="5" step="0.5"
+            class="range-input"
+          />
+        </div>
+        <div class="range-row">
+          <span>{t('structure.dos_tick_length')}</span>
+          <input
+            type="number"
+            bind:value={band_state.tick_length}
+            min="0" max="15" step="1"
+            class="range-input"
+          />
+        </div>
+        <div class="range-row">
+          <span>{t('structure.dos_tick_width')}</span>
+          <input
+            type="number"
+            bind:value={band_state.tick_width}
+            min="0.5" max="5" step="0.5"
+            class="range-input"
+          />
+        </div>
+        <div class="range-row">
+          <span>{t('structure.dos_title_size')}</span>
+          <input
+            type="number"
+            bind:value={band_state.title_size}
+            min="6" max="24" step="1"
+            class="range-input"
+          />
+        </div>
+        <div class="range-row">
+          <span>{t('structure.dos_font_size')}</span>
+          <input
+            type="number"
+            bind:value={band_state.font_size}
+            min="6" max="24" step="1"
+            class="range-input"
+          />
+        </div>
       </div>
     </details>
   {/if}

--- a/src/lib/electronic/BandPlot.svelte
+++ b/src/lib/electronic/BandPlot.svelte
@@ -22,6 +22,8 @@
     axis_line_width = 1,
     tick_length = 5,
     tick_width = 1,
+    title_size = 14,
+    font_size = 12,
     legend_visible = true,
   }: {
     distance: number[]
@@ -42,6 +44,8 @@
     axis_line_width?: number
     tick_length?: number
     tick_width?: number
+    title_size?: number
+    font_size?: number
     legend_visible?: boolean
   } = $props()
 
@@ -236,7 +240,7 @@
 
     const layout: any = {
       xaxis: {
-        title: { text: `Wave Vector` },
+        title: { text: `Wave Vector`, font: { size: title_size } },
         tickmode: `array`,
         tickvals: tick_positions,
         ticktext: tick_labels,
@@ -248,7 +252,7 @@
         ...tick_props_obj,
       },
       yaxis: {
-        title: { text: `E \u2013 E<sub>f</sub> (eV)` },
+        title: { text: `E \u2013 E<sub>f</sub> (eV)`, font: { size: title_size } },
         range: [emin, emax],
         zeroline: false,
         ...grid_props,
@@ -259,11 +263,11 @@
       annotations,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { family: pc.font, color: pc.text, size: 11 },
+      font: { family: pc.font, color: pc.text, size: font_size },
       showlegend: legend_visible,
       legend: {
         bgcolor: pc.legend_bg,
-        font: { family: pc.font, color: pc.text, size: 10 },
+        font: { family: pc.font, color: pc.text, size: font_size },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/BandPlot.svelte
+++ b/src/lib/electronic/BandPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { BandSeries, BandProjection } from './band_types'
+  import { plot_theme_colors } from './plot-theme.svelte'
 
   let {
     distance = [],
@@ -100,6 +101,7 @@
   $effect(() => {
     if (!Plotly || !plot_div || distance.length === 0 || band_series.length === 0) return
 
+    const pc = plot_theme_colors()
     const traces: any[] = []
     const [emin, emax] = energy_range
 
@@ -216,12 +218,12 @@
     // Axis appearance
     const grid_props = {
       showgrid: show_gridlines,
-      gridcolor: `rgba(255,255,255,0.1)`,
+      gridcolor: pc.grid,
       gridwidth: 1,
     }
     const line_props = {
       showline: show_axis_lines,
-      linecolor: `rgba(200,200,200,0.5)`,
+      linecolor: pc.line,
       linewidth: axis_line_width,
       mirror: show_axis_lines,
     }
@@ -229,7 +231,7 @@
       ticks: `outside` as const,
       ticklen: tick_length,
       tickwidth: tick_width,
-      tickcolor: `rgba(200,200,200,0.5)`,
+      tickcolor: pc.tick,
     }
 
     const layout: any = {
@@ -257,11 +259,11 @@
       annotations,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { color: `#ccc`, size: 11 },
+      font: { color: pc.text, size: 11 },
       showlegend: legend_visible,
       legend: {
-        bgcolor: `rgba(0,0,0,0.3)`,
-        font: { color: `#ccc`, size: 10 },
+        bgcolor: pc.legend_bg,
+        font: { color: pc.text, size: 10 },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/BandPlot.svelte
+++ b/src/lib/electronic/BandPlot.svelte
@@ -259,11 +259,11 @@
       annotations,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { color: pc.text, size: 11 },
+      font: { family: pc.font, color: pc.text, size: 11 },
       showlegend: legend_visible,
       legend: {
         bgcolor: pc.legend_bg,
-        font: { color: pc.text, size: 10 },
+        font: { family: pc.font, color: pc.text, size: 10 },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/BandPlot.svelte
+++ b/src/lib/electronic/BandPlot.svelte
@@ -234,7 +234,7 @@
 
     const layout: any = {
       xaxis: {
-        title: ``,
+        title: { text: `Wave Vector` },
         tickmode: `array`,
         tickvals: tick_positions,
         ticktext: tick_labels,
@@ -246,7 +246,7 @@
         ...tick_props_obj,
       },
       yaxis: {
-        title: `E \u2013 E<sub>f</sub> (eV)`,
+        title: { text: `E \u2013 E<sub>f</sub> (eV)` },
         range: [emin, emax],
         zeroline: false,
         ...grid_props,
@@ -263,7 +263,7 @@
         bgcolor: `rgba(0,0,0,0.3)`,
         font: { color: `#ccc`, size: 10 },
       },
-      margin: { l: 55, r: 10, t: 10, b: 30 },
+      margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,
       hovermode: `closest`,
       autosize: true,

--- a/src/lib/electronic/CohpAnalysisPane.svelte
+++ b/src/lib/electronic/CohpAnalysisPane.svelte
@@ -627,7 +627,8 @@
   .color-input { width: 28px; height: 22px; padding: 0; border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; cursor: pointer; background: transparent; }
   .slider-input { flex: 1; accent-color: var(--accent-color, #007acc); }
   .slider-val { font-size: 0.85em; color: var(--text-color-muted, rgba(255, 255, 255, 0.5)); min-width: 30px; text-align: right; }
-  .btn-compute { padding: 6px 12px; background: var(--accent-color, #007acc); color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-compute { padding: 6px 12px; background: #2563eb; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-compute:hover:not(:disabled) { background: #1d4ed8; }
   .btn-compute:disabled { opacity: 0.5; cursor: not-allowed; }
   .btn-small { padding: 3px 8px; background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1)); border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; color: var(--text-color, #fff); cursor: pointer; font-size: 0.85em; }
   .btn-small:hover { background: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.2)); }

--- a/src/lib/electronic/CohpAnalysisPane.svelte
+++ b/src/lib/electronic/CohpAnalysisPane.svelte
@@ -385,6 +385,24 @@
             class="range-input"
           />
         </div>
+        <div class="range-row">
+          <span>{t('structure.dos_title_size')}</span>
+          <input
+            type="number"
+            bind:value={cohp_state.title_size}
+            min="6" max="24" step="1"
+            class="range-input"
+          />
+        </div>
+        <div class="range-row">
+          <span>{t('structure.dos_font_size')}</span>
+          <input
+            type="number"
+            bind:value={cohp_state.font_size}
+            min="6" max="24" step="1"
+            class="range-input"
+          />
+        </div>
       </div>
     </details>
 

--- a/src/lib/electronic/CohpPlot.svelte
+++ b/src/lib/electronic/CohpPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { COHPSeries } from './cohp_types'
+  import { plot_theme_colors } from './plot-theme.svelte'
 
   let {
     energies = [],
@@ -127,6 +128,7 @@
   $effect(() => {
     if (!Plotly || !plot_div || energies.length === 0 || series.length === 0) return
 
+    const pc = plot_theme_colors()
     const sign = invert_cohp ? -1 : 1
     const traces: any[] = []
     const fa = Math.max(0, Math.min(1, fill_opacity))  // clamp
@@ -240,12 +242,12 @@
     // Axis appearance shared properties
     const grid_props = {
       showgrid: show_gridlines,
-      gridcolor: `rgba(255,255,255,0.1)`,
+      gridcolor: pc.grid,
       gridwidth: 1,
     }
     const line_props = {
       showline: show_axis_lines,
-      linecolor: `rgba(200,200,200,0.5)`,
+      linecolor: pc.line,
       linewidth: axis_line_width,
       mirror: show_axis_lines,
     }
@@ -253,7 +255,7 @@
       ticks: `outside` as const,
       ticklen: tick_length,
       tickwidth: tick_width,
-      tickcolor: `rgba(200,200,200,0.5)`,
+      tickcolor: pc.tick,
     }
 
     const cohp_label = invert_cohp ? `\u2013COHP (eV)` : `COHP (eV)`
@@ -280,11 +282,11 @@
       shapes,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { color: `#ccc`, size: 11 },
+      font: { color: pc.text, size: 11 },
       showlegend: legend_visible,
       legend: {
-        bgcolor: `rgba(0,0,0,0.3)`,
-        font: { color: `#ccc`, size: 10 },
+        bgcolor: pc.legend_bg,
+        font: { color: pc.text, size: 10 },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/CohpPlot.svelte
+++ b/src/lib/electronic/CohpPlot.svelte
@@ -282,11 +282,11 @@
       shapes,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { color: pc.text, size: 11 },
+      font: { family: pc.font, color: pc.text, size: 11 },
       showlegend: legend_visible,
       legend: {
         bgcolor: pc.legend_bg,
-        font: { color: pc.text, size: 10 },
+        font: { family: pc.font, color: pc.text, size: 10 },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/CohpPlot.svelte
+++ b/src/lib/electronic/CohpPlot.svelte
@@ -22,6 +22,8 @@
     axis_line_width = 1,
     tick_length = 5,
     tick_width = 1,
+    title_size = 14,
+    font_size = 12,
     legend_visible = true,
     hidden_series = [],
   }: {
@@ -43,6 +45,8 @@
     axis_line_width?: number
     tick_length?: number
     tick_width?: number
+    title_size?: number
+    font_size?: number
     legend_visible?: boolean
     hidden_series?: string[]
   } = $props()
@@ -260,7 +264,7 @@
 
     const cohp_label = invert_cohp ? `\u2013COHP (eV)` : `COHP (eV)`
     const energy_axis = {
-      title: { text: `E \u2013 E<sub>f</sub> (eV)` },
+      title: { text: `E \u2013 E<sub>f</sub> (eV)`, font: { size: title_size } },
       zeroline: false,
       range: is_horizontal ? (y_range ?? undefined) : (x_range ?? undefined),
       ...grid_props,
@@ -268,7 +272,7 @@
       ...tick_props,
     }
     const cohp_axis = {
-      title: { text: cohp_label },
+      title: { text: cohp_label, font: { size: title_size } },
       zeroline: true,
       range: is_horizontal ? (x_range ?? undefined) : (y_range ?? undefined),
       ...grid_props,
@@ -282,11 +286,11 @@
       shapes,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { family: pc.font, color: pc.text, size: 11 },
+      font: { family: pc.font, color: pc.text, size: font_size },
       showlegend: legend_visible,
       legend: {
         bgcolor: pc.legend_bg,
-        font: { family: pc.font, color: pc.text, size: 10 },
+        font: { family: pc.font, color: pc.text, size: font_size },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/CohpPlot.svelte
+++ b/src/lib/electronic/CohpPlot.svelte
@@ -258,7 +258,7 @@
 
     const cohp_label = invert_cohp ? `\u2013COHP (eV)` : `COHP (eV)`
     const energy_axis = {
-      title: `E \u2013 E<sub>f</sub> (eV)`,
+      title: { text: `E \u2013 E<sub>f</sub> (eV)` },
       zeroline: false,
       range: is_horizontal ? (y_range ?? undefined) : (x_range ?? undefined),
       ...grid_props,
@@ -266,7 +266,7 @@
       ...tick_props,
     }
     const cohp_axis = {
-      title: cohp_label,
+      title: { text: cohp_label },
       zeroline: true,
       range: is_horizontal ? (x_range ?? undefined) : (y_range ?? undefined),
       ...grid_props,
@@ -286,7 +286,7 @@
         bgcolor: `rgba(0,0,0,0.3)`,
         font: { color: `#ccc`, size: 10 },
       },
-      margin: { l: 55, r: 10, t: 10, b: 40 },
+      margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,
       hovermode: is_horizontal ? `y unified` : `x unified`,
       autosize: true,

--- a/src/lib/electronic/DosAnalysisPane.svelte
+++ b/src/lib/electronic/DosAnalysisPane.svelte
@@ -128,6 +128,12 @@
     session ? [...new Set(session.elements)] : []
   )
 
+  $effect(() => {
+    if (selection_mode === `element` && !new_element && unique_elements.length > 0) {
+      new_element = unique_elements[0]
+    }
+  })
+
   function get_orbital_value(): string {
     return new_orbital === `custom` ? new_orbital_custom : new_orbital
   }

--- a/src/lib/electronic/DosAnalysisPane.svelte
+++ b/src/lib/electronic/DosAnalysisPane.svelte
@@ -1044,7 +1044,8 @@
   .line-style-row .group-label { min-width: 60px; font-size: 0.9em; }
   .line-style-row select { padding: 2px 4px; background: light-dark(rgba(0, 0, 0, 0.04), rgba(255, 255, 255, 0.08)); border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; color: var(--text-color, #fff); font-size: 0.85em; }
   .width-input { width: 45px; padding: 2px 4px; background: light-dark(rgba(0, 0, 0, 0.04), rgba(255, 255, 255, 0.08)); border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; color: var(--text-color, #fff); font-size: 0.85em; }
-  .btn-compute { padding: 6px 12px; background: var(--accent-color, #007acc); color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-compute { padding: 6px 12px; background: #2563eb; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-compute:hover:not(:disabled) { background: #1d4ed8; }
   .btn-compute:disabled { opacity: 0.5; cursor: not-allowed; }
   .btn-small { padding: 3px 8px; background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1)); border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)); border-radius: 3px; color: var(--text-color, #fff); cursor: pointer; font-size: 0.85em; }
   .btn-small:hover { background: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.2)); }

--- a/src/lib/electronic/DosAnalysisPane.svelte
+++ b/src/lib/electronic/DosAnalysisPane.svelte
@@ -710,6 +710,24 @@
             class="range-input"
           />
         </div>
+        <div class="range-row">
+          <span>{t('structure.dos_title_size')}</span>
+          <input
+            type="number"
+            bind:value={dos_state.title_size}
+            min="6" max="24" step="1"
+            class="range-input"
+          />
+        </div>
+        <div class="range-row">
+          <span>{t('structure.dos_font_size')}</span>
+          <input
+            type="number"
+            bind:value={dos_state.font_size}
+            min="6" max="24" step="1"
+            class="range-input"
+          />
+        </div>
       </div>
     </details>
 

--- a/src/lib/electronic/DosPlot.svelte
+++ b/src/lib/electronic/DosPlot.svelte
@@ -20,6 +20,8 @@
     axis_line_width = 1,
     tick_length = 5,
     tick_width = 1,
+    title_size = 14,
+    font_size = 12,
     legend_visible = true,
     hidden_series = [],
   }: {
@@ -40,6 +42,8 @@
     axis_line_width?: number
     tick_length?: number
     tick_width?: number
+    title_size?: number
+    font_size?: number
     legend_visible?: boolean
     /** Series labels to hide from the plot and legend */
     hidden_series?: string[]
@@ -231,7 +235,7 @@
     }
 
     const energy_axis = {
-      title: { text: `E \u2013 E<sub>f</sub> (eV)` },
+      title: { text: `E \u2013 E<sub>f</sub> (eV)`, font: { size: title_size } },
       zeroline: false,
       range: is_horizontal ? (y_range ?? undefined) : (x_range ?? undefined),
       ...grid_props,
@@ -239,7 +243,7 @@
       ...tick_props,
     }
     const dos_axis = {
-      title: { text: `DOS (states/eV)` },
+      title: { text: `DOS (states/eV)`, font: { size: title_size } },
       zeroline: true,
       range: is_horizontal ? (x_range ?? undefined) : (y_range ?? undefined),
       ...grid_props,
@@ -254,11 +258,11 @@
       annotations,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { family: pc.font, color: pc.text, size: 11 },
+      font: { family: pc.font, color: pc.text, size: font_size },
       showlegend: legend_visible,
       legend: {
         bgcolor: pc.legend_bg,
-        font: { family: pc.font, color: pc.text, size: 10 },
+        font: { family: pc.font, color: pc.text, size: font_size },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/DosPlot.svelte
+++ b/src/lib/electronic/DosPlot.svelte
@@ -229,7 +229,7 @@
     }
 
     const energy_axis = {
-      title: `E \u2013 E<sub>f</sub> (eV)`,
+      title: { text: `E \u2013 E<sub>f</sub> (eV)` },
       zeroline: false,
       range: is_horizontal ? (y_range ?? undefined) : (x_range ?? undefined),
       ...grid_props,
@@ -237,7 +237,7 @@
       ...tick_props,
     }
     const dos_axis = {
-      title: `DOS (states/eV)`,
+      title: { text: `DOS (states/eV)` },
       zeroline: true,
       range: is_horizontal ? (x_range ?? undefined) : (y_range ?? undefined),
       ...grid_props,
@@ -258,7 +258,7 @@
         bgcolor: `rgba(0,0,0,0.3)`,
         font: { color: `#ccc`, size: 10 },
       },
-      margin: { l: 55, r: 10, t: 10, b: 40 },
+      margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,
       hovermode: is_horizontal ? `y unified` : `x unified`,
       autosize: true,

--- a/src/lib/electronic/DosPlot.svelte
+++ b/src/lib/electronic/DosPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PDOSSeries } from './types'
+  import { plot_theme_colors } from './plot-theme.svelte'
 
   let {
     grid = [],
@@ -102,6 +103,7 @@
   $effect(() => {
     if (!Plotly || !plot_div || grid.length === 0 || series.length === 0) return
 
+    const pc = plot_theme_colors()
     const traces: any[] = []
     // Track color index per original series position (so colors stay stable)
     for (let i = 0; i < series.length; i++) {
@@ -212,12 +214,12 @@
     // Axis appearance shared properties
     const grid_props = {
       showgrid: show_gridlines,
-      gridcolor: `rgba(255,255,255,0.1)`,
+      gridcolor: pc.grid,
       gridwidth: 1,
     }
     const line_props = {
       showline: show_axis_lines,
-      linecolor: `rgba(200,200,200,0.5)`,
+      linecolor: pc.line,
       linewidth: axis_line_width,
       mirror: show_axis_lines,
     }
@@ -225,7 +227,7 @@
       ticks: `outside` as const,
       ticklen: tick_length,
       tickwidth: tick_width,
-      tickcolor: `rgba(200,200,200,0.5)`,
+      tickcolor: pc.tick,
     }
 
     const energy_axis = {
@@ -252,11 +254,11 @@
       annotations,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { color: `#ccc`, size: 11 },
+      font: { color: pc.text, size: 11 },
       showlegend: legend_visible,
       legend: {
-        bgcolor: `rgba(0,0,0,0.3)`,
-        font: { color: `#ccc`, size: 10 },
+        bgcolor: pc.legend_bg,
+        font: { color: pc.text, size: 10 },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/DosPlot.svelte
+++ b/src/lib/electronic/DosPlot.svelte
@@ -254,11 +254,11 @@
       annotations,
       plot_bgcolor: `rgba(0,0,0,0)`,
       paper_bgcolor: `rgba(0,0,0,0)`,
-      font: { color: pc.text, size: 11 },
+      font: { family: pc.font, color: pc.text, size: 11 },
       showlegend: legend_visible,
       legend: {
         bgcolor: pc.legend_bg,
-        font: { color: pc.text, size: 10 },
+        font: { family: pc.font, color: pc.text, size: 10 },
       },
       margin: { l: 60, r: 10, t: 10, b: 45 },
       height: container_height,

--- a/src/lib/electronic/DosPlot.svelte
+++ b/src/lib/electronic/DosPlot.svelte
@@ -147,7 +147,7 @@
           type: `scatter`,
           mode: `lines`,
           name: `${s.label} (down)`,
-          line: { color, width: lw, dash: `dash` },
+          line: { color, width: lw, dash },
           showlegend: true,
           visible: is_hidden ? `legendonly` : true,
         }

--- a/src/lib/electronic/FileSourceDialog.svelte
+++ b/src/lib/electronic/FileSourceDialog.svelte
@@ -752,8 +752,12 @@
   }
 
   .btn-primary {
+    background: var(--accent-color, light-dark(#4f46e5, #3b82f6));
     border-color: var(--accent-color, light-dark(#4f46e5, #3b82f6));
+    color: #fff;
   }
+  .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
   /* ─── Remote / Workflow content ─── */
   .remote-content,

--- a/src/lib/electronic/band_types.ts
+++ b/src/lib/electronic/band_types.ts
@@ -77,5 +77,7 @@ export interface BandViewState {
   axis_line_width: number
   tick_length: number
   tick_width: number
+  title_size: number
+  font_size: number
   legend_visible: boolean
 }

--- a/src/lib/electronic/cohp_types.ts
+++ b/src/lib/electronic/cohp_types.ts
@@ -77,6 +77,8 @@ export interface CohpViewState {
   axis_line_width: number
   tick_length: number
   tick_width: number
+  title_size: number
+  font_size: number
   legend_visible: boolean
   hidden_series: string[]
   line_styles: Record<string, { dash?: string; width?: number; color?: string; fill_color?: string }>

--- a/src/lib/electronic/plot-theme.svelte.ts
+++ b/src/lib/electronic/plot-theme.svelte.ts
@@ -1,0 +1,32 @@
+import { THEME_TYPE, type ThemeName } from '$lib/theme'
+
+function read_theme(): string {
+  if (typeof document === `undefined`) return `light`
+  return document.documentElement.getAttribute(`data-theme`) ?? `light`
+}
+
+let _theme = $state(read_theme())
+
+if (typeof MutationObserver !== `undefined` && typeof document !== `undefined`) {
+  new MutationObserver(() => { _theme = read_theme() }).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: [`data-theme`],
+  })
+}
+
+export interface PlotThemeColors {
+  text: string
+  grid: string
+  line: string
+  tick: string
+  legend_bg: string
+}
+
+/** Reactive plot colors for the current app theme. Call inside a reactive
+ *  context (template / $derived) so plots restyle when the theme changes. */
+export function plot_theme_colors(): PlotThemeColors {
+  const dark = THEME_TYPE[_theme as ThemeName] !== `light`
+  return dark
+    ? { text: `#ccc`, grid: `rgba(255,255,255,0.1)`, line: `rgba(200,200,200,0.5)`, tick: `rgba(200,200,200,0.5)`, legend_bg: `rgba(0,0,0,0.3)` }
+    : { text: `#374151`, grid: `rgba(0,0,0,0.12)`, line: `rgba(60,60,60,0.55)`, tick: `rgba(60,60,60,0.55)`, legend_bg: `rgba(255,255,255,0.6)` }
+}

--- a/src/lib/electronic/plot-theme.svelte.ts
+++ b/src/lib/electronic/plot-theme.svelte.ts
@@ -1,4 +1,13 @@
+// Bundle Arimo (Apache-2.0, metric-compatible with Arial) so plots render in an
+// Arial-identical face on every OS — real Arial is proprietary and can't ship.
+// These side-effect imports register the @font-face globally via Vite.
+import '@fontsource/arimo/400.css'
+import '@fontsource/arimo/700.css'
 import { THEME_TYPE, type ThemeName } from '$lib/theme'
+
+/** Plot font stack — bundled Arimo first, then a real Arial / Arial-clone if the
+ *  OS has one, then generic sans-serif. */
+export const PLOT_FONT = `Arimo, Arial, 'Liberation Sans', 'Helvetica Neue', sans-serif`
 
 function read_theme(): string {
   if (typeof document === `undefined`) return `light`
@@ -20,6 +29,7 @@ export interface PlotThemeColors {
   line: string
   tick: string
   legend_bg: string
+  font: string
 }
 
 /** Reactive plot colors for the current app theme. Call inside a reactive
@@ -27,6 +37,6 @@ export interface PlotThemeColors {
 export function plot_theme_colors(): PlotThemeColors {
   const dark = THEME_TYPE[_theme as ThemeName] !== `light`
   return dark
-    ? { text: `#ccc`, grid: `rgba(255,255,255,0.1)`, line: `rgba(200,200,200,0.5)`, tick: `rgba(200,200,200,0.5)`, legend_bg: `rgba(0,0,0,0.3)` }
-    : { text: `#374151`, grid: `rgba(0,0,0,0.12)`, line: `rgba(60,60,60,0.55)`, tick: `rgba(60,60,60,0.55)`, legend_bg: `rgba(255,255,255,0.6)` }
+    ? { text: `#ccc`, grid: `rgba(255,255,255,0.1)`, line: `rgba(200,200,200,0.5)`, tick: `rgba(200,200,200,0.5)`, legend_bg: `rgba(0,0,0,0.3)`, font: PLOT_FONT }
+    : { text: `#374151`, grid: `rgba(0,0,0,0.12)`, line: `rgba(60,60,60,0.55)`, tick: `rgba(60,60,60,0.55)`, legend_bg: `rgba(255,255,255,0.6)`, font: PLOT_FONT }
 }

--- a/src/lib/electronic/types.ts
+++ b/src/lib/electronic/types.ts
@@ -82,6 +82,8 @@ export interface DosViewState {
   axis_line_width: number
   tick_length: number
   tick_width: number
+  title_size: number
+  font_size: number
   legend_visible: boolean
   hidden_series: string[]  // series labels to hide from legend & plot
 }

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -1408,6 +1408,8 @@ const structure: Record<string, string> = {
   dos_axis_width: `Axis width:`,
   dos_tick_length: `Tick length:`,
   dos_tick_width: `Tick width:`,
+  dos_title_size: `Title size:`,
+  dos_font_size: `Font size:`,
   dos_series_visibility: `Series Visibility`,
   dos_line_styles: `Line Styles`,
   dos_line_solid: `Solid`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -1408,6 +1408,8 @@ const structure: Record<string, string> = {
   dos_axis_width: `坐标轴线宽：`,
   dos_tick_length: `刻度长度：`,
   dos_tick_width: `刻度线宽：`,
+  dos_title_size: `标题字号：`,
+  dos_font_size: `字号：`,
   dos_series_visibility: `序列可见性`,
   dos_line_styles: `线型`,
   dos_line_solid: `实线`,

--- a/src/lib/structure/OptimadeSearchModal.svelte
+++ b/src/lib/structure/OptimadeSearchModal.svelte
@@ -28,6 +28,22 @@
   import { SvelteMap } from 'svelte/reactivity'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
+  // Structure fingerprint helpers for MP id-migration fallback matching
+  function norm_formula(f: string | undefined): string {
+    if (!f) return ``
+    const counts: Record<string, number> = {}
+    const re = /([A-Z][a-z]?)(\d*)/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(f)) !== null) {
+      if (!m[1]) continue
+      counts[m[1]] = (counts[m[1]] ?? 0) + (m[2] ? parseInt(m[2], 10) : 1)
+    }
+    return Object.keys(counts).sort().map((el) => `${el}${counts[el]}`).join(``)
+  }
+  function struct_key(formula: string | undefined, nsites: number | undefined, sg: string | undefined): string {
+    return `${norm_formula(formula)}|${nsites ?? `?`}|${(sg ?? ``).replace(/\s+/g, ``)}`
+  }
+
   // Lazy-load structure translations
   load_i18n_module('structure')
 
@@ -93,6 +109,8 @@
 
   // Cache for MP summary data (keyed by material_id)
   let mp_summaries = $state<Map<string, MPSummaryData>>(new Map())
+  // Fallback map keyed by structure fingerprint (formula|nsites|sg) for MP id-migration matching
+  let mp_summaries_by_key = $state(new SvelteMap<string, MPSummaryData>())
 
   // Locally computed structure details (keyed by structure id)
   interface ComputedDetails {
@@ -239,6 +257,7 @@
     set_mp_api_key(``)
     mp_has_key = false
     mp_summaries = new Map()
+    mp_summaries_by_key = new SvelteMap()
   }
 
   // Fetch MP summary data by material IDs from OPTIMADE results
@@ -261,20 +280,24 @@
 
       console.log(`[MP ENRICH] Got ${summaries.length} MP results for ${material_ids.length} requested IDs`)
 
-      // Build map keyed by material_id
+      // Build map keyed by material_id + fallback map keyed by structure fingerprint
       const new_map = new SvelteMap<string, MPSummaryData>()
+      const new_by_key = new SvelteMap<string, MPSummaryData>()
       for (const s of summaries) {
         new_map.set(s.material_id, s)
+        const k = struct_key(s.formula_pretty, s.nsites, s.symmetry?.symbol)
+        if (!new_by_key.has(k)) new_by_key.set(k, s)
       }
 
       // Log matching stats
       const matches = material_ids.filter(id => new_map.has(id))
-      console.log(`[MP ENRICH] Matched ${matches.length}/${material_ids.length} structures`)
+      console.log(`[MP ENRICH] Matched ${matches.length}/${material_ids.length} structures by id; fingerprint map has ${new_by_key.size} entries`)
       if (summaries.length > 0) {
         console.log(`[MP ENRICH] Sample MP data:`, summaries[0])
       }
 
       mp_summaries = new_map
+      mp_summaries_by_key = new_by_key
 
       // Re-sort current results by stability now that we have authoritative
       // numbers: energy_above_hull ascending (0 = on the hull), formation
@@ -904,9 +927,10 @@
                 <div class="results-list">
                   {#each search_results.structures as struct (struct.id)}
                     {@const attrs = struct.attributes}
-                    {@const mp_data = mp_summaries.get(struct.id)}
                     {@const prov = extract_provider_details(attrs)}
                     {@const comp = computed_details.get(struct.id)}
+                    {@const mp_data = mp_summaries.get(struct.id)
+                      ?? mp_summaries_by_key.get(struct_key(attrs.chemical_formula_reduced, attrs.nsites ?? attrs.n_sites, prov.spacegroup_symbol ?? comp?.spacegroup_symbol))}
                     {@const formula = mp_data?.formula_pretty ?? attrs.chemical_formula_descriptive ?? attrs.chemical_formula_reduced ?? ``}
                     {@const n_sites = mp_data?.nsites ?? attrs.nsites ?? attrs.n_sites}
                     {@const n_elements = mp_data?.nelements ?? attrs.nelements}

--- a/src/lib/structure/OptimadeSearchModal.svelte
+++ b/src/lib/structure/OptimadeSearchModal.svelte
@@ -916,7 +916,7 @@
                     {@const sg_number = prov.spacegroup_number ?? comp?.spacegroup_number}
                     {@const e_above_hull = mp_data?.energy_above_hull ?? prov.energy_above_hull}
                     {@const formation_energy = mp_data?.formation_energy_per_atom ?? prov.formation_energy ?? attrs._mp_formation_energy_per_atom}
-                    {@const band_gap = mp_data?.band_gap ?? prov.band_gap}
+                    {@const band_gap = mp_data?.band_gap ?? prov.band_gap ?? attrs._mp_band_gap ?? attrs._odbx_band_gap ?? attrs._exmpl_band_gap}
                     {@const is_stable = mp_data?.is_stable ?? prov.is_stable}
                     {@const volume = comp?.volume}
                     {@const density = comp?.density}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1510,6 +1510,7 @@
         const filename = `${base_name}_data.csv`
         download(csv, filename, `text/csv;charset=utf-8`)
         set_status(t(`structure.export_started`, { filename }))
+        setTimeout(() => set_status(null), 4000)
         return
       }
 
@@ -1521,6 +1522,7 @@
       const filename = `${base_name}_plot.${format}`
       download(await data_url_to_blob(url), filename, format === `svg` ? `image/svg+xml` : `image/png`)
       set_status(t(`structure.export_started`, { filename }))
+      setTimeout(() => set_status(null), 4000)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       set_status(t(`structure.export_failed`, { what: format.toUpperCase(), message }))

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -5291,10 +5291,12 @@
   }
   .dos-layout-btn, .dos-export-btn, .dos-close-btn {
     padding: 2px 6px;
-    background: light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.08));
-    border: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.12));
+    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.08));
+    border: 1px solid light-dark(rgba(0, 0, 0, 0.18), rgba(255, 255, 255, 0.18));
     border-radius: 3px;
-    color: var(--struct-text-color, #ccc);
+    /* Theme-aware text so the buttons read as clickable on a light header
+       (the old flat #ccc washed out to look disabled in light mode). */
+    color: light-dark(#374151, #ccc);
     cursor: pointer;
     font-size: 0.75em;
   }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1403,6 +1403,8 @@
     axis_line_width: 1,
     tick_length: 5,
     tick_width: 1,
+    title_size: 14,
+    font_size: 12,
     legend_visible: true,
     hidden_series: [],
   })
@@ -1432,6 +1434,8 @@
     axis_line_width: 1,
     tick_length: 5,
     tick_width: 1,
+    title_size: 14,
+    font_size: 12,
     legend_visible: true,
   })
   let band_layout = $state<`horizontal` | `vertical`>(`horizontal`)
@@ -1459,6 +1463,8 @@
     axis_line_width: 1,
     tick_length: 5,
     tick_width: 1,
+    title_size: 14,
+    font_size: 12,
     legend_visible: true,
     hidden_series: [],
     line_styles: {},
@@ -4890,6 +4896,8 @@
           axis_line_width={dos_state.axis_line_width}
           tick_length={dos_state.tick_length}
           tick_width={dos_state.tick_width}
+          title_size={dos_state.title_size}
+          font_size={dos_state.font_size}
           legend_visible={dos_state.legend_visible}
           hidden_series={dos_state.hidden_series}
         />
@@ -4998,6 +5006,8 @@
           axis_line_width={cohp_state.axis_line_width}
           tick_length={cohp_state.tick_length}
           tick_width={cohp_state.tick_width}
+          title_size={cohp_state.title_size}
+          font_size={cohp_state.font_size}
           legend_visible={cohp_state.legend_visible}
           hidden_series={cohp_state.hidden_series}
         />
@@ -5052,6 +5062,8 @@
           axis_line_width={band_state.axis_line_width}
           tick_length={band_state.tick_length}
           tick_width={band_state.tick_width}
+          title_size={band_state.title_size}
+          font_size={band_state.font_size}
           legend_visible={band_state.legend_visible}
         />
       </div>

--- a/src/lib/structure/controllers/tool-controller.svelte.ts
+++ b/src/lib/structure/controllers/tool-controller.svelte.ts
@@ -101,6 +101,8 @@ export function create_tool_controller(deps: ToolDeps) {
     axis_line_width: 1,
     tick_length: 5,
     tick_width: 1,
+    title_size: 14,
+    font_size: 12,
     legend_visible: true,
     hidden_series: [],
   })
@@ -127,6 +129,8 @@ export function create_tool_controller(deps: ToolDeps) {
     axis_line_width: 1,
     tick_length: 5,
     tick_width: 1,
+    title_size: 14,
+    font_size: 12,
     legend_visible: true,
   })
   let band_layout = $state<'horizontal' | 'vertical'>('horizontal')
@@ -150,6 +154,8 @@ export function create_tool_controller(deps: ToolDeps) {
     axis_line_width: 1,
     tick_length: 5,
     tick_width: 1,
+    title_size: 14,
+    font_size: 12,
     legend_visible: true,
     hidden_series: [],
     line_styles: {},


### PR DESCRIPTION
## Summary
A batch of electronic-structure plot + structure-fetch + UI polish surfaced during live use.

### Plots (band / DOS / COHP)
- **Axis titles render** — Plotly 3 dropped string axis titles; switched to `title: { text }` (+ band x-axis title, larger margins).
- **Readable on light theme** — plot font/tick/grid/axis-line colors were hardcoded dark-theme (#ccc) and washed out; now theme-aware via a reactive `plot-theme` helper.
- **Arial font, bundled** — real Arial is proprietary, so `@fontsource/arimo` (Apache-2.0, metric-identical) is bundled into the build and used as the plot font on every OS.
- **Adjustable sizes** — new Display-Options controls for axis-title font size and tick/legend font size.
- **Consistent spin lines** — the per-element Line Styles control now restyles spin-down too (it hardcoded `dash`); up/down already differ by ±y sign.
- **Export status auto-dismisses** after 4 s.

### structure-fetch
- **Band gap now shows** — MP migrated material ids (classic `mp-390` → canonical `mp-aaaa…`), breaking the enrichment id match; now also matches by structure fingerprint (formula + nsites + spacegroup) and falls back to OPTIMADE `_mp_band_gap`.

### UI / buttons
- **Stop graying out accent buttons** — `.draggable-pane :global(button)` forced a gray bg on every pane button (Download&Load, Compute PDOS, plot export); wrapped in `:where()` so it's a zero-specificity default that styled buttons override. Unified compute buttons to one blue; primary buttons get a real background; inactive dialog tabs darkened; PDOS element defaults so the button isn't confusingly disabled.

## Verification
- `pnpm check`: 0 errors.
- Manual: verified each item in the running Tauri app (band gap on TiO2, plot fonts/sizes/titles, spin line styles, all the button states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)