### PR TITLE
feat(voice): in-app GPU accelerator (Vulkan/Metal) download

### DIFF
--- a/.github/workflows/build-stt-accel.yml
+++ b/.github/workflows/build-stt-accel.yml
@@ -1,0 +1,149 @@
+name: Build STT accelerator
+
+# Builds prebuilt whisper.cpp `whisper-cli` (GPU backends) for the optional
+# in-app STT accelerator and attaches them — plus a manifest the app reads — to
+# a GitHub Release. Not part of the app release; cut on demand.
+#   Vulkan → Linux/Windows (AMD/Intel iGPU);  Metal → macOS (Apple Silicon).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish assets under
+        default: stt-accel-v1
+  push:
+    tags: ['stt-accel-v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            key: linux-x64-vulkan
+            backend: vulkan
+            ext: tar.gz
+          - os: macos-latest
+            key: macos-arm64-metal
+            backend: metal
+            ext: tar.gz
+          - os: windows-latest
+            key: windows-x64-vulkan
+            backend: vulkan
+            ext: zip
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.key }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "TAG=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Install Vulkan toolchain (Linux)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake glslc glslang-tools spirv-headers libvulkan-dev
+
+      - name: Install Vulkan SDK (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: 1.3.275.0
+          install_runtime: true
+          cache: true
+
+      - name: Build (Unix)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: bash scripts/build-whispercpp.sh ${{ matrix.backend }} "dist/${{ matrix.key }}"
+
+      - name: Build (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          git clone --depth 1 https://github.com/ggml-org/whisper.cpp src
+          cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=1
+          cmake --build src/build --config Release --target whisper-cli
+          New-Item -ItemType Directory -Force "dist/${{ matrix.key }}" | Out-Null
+          Copy-Item "src/build/bin/Release/*" "dist/${{ matrix.key }}/" -Recurse -Force
+
+      - name: Package + checksum
+        shell: bash
+        run: |
+          mkdir -p out
+          asset="whisper-cli-${{ matrix.key }}.${{ matrix.ext }}"
+          if [ "${{ matrix.ext }}" = "zip" ]; then
+            ( cd "dist/${{ matrix.key }}" && 7z a -tzip "$GITHUB_WORKSPACE/out/$asset" . )
+          else
+            tar -C "dist/${{ matrix.key }}" -czf "out/$asset" .
+          fi
+          if command -v sha256sum >/dev/null; then
+            sha=$(sha256sum "out/$asset" | awk '{print $1}')
+          else
+            sha=$(shasum -a 256 "out/$asset" | awk '{print $1}')
+          fi
+          echo "$sha" > "out/$asset.sha256"
+          echo "ASSET=$asset" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.key }}
+          path: out/*
+
+      - name: Upload to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$TAG" >/dev/null 2>&1 \
+            || gh release create "$TAG" --title "$TAG" --notes "CatGo STT GPU accelerator binaries"
+          gh release upload "$TAG" "out/$ASSET" "out/$ASSET.sha256" --clobber
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Assemble manifest
+        shell: bash
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG="${INPUT_TAG:-$REF_NAME}"
+          BASE="https://github.com/$REPO/releases/download/$TAG"
+          python3 - "$BASE" <<'PY'
+          import json, sys, glob, os
+          base = sys.argv[1]
+          binaries = {}
+          for shafile in glob.glob('artifacts/**/*.sha256', recursive=True):
+              asset = os.path.basename(shafile)[:-len('.sha256')]
+              key = asset[len('whisper-cli-'):]
+              for suf in ('.tar.gz', '.zip'):
+                  if key.endswith(suf):
+                      key = key[:-len(suf)]
+                      break
+              binaries[key] = {'url': f'{base}/{asset}', 'sha256': open(shafile).read().strip()}
+          json.dump({'version': '1', 'binaries': binaries},
+                    open('stt-accel-manifest.json', 'w'), indent=2)
+          print(open('stt-accel-manifest.json').read())
+          PY
+      - name: Upload manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          gh release upload "${INPUT_TAG:-$REF_NAME}" stt-accel-manifest.json --clobber

--- a/deploy/stt-accel/README.md
+++ b/deploy/stt-accel/README.md
@@ -1,0 +1,58 @@
+# STT GPU Accelerator (whisper.cpp Vulkan/Metal)
+
+The default backend ships **faster-whisper** (CPU int8 everywhere, auto-CUDA on
+NVIDIA). Users on **AMD/Intel iGPU** (Vulkan) or **Apple Silicon** (Metal) can
+opt into a GPU build of whisper.cpp from inside the app — it is **not** bundled
+in the installer (the Vulkan shader lib alone is ~60 MB).
+
+## How it works
+
+- App (`src/lib/gesture/stt-accel.ts` + the voice menu) calls the backend
+  `/api/stt/accel/*` endpoints to detect the GPU, download the platform binary +
+  the selected GGML model, and switch the engine at runtime
+  (`catgo.stt.engine_state`, persisted).
+- Binaries are downloaded from a GitHub Release, selected via a manifest
+  (`stt-accel-manifest.json`) keyed `"<os>-<arch>-<api>"`
+  (e.g. `linux-x64-vulkan`, `macos-arm64-metal`, `windows-x64-vulkan`).
+- Everything lands in `~/.catgo/stt-accel/{bin,models}` — never the app bundle.
+  Downloads are sha256-verified and extracted with Zip/Tar-Slip guards.
+
+## Cutting a release
+
+The `Build STT accelerator` workflow (`.github/workflows/build-stt-accel.yml`)
+builds `whisper-cli` per platform and attaches the archives + manifest to a
+Release. Run it manually:
+
+```
+gh workflow run "Build STT accelerator" -f tag=stt-accel-v1
+```
+
+or push a tag matching `stt-accel-v*`. The app's default manifest URL
+(`accel.DEFAULT_MANIFEST_URL`, overridable via `CATGO_STT_MANIFEST_URL`) points
+at the `stt-accel-v1` release — bump both together when publishing a new line.
+
+## Local build (dev / testing)
+
+```
+scripts/build-whispercpp.sh vulkan ./dist/linux-x64-vulkan      # Linux/Win (AMD/Intel)
+scripts/build-whispercpp.sh metal  ./dist/macos-arm64-metal     # macOS
+```
+Toolchain: Linux Vulkan → `cmake glslc glslang-tools spirv-headers
+libvulkan-dev`; Windows → Vulkan SDK; macOS Metal → Xcode only.
+
+To point a running backend at a local build without the download UI:
+
+```
+CATGO_STT_ENGINE=whispercpp \
+CATGO_WHISPERCPP_BIN=$PWD/dist/linux-x64-vulkan/whisper-cli \
+CATGO_WHISPERCPP_MODELS=$PWD/models   # contains ggml-<size>.bin
+```
+
+## Notes
+
+- NVIDIA GPUs do **not** need this — faster-whisper auto-uses CUDA (the sidecar
+  bundles a CUDA-capable ctranslate2; it falls back to CPU when the user lacks
+  cuBLAS/cuDNN). Out-of-box NVIDIA GPU still requires shipping those libs (~2 GB,
+  not done — separate decision).
+- Trust anchor for downloads is HTTPS to GitHub Releases + the per-asset sha256
+  in the manifest. Signing the manifest itself is a possible future hardening.

--- a/docs/superpowers/plans/2026-06-18-stt-gpu-accel-download.md
+++ b/docs/superpowers/plans/2026-06-18-stt-gpu-accel-download.md
@@ -1,0 +1,73 @@
+# STT GPU Accelerator Download — Implementation Plan
+
+> Execute with superpowers:subagent-driven-development or inline. Builds on PR
+> #379 (pluggable `whispercpp` engine). Branch: `feat/stt-gpu-accel`.
+
+**Goal:** in-app optional download + runtime-switch to whisper.cpp Vulkan/Metal STT.
+
+## Global Constraints
+- Project style: single quotes, no semicolons, 2-space (TS/Svelte); ruff/PEP8 (py).
+- i18n en+zh key parity.
+- Never auto-download; explicit user action. Downloads sha256-verified + atomic.
+- Default stays faster-whisper; NVIDIA auto-CUDA untouched.
+- `<catgo-data>` = existing CatGo data-dir helper (find + reuse, don't invent).
+
+---
+
+### Task 1: Runtime engine state (backend)
+**Files:** Create `server/catgo/stt/__init__.py`, `server/catgo/stt/engine_state.py`;
+Test `server/tests/test_stt_engine_state.py`.
+- `engine_state.py`: module holding current `{engine, model}`, persisted to
+  `<data>/stt-accel/state.json`. API: `get_engine()`, `set_engine(name)`,
+  `get_state()/save`. Initial default from `CATGO_STT_ENGINE` env else
+  `faster-whisper`. Data dir via a small `_data_dir()` (reuse CatGo's if present).
+- Tests: default; env override; set+persist+reload; reject unknown engine.
+
+### Task 2: Accelerator manager (backend)
+**Files:** Create `server/catgo/stt/accel.py`; Test `server/tests/test_stt_accel.py`.
+- `platform_key() -> "linux-x64-vulkan"|"windows-x64-vulkan"|"macos-arm64-metal"|None`
+  (os+arch+gpu api; None when unsupported/no GPU).
+- `detect_gpu() -> {gpu_api, gpu_name}` best-effort (vulkaninfo / platform.mac).
+- `install_dir()`, `binary_path()`, `model_path(size)`.
+- `download_file(url, dest, sha256, progress_cb)` — stream, verify, atomic rename.
+- `install_binary(manifest_url, progress_cb)` — fetch manifest, pick platform_key,
+  download+extract (tar.zst/zip), mark executable.
+- `download_model(size, progress_cb)` — ggml-<size>.bin from HF (+hf-mirror fallback).
+- A `Download` progress holder (active/kind/pct) shared with status.
+- Tests (no network): sha256 verify pass/fail, atomic rename, platform_key matrix,
+  manifest entry selection.
+
+### Task 3: Endpoints + stt.py wiring (backend)
+**Files:** Modify `server/catgo/routers/stt.py`; Test `server/tests/test_stt_accel_api.py`.
+- stt.py reads engine/model from `engine_state` per request; whispercpp uses
+  `accel.binary_path()/model_path()`.
+- `GET /accel/status`, `POST /accel/install`, `POST /accel/model?size=`,
+  `POST /accel/engine {engine}` (reject whispercpp if binary/model missing).
+- Downloads run via FastAPI BackgroundTasks; progress in status.
+- Tests: status shape; engine switch validation; (install/model mocked).
+
+### Task 4: Client API (frontend)
+**Files:** Create `src/lib/gesture/stt-accel.ts`; Test
+`src/lib/gesture/__tests__/stt-accel.test.ts`.
+- Typed wrappers: `accel_status()`, `accel_install()`, `accel_download_model(size)`,
+  `accel_set_engine(engine)`, `poll_progress(cb)`.
+- Tests: mocked fetch — status parse, install trigger, progress poll, switch.
+
+### Task 5: Voice menu GPU section (frontend)
+**Files:** Modify `src/lib/structure/TerminalWindow.svelte`,
+`src/lib/i18n/{en,zh}/*.ts` (find the voice-menu namespace).
+- GPU section gated on `status.gpu_api != null`: status line, Download&enable
+  button + progress, engine toggle (GPU/CPU). i18n keys (en+zh parity).
+
+### Task 6: Build script + CI
+**Files:** Create `scripts/build-whispercpp.sh`, `.github/workflows/build-stt-accel.yml`.
+- `build-whispercpp.sh <vulkan|metal> <out-dir>`: clone pinned whisper.cpp,
+  cmake `-DGGML_VULKAN=1`/`-DGGML_METAL=1`, build `whisper-cli`, stage binary+libs.
+- Workflow: `workflow_dispatch` + tag `stt-accel-v*`; matrix ubuntu(vulkan) /
+  windows(vulkan SDK) / macos(metal); build, package (tar.zst/zip), sha256,
+  upload Release assets; final job writes `stt-accel-manifest.json`.
+- Verify build script locally on Linux (proven in spike).
+
+### Task 7: Docs + verify
+- Short note in deploy docs: how to cut an `stt-accel-v1` release + that the
+  binary is opt-in. Run `pnpm test` + backend pytest green.

--- a/docs/superpowers/specs/2026-06-18-stt-gpu-accel-download-design.md
+++ b/docs/superpowers/specs/2026-06-18-stt-gpu-accel-download-design.md
@@ -1,0 +1,159 @@
+# In-App STT GPU Accelerator (whisper.cpp Vulkan/Metal) — Design
+
+**Goal:** Let users opt into GPU-accelerated voice dictation from inside CatGo —
+a "GPU acceleration" control that downloads the right whisper.cpp binary for
+their platform/GPU (Vulkan on Linux/Windows, Metal on macOS) plus the chosen
+GGML model, then switches the STT backend to it at runtime. No 60 MB bundled
+into the default installer; NVIDIA users keep the auto-CUDA faster-whisper path.
+
+**Builds on:** PR #379 (native backend STT, pluggable `CATGO_STT_ENGINE`
+faster-whisper | whispercpp). This spec makes the `whispercpp` engine
+**user-installable and runtime-switchable** instead of env-var only.
+
+## Why
+
+- Default engine faster-whisper: CPU int8 everywhere + auto-CUDA on NVIDIA. Good
+  baseline, ships in the sidecar (~60 MB ctranslate2).
+- AMD/Intel iGPU (Vulkan) and Apple Silicon (Metal) get no GPU from CTranslate2
+  (CUDA-only). whisper.cpp covers them but its Vulkan shader lib is ~60 MB and
+  models are a separate format — too heavy to bundle for everyone.
+- So: ship nothing extra by default; let the ~minority who want iGPU/Metal GPU
+  download it on demand.
+
+## User experience
+
+In the terminal voice menu (`TerminalWindow.svelte`), a new **GPU 加速 / GPU
+Acceleration** section, shown only when the platform can benefit (not Windows
+NVIDIA-CUDA-already-working — see detection):
+
+1. Status line: detected GPU + API, e.g. "AMD Radeon (Vulkan) — 未安装" /
+   "Apple M3 (Metal) — 已启用".
+2. **Download & enable** button → downloads the accelerator binary (~30 MB
+   compressed) with a progress bar, then prompts to download the selected
+   model's GGML file (e.g. small ~488 MB) with progress.
+3. Once installed, a toggle: **GPU (whisper.cpp)** vs **CPU (faster-whisper)**.
+4. Errors degrade gracefully back to CPU; never blocks dictation.
+
+## Architecture
+
+### Components / file layout
+
+```
+server/catgo/routers/stt.py            # extend: runtime engine state + new endpoints
+server/catgo/stt/accel.py    (new)     # download/install manager (binary + model)
+server/catgo/stt/engine_state.py (new) # runtime engine selection + persistence
+src/lib/gesture/stt-accel.ts (new)     # client: status/install/model/switch API + progress
+src/lib/structure/TerminalWindow.svelte# extend: GPU acceleration menu section
+src/lib/i18n/{en,zh}/*.ts              # new keys (parity)
+.github/workflows/build-stt-accel.yml (new)  # build whisper.cpp per platform → Release
+scripts/build-whispercpp.sh  (new)     # reusable build (Vulkan/Metal), used by CI + local
+```
+
+Install destination (per-user, not in the app bundle):
+```
+<catgo-data>/stt-accel/<platform>/whisper-cli(+libs)     # downloaded binary
+<catgo-data>/stt-accel/models/ggml-<size>.bin            # downloaded models
+```
+`<catgo-data>` = platform config/cache dir (reuse CatGo's existing data dir helper).
+
+### Backend
+
+**Runtime engine state** (`engine_state.py`): replace the load-time-only
+`_ENGINE` constant with a mutable selection persisted to
+`<catgo-data>/stt-accel/state.json` (`{"engine": "...", "model": "..."}`).
+`stt.py` reads it per request. `CATGO_STT_ENGINE` env, if set, is the initial
+default and an override.
+
+**New endpoints** (under existing `/api/stt`):
+
+- `GET  /accel/status` → `{platform, arch, gpu_api: "vulkan"|"metal"|null,
+  gpu_name, binary_installed: bool, engine: "faster-whisper"|"whispercpp",
+  models_installed: [size,...], download: {active, kind, pct} | null}`
+- `POST /accel/install` → start binary download+extract from the release
+  manifest for this platform/gpu; returns immediately, progress via status.
+- `POST /accel/model?size=small` → start GGML model download (HF + hf-mirror
+  fallback); progress via status.
+- `POST /accel/engine` `{engine}` → switch + persist; validates binary present
+  when selecting whispercpp.
+- (downloads run in a background task; `status.download.pct` polled by client.)
+
+**Manifest:** a release asset `stt-accel-manifest.json`:
+```json
+{ "version": "1",
+  "binaries": {
+    "linux-x64-vulkan":  {"url": "...whisper-cli-linux-x64-vulkan.tar.zst", "sha256": "..."},
+    "windows-x64-vulkan":{"url": "...", "sha256": "..."},
+    "macos-arm64-metal": {"url": "...", "sha256": "..."}
+  } }
+```
+App fetches the manifest from a pinned Release tag (e.g. `stt-accel-v1`), picks
+its `<os>-<arch>-<api>` entry, downloads, verifies sha256, extracts to the
+install dir, marks `_WHISPERCPP_BIN`/`_WHISPERCPP_MODELS` to the install paths.
+
+**GPU detection:** Linux/Windows → probe Vulkan (try `vulkaninfo`/loader, or
+assume offer-able and let install/run validate). macOS → Metal always present on
+Apple Silicon. Report `gpu_api=null` (hide the section) when no usable GPU API
+(e.g. headless Linux without a GPU) — best-effort; the feature is opt-in so a
+false-positive just fails the first run gracefully.
+
+### Frontend
+
+`stt-accel.ts`: typed wrappers for the endpoints + a small polling helper for
+download progress. `TerminalWindow.svelte` voice menu gains the GPU section
+(status, download button + progress, engine toggle), gated on
+`status.gpu_api != null`. New i18n keys in en + zh (parity enforced).
+
+When the user picks a model size that isn't installed for whispercpp, prompt to
+download it first.
+
+### CI / hosting
+
+`build-stt-accel.yml` (manual `workflow_dispatch` + on tag `stt-accel-v*`):
+matrix over `ubuntu-latest` (Vulkan), `windows-latest` (Vulkan SDK),
+`macos-latest` (Metal). Each:
+1. install toolchain (Linux: cmake glslc glslang-tools spirv-headers
+   libvulkan-dev; Windows: Vulkan SDK; macOS: native Metal).
+2. `scripts/build-whispercpp.sh` → build `whisper-cli` + required `.so/.dll/.dylib`.
+3. package (tar.zst / zip) + compute sha256.
+4. upload as Release assets + (last job) assemble & upload `stt-accel-manifest.json`.
+
+`scripts/build-whispercpp.sh` clones a pinned whisper.cpp commit, configures
+`-DGGML_VULKAN=1` or `-DGGML_METAL=1`, builds the `whisper-cli` target, and
+collects the binary + libs into a staging dir. Reused by CI and for local dev.
+
+## Error handling / safety
+
+- All downloads: sha256-verified, atomic (download to tmp, rename on success),
+  resumable-not-required (small enough; restart on failure).
+- Selecting whispercpp without an installed binary or model → 400 with a clear
+  message; client keeps faster-whisper.
+- whisper-cli run failure at request time → log + 500; the client's
+  `BackendWhisperEngine` already swallows non-OK and skips injection (no crash).
+- Engine switch is per-process state; persisted so it survives restart.
+- Never auto-download; always explicit user action.
+
+## Testing
+
+- Backend: unit-test `engine_state` (default/override/persist), `_resolve_size`
+  unchanged, manifest selection (`os/arch/api` → entry), and `/accel/engine`
+  validation (reject whispercpp when binary absent). Download manager: test the
+  sha256-verify + atomic-rename path with a local fixture server (no network).
+- Frontend: `stt-accel.ts` unit tests with mocked fetch (status parse, install
+  trigger, progress poll, engine switch); menu gating on `gpu_api`.
+- CI build: dry-run the build script locally on Linux (already proven in the
+  spike: builds + runs on AMD RADV, ~2.5 min, correct output).
+
+## Out of scope (separate follow-ups)
+
+- Bundling NVIDIA cuBLAS/cuDNN for out-of-box CUDA GPU (~2 GB) — keep relying on
+  the user's system CUDA libs (auto-detect + CPU fallback already shipped).
+- MLX (Apple) engine — Metal via whisper.cpp covers Apple Silicon GPU.
+- Auto-selecting GPU without a user click.
+
+## Open decisions (resolved as defaults unless changed)
+
+- Release tag for assets: `stt-accel-v1` (manifest-versioned, decoupled from app
+  version so the app doesn't need a matching app release to fetch accel).
+- Default model offered for download: match the user's current picker selection;
+  recommend `small` for GPU (where the GPU win is clear).
+- Compression: `tar.zst` (Linux/macOS), `zip` (Windows).

--- a/scripts/build-whispercpp.sh
+++ b/scripts/build-whispercpp.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Build whisper.cpp `whisper-cli` with a GPU backend and stage the binary plus
+# its shared libs into an output dir, for the optional CatGo STT accelerator.
+#
+# Usage: build-whispercpp.sh <vulkan|metal> <out-dir> [whisper-ref]
+#
+# Mirrors the exact cmake invocation verified locally on AMD Radeon (RADV):
+# configure with -DGGML_VULKAN=1 / -DGGML_METAL=1, build the whisper-cli target.
+# Toolchain (install before running): Linux Vulkan → cmake glslc glslang-tools
+# spirv-headers libvulkan-dev; Windows → Vulkan SDK; macOS Metal → Xcode only.
+set -euo pipefail
+
+BACKEND="${1:?usage: build-whispercpp.sh <vulkan|metal> <out-dir> [ref]}"
+OUT="${2:?output dir required}"
+# Pin a whisper.cpp ref for reproducible release builds; override per release.
+REF="${3:-master}"
+
+case "$BACKEND" in
+  vulkan) FLAG="-DGGML_VULKAN=1" ;;
+  metal)  FLAG="-DGGML_METAL=1" ;;
+  *) echo "unknown backend: $BACKEND (expected vulkan|metal)" >&2; exit 1 ;;
+esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+git clone --depth 1 --branch "$REF" https://github.com/ggml-org/whisper.cpp "$WORK/src" \
+  || git clone --depth 1 https://github.com/ggml-org/whisper.cpp "$WORK/src"
+cd "$WORK/src"
+
+JOBS="$( (command -v nproc >/dev/null && nproc) || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+cmake -B build -DCMAKE_BUILD_TYPE=Release $FLAG
+cmake --build build -j"$JOBS" --target whisper-cli
+
+mkdir -p "$OUT"
+# Binary (Release/ subdir on multi-config generators, bin/ otherwise).
+found=""
+for c in build/bin/whisper-cli build/bin/Release/whisper-cli.exe build/bin/whisper-cli.exe; do
+  [ -f "$c" ] && cp "$c" "$OUT/" && found="$c" && break
+done
+[ -n "$found" ] || { echo "whisper-cli not found after build" >&2; exit 1; }
+# Shared libs it links (ggml*, whisper) — copy whatever exists for this OS.
+find build -maxdepth 4 \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) \
+  -exec cp {} "$OUT/" \; 2>/dev/null || true
+
+echo "Staged whisper.cpp ($BACKEND) to $OUT:"
+ls -la "$OUT"

--- a/server/catgo/routers/__init__.py
+++ b/server/catgo/routers/__init__.py
@@ -71,6 +71,7 @@ _ROUTERS: dict[str, str] = {
     "skills_router": "skills",
     "campaign_router": "campaign",
     "terminal_bridge_router": "terminal_bridge",
+    "stt_router": "stt",
 }
 
 __all__ = list(_ROUTERS.keys())

--- a/server/catgo/routers/stt.py
+++ b/server/catgo/routers/stt.py
@@ -1,0 +1,170 @@
+"""Local speech-to-text via faster-whisper (CTranslate2).
+
+Desktop/Tauri voice dictation routes audio here instead of running Whisper in
+the webview. On WebKit engines (WebKitGTK on Linux, WKWebView on macOS/iOS —
+i.e. every Tauri webview except Windows' Chromium WebView2) the onnxruntime-web
+WASM backend leaks ~0.8 GB of unreclaimable linear memory per inference, so a
+few utterances OOM-kill the WebContent process (blank window). Native
+CTranslate2 inference avoids the webview entirely: it is faster, uses the GPU
+when a CUDA device is present, and costs the renderer nothing.
+
+The browser still runs the (tiny) Silero VAD to segment speech; only the
+finished audio segment is POSTed here as raw little-endian float32 PCM at
+16 kHz. The response is plain text — language post-processing (e.g. zh
+Traditional→Simplified) stays on the client so this endpoint is engine-only.
+"""
+
+import logging
+import os
+
+import numpy as np
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/stt", tags=["stt"])
+
+# CPU inference threads for CTranslate2. Its default is a conservative 4; on a
+# many-core desktop that leaves the machine idle. Use up to 8 (Whisper is
+# memory-bandwidth bound past that), overridable via CATGO_STT_CPU_THREADS.
+_CPU_THREADS = int(os.environ.get("CATGO_STT_CPU_THREADS") or min(8, os.cpu_count() or 4))
+
+# Lazily-built WhisperModel cache, keyed by "<size>:<device>". Building a model
+# loads weights + allocates the CTranslate2 translator, so we keep one per size.
+_model_cache: dict[str, object] = {}
+# Resolved (device, compute_type) — probed once. cuda/float16 when a CUDA GPU is
+# present, else cpu/int8 (fast, low-memory; works on any machine incl. iGPU,
+# which CTranslate2 cannot target — CUDA only).
+_device_compute: tuple[str, str] | None = None
+
+# Map the client's whisper model ids / aliases to faster-whisper size names.
+_SIZE_ALIASES = {
+    "tiny": "tiny",
+    "tiny.en": "tiny.en",
+    "base": "base",
+    "base.en": "base.en",
+    "small": "small",
+    "small.en": "small.en",
+    "medium": "medium",
+    "medium.en": "medium.en",
+    "large": "large-v3",
+    "large-v2": "large-v2",
+    "large-v3": "large-v3",
+    "large-v3-turbo": "large-v3-turbo",
+    "turbo": "large-v3-turbo",
+}
+
+
+def _select_device() -> tuple[str, str]:
+    """Probe for a usable CUDA device, else fall back to CPU int8."""
+    try:
+        import ctranslate2
+
+        if ctranslate2.get_cuda_device_count() > 0:
+            return "cuda", "float16"
+    except Exception as exc:  # pragma: no cover - probe is best-effort
+        logger.debug("CUDA probe failed, using CPU: %s", exc)
+    return "cpu", "int8"
+
+
+def _resolve_size(model: str) -> str:
+    """Turn a client model id (e.g. 'onnx-community/whisper-base') into a
+    faster-whisper size ('base'). Unknown ids fall back to 'base'."""
+    name = (model or "").split("/")[-1].lower()
+    name = name.replace("whisper-", "")
+    return _SIZE_ALIASES.get(name, "base")
+
+
+def _build_model(size: str, device: str, compute_type: str):
+    from faster_whisper import WhisperModel
+
+    kwargs: dict = {"device": device, "compute_type": compute_type}
+    if device == "cpu":
+        kwargs["cpu_threads"] = _CPU_THREADS
+    try:
+        return WhisperModel(size, **kwargs)
+    except Exception as exc:
+        # First-run download pulls weights from HuggingFace, frequently blocked
+        # (e.g. mainland China). Retry once via the hf-mirror.com mirror, unless
+        # the user pinned their own HF_ENDPOINT.
+        if os.environ.get("HF_ENDPOINT"):
+            raise
+        logger.warning(
+            "STT model %s download failed (%s); retrying via hf-mirror.com", size, exc
+        )
+        os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+        return WhisperModel(size, **kwargs)
+
+
+def _get_model(size: str):
+    global _device_compute
+    if _device_compute is None:
+        _device_compute = _select_device()
+        logger.info("STT engine: device=%s compute=%s", *_device_compute)
+    device, compute_type = _device_compute
+    key = f"{size}:{device}"
+    if key not in _model_cache:
+        logger.info(
+            "STT loading model %s (%s/%s, cpu_threads=%s)",
+            size, device, compute_type, _CPU_THREADS if device == "cpu" else "-",
+        )
+        _model_cache[key] = _build_model(size, device, compute_type)
+    return _model_cache[key]
+
+
+class STTHealth(BaseModel):
+    available: bool
+    device: str
+    compute_type: str
+
+
+class STTResult(BaseModel):
+    text: str
+    language: str | None = None
+
+
+@router.get("/health", response_model=STTHealth)
+def health() -> STTHealth:
+    """Report whether native STT is usable and on what device. The client uses
+    this to decide between backend STT and the in-browser WASM fallback."""
+    try:
+        import faster_whisper  # noqa: F401
+
+        device, compute_type = _select_device()
+        return STTHealth(available=True, device=device, compute_type=compute_type)
+    except Exception as exc:
+        logger.info("Native STT unavailable: %s", exc)
+        return STTHealth(available=False, device="none", compute_type="none")
+
+
+@router.post("/transcribe", response_model=STTResult)
+async def transcribe(
+    request: Request,
+    language: str = Query("en", description="BCP-47-ish tag; 'auto'/'' = detect"),
+    model: str = Query("base", description="Client model id or size alias"),
+) -> STTResult:
+    """Transcribe a raw float32 PCM (16 kHz mono, little-endian) request body."""
+    raw = await request.body()
+    if not raw:
+        raise HTTPException(status_code=400, detail="empty audio body")
+    if len(raw) % 4 != 0:
+        raise HTTPException(status_code=400, detail="body length not float32-aligned")
+
+    audio = np.frombuffer(raw, dtype="<f4").astype(np.float32)
+    if audio.size == 0:
+        return STTResult(text="", language=None)
+
+    lang = None if language in ("", "auto") else language.split("-")[0]
+    try:
+        whisper = _get_model(_resolve_size(model))
+        # beam_size=1 keeps dictation latency low; the VAD already trimmed silence.
+        segments, info = whisper.transcribe(
+            audio, language=lang, beam_size=1, vad_filter=False
+        )
+        text = "".join(seg.text for seg in segments).strip()
+    except Exception as exc:
+        logger.exception("STT transcription failed")
+        raise HTTPException(status_code=500, detail=f"transcription failed: {exc}")
+
+    return STTResult(text=text, language=getattr(info, "language", None))

--- a/server/catgo/routers/stt.py
+++ b/server/catgo/routers/stt.py
@@ -1,21 +1,34 @@
-"""Local speech-to-text via faster-whisper (CTranslate2).
+"""Local speech-to-text — pluggable native engine.
 
 Desktop/Tauri voice dictation routes audio here instead of running Whisper in
 the webview. On WebKit engines (WebKitGTK on Linux, WKWebView on macOS/iOS —
-i.e. every Tauri webview except Windows' Chromium WebView2) the onnxruntime-web
-WASM backend leaks ~0.8 GB of unreclaimable linear memory per inference, so a
-few utterances OOM-kill the WebContent process (blank window). Native
-CTranslate2 inference avoids the webview entirely: it is faster, uses the GPU
-when a CUDA device is present, and costs the renderer nothing.
+every Tauri webview except Windows' Chromium WebView2) the onnxruntime-web WASM
+backend leaks ~0.8 GB of unreclaimable linear memory per inference, so a few
+utterances OOM-kill the WebContent process (blank window). Native inference
+avoids the webview entirely.
 
-The browser still runs the (tiny) Silero VAD to segment speech; only the
-finished audio segment is POSTed here as raw little-endian float32 PCM at
-16 kHz. The response is plain text — language post-processing (e.g. zh
-Traditional→Simplified) stays on the client so this endpoint is engine-only.
+Two engines, selected by ``CATGO_STT_ENGINE``:
+
+- ``faster-whisper`` (default): CTranslate2. CPU int8 everywhere, CUDA float16
+  when an NVIDIA GPU is present. Self-contained pip dependency.
+- ``whispercpp``: shells out to a whisper.cpp ``whisper-cli`` binary. Its value
+  is the **Vulkan** backend, which runs on AMD/Intel iGPUs that CTranslate2
+  (CUDA-only) cannot target. Requires a Vulkan-built ``whisper-cli`` and GGML
+  models supplied by the host:
+    CATGO_WHISPERCPP_BIN     path to whisper-cli (default: "whisper-cli" on PATH)
+    CATGO_WHISPERCPP_MODELS  dir of ggml-<size>.bin (default ~/.cache/whisper.cpp/models)
+
+The browser still runs the (tiny) Silero VAD and POSTs each finished segment as
+raw little-endian float32 PCM at 16 kHz. Language post-processing (zh
+Traditional→Simplified) stays on the client.
 """
 
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
+import wave
 
 import numpy as np
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -25,20 +38,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/stt", tags=["stt"])
 
-# CPU inference threads for CTranslate2. Its default is a conservative 4; on a
-# many-core desktop that leaves the machine idle. Use up to 8 (Whisper is
-# memory-bandwidth bound past that), overridable via CATGO_STT_CPU_THREADS.
+# ─── Config ──────────────────────────────────────────────────────────────
+_ENGINE = (os.environ.get("CATGO_STT_ENGINE") or "faster-whisper").strip().lower()
+# CPU inference threads. faster-whisper/CTranslate2 defaults to a conservative 4;
+# whisper.cpp uses this for -t too. Overridable via CATGO_STT_CPU_THREADS.
 _CPU_THREADS = int(os.environ.get("CATGO_STT_CPU_THREADS") or min(8, os.cpu_count() or 4))
+_WHISPERCPP_BIN = os.environ.get("CATGO_WHISPERCPP_BIN") or "whisper-cli"
+_WHISPERCPP_MODELS = (
+    os.environ.get("CATGO_WHISPERCPP_MODELS")
+    or os.path.expanduser("~/.cache/whisper.cpp/models")
+)
 
-# Lazily-built WhisperModel cache, keyed by "<size>:<device>". Building a model
-# loads weights + allocates the CTranslate2 translator, so we keep one per size.
-_model_cache: dict[str, object] = {}
-# Resolved (device, compute_type) — probed once. cuda/float16 when a CUDA GPU is
-# present, else cpu/int8 (fast, low-memory; works on any machine incl. iGPU,
-# which CTranslate2 cannot target — CUDA only).
-_device_compute: tuple[str, str] | None = None
-
-# Map the client's whisper model ids / aliases to faster-whisper size names.
+# Map the client's whisper model ids / aliases to a canonical size name shared by
+# both engines (faster-whisper size and whisper.cpp ggml-<size>.bin).
 _SIZE_ALIASES = {
     "tiny": "tiny",
     "tiny.en": "tiny.en",
@@ -56,6 +68,18 @@ _SIZE_ALIASES = {
 }
 
 
+def _resolve_size(model: str) -> str:
+    """Turn a client model id (e.g. 'onnx-community/whisper-base') into a shared
+    size name ('base'). Unknown ids fall back to 'base'."""
+    name = (model or "").split("/")[-1].lower().replace("whisper-", "")
+    return _SIZE_ALIASES.get(name, "base")
+
+
+# ─── faster-whisper engine ───────────────────────────────────────────────
+_model_cache: dict[str, object] = {}
+_device_compute: tuple[str, str] | None = None
+
+
 def _select_device() -> tuple[str, str]:
     """Probe for a usable CUDA device, else fall back to CPU int8."""
     try:
@@ -63,17 +87,9 @@ def _select_device() -> tuple[str, str]:
 
         if ctranslate2.get_cuda_device_count() > 0:
             return "cuda", "float16"
-    except Exception as exc:  # pragma: no cover - probe is best-effort
+    except Exception as exc:  # pragma: no cover - best-effort probe
         logger.debug("CUDA probe failed, using CPU: %s", exc)
     return "cpu", "int8"
-
-
-def _resolve_size(model: str) -> str:
-    """Turn a client model id (e.g. 'onnx-community/whisper-base') into a
-    faster-whisper size ('base'). Unknown ids fall back to 'base'."""
-    name = (model or "").split("/")[-1].lower()
-    name = name.replace("whisper-", "")
-    return _SIZE_ALIASES.get(name, "base")
 
 
 def _build_model(size: str, device: str, compute_type: str):
@@ -86,8 +102,8 @@ def _build_model(size: str, device: str, compute_type: str):
         return WhisperModel(size, **kwargs)
     except Exception as exc:
         # First-run download pulls weights from HuggingFace, frequently blocked
-        # (e.g. mainland China). Retry once via the hf-mirror.com mirror, unless
-        # the user pinned their own HF_ENDPOINT.
+        # (e.g. mainland China). Retry once via hf-mirror.com unless the user
+        # pinned their own HF_ENDPOINT.
         if os.environ.get("HF_ENDPOINT"):
             raise
         logger.warning(
@@ -101,7 +117,7 @@ def _get_model(size: str):
     global _device_compute
     if _device_compute is None:
         _device_compute = _select_device()
-        logger.info("STT engine: device=%s compute=%s", *_device_compute)
+        logger.info("STT engine: faster-whisper device=%s compute=%s", *_device_compute)
     device, compute_type = _device_compute
     key = f"{size}:{device}"
     if key not in _model_cache:
@@ -113,8 +129,67 @@ def _get_model(size: str):
     return _model_cache[key]
 
 
+def _transcribe_faster_whisper(audio: np.ndarray, lang: str | None, size: str):
+    whisper = _get_model(size)
+    segments, info = whisper.transcribe(audio, language=lang, beam_size=1, vad_filter=False)
+    text = "".join(seg.text for seg in segments).strip()
+    return text, getattr(info, "language", None)
+
+
+# ─── whisper.cpp (Vulkan) engine ─────────────────────────────────────────
+def _whispercpp_model_path(size: str) -> str:
+    return os.path.join(_WHISPERCPP_MODELS, f"ggml-{size}.bin")
+
+
+def _transcribe_whispercpp(audio: np.ndarray, lang: str | None, size: str):
+    model_path = _whispercpp_model_path(size)
+    if not os.path.exists(model_path):
+        raise HTTPException(
+            status_code=503,
+            detail=f"whisper.cpp model missing: {model_path} "
+            f"(download-ggml-model.sh {size})",
+        )
+
+    # whisper.cpp reads a 16 kHz mono PCM16 WAV file.
+    pcm16 = np.clip(audio * 32767.0, -32768, 32767).astype("<i2")
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
+        wav_path = tf.name
+    try:
+        with wave.open(wav_path, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(16000)
+            w.writeframes(pcm16.tobytes())
+
+        cmd = [
+            _WHISPERCPP_BIN, "-m", model_path, "-f", wav_path,
+            "-nt",  # no timestamps → clean text on stdout
+            "-t", str(_CPU_THREADS),
+        ]
+        if lang:
+            cmd += ["-l", lang]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=503, detail=f"whisper-cli not found: {_WHISPERCPP_BIN}"
+            )
+        if proc.returncode != 0:
+            logger.error("whisper.cpp failed: %s", proc.stderr[-500:])
+            raise HTTPException(status_code=500, detail="whisper.cpp transcription failed")
+        text = " ".join(line.strip() for line in proc.stdout.splitlines() if line.strip())
+        return text.strip(), lang
+    finally:
+        try:
+            os.unlink(wav_path)
+        except OSError:
+            pass
+
+
+# ─── API ─────────────────────────────────────────────────────────────────
 class STTHealth(BaseModel):
     available: bool
+    engine: str
     device: str
     compute_type: str
 
@@ -126,16 +201,28 @@ class STTResult(BaseModel):
 
 @router.get("/health", response_model=STTHealth)
 def health() -> STTHealth:
-    """Report whether native STT is usable and on what device. The client uses
-    this to decide between backend STT and the in-browser WASM fallback."""
+    """Report whether native STT is usable, which engine, and on what device.
+    The client uses this to decide between backend STT and the WASM fallback."""
+    if _ENGINE == "whispercpp":
+        ok = bool(shutil.which(_WHISPERCPP_BIN) or os.path.exists(_WHISPERCPP_BIN))
+        return STTHealth(
+            available=ok, engine="whispercpp",
+            device="vulkan/cpu", compute_type="ggml",
+        )
     try:
         import faster_whisper  # noqa: F401
 
         device, compute_type = _select_device()
-        return STTHealth(available=True, device=device, compute_type=compute_type)
+        return STTHealth(
+            available=True, engine="faster-whisper",
+            device=device, compute_type=compute_type,
+        )
     except Exception as exc:
         logger.info("Native STT unavailable: %s", exc)
-        return STTHealth(available=False, device="none", compute_type="none")
+        return STTHealth(
+            available=False, engine="faster-whisper",
+            device="none", compute_type="none",
+        )
 
 
 @router.post("/transcribe", response_model=STTResult)
@@ -155,16 +242,18 @@ async def transcribe(
     if audio.size == 0:
         return STTResult(text="", language=None)
 
+    size = _resolve_size(model)
     lang = None if language in ("", "auto") else language.split("-")[0]
     try:
-        whisper = _get_model(_resolve_size(model))
-        # beam_size=1 keeps dictation latency low; the VAD already trimmed silence.
-        segments, info = whisper.transcribe(
-            audio, language=lang, beam_size=1, vad_filter=False
-        )
-        text = "".join(seg.text for seg in segments).strip()
+        if _ENGINE == "whispercpp":
+            # whisper.cpp wants a concrete language code; default to English.
+            text, out_lang = _transcribe_whispercpp(audio, lang or "en", size)
+        else:
+            text, out_lang = _transcribe_faster_whisper(audio, lang, size)
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("STT transcription failed")
         raise HTTPException(status_code=500, detail=f"transcription failed: {exc}")
 
-    return STTResult(text=text, language=getattr(info, "language", None))
+    return STTResult(text=text, language=out_lang)

--- a/server/catgo/routers/stt.py
+++ b/server/catgo/routers/stt.py
@@ -125,7 +125,19 @@ def _get_model(size: str):
             "STT loading model %s (%s/%s, cpu_threads=%s)",
             size, device, compute_type, _CPU_THREADS if device == "cpu" else "-",
         )
-        _model_cache[key] = _build_model(size, device, compute_type)
+        try:
+            _model_cache[key] = _build_model(size, device, compute_type)
+        except Exception as exc:
+            # A CUDA device was detected but the runtime (cuBLAS/cuDNN) is missing
+            # or incompatible — don't 500, fall back to CPU int8 for this and all
+            # subsequent loads.
+            if device != "cuda":
+                raise
+            logger.warning("CUDA STT load failed (%s); falling back to CPU int8", exc)
+            _device_compute = ("cpu", "int8")
+            device, compute_type = _device_compute
+            key = f"{size}:{device}"
+            _model_cache[key] = _build_model(size, device, compute_type)
     return _model_cache[key]
 
 

--- a/server/catgo/routers/stt.py
+++ b/server/catgo/routers/stt.py
@@ -1,78 +1,63 @@
-"""Local speech-to-text — pluggable native engine.
+"""Local speech-to-text — pluggable native engine + optional GPU accelerator.
 
 Desktop/Tauri voice dictation routes audio here instead of running Whisper in
-the webview. On WebKit engines (WebKitGTK on Linux, WKWebView on macOS/iOS —
-every Tauri webview except Windows' Chromium WebView2) the onnxruntime-web WASM
-backend leaks ~0.8 GB of unreclaimable linear memory per inference, so a few
-utterances OOM-kill the WebContent process (blank window). Native inference
-avoids the webview entirely.
-
-Two engines, selected by ``CATGO_STT_ENGINE``:
+the webview (WebKit webviews leak ~0.8 GB of unreclaimable WASM memory per
+inference and OOM). Two engines, chosen at runtime (engine_state, persisted):
 
 - ``faster-whisper`` (default): CTranslate2. CPU int8 everywhere, CUDA float16
-  when an NVIDIA GPU is present. Self-contained pip dependency.
-- ``whispercpp``: shells out to a whisper.cpp ``whisper-cli`` binary. Its value
-  is the **Vulkan** backend, which runs on AMD/Intel iGPUs that CTranslate2
-  (CUDA-only) cannot target. Requires a Vulkan-built ``whisper-cli`` and GGML
-  models supplied by the host:
-    CATGO_WHISPERCPP_BIN     path to whisper-cli (default: "whisper-cli" on PATH)
-    CATGO_WHISPERCPP_MODELS  dir of ggml-<size>.bin (default ~/.cache/whisper.cpp/models)
+  on NVIDIA. Bundled in the sidecar.
+- ``whispercpp``: shells out to a whisper.cpp ``whisper-cli`` built with Vulkan
+  (AMD/Intel iGPU) or Metal (Apple). Not bundled — downloaded on demand via the
+  /accel/* endpoints into a per-user dir (see catgo.stt.accel).
 
-The browser still runs the (tiny) Silero VAD and POSTs each finished segment as
-raw little-endian float32 PCM at 16 kHz. Language post-processing (zh
-Traditional→Simplified) stays on the client.
+The browser still runs the Silero VAD and POSTs each segment as raw
+little-endian float32 PCM at 16 kHz. zh Traditional→Simplified stays client-side.
 """
 
 import logging
 import os
-import shutil
 import subprocess
 import tempfile
 import wave
 
 import numpy as np
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Body, HTTPException, Query, Request
 from pydantic import BaseModel
+
+from ..stt import accel, engine_state
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/stt", tags=["stt"])
 
-# ─── Config ──────────────────────────────────────────────────────────────
-_ENGINE = (os.environ.get("CATGO_STT_ENGINE") or "faster-whisper").strip().lower()
-# CPU inference threads. faster-whisper/CTranslate2 defaults to a conservative 4;
-# whisper.cpp uses this for -t too. Overridable via CATGO_STT_CPU_THREADS.
+# CPU inference threads. CTranslate2 defaults to a conservative 4; whisper.cpp
+# uses this for -t too. Overridable via CATGO_STT_CPU_THREADS.
 _CPU_THREADS = int(os.environ.get("CATGO_STT_CPU_THREADS") or min(8, os.cpu_count() or 4))
-_WHISPERCPP_BIN = os.environ.get("CATGO_WHISPERCPP_BIN") or "whisper-cli"
-_WHISPERCPP_MODELS = (
-    os.environ.get("CATGO_WHISPERCPP_MODELS")
-    or os.path.expanduser("~/.cache/whisper.cpp/models")
-)
 
-# Map the client's whisper model ids / aliases to a canonical size name shared by
-# both engines (faster-whisper size and whisper.cpp ggml-<size>.bin).
 _SIZE_ALIASES = {
-    "tiny": "tiny",
-    "tiny.en": "tiny.en",
-    "base": "base",
-    "base.en": "base.en",
-    "small": "small",
-    "small.en": "small.en",
-    "medium": "medium",
-    "medium.en": "medium.en",
-    "large": "large-v3",
-    "large-v2": "large-v2",
-    "large-v3": "large-v3",
-    "large-v3-turbo": "large-v3-turbo",
-    "turbo": "large-v3-turbo",
+    "tiny": "tiny", "tiny.en": "tiny.en",
+    "base": "base", "base.en": "base.en",
+    "small": "small", "small.en": "small.en",
+    "medium": "medium", "medium.en": "medium.en",
+    "large": "large-v3", "large-v2": "large-v2", "large-v3": "large-v3",
+    "large-v3-turbo": "large-v3-turbo", "turbo": "large-v3-turbo",
 }
 
 
 def _resolve_size(model: str) -> str:
-    """Turn a client model id (e.g. 'onnx-community/whisper-base') into a shared
-    size name ('base'). Unknown ids fall back to 'base'."""
     name = (model or "").split("/")[-1].lower().replace("whisper-", "")
     return _SIZE_ALIASES.get(name, "base")
+
+
+def _whispercpp_bin() -> str:
+    return os.environ.get("CATGO_WHISPERCPP_BIN") or str(accel.binary_path())
+
+
+def _whispercpp_model_path(size: str) -> str:
+    override = os.environ.get("CATGO_WHISPERCPP_MODELS")
+    if override:
+        return os.path.join(override, f"ggml-{size}.bin")
+    return str(accel.model_path(size))
 
 
 # ─── faster-whisper engine ───────────────────────────────────────────────
@@ -81,7 +66,6 @@ _device_compute: tuple[str, str] | None = None
 
 
 def _select_device() -> tuple[str, str]:
-    """Probe for a usable CUDA device, else fall back to CPU int8."""
     try:
         import ctranslate2
 
@@ -101,9 +85,6 @@ def _build_model(size: str, device: str, compute_type: str):
     try:
         return WhisperModel(size, **kwargs)
     except Exception as exc:
-        # First-run download pulls weights from HuggingFace, frequently blocked
-        # (e.g. mainland China). Retry once via hf-mirror.com unless the user
-        # pinned their own HF_ENDPOINT.
         if os.environ.get("HF_ENDPOINT"):
             raise
         logger.warning(
@@ -128,9 +109,6 @@ def _get_model(size: str):
         try:
             _model_cache[key] = _build_model(size, device, compute_type)
         except Exception as exc:
-            # A CUDA device was detected but the runtime (cuBLAS/cuDNN) is missing
-            # or incompatible — don't 500, fall back to CPU int8 for this and all
-            # subsequent loads.
             if device != "cuda":
                 raise
             logger.warning("CUDA STT load failed (%s); falling back to CPU int8", exc)
@@ -148,21 +126,14 @@ def _transcribe_faster_whisper(audio: np.ndarray, lang: str | None, size: str):
     return text, getattr(info, "language", None)
 
 
-# ─── whisper.cpp (Vulkan) engine ─────────────────────────────────────────
-def _whispercpp_model_path(size: str) -> str:
-    return os.path.join(_WHISPERCPP_MODELS, f"ggml-{size}.bin")
-
-
+# ─── whisper.cpp (Vulkan/Metal) engine ───────────────────────────────────
 def _transcribe_whispercpp(audio: np.ndarray, lang: str | None, size: str):
     model_path = _whispercpp_model_path(size)
     if not os.path.exists(model_path):
         raise HTTPException(
             status_code=503,
-            detail=f"whisper.cpp model missing: {model_path} "
-            f"(download-ggml-model.sh {size})",
+            detail=f"whisper.cpp model missing: ggml-{size}.bin (download it first)",
         )
-
-    # whisper.cpp reads a 16 kHz mono PCM16 WAV file.
     pcm16 = np.clip(audio * 32767.0, -32768, 32767).astype("<i2")
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
         wav_path = tf.name
@@ -172,20 +143,13 @@ def _transcribe_whispercpp(audio: np.ndarray, lang: str | None, size: str):
             w.setsampwidth(2)
             w.setframerate(16000)
             w.writeframes(pcm16.tobytes())
-
-        cmd = [
-            _WHISPERCPP_BIN, "-m", model_path, "-f", wav_path,
-            "-nt",  # no timestamps → clean text on stdout
-            "-t", str(_CPU_THREADS),
-        ]
+        cmd = [_whispercpp_bin(), "-m", model_path, "-f", wav_path, "-nt", "-t", str(_CPU_THREADS)]
         if lang:
             cmd += ["-l", lang]
         try:
             proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
         except FileNotFoundError:
-            raise HTTPException(
-                status_code=503, detail=f"whisper-cli not found: {_WHISPERCPP_BIN}"
-            )
+            raise HTTPException(status_code=503, detail="whisper-cli not installed")
         if proc.returncode != 0:
             logger.error("whisper.cpp failed: %s", proc.stderr[-500:])
             raise HTTPException(status_code=500, detail="whisper.cpp transcription failed")
@@ -198,7 +162,7 @@ def _transcribe_whispercpp(audio: np.ndarray, lang: str | None, size: str):
             pass
 
 
-# ─── API ─────────────────────────────────────────────────────────────────
+# ─── API models ──────────────────────────────────────────────────────────
 class STTHealth(BaseModel):
     available: bool
     engine: str
@@ -211,30 +175,35 @@ class STTResult(BaseModel):
     language: str | None = None
 
 
+class AccelStatus(BaseModel):
+    platform_key: str | None
+    gpu_api: str | None
+    gpu_name: str | None
+    engine: str
+    binary_installed: bool
+    models_installed: list[str]
+    download: dict
+
+
+class EngineChoice(BaseModel):
+    engine: str
+
+
+# ─── Transcription ─────────────────────────────────────────────────────────
 @router.get("/health", response_model=STTHealth)
 def health() -> STTHealth:
-    """Report whether native STT is usable, which engine, and on what device.
-    The client uses this to decide between backend STT and the WASM fallback."""
-    if _ENGINE == "whispercpp":
-        ok = bool(shutil.which(_WHISPERCPP_BIN) or os.path.exists(_WHISPERCPP_BIN))
-        return STTHealth(
-            available=ok, engine="whispercpp",
-            device="vulkan/cpu", compute_type="ggml",
-        )
+    engine = engine_state.get_engine()
+    if engine == "whispercpp":
+        ok = os.path.exists(_whispercpp_bin())
+        return STTHealth(available=ok, engine="whispercpp", device="vulkan/metal/cpu", compute_type="ggml")
     try:
         import faster_whisper  # noqa: F401
 
         device, compute_type = _select_device()
-        return STTHealth(
-            available=True, engine="faster-whisper",
-            device=device, compute_type=compute_type,
-        )
+        return STTHealth(available=True, engine="faster-whisper", device=device, compute_type=compute_type)
     except Exception as exc:
         logger.info("Native STT unavailable: %s", exc)
-        return STTHealth(
-            available=False, engine="faster-whisper",
-            device="none", compute_type="none",
-        )
+        return STTHealth(available=False, engine="faster-whisper", device="none", compute_type="none")
 
 
 @router.post("/transcribe", response_model=STTResult)
@@ -243,13 +212,11 @@ async def transcribe(
     language: str = Query("en", description="BCP-47-ish tag; 'auto'/'' = detect"),
     model: str = Query("base", description="Client model id or size alias"),
 ) -> STTResult:
-    """Transcribe a raw float32 PCM (16 kHz mono, little-endian) request body."""
     raw = await request.body()
     if not raw:
         raise HTTPException(status_code=400, detail="empty audio body")
     if len(raw) % 4 != 0:
         raise HTTPException(status_code=400, detail="body length not float32-aligned")
-
     audio = np.frombuffer(raw, dtype="<f4").astype(np.float32)
     if audio.size == 0:
         return STTResult(text="", language=None)
@@ -257,8 +224,7 @@ async def transcribe(
     size = _resolve_size(model)
     lang = None if language in ("", "auto") else language.split("-")[0]
     try:
-        if _ENGINE == "whispercpp":
-            # whisper.cpp wants a concrete language code; default to English.
+        if engine_state.get_engine() == "whispercpp":
             text, out_lang = _transcribe_whispercpp(audio, lang or "en", size)
         else:
             text, out_lang = _transcribe_faster_whisper(audio, lang, size)
@@ -267,5 +233,48 @@ async def transcribe(
     except Exception as exc:
         logger.exception("STT transcription failed")
         raise HTTPException(status_code=500, detail=f"transcription failed: {exc}")
-
     return STTResult(text=text, language=out_lang)
+
+
+# ─── Accelerator management ────────────────────────────────────────────────
+@router.get("/accel/status", response_model=AccelStatus)
+def accel_status() -> AccelStatus:
+    gpu = accel.detect_gpu()
+    return AccelStatus(
+        platform_key=accel.platform_key(),
+        gpu_api=gpu["gpu_api"],
+        gpu_name=gpu["gpu_name"],
+        engine=engine_state.get_engine(),
+        binary_installed=accel.binary_installed(),
+        models_installed=accel.installed_models(),
+        download=accel.get_download(),
+    )
+
+
+@router.post("/accel/install")
+def accel_install(background: BackgroundTasks) -> dict:
+    if accel.get_download().get("active"):
+        raise HTTPException(status_code=409, detail="a download is already in progress")
+    if not accel.platform_key():
+        raise HTTPException(status_code=400, detail="no GPU accelerator for this platform")
+    background.add_task(accel.install_binary)
+    return {"started": True}
+
+
+@router.post("/accel/model")
+def accel_model(background: BackgroundTasks, size: str = Query(...)) -> dict:
+    if accel.get_download().get("active"):
+        raise HTTPException(status_code=409, detail="a download is already in progress")
+    background.add_task(accel.download_model, _resolve_size(size))
+    return {"started": True}
+
+
+@router.post("/accel/engine")
+def accel_engine(choice: EngineChoice = Body(...)) -> dict:
+    engine = choice.engine
+    if engine not in engine_state.VALID_ENGINES:
+        raise HTTPException(status_code=400, detail=f"unknown engine: {engine}")
+    if engine == "whispercpp" and not os.path.exists(_whispercpp_bin()):
+        raise HTTPException(status_code=400, detail="whisper.cpp not installed — download it first")
+    engine_state.set_engine(engine)
+    return {"engine": engine}

--- a/server/catgo/routers/stt.py
+++ b/server/catgo/routers/stt.py
@@ -18,6 +18,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import threading
 import wave
 
 import numpy as np
@@ -63,6 +64,10 @@ def _whispercpp_model_path(size: str) -> str:
 # ─── faster-whisper engine ───────────────────────────────────────────────
 _model_cache: dict[str, object] = {}
 _device_compute: tuple[str, str] | None = None
+# Serializes model build + the cuda→cpu fallback. FastAPI runs sync endpoints in
+# a threadpool, so concurrent first requests could otherwise build the same model
+# twice or race on _device_compute during fallback.
+_model_lock = threading.Lock()
 
 
 def _select_device() -> tuple[str, str]:
@@ -96,12 +101,14 @@ def _build_model(size: str, device: str, compute_type: str):
 
 def _get_model(size: str):
     global _device_compute
-    if _device_compute is None:
-        _device_compute = _select_device()
-        logger.info("STT engine: faster-whisper device=%s compute=%s", *_device_compute)
-    device, compute_type = _device_compute
-    key = f"{size}:{device}"
-    if key not in _model_cache:
+    with _model_lock:
+        if _device_compute is None:
+            _device_compute = _select_device()
+            logger.info("STT engine: faster-whisper device=%s compute=%s", *_device_compute)
+        device, compute_type = _device_compute
+        key = f"{size}:{device}"
+        if key in _model_cache:
+            return _model_cache[key]
         logger.info(
             "STT loading model %s (%s/%s, cpu_threads=%s)",
             size, device, compute_type, _CPU_THREADS if device == "cpu" else "-",
@@ -115,8 +122,9 @@ def _get_model(size: str):
             _device_compute = ("cpu", "int8")
             device, compute_type = _device_compute
             key = f"{size}:{device}"
-            _model_cache[key] = _build_model(size, device, compute_type)
-    return _model_cache[key]
+            if key not in _model_cache:
+                _model_cache[key] = _build_model(size, device, compute_type)
+        return _model_cache[key]
 
 
 def _transcribe_faster_whisper(audio: np.ndarray, lang: str | None, size: str):

--- a/server/catgo/stt/__init__.py
+++ b/server/catgo/stt/__init__.py
@@ -1,0 +1,1 @@
+"""STT support package: runtime engine selection + accelerator management."""

--- a/server/catgo/stt/accel.py
+++ b/server/catgo/stt/accel.py
@@ -193,13 +193,31 @@ def _pick_asset(manifest: dict, key: str) -> dict | None:
     return (manifest.get("binaries") or {}).get(key)
 
 
+def _is_within(base: Path, target: Path) -> bool:
+    try:
+        target.resolve().relative_to(base.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 def _extract(archive: Path, dest_dir: Path) -> None:
+    """Extract an archive, rejecting path-traversal (Zip/Tar Slip) and link
+    members so a malicious/compromised asset can't write outside dest_dir."""
     dest_dir.mkdir(parents=True, exist_ok=True)
     if archive.name.endswith(".zip"):
         with zipfile.ZipFile(archive) as z:
+            for name in z.namelist():
+                if not _is_within(dest_dir, dest_dir / name):
+                    raise ValueError(f"unsafe path in archive: {name}")
             z.extractall(dest_dir)
     else:  # .tar.gz / .tgz
         with tarfile.open(archive) as t:
+            for m in t.getmembers():
+                if m.issym() or m.islnk():
+                    raise ValueError(f"link member not allowed: {m.name}")
+                if not _is_within(dest_dir, dest_dir / m.name):
+                    raise ValueError(f"unsafe path in archive: {m.name}")
             t.extractall(dest_dir)
 
 

--- a/server/catgo/stt/accel.py
+++ b/server/catgo/stt/accel.py
@@ -1,0 +1,258 @@
+"""Optional STT accelerator manager — download/install whisper.cpp (Vulkan/Metal).
+
+The default sidecar ships only faster-whisper. Users on AMD/Intel iGPU (Vulkan)
+or Apple Silicon (Metal) can download a prebuilt whisper.cpp `whisper-cli` from
+the project's GitHub Releases on demand, plus GGML models. Everything lands in a
+per-user dir (never the app bundle) and is sha256-verified + written atomically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+import httpx
+
+from .engine_state import data_dir
+
+logger = logging.getLogger(__name__)
+
+# Default manifest: a Release asset listing per-platform binary archives. Pinned
+# to a tag decoupled from the app version so the accelerator can ship/update
+# independently. Overridable for testing / self-hosting.
+DEFAULT_MANIFEST_URL = os.environ.get(
+    "CATGO_STT_MANIFEST_URL",
+    "https://github.com/Hello-QM/catgo-LRG/releases/download/stt-accel-v1/"
+    "stt-accel-manifest.json",
+)
+# GGML model hosts (whisper.cpp format). hf-mirror used as a fallback for blocked
+# HuggingFace (e.g. mainland China).
+_GGML_HOSTS = [
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main",
+    "https://hf-mirror.com/ggerganov/whisper.cpp/resolve/main",
+]
+
+ProgressCb = Callable[[int, int], None]
+
+# Shared, single-flight download progress (one download at a time is plenty for
+# this UI). Read by GET /accel/status.
+_download: dict = {"active": False, "kind": None, "pct": 0, "error": None}
+
+
+def get_download() -> dict:
+    return dict(_download)
+
+
+def _set_progress(kind: str, pct: int, active: bool = True, error: str | None = None) -> None:
+    _download.update(active=active, kind=kind, pct=pct, error=error)
+
+
+# ─── Platform / GPU ──────────────────────────────────────────────────────
+def _os_arch() -> tuple[str, str]:
+    sysname = platform.system().lower()
+    machine = platform.machine().lower()
+    os_ = {"linux": "linux", "darwin": "macos", "windows": "windows"}.get(sysname, sysname)
+    if machine in ("arm64", "aarch64"):
+        arch = "arm64"
+    elif machine in ("x86_64", "amd64"):
+        arch = "x64"
+    else:
+        arch = machine
+    return os_, arch
+
+
+def gpu_api() -> str | None:
+    """The GPU compute API whisper.cpp would use on this platform. macOS→metal,
+    Linux/Windows→vulkan. None when unsupported (offer hidden)."""
+    os_, _ = _os_arch()
+    if os_ == "macos":
+        return "metal"
+    if os_ in ("linux", "windows"):
+        return "vulkan"
+    return None
+
+
+def detect_gpu() -> dict:
+    """Best-effort GPU name + api for the UI status line."""
+    api = gpu_api()
+    name = None
+    try:
+        if api == "vulkan" and shutil.which("vulkaninfo"):
+            import subprocess
+
+            out = subprocess.run(
+                ["vulkaninfo", "--summary"], capture_output=True, text=True, timeout=5
+            ).stdout
+            for line in out.splitlines():
+                if "deviceName" in line and "llvmpipe" not in line:
+                    name = line.split("=", 1)[1].strip()
+                    break
+        elif api == "metal":
+            name = "Apple GPU (Metal)"
+    except Exception as exc:  # pragma: no cover - probe best-effort
+        logger.debug("GPU probe failed: %s", exc)
+    return {"gpu_api": api, "gpu_name": name}
+
+
+def platform_key() -> str | None:
+    api = gpu_api()
+    if not api:
+        return None
+    os_, arch = _os_arch()
+    return f"{os_}-{arch}-{api}"
+
+
+# ─── Paths ───────────────────────────────────────────────────────────────
+def install_dir() -> Path:
+    return data_dir() / "bin"
+
+
+def models_dir() -> Path:
+    return data_dir() / "models"
+
+
+def binary_path() -> Path:
+    name = "whisper-cli.exe" if _os_arch()[0] == "windows" else "whisper-cli"
+    return install_dir() / name
+
+
+def model_path(size: str) -> Path:
+    return models_dir() / f"ggml-{size}.bin"
+
+
+def binary_installed() -> bool:
+    return binary_path().exists()
+
+
+def installed_models() -> list[str]:
+    d = models_dir()
+    if not d.is_dir():
+        return []
+    out = []
+    for p in d.glob("ggml-*.bin"):
+        out.append(p.name[len("ggml-"):-len(".bin")])
+    return sorted(out)
+
+
+# ─── Download primitives ─────────────────────────────────────────────────
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _verify_and_place(tmp: Path, dest: Path, expected_sha: str | None) -> None:
+    """Verify sha256 (if given) then atomically move tmp → dest."""
+    if expected_sha:
+        actual = _sha256_file(tmp)
+        if actual.lower() != expected_sha.lower():
+            tmp.unlink(missing_ok=True)
+            raise ValueError(f"sha256 mismatch: expected {expected_sha}, got {actual}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(tmp, dest)
+
+
+def download_file(
+    url: str, dest: Path, sha256: str | None = None, progress: ProgressCb | None = None
+) -> Path:
+    """Stream url → dest with sha256 verification and atomic rename."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(dest.parent), suffix=".part")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as out, httpx.stream(
+            "GET", url, follow_redirects=True, timeout=60
+        ) as resp:
+            resp.raise_for_status()
+            total = int(resp.headers.get("content-length", 0))
+            done = 0
+            for chunk in resp.iter_bytes(1 << 20):
+                out.write(chunk)
+                done += len(chunk)
+                if progress:
+                    progress(done, total)
+        _verify_and_place(tmp, dest, sha256)
+        return dest
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _pick_asset(manifest: dict, key: str) -> dict | None:
+    return (manifest.get("binaries") or {}).get(key)
+
+
+def _extract(archive: Path, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as z:
+            z.extractall(dest_dir)
+    else:  # .tar.gz / .tgz
+        with tarfile.open(archive) as t:
+            t.extractall(dest_dir)
+
+
+def _mark_executable(path: Path) -> None:
+    if path.exists() and os.name != "nt":
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+# ─── High-level installs ─────────────────────────────────────────────────
+def install_binary(manifest_url: str | None = None) -> Path:
+    """Download + extract the whisper.cpp binary for this platform/GPU."""
+    key = platform_key()
+    if not key:
+        raise RuntimeError("no supported GPU accelerator for this platform")
+    _set_progress("binary", 0)
+    try:
+        url = manifest_url or DEFAULT_MANIFEST_URL
+        manifest = httpx.get(url, follow_redirects=True, timeout=30).raise_for_status().json()
+        asset = _pick_asset(manifest, key)
+        if not asset:
+            raise RuntimeError(f"no accelerator binary for {key}")
+        suffix = ".zip" if asset["url"].endswith(".zip") else ".tar.gz"
+        with tempfile.TemporaryDirectory() as td:
+            archive = Path(td) / f"accel{suffix}"
+            download_file(
+                asset["url"], archive, asset.get("sha256"),
+                progress=lambda d, t: _set_progress("binary", int(d * 100 / t) if t else 0),
+            )
+            _extract(archive, install_dir())
+        _mark_executable(binary_path())
+        # Some builds ship libs next to the binary; mark any .so/.dylib readable.
+        _set_progress("binary", 100, active=False)
+        return binary_path()
+    except Exception as exc:
+        _set_progress("binary", 0, active=False, error=str(exc))
+        raise
+
+
+def download_model(size: str) -> Path:
+    """Download a GGML model (ggml-<size>.bin), trying HF then the mirror."""
+    dest = model_path(size)
+    _set_progress("model", 0)
+    last_exc: Exception | None = None
+    for host in _GGML_HOSTS:
+        try:
+            download_file(
+                f"{host}/ggml-{size}.bin", dest,
+                progress=lambda d, t: _set_progress("model", int(d * 100 / t) if t else 0),
+            )
+            _set_progress("model", 100, active=False)
+            return dest
+        except Exception as exc:
+            last_exc = exc
+            logger.warning("model download from %s failed: %s", host, exc)
+    _set_progress("model", 0, active=False, error=str(last_exc))
+    raise RuntimeError(f"model download failed: {last_exc}")

--- a/server/catgo/stt/engine_state.py
+++ b/server/catgo/stt/engine_state.py
@@ -1,0 +1,94 @@
+"""Runtime STT engine selection, persisted across restarts.
+
+PR #379's stt.py read CATGO_STT_ENGINE once at import. The in-app GPU
+accelerator lets the user switch faster-whisper <-> whispercpp at runtime
+(after downloading the binary), so the choice must be mutable and survive a
+restart. State lives in <data-dir>/state.json, where <data-dir> defaults to
+~/.catgo/stt-accel (override with CATGO_STT_DATA_DIR, mainly for tests).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+VALID_ENGINES = ("faster-whisper", "whispercpp")
+
+_state: dict | None = None
+
+
+def data_dir() -> Path:
+    override = os.environ.get("CATGO_STT_DATA_DIR")
+    return Path(override) if override else (Path.home() / ".catgo" / "stt-accel")
+
+
+def _state_file() -> Path:
+    return data_dir() / "state.json"
+
+
+def _default_engine() -> str:
+    env = (os.environ.get("CATGO_STT_ENGINE") or "").strip().lower()
+    return env if env in VALID_ENGINES else "faster-whisper"
+
+
+def _load() -> dict:
+    global _state
+    if _state is not None:
+        return _state
+    state = {"engine": _default_engine(), "model": None}
+    try:
+        sf = _state_file()
+        if sf.exists():
+            saved = json.loads(sf.read_text())
+            if isinstance(saved, dict):
+                if saved.get("engine") in VALID_ENGINES:
+                    state["engine"] = saved["engine"]
+                if isinstance(saved.get("model"), str):
+                    state["model"] = saved["model"]
+    except Exception as exc:
+        logger.warning("STT state load failed: %s", exc)
+    _state = state
+    return _state
+
+
+def _save() -> None:
+    try:
+        d = data_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        _state_file().write_text(json.dumps(_load()))
+    except Exception as exc:
+        logger.warning("STT state save failed: %s", exc)
+
+
+def get_state() -> dict:
+    return dict(_load())
+
+
+def get_engine() -> str:
+    return _load()["engine"]
+
+
+def set_engine(engine: str) -> None:
+    if engine not in VALID_ENGINES:
+        raise ValueError(f"unknown STT engine: {engine!r}")
+    _load()["engine"] = engine
+    _save()
+
+
+def get_model() -> str | None:
+    return _load()["model"]
+
+
+def set_model(model: str | None) -> None:
+    _load()["model"] = model
+    _save()
+
+
+def _reset_for_test() -> None:
+    """Drop the in-memory cache so the next access re-reads env / disk."""
+    global _state
+    _state = None

--- a/server/catgo_server.spec
+++ b/server/catgo_server.spec
@@ -67,7 +67,15 @@ try:
         + collect_submodules('ctranslate2')
         + collect_submodules('faster_whisper')
     )
-except Exception:
+except Exception as _stt_exc:
+    # Don't fail the whole build, but make a missing dep loud — otherwise the
+    # shipped sidecar silently has no native STT and falls back to the broken
+    # in-webview WASM path. Install `faster-whisper` before building.
+    print(
+        f"WARNING [catgo_server.spec]: faster-whisper not collected ({_stt_exc!r}); "
+        "native STT will be UNAVAILABLE in this build — `pip install faster-whisper`",
+        file=sys.stderr,
+    )
     ctranslate2_bins, faster_whisper_datas, stt_hiddenimports = [], [], []
 
 a = Analysis(

--- a/server/catgo_server.spec
+++ b/server/catgo_server.spec
@@ -17,7 +17,7 @@ MACE and other ML potentials are excluded to keep the bundle size reasonable.
 
 import sys
 from pathlib import Path
-from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs
 
 block_cipher = None
 
@@ -52,10 +52,28 @@ ase_datas = collect_data_files('ase', include_py_files=False)
 # `/api/mcp/*` endpoints 404.
 rfc3987_syntax_datas = collect_data_files('rfc3987_syntax')
 
+# faster-whisper (CTranslate2) — native STT engine for desktop voice dictation.
+# routers/stt.py imports it LAZILY (inside functions), so PyInstaller's static
+# analysis never sees it; without explicit collection the bundled backend ships
+# no native STT and /api/stt/health reports unavailable, forcing the broken
+# in-webview WASM fallback. Collect the package, its submodules, and the
+# CTranslate2 native shared libs. CPU int8 works on every platform incl. Apple
+# Silicon (no NVIDIA); CUDA uses the user's own cuBLAS/cuDNN (not bundled).
+try:
+    ctranslate2_bins = collect_dynamic_libs('ctranslate2')
+    faster_whisper_datas = collect_data_files('faster_whisper')
+    stt_hiddenimports = (
+        ['faster_whisper', 'ctranslate2', 'tokenizers', 'huggingface_hub']
+        + collect_submodules('ctranslate2')
+        + collect_submodules('faster_whisper')
+    )
+except Exception:
+    ctranslate2_bins, faster_whisper_datas, stt_hiddenimports = [], [], []
+
 a = Analysis(
     ['main.py'],
     pathex=[str(server_dir)],
-    binaries=[],
+    binaries=ctranslate2_bins,
     datas=[
         # Workflow engine definition YAML files
         ('workflow/engine_defs/*.yaml', 'workflow/engine_defs'),
@@ -85,8 +103,9 @@ a = Analysis(
          'extensions/dos-analysis/catgo_dos'),
         ('../extensions/cohp-analysis/catgo_cohp',
          'extensions/cohp-analysis/catgo_cohp'),
-    ] + pymatgen_datas + tblite_datas + ase_datas + rfc3987_syntax_datas,
-    hiddenimports=catgo_submodules + workflow_submodules + dos_submodules + cohp_submodules + [
+    ] + pymatgen_datas + tblite_datas + ase_datas + rfc3987_syntax_datas
+      + faster_whisper_datas,
+    hiddenimports=catgo_submodules + workflow_submodules + dos_submodules + cohp_submodules + stt_hiddenimports + [
         # ---------------------------------------------------------------
         # FastAPI / ASGI stack
         # ---------------------------------------------------------------

--- a/server/main.py
+++ b/server/main.py
@@ -178,6 +178,7 @@ _DEFERRED_ROUTER_ATTRS: list[str] = ["hpc_router"] if CATGO_THIN else [
     "quacc_router",
     "atomate2_router",
     "forcefield_router",        # ~76 ms (openbabel)
+    "stt_router",               # faster-whisper (CTranslate2) — heavy import
 ]
 
 # Light-weight import; plugin_manager.initialize() is the slow part and is

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
     "ase>=3.22.0",
     "pymatgen>=2024.1.0",
     "networkx>=2.8",
+    # Native speech-to-text for desktop voice dictation (CTranslate2). Runs
+    # Whisper outside the webview — WebKit webviews (Linux/macOS Tauri) leak
+    # unreclaimable WASM memory per inference and OOM. CPU int8 by default,
+    # CUDA float16 when a GPU is present. See routers/stt.py.
+    "faster-whisper>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,6 +13,11 @@ mcp>=1.0.0
 # SSH/SFTP for HPC connectivity
 asyncssh>=2.14.0
 
+# Native speech-to-text for desktop voice dictation (CTranslate2 Whisper).
+# Runs outside the webview — WebKit Tauri webviews leak WASM memory per
+# inference and OOM. CPU int8 default, CUDA float16 when a GPU is present.
+faster-whisper>=1.0.0
+
 # Scientific computing
 numpy>=1.24.0
 scipy>=1.10.0

--- a/server/tests/test_stt_accel.py
+++ b/server/tests/test_stt_accel.py
@@ -62,6 +62,47 @@ def test_verify_and_place_sha_mismatch(accel, tmp_path):
     assert not src.exists()  # cleaned up
 
 
+def test_extract_rejects_tar_slip(accel, tmp_path):
+    import io
+    import tarfile
+
+    arc = tmp_path / "evil.tar.gz"
+    with tarfile.open(arc, "w:gz") as t:
+        data = b"pwned"
+        info = tarfile.TarInfo("../escape.txt")
+        info.size = len(data)
+        t.addfile(info, io.BytesIO(data))
+    with pytest.raises(ValueError):
+        accel._extract(arc, tmp_path / "dest")
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_extract_rejects_zip_slip(accel, tmp_path):
+    import zipfile
+
+    arc = tmp_path / "evil.zip"
+    with zipfile.ZipFile(arc, "w") as z:
+        z.writestr("../escape.txt", "pwned")
+    with pytest.raises(ValueError):
+        accel._extract(arc, tmp_path / "dest")
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_extract_ok(accel, tmp_path):
+    import io
+    import tarfile
+
+    arc = tmp_path / "ok.tar.gz"
+    with tarfile.open(arc, "w:gz") as t:
+        data = b"hi"
+        info = tarfile.TarInfo("whisper-cli")
+        info.size = len(data)
+        t.addfile(info, io.BytesIO(data))
+    dest = tmp_path / "dest"
+    accel._extract(arc, dest)
+    assert (dest / "whisper-cli").read_bytes() == b"hi"
+
+
 def test_paths_and_installed(accel, tmp_path):
     assert str(accel.install_dir()).startswith(str(tmp_path))
     assert accel.model_path("small").name == "ggml-small.bin"

--- a/server/tests/test_stt_accel.py
+++ b/server/tests/test_stt_accel.py
@@ -1,0 +1,72 @@
+"""Accelerator manager: platform keys, sha256 verify, atomic place, paths."""
+
+import hashlib
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def accel(tmp_path, monkeypatch):
+    monkeypatch.setenv("CATGO_STT_DATA_DIR", str(tmp_path))
+    mod = importlib.import_module("catgo.stt.accel")
+    importlib.reload(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "system,machine,expected",
+    [
+        ("Linux", "x86_64", "linux-x64-vulkan"),
+        ("Windows", "AMD64", "windows-x64-vulkan"),
+        ("Darwin", "arm64", "macos-arm64-metal"),
+        ("Darwin", "x86_64", "macos-x64-metal"),
+    ],
+)
+def test_platform_key(accel, monkeypatch, system, machine, expected):
+    monkeypatch.setattr("platform.system", lambda: system)
+    monkeypatch.setattr("platform.machine", lambda: machine)
+    assert accel.platform_key() == expected
+
+
+def test_gpu_api(accel, monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    assert accel.gpu_api() == "metal"
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    assert accel.gpu_api() == "vulkan"
+
+
+def test_pick_asset(accel):
+    m = {"binaries": {"linux-x64-vulkan": {"url": "u", "sha256": "s"}}}
+    assert accel._pick_asset(m, "linux-x64-vulkan") == {"url": "u", "sha256": "s"}
+    assert accel._pick_asset(m, "macos-arm64-metal") is None
+    assert accel._pick_asset({}, "x") is None
+
+
+def test_verify_and_place_ok(accel, tmp_path):
+    src = tmp_path / "src.part"
+    src.write_bytes(b"hello")
+    dest = tmp_path / "out" / "f.bin"
+    accel._verify_and_place(src, dest, hashlib.sha256(b"hello").hexdigest())
+    assert dest.read_bytes() == b"hello"
+    assert not src.exists()  # moved, not copied
+
+
+def test_verify_and_place_sha_mismatch(accel, tmp_path):
+    src = tmp_path / "src.part"
+    src.write_bytes(b"hello")
+    dest = tmp_path / "f.bin"
+    with pytest.raises(ValueError):
+        accel._verify_and_place(src, dest, "deadbeef")
+    assert not dest.exists()
+    assert not src.exists()  # cleaned up
+
+
+def test_paths_and_installed(accel, tmp_path):
+    assert str(accel.install_dir()).startswith(str(tmp_path))
+    assert accel.model_path("small").name == "ggml-small.bin"
+    assert accel.binary_installed() is False
+    assert accel.installed_models() == []
+    accel.models_dir().mkdir(parents=True, exist_ok=True)
+    (accel.models_dir() / "ggml-base.bin").write_bytes(b"x")
+    assert accel.installed_models() == ["base"]

--- a/server/tests/test_stt_accel_api.py
+++ b/server/tests/test_stt_accel_api.py
@@ -1,0 +1,76 @@
+"""STT accelerator endpoints: status shape, engine switch validation, install gate."""
+
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("CATGO_STT_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("CATGO_STT_ENGINE", raising=False)
+    monkeypatch.delenv("CATGO_WHISPERCPP_BIN", raising=False)
+    monkeypatch.delenv("CATGO_WHISPERCPP_MODELS", raising=False)
+    es = importlib.import_module("catgo.stt.engine_state")
+    es._reset_for_test()
+    accel = importlib.import_module("catgo.stt.accel")
+    importlib.reload(accel)
+    stt = importlib.import_module("catgo.routers.stt")
+    importlib.reload(stt)
+    app = FastAPI()
+    app.include_router(stt.router, prefix="/api")
+    c = TestClient(app)
+    c._stt, c._accel, c._es = stt, accel, es
+    yield c
+    es._reset_for_test()
+
+
+def test_status_shape(client):
+    r = client.get("/api/stt/accel/status")
+    assert r.status_code == 200
+    d = r.json()
+    assert d["engine"] == "faster-whisper"
+    assert d["binary_installed"] is False
+    assert d["models_installed"] == []
+    assert "gpu_api" in d and "download" in d
+
+
+def test_switch_to_whispercpp_without_binary_rejected(client):
+    r = client.post("/api/stt/accel/engine", json={"engine": "whispercpp"})
+    assert r.status_code == 400
+    assert client.get("/api/stt/accel/status").json()["engine"] == "faster-whisper"
+
+
+def test_switch_to_whispercpp_with_binary_ok(client):
+    binp = client._accel.binary_path()
+    binp.parent.mkdir(parents=True, exist_ok=True)
+    binp.write_text("#!/bin/sh\n")
+    r = client.post("/api/stt/accel/engine", json={"engine": "whispercpp"})
+    assert r.status_code == 200
+    assert r.json()["engine"] == "whispercpp"
+    assert client.get("/api/stt/accel/status").json()["engine"] == "whispercpp"
+
+
+def test_switch_unknown_engine_rejected(client):
+    assert client.post("/api/stt/accel/engine", json={"engine": "bogus"}).status_code == 400
+
+
+def test_install_unsupported_platform_rejected(client, monkeypatch):
+    monkeypatch.setattr(client._accel, "platform_key", lambda: None)
+    assert client.post("/api/stt/accel/install").status_code == 400
+
+
+def test_install_starts_background(client, monkeypatch):
+    called = {}
+    monkeypatch.setattr(client._accel, "platform_key", lambda: "linux-x64-vulkan")
+    monkeypatch.setattr(client._accel, "install_binary", lambda: called.setdefault("ok", True))
+    r = client.post("/api/stt/accel/install")
+    assert r.status_code == 200 and r.json()["started"] is True
+    assert called.get("ok") is True  # background task ran (TestClient runs them)
+
+
+def test_transcribe_empty_body(client):
+    r = client.post("/api/stt/transcribe", content=b"")
+    assert r.status_code == 400

--- a/server/tests/test_stt_engine_state.py
+++ b/server/tests/test_stt_engine_state.py
@@ -1,0 +1,49 @@
+"""Runtime STT engine state: default, env override, persistence, validation."""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def es(tmp_path, monkeypatch):
+    monkeypatch.setenv("CATGO_STT_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("CATGO_STT_ENGINE", raising=False)
+    mod = importlib.import_module("catgo.stt.engine_state")
+    mod._reset_for_test()
+    yield mod
+    mod._reset_for_test()
+
+
+def test_default_is_faster_whisper(es):
+    assert es.get_engine() == "faster-whisper"
+    assert es.get_state() == {"engine": "faster-whisper", "model": None}
+
+
+def test_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("CATGO_STT_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CATGO_STT_ENGINE", "whispercpp")
+    mod = importlib.import_module("catgo.stt.engine_state")
+    mod._reset_for_test()
+    assert mod.get_engine() == "whispercpp"
+    mod._reset_for_test()
+
+
+def test_set_engine_persists_across_reload(es):
+    es.set_engine("whispercpp")
+    es.set_model("small")
+    es._reset_for_test()  # forget in-memory; must re-read from disk
+    assert es.get_engine() == "whispercpp"
+    assert es.get_model() == "small"
+
+
+def test_reject_unknown_engine(es):
+    with pytest.raises(ValueError):
+        es.set_engine("bogus")
+    assert es.get_engine() == "faster-whisper"
+
+
+def test_corrupt_state_file_falls_back(es, tmp_path):
+    (tmp_path / "state.json").write_text("{not json")
+    es._reset_for_test()
+    assert es.get_engine() == "faster-whisper"

--- a/src/lib/gesture/__tests__/backend-whisper.test.ts
+++ b/src/lib/gesture/__tests__/backend-whisper.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { VoiceEvent } from '$lib/gesture/gesture-types'
+
+// Capture the VAD's speech-end callback so tests can drive transcription
+// without a real microphone / Silero model.
+const vad = vi.hoisted(() => ({
+  on_speech_end: null as ((a: Float32Array) => void) | null,
+  start: vi.fn(),
+  stop: vi.fn(),
+}))
+
+vi.mock('$lib/gesture/vad', () => ({
+  start_vad: vi.fn(async (cfg: { on_speech_end: (a: Float32Array) => void }) => {
+    vad.on_speech_end = cfg.on_speech_end
+    vad.start()
+  }),
+  stop_vad: () => vad.stop(),
+}))
+
+import { BackendWhisperEngine, backend_stt_available } from '../backend-whisper'
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('BackendWhisperEngine', () => {
+  beforeEach(() => {
+    vad.on_speech_end = null
+    vad.start.mockClear()
+    vad.stop.mockClear()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs each speech segment to /stt/transcribe and forwards the text', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ text: 'hello world' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const eng = new BackendWhisperEngine()
+    const events: VoiceEvent[] = []
+    await eng.start((e) => events.push(e), 'en-US', false, undefined, false, 'whisper-base')
+    expect(vad.start).toHaveBeenCalled()
+
+    vad.on_speech_end!(new Float32Array([0.1, 0.2, 0.3]))
+    await flush()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/stt/transcribe')
+    expect(url).toContain('language=en')
+    expect(url).toContain('model=whisper-base')
+    expect(init.method).toBe('POST')
+
+    expect(events).toHaveLength(1)
+    expect(events[0].raw_text).toBe('hello world')
+    expect(events[0].is_final).toBe(true)
+  })
+
+  it('drops empty / whitespace-only transcriptions', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ text: '   ' }) })))
+    const eng = new BackendWhisperEngine()
+    const events: VoiceEvent[] = []
+    await eng.start((e) => events.push(e))
+    vad.on_speech_end!(new Float32Array([0]))
+    await flush()
+    expect(events).toEqual([])
+  })
+
+  it('serializes: a segment arriving mid-request is dropped (no backlog)', async () => {
+    // First request never resolves → the second speech-end must be ignored.
+    const fetchMock = vi.fn(() => new Promise(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+    const eng = new BackendWhisperEngine()
+    await eng.start(() => {})
+    vad.on_speech_end!(new Float32Array([0.1]))
+    vad.on_speech_end!(new Float32Array([0.2]))
+    await flush()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw / inject when the backend errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })))
+    const eng = new BackendWhisperEngine()
+    const events: VoiceEvent[] = []
+    await eng.start((e) => events.push(e))
+    vad.on_speech_end!(new Float32Array([0.1]))
+    await flush()
+    expect(events).toEqual([])
+  })
+})
+
+describe('backend_stt_available', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('true when /stt/health reports available', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ available: true }) })))
+    expect(await backend_stt_available(true)).toBe(true)
+  })
+
+  it('false when health reports unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ available: false }) })))
+    expect(await backend_stt_available(true)).toBe(false)
+  })
+
+  it('false when the request throws (no backend)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('refused') }))
+    expect(await backend_stt_available(true)).toBe(false)
+  })
+})

--- a/src/lib/gesture/__tests__/stt-accel.test.ts
+++ b/src/lib/gesture/__tests__/stt-accel.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  accel_status,
+  accel_install,
+  accel_download_model,
+  accel_set_engine,
+  poll_accel_progress,
+} from '../stt-accel'
+
+const okJson = (body: unknown) => ({ ok: true, json: async () => body })
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('stt-accel client', () => {
+  it('accel_status parses the payload', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okJson({
+      platform_key: 'linux-x64-vulkan', gpu_api: 'vulkan', gpu_name: 'AMD',
+      engine: 'faster-whisper', binary_installed: false, models_installed: [],
+      download: { active: false, kind: null, pct: 0, error: null },
+    })))
+    const s = await accel_status()
+    expect(s?.gpu_api).toBe('vulkan')
+    expect(s?.engine).toBe('faster-whisper')
+  })
+
+  it('accel_status returns null on error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('refused') }))
+    expect(await accel_status()).toBeNull()
+  })
+
+  it('accel_install POSTs', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({ started: true }) }))
+    vi.stubGlobal('fetch', f)
+    expect(await accel_install()).toBe(true)
+    expect(f.mock.calls[0][0]).toContain('/stt/accel/install')
+    expect(f.mock.calls[0][1].method).toBe('POST')
+  })
+
+  it('accel_download_model passes the size', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+    vi.stubGlobal('fetch', f)
+    await accel_download_model('small')
+    expect(f.mock.calls[0][0]).toContain('size=small')
+  })
+
+  it('accel_set_engine sends the engine in the body', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+    vi.stubGlobal('fetch', f)
+    await accel_set_engine('whispercpp')
+    expect(JSON.parse(f.mock.calls[0][1].body)).toEqual({ engine: 'whispercpp' })
+  })
+
+  it('poll_accel_progress loops until download inactive', async () => {
+    let n = 0
+    vi.stubGlobal('fetch', vi.fn(async () => okJson({
+      platform_key: null, gpu_api: null, gpu_name: null, engine: 'whispercpp',
+      binary_installed: true, models_installed: [],
+      download: { active: n++ < 2, kind: 'binary', pct: n * 30, error: null },
+    })))
+    const ticks: number[] = []
+    const final = await poll_accel_progress((s) => ticks.push(s.download.pct), 1)
+    expect(ticks.length).toBeGreaterThanOrEqual(3)
+    expect(final?.download.active).toBe(false)
+  })
+})

--- a/src/lib/gesture/backend-whisper.ts
+++ b/src/lib/gesture/backend-whisper.ts
@@ -1,0 +1,171 @@
+/**
+ * Backend Whisper STT engine — transcribes via the native faster-whisper
+ * endpoint instead of running Whisper in the webview.
+ *
+ * WebKit webviews (WebKitGTK on Linux, WKWebView on macOS/iOS — every Tauri
+ * webview except Windows' Chromium WebView2) leak ~0.8 GB of unreclaimable WASM
+ * memory per inference with the in-browser engine, OOM-killing the renderer
+ * (blank window). This engine keeps only the tiny Silero VAD in the browser to
+ * segment speech, then POSTs each finished 16 kHz float32 segment to
+ * `/api/stt/transcribe`, where native CTranslate2 runs it (CPU int8 or CUDA) at
+ * no webview memory cost. Drop-in for LocalWhisperEngine (same VoiceEngineLike
+ * shape); language post-processing (zh Traditional→Simplified) stays in
+ * TerminalVoice, so this engine only forwards raw recognized text.
+ */
+
+import type { VoiceCallback, VoiceErrorCallback } from './voice-engine'
+import { match_command_with_score } from './voice-engine'
+import { start_vad, stop_vad } from './vad'
+import type { AudioPipeline } from './audio-pipeline'
+import { API_BASE } from '$lib/api/config'
+
+export type Accel = `cpu` | `gpu`
+
+/** Probe the native STT endpoint. Cached so each pane's engine doesn't re-hit
+ *  it. Returns false when the backend is absent (static web) or the dependency
+ *  is missing, so the caller can fall back to the in-browser WASM engine. */
+let _availability: Promise<boolean> | null = null
+export function backend_stt_available(force = false): Promise<boolean> {
+  if (force) _availability = null
+  if (!_availability) {
+    _availability = (async () => {
+      try {
+        const resp = await fetch(`${API_BASE}/stt/health`, { method: `GET` })
+        if (!resp.ok) return false
+        const data = await resp.json()
+        return data?.available === true
+      } catch {
+        return false
+      }
+    })()
+  }
+  return _availability
+}
+
+export class BackendWhisperEngine {
+  private callback: VoiceCallback | null = null
+  private error_callback: VoiceErrorCallback | null = null
+  private running = false
+  private language = `en`
+  private ai_enabled = false
+  private model_id = `base`
+  private transcribing = false
+  private pipeline: AudioPipeline | null = null
+
+  get is_supported(): boolean {
+    return typeof navigator !== `undefined`
+      && !!navigator.mediaDevices?.getUserMedia
+  }
+
+  get is_running(): boolean {
+    return this.running
+  }
+
+  async start(
+    callback: VoiceCallback,
+    language = `en-US`,
+    ai_enabled = false,
+    on_error?: VoiceErrorCallback,
+    noise_suppression = false,
+    model_id?: string,
+    _accel: Accel = `cpu`, // backend picks its own device (CUDA/CPU)
+  ): Promise<void> {
+    if (this.running) return
+    this.callback = callback
+    this.error_callback = on_error ?? null
+    this.language = language.split(`-`)[0]
+    this.ai_enabled = ai_enabled
+    this.model_id = model_id ?? `base`
+
+    try {
+      let stream: MediaStream | undefined
+      if (noise_suppression) {
+        try {
+          const { create_audio_pipeline } = await import(`./audio-pipeline`)
+          this.pipeline = await create_audio_pipeline()
+          stream = this.pipeline.stream
+        } catch (err) {
+          console.warn(`[BackendWhisper] Noise suppression failed, using raw mic:`, err)
+        }
+      }
+
+      await start_vad({
+        on_speech_end: (audio: Float32Array) => {
+          this.transcribe_remote(audio)
+        },
+        stream,
+      })
+
+      this.running = true
+      console.info(`[BackendWhisper] Started (lang=${this.language}, native backend STT)`)
+    } catch (err) {
+      console.error(`[BackendWhisper] Failed to start:`, err)
+      this.error_callback?.(err instanceof DOMException ? `not-allowed` : `audio-capture`)
+      throw err
+    }
+  }
+
+  stop(): void {
+    this.running = false
+    stop_vad()
+    if (this.pipeline) {
+      this.pipeline.destroy()
+      this.pipeline = null
+    }
+    this.callback = null
+  }
+
+  set_language(lang: string, ai_enabled = false): void {
+    this.language = lang.split(`-`)[0]
+    this.ai_enabled = ai_enabled
+  }
+
+  set_model(model_id: string): void {
+    this.model_id = model_id
+  }
+
+  private async transcribe_remote(audio: Float32Array): Promise<void> {
+    // Serialize: drop overlapping segments while one request is in flight, so a
+    // slow backend can't queue a backlog of POSTs.
+    if (this.transcribing) return
+    this.transcribing = true
+
+    try {
+      // Copy into a fresh (non-shared) ArrayBuffer: under cross-origin isolation
+      // the VAD's buffer may be a SharedArrayBuffer, which fetch refuses as a body.
+      const pcm = new Float32Array(audio)
+      const lang = encodeURIComponent(this.language || `en`)
+      const model = encodeURIComponent(this.model_id || `base`)
+      const resp = await fetch(
+        `${API_BASE}/stt/transcribe?language=${lang}&model=${model}`,
+        {
+          method: `POST`,
+          headers: { 'Content-Type': `application/octet-stream` },
+          body: pcm.buffer,
+        },
+      )
+      if (!resp.ok) {
+        console.error(`[BackendWhisper] transcribe failed: HTTP ${resp.status}`)
+        return
+      }
+      const data = await resp.json()
+      const text = (data?.text ?? ``).trim()
+      if (!text) return
+
+      const confidence = 0.9
+      const { action, match_score } = match_command_with_score(text, this.ai_enabled, confidence)
+      this.callback?.({
+        action,
+        raw_text: text,
+        confidence,
+        is_final: true,
+        match_score,
+        timestamp: performance.now(),
+      })
+    } catch (err) {
+      console.error(`[BackendWhisper] Transcription failed:`, err)
+    } finally {
+      this.transcribing = false
+    }
+  }
+}

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -227,7 +227,8 @@ export class LocalWhisperEngine {
     // If the resolved model changed, the pipeline will reload on next transcription
     if (model_changed) {
       pipeline_promise = null
-      current_model_id = null
+      current_key = null // reset the cache key so the pipeline rebuilds (was a
+      // ReferenceError: current_model_id is a getter, not the module-level var)
       console.info(`[LocalWhisper] Language changed, model will reload on next transcription`)
     }
   }

--- a/src/lib/gesture/local-whisper.ts
+++ b/src/lib/gesture/local-whisper.ts
@@ -58,11 +58,22 @@ async function get_pipeline(
       const isolated = typeof globalThis !== `undefined`
         && (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
       const cores = (typeof navigator !== `undefined` && navigator.hardwareConcurrency) || 4
+      // WebKit engines (WebKitGTK on Linux Tauri, WKWebView on macOS/iOS) deadlock
+      // on multi-threaded wasm: the SharedArrayBuffer pthread sync hangs and the
+      // inference call never returns → permanent UI freeze (needs app restart).
+      // Chromium (web, Windows WebView2) and Firefox run multi-threaded fine. The
+      // Chromium UA also contains "AppleWebKit", so a true WebKit engine is one
+      // whose UA has AppleWebKit but NOT Chrome/Chromium/Edg. Force single-thread
+      // there (slower but does not hang).
+      const ua = typeof navigator !== `undefined` ? navigator.userAgent : ``
+      const is_webkit = /AppleWebKit/.test(ua) && !/Chrome|Chromium|Edg\//.test(ua)
       // Use most cores but leave ~2 for the audio worklet / VAD / UI, and cap at
       // 8 — beyond that wasm Whisper is memory-bandwidth bound and thread-sync
       // overhead eats the gains (16 threads ≠ 2× of 8). Single thread without
-      // cross-origin isolation (no SharedArrayBuffer).
-      env.backends.onnx.wasm.numThreads = isolated ? Math.max(1, Math.min(8, cores - 2)) : 1
+      // cross-origin isolation (no SharedArrayBuffer) or on a WebKit engine.
+      env.backends.onnx.wasm.numThreads = (isolated && !is_webkit)
+        ? Math.max(1, Math.min(8, cores - 2))
+        : 1
       // Load the onnxruntime-web wasm runtime from a CDN pinned to the version
       // @huggingface/transformers bundles. Without this, the WASM backend (the
       // fallback when WebGPU is unavailable — e.g. machines without a discrete

--- a/src/lib/gesture/stt-accel.ts
+++ b/src/lib/gesture/stt-accel.ts
@@ -1,0 +1,104 @@
+/**
+ * Client for the optional STT GPU accelerator (whisper.cpp Vulkan/Metal).
+ *
+ * Wraps the backend /api/stt/accel/* endpoints: report status, download the
+ * platform binary + GGML models on demand, and switch the active engine at
+ * runtime. All calls degrade to a safe default (null / false) on error so the
+ * voice menu never throws.
+ */
+
+import { API_BASE } from '$lib/api/config'
+
+export type SttEngine = `faster-whisper` | `whispercpp`
+
+export interface AccelDownload {
+  active: boolean
+  kind: string | null
+  pct: number
+  error: string | null
+}
+
+export interface AccelStatus {
+  platform_key: string | null
+  gpu_api: string | null
+  gpu_name: string | null
+  engine: SttEngine
+  binary_installed: boolean
+  models_installed: string[]
+  download: AccelDownload
+}
+
+const _SIZE_ALIASES: Record<string, string> = {
+  tiny: `tiny`, 'tiny.en': `tiny.en`, base: `base`, 'base.en': `base.en`,
+  small: `small`, 'small.en': `small.en`, medium: `medium`, 'medium.en': `medium.en`,
+  large: `large-v3`, 'large-v2': `large-v2`, 'large-v3': `large-v3`,
+  'large-v3-turbo': `large-v3-turbo`, turbo: `large-v3-turbo`,
+}
+
+/** Mirror of the backend size resolver — maps a client model id
+ *  ('onnx-community/whisper-small') to the size name the accelerator uses
+ *  ('small'), so the UI can tell whether that GGML model is installed. */
+export function resolve_stt_size(model_id: string): string {
+  const name = (model_id || ``).split(`/`).pop()!.toLowerCase().replace(`whisper-`, ``)
+  return _SIZE_ALIASES[name] ?? `base`
+}
+
+export async function accel_status(): Promise<AccelStatus | null> {
+  try {
+    const r = await fetch(`${API_BASE}/stt/accel/status`)
+    if (!r.ok) return null
+    return await r.json() as AccelStatus
+  } catch {
+    return null
+  }
+}
+
+export async function accel_install(): Promise<boolean> {
+  try {
+    const r = await fetch(`${API_BASE}/stt/accel/install`, { method: `POST` })
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+export async function accel_download_model(size: string): Promise<boolean> {
+  try {
+    const r = await fetch(
+      `${API_BASE}/stt/accel/model?size=${encodeURIComponent(size)}`,
+      { method: `POST` },
+    )
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+export async function accel_set_engine(engine: SttEngine): Promise<boolean> {
+  try {
+    const r = await fetch(`${API_BASE}/stt/accel/engine`, {
+      method: `POST`,
+      headers: { 'Content-Type': `application/json` },
+      body: JSON.stringify({ engine }),
+    })
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+/** Poll status, invoking `cb` each tick, until no download is active (or error).
+ *  Resolves with the final status. */
+export async function poll_accel_progress(
+  cb: (s: AccelStatus) => void,
+  interval = 800,
+): Promise<AccelStatus | null> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const s = await accel_status()
+    if (!s) return null
+    cb(s)
+    if (!s.download.active) return s
+    await new Promise((r) => setTimeout(r, interval))
+  }
+}

--- a/src/lib/gesture/vad.ts
+++ b/src/lib/gesture/vad.ts
@@ -26,6 +26,10 @@ export interface VadConfig {
 let vad_instance: any = null
 
 export async function start_vad(config: VadConfig): Promise<void> {
+  // Tear down any previous instance first — MicVAD holds the mic and a worklet,
+  // so a leaked instance keeps transcribing in parallel (duplicated input). One
+  // mic, one VAD.
+  stop_vad()
   // Dynamic import to avoid SSR issues
   const { MicVAD } = await import(`@ricky0123/vad-web`)
 

--- a/src/lib/gesture/vad.ts
+++ b/src/lib/gesture/vad.ts
@@ -76,3 +76,10 @@ export function stop_vad(): void {
 export function is_vad_running(): boolean {
   return vad_instance !== null
 }
+
+// Dev only: on hot-reload, tear down the live MicVAD. Otherwise its mic stream +
+// audio worklet keep running (orphaned) across reloads and fire the stale
+// callback — phantom dictation with the button off.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => stop_vad())
+}

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -6,6 +6,16 @@
   import { WHISPER_MODELS } from '$lib/gesture/whisper-models'
   import { get_active_terminal } from './terminal-registry.svelte'
   import { backend_stt_available } from '$lib/gesture/backend-whisper'
+  import {
+    accel_status,
+    accel_install,
+    accel_download_model,
+    accel_set_engine,
+    poll_accel_progress,
+    resolve_stt_size,
+    type AccelStatus,
+    type SttEngine,
+  } from '$lib/gesture/stt-accel'
   import { fetchConnections, type ConnectionInfo } from '$lib/api/hpc'
   import { fetchAvailableShells, type ShellInfo } from '$lib/api/pty'
   import { hpc_session_store, LOCAL_SESSION_ID } from '$lib/hpc-sessions.svelte'
@@ -191,6 +201,37 @@
   let stt_backend = $state(false)
   $effect(() => { backend_stt_available().then((v) => { stt_backend = v }) })
 
+  // Optional GPU accelerator (whisper.cpp Vulkan/Metal) — status refreshed when
+  // the voice menu opens; download/enable drives it via the backend /accel/* API.
+  let accel_state = $state<AccelStatus | null>(null)
+  let accel_busy = $state(false)
+  async function refresh_accel() { accel_state = await accel_status() }
+  $effect(() => { if (show_voice_menu) refresh_accel() })
+
+  async function enable_gpu() {
+    accel_busy = true
+    try {
+      if (accel_state && !accel_state.binary_installed) {
+        await accel_install()
+        await poll_accel_progress((s) => { accel_state = s })
+      }
+      const size = resolve_stt_size(voice.model_id)
+      if (accel_state && !accel_state.models_installed.includes(size)) {
+        await accel_download_model(size)
+        await poll_accel_progress((s) => { accel_state = s })
+      }
+      await accel_set_engine(`whispercpp`)
+      await refresh_accel()
+    } finally {
+      accel_busy = false
+    }
+  }
+
+  async function set_stt_engine(engine: SttEngine) {
+    await accel_set_engine(engine)
+    await refresh_accel()
+  }
+
   function toggle_voice() {
     voice.toggle((text) => { get_active_terminal()?.send_keys(text) })
   }
@@ -360,7 +401,30 @@
                 onclick={() => { voice.set_language(l.tag) }}
               >{l.label}</button>
             {/each}
-            {#if stt_backend}
+            {#if accel_state?.gpu_api}
+              <div class="tw-dropdown-divider"></div>
+              <div class="tw-dropdown-header">GPU 加速 · {accel_state.gpu_api}</div>
+              <div class="tw-dropdown-note">
+                {accel_state.gpu_name ?? accel_state.gpu_api} —
+                {accel_state.engine === `whispercpp` ? `已启用` : `未启用`}
+              </div>
+              {#if accel_state.download.active}
+                <div class="tw-dropdown-note">下载中（{accel_state.download.kind}）{accel_state.download.pct}%…</div>
+              {:else if accel_state.engine === `whispercpp`}
+                <button class="tw-dropdown-item tw-voice-selected" onclick={() => set_stt_engine(`faster-whisper`)}>切回 CPU（faster-whisper）</button>
+              {:else}
+                <button class="tw-dropdown-item" disabled={accel_busy} onclick={enable_gpu}>
+                  {accel_busy
+                    ? `处理中…`
+                    : accel_state.binary_installed
+                    ? `启用 GPU 加速（whisper.cpp）`
+                    : `下载并启用 GPU（whisper.cpp，~60MB + 模型）`}
+                </button>
+              {/if}
+              {#if accel_state.download.error}
+                <div class="tw-dropdown-note tw-voice-error">下载失败：{accel_state.download.error}</div>
+              {/if}
+            {:else if stt_backend}
               <div class="tw-dropdown-divider"></div>
               <div class="tw-dropdown-note">原生后端转写（设备自动：CPU / CUDA）· 不占内存 · 可放心选更大模型。中英混合选「中文」+ 更大模型</div>
             {:else}

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -5,6 +5,7 @@
   import { TerminalVoice } from './terminal-voice.svelte'
   import { WHISPER_MODELS } from '$lib/gesture/whisper-models'
   import { get_active_terminal } from './terminal-registry.svelte'
+  import { backend_stt_available } from '$lib/gesture/backend-whisper'
   import { fetchConnections, type ConnectionInfo } from '$lib/api/hpc'
   import { fetchAvailableShells, type ShellInfo } from '$lib/api/pty'
   import { hpc_session_store, LOCAL_SESSION_ID } from '$lib/hpc-sessions.svelte'
@@ -185,6 +186,10 @@
   // uses), with no Enter appended.
   const voice = new TerminalVoice()
   let show_voice_menu = $state(false)
+  // Whether native backend STT is reachable — decides if the menu shows the
+  // webview-only Acceleration control or the "native backend" note.
+  let stt_backend = $state(false)
+  $effect(() => { backend_stt_available().then((v) => { stt_backend = v }) })
 
   function toggle_voice() {
     voice.toggle((text) => { get_active_terminal()?.send_keys(text) })
@@ -355,16 +360,21 @@
                 onclick={() => { voice.set_language(l.tag) }}
               >{l.label}</button>
             {/each}
-            <div class="tw-dropdown-divider"></div>
-            <div class="tw-dropdown-header">Acceleration</div>
-            {#each [{ a: `cpu`, label: `CPU (稳定)` }, { a: `gpu`, label: `GPU / WebGPU (实验·更快)` }] as opt}
-              <button
-                class="tw-dropdown-item"
-                class:tw-voice-selected={voice.accel === opt.a}
-                onclick={() => { voice.set_accel(opt.a === `gpu` ? `gpu` : `cpu`) }}
-              >{opt.label}</button>
-            {/each}
-            <div class="tw-dropdown-note">中英混合：选「中文」+ 更大模型。GPU 需浏览器支持 WebGPU,出乱码就切回 CPU</div>
+            {#if stt_backend}
+              <div class="tw-dropdown-divider"></div>
+              <div class="tw-dropdown-note">原生后端转写（设备自动：CPU / CUDA）· 不占内存 · 可放心选更大模型。中英混合选「中文」+ 更大模型</div>
+            {:else}
+              <div class="tw-dropdown-divider"></div>
+              <div class="tw-dropdown-header">Acceleration</div>
+              {#each [{ a: `cpu`, label: `CPU (稳定)` }, { a: `gpu`, label: `GPU / WebGPU (实验·更快)` }] as opt}
+                <button
+                  class="tw-dropdown-item"
+                  class:tw-voice-selected={voice.accel === opt.a}
+                  onclick={() => { voice.set_accel(opt.a === `gpu` ? `gpu` : `cpu`) }}
+                >{opt.label}</button>
+              {/each}
+              <div class="tw-dropdown-note">中英混合：选「中文」+ 更大模型。GPU 需浏览器支持 WebGPU,出乱码就切回 CPU</div>
+            {/if}
             {#if voice.model_status === `downloading`}
               <div class="tw-dropdown-note">Downloading… {Math.round(voice.download_progress)}%</div>
             {:else if voice.model_status === `error` || voice.error}

--- a/src/lib/structure/__tests__/terminal-voice.test.ts
+++ b/src/lib/structure/__tests__/terminal-voice.test.ts
@@ -55,6 +55,33 @@ describe('TerminalVoice', () => {
     expect(tv.recording).toBe(false)
   })
 
+  it('only one voice records at a time — starting a second stops the first', async () => {
+    // Regression: two terminal panes each enabling voice spun up two MicVADs that
+    // both transcribed the same speech, duplicating injected keystrokes. Starting
+    // voice on pane B must stop pane A (single microphone → single voice).
+    const a = make_fake()
+    const b = make_fake()
+    const va = new TerminalVoice(() => a.engine)
+    const vb = new TerminalVoice(() => b.engine)
+
+    await va.toggle(() => {})
+    expect(va.recording).toBe(true)
+
+    await vb.toggle(() => {})
+    expect(vb.recording).toBe(true)
+    // A was taken over → stopped and no longer recording.
+    expect(va.recording).toBe(false)
+    expect(a.engine.stop).toHaveBeenCalled()
+
+    // A no longer receives transcripts; only B injects.
+    const sent: string[] = []
+    await vb.toggle(() => {}) // stop B to reset, then restart capturing
+    await vb.toggle((t) => sent.push(t))
+    b.fire(fake_event(`one`, true))
+    a.fire(fake_event(`one`, true)) // A is dead — must not fire
+    expect(sent).toEqual([`one `])
+  })
+
   it('reports unsupported when the engine is unsupported', () => {
     const tv = new TerminalVoice(() => ({ is_supported: false, start: vi.fn(), stop: vi.fn() }))
     expect(tv.is_supported).toBe(false)

--- a/src/lib/structure/__tests__/terminal-voice.test.ts
+++ b/src/lib/structure/__tests__/terminal-voice.test.ts
@@ -82,6 +82,24 @@ describe('TerminalVoice', () => {
     expect(sent).toEqual([`one `])
   })
 
+  it('on_error fully stops — no phantom dictation with the button off', async () => {
+    // Regression: on_error only cleared `recording`, leaving the VAD/mic running
+    // so it kept transcribing + injecting while the mic button showed off.
+    let on_err: ((e: string) => void) | null = null
+    const engine = {
+      is_supported: true,
+      start: vi.fn((_cb: any, _l: any, _ai: any, oe: any) => { on_err = oe }),
+      stop: vi.fn(),
+    }
+    const tv = new TerminalVoice(() => engine)
+    await tv.toggle(() => {})
+    expect(tv.recording).toBe(true)
+
+    on_err!('audio-capture')
+    expect(tv.recording).toBe(false)
+    expect(engine.stop).toHaveBeenCalled()
+  })
+
   it('reports unsupported when the engine is unsupported', () => {
     const tv = new TerminalVoice(() => ({ is_supported: false, start: vi.fn(), stop: vi.fn() }))
     expect(tv.is_supported).toBe(false)

--- a/src/lib/structure/terminal-voice.svelte.ts
+++ b/src/lib/structure/terminal-voice.svelte.ts
@@ -8,6 +8,7 @@
  */
 
 import { LocalWhisperEngine, type ModelStatus } from '$lib/gesture/local-whisper'
+import { backend_stt_available, BackendWhisperEngine } from '$lib/gesture/backend-whisper'
 import { DEFAULT_WHISPER_MODEL_ID } from '$lib/gesture/whisper-models'
 import type { VoiceEvent } from '$lib/gesture/gesture-types'
 
@@ -31,6 +32,13 @@ const STORAGE_KEY = `catgo-terminal-voice-model`
 const LANG_KEY = `catgo-terminal-voice-lang`
 const ACCEL_KEY = `catgo-terminal-voice-accel`
 
+// Only one terminal voice may record at a time. There is a single microphone and
+// the VAD + Whisper pipeline is a shared singleton; enabling voice on two panes
+// otherwise spins up two MicVAD instances that BOTH transcribe the same speech
+// and each inject keystrokes → duplicated input. Starting voice on any pane stops
+// it on whichever pane held it before.
+let active_voice: TerminalVoice | null = null
+
 export class TerminalVoice {
   recording = $state(false)
   model_status = $state<ModelStatus>(`idle`)
@@ -45,7 +53,9 @@ export class TerminalVoice {
   accel = $state<Accel>(`cpu`)
   error = $state<string | null>(null)
 
-  private make_engine: () => VoiceEngineLike
+  // Injected factory (tests / explicit override). When absent, the engine is
+  // chosen at start time: native backend STT when reachable, else in-browser WASM.
+  private injected_make?: () => VoiceEngineLike
   private engine: VoiceEngineLike | null = null
   // Lazy Traditional→Simplified converter. Whisper's multilingual model emits
   // Traditional Chinese for Mandarin; convert to Simplified for zh-CN. Loaded
@@ -60,12 +70,7 @@ export class TerminalVoice {
   }
 
   constructor(make_engine?: () => VoiceEngineLike) {
-    this.make_engine = make_engine
-      ?? (() =>
-        new LocalWhisperEngine((status, progress) => {
-          this.model_status = status
-          if (typeof progress === `number`) this.download_progress = progress
-        }))
+    this.injected_make = make_engine
     if (typeof localStorage !== `undefined`) {
       const saved = localStorage.getItem(STORAGE_KEY)
       if (saved) this.model_id = saved
@@ -77,13 +82,33 @@ export class TerminalVoice {
   }
 
   get is_supported(): boolean {
-    if (!this.engine) this.engine = this.make_engine()
-    return this.engine.is_supported
+    if (this.injected_make) {
+      if (!this.engine) this.engine = this.injected_make()
+      return this.engine.is_supported
+    }
+    // Both real engines only need a microphone — don't instantiate one (and
+    // commit to backend-vs-WASM) just to answer the button's disabled state.
+    return typeof navigator !== `undefined`
+      && !!navigator.mediaDevices?.getUserMedia
+  }
+
+  /** Pick the STT engine: native backend (faster-whisper) when the server is
+   *  reachable, else the in-browser WASM engine. Injected factory wins (tests). */
+  private async create_engine(): Promise<VoiceEngineLike> {
+    if (this.injected_make) return this.injected_make()
+    if (await backend_stt_available()) return new BackendWhisperEngine()
+    return new LocalWhisperEngine((status, progress) => {
+      this.model_status = status
+      if (typeof progress === `number`) this.download_progress = progress
+    })
   }
 
   set_model(id: string): void {
     this.model_id = id
     if (typeof localStorage !== `undefined`) localStorage.setItem(STORAGE_KEY, id)
+    // Apply live so a mid-session model switch takes effect on the next utterance
+    // (the backend engine reads model_id per request; no restart needed).
+    ;(this.engine as { set_model?: (id: string) => void } | null)?.set_model?.(id)
   }
 
   set_language(lang: string): void {
@@ -105,7 +130,7 @@ export class TerminalVoice {
       return
     }
     this.error = null
-    if (!this.engine) this.engine = this.make_engine()
+    if (!this.engine) this.engine = await this.create_engine()
 
     const on_event = async (e: VoiceEvent) => {
       if (!e.is_final) return
@@ -123,6 +148,10 @@ export class TerminalVoice {
       this.error = err
       this.recording = false
     }
+
+    // Single global voice: stop whichever pane was recording before taking over.
+    if (active_voice && active_voice !== this) active_voice.stop()
+    active_voice = this
 
     this.recording = true
     try {
@@ -143,5 +172,6 @@ export class TerminalVoice {
   stop(): void {
     this.recording = false
     this.engine?.stop()
+    if (active_voice === this) active_voice = null
   }
 }

--- a/src/lib/structure/terminal-voice.svelte.ts
+++ b/src/lib/structure/terminal-voice.svelte.ts
@@ -146,7 +146,9 @@ export class TerminalVoice {
     }
     const on_error = (err: string) => {
       this.error = err
-      this.recording = false
+      // Fully stop — clearing only `recording` would leave the VAD/mic running,
+      // so it keeps transcribing and injecting with the button visibly off.
+      this.stop()
     }
 
     // Single global voice: stop whichever pane was recording before taking over.
@@ -165,7 +167,7 @@ export class TerminalVoice {
         this.accel,
       )
     } catch {
-      this.recording = false
+      this.stop() // tear down any partially-started VAD/mic
     }
   }
 


### PR DESCRIPTION
**Stacked on #379** (pluggable `whispercpp` engine) — merge #379 first, then this rebases onto main.

## What

Make the whisper.cpp GPU engine **user-installable from inside the app** instead of env-var-only. A "GPU 加速" section in the voice menu detects the GPU, downloads the right binary + model on demand, and switches the engine at runtime. Nothing extra in the default installer (the Vulkan shader lib alone is ~60 MB); NVIDIA keeps the auto-CUDA faster-whisper path.

Verified in the spike on AMD Radeon Vega (RADV): whisper.cpp Vulkan transcribes correctly and is **~2x faster total / ~4.6x encode** vs CPU on `small`, and the user confirmed the speedup in-app.

## Changes

**Backend**
- `catgo/stt/engine_state.py` — runtime engine selection (faster-whisper | whispercpp), persisted to `~/.catgo/stt-accel/state.json`.
- `catgo/stt/accel.py` — platform/GPU detection (linux/win→vulkan, mac→metal), sha256-verified atomic downloads, binary install from a Release manifest, GGML model download (HF + hf-mirror fallback), Zip/Tar-Slip-guarded extraction, single-flight progress.
- `routers/stt.py` — reads engine_state per request; `GET /accel/status`, `POST /accel/install`, `POST /accel/model`, `POST /accel/engine` (rejects whispercpp when binary absent).

**Frontend**
- `gesture/stt-accel.ts` — typed client + `resolve_stt_size` mirror.
- `TerminalWindow.svelte` — voice-menu GPU section: status, one-tap download&enable (binary + current model, with progress), GPU↔CPU toggle, gated on a detected GPU.

**CI / release**
- `scripts/build-whispercpp.sh` + `.github/workflows/build-stt-accel.yml`: build per platform (ubuntu vulkan / macos metal / windows vulkan-SDK) → `gh release upload` + `stt-accel-manifest.json`. `deploy/stt-accel/README.md` documents cutting a release.

## Platform matrix

| HW | Engine | This PR |
|---|---|---|
| NVIDIA (Win/Linux) | faster-whisper CUDA | unchanged (auto) |
| AMD/Intel iGPU (Win/Linux) | whisper.cpp **Vulkan** | downloadable |
| Apple Silicon | whisper.cpp **Metal** | downloadable |
| CPU | faster-whisper int8 | unchanged |

## Tests
- Backend 24 (engine_state persistence/validation; accel platform keys, sha verify, atomic place, **Zip/Tar-Slip rejection**; endpoint status/switch/install gates).
- Frontend 18 (stt-accel client + existing voice tests).
- Security: commit-review HIGH (Tar/Zip Slip) fixed; workflow tag-injection hardened (env, not inline interpolation).

## Not verified here
- The CI workflow can't run without GitHub runners — needs a `Build STT accelerator` dispatch to actually produce the `stt-accel-v1` release the in-app download reads. Build commands mirror the locally-verified spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)