### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.1.15";
+  const VERSION = "1.2.1";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.16",
+  "version": "1.2.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.1.16"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.1.16"
+version = "1.2.1"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.1.16",
+  "version": "1.2.1",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump to **1.2.1** for the major STT release (native backend STT + in-app GPU accelerator). Bumps tauri.conf.json, package.json, Cargo.toml/lock, and the download-page VERSION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)