### PR TITLE
fix(ci): make Build STT accelerator workflow actually produce binaries

### DIFF
--- a/.github/workflows/build-stt-accel.yml
+++ b/.github/workflows/build-stt-accel.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             key: linux-x64-vulkan
             backend: vulkan
             ext: tar.gz
@@ -48,7 +48,7 @@ jobs:
         run: echo "TAG=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_ENV"
 
       - name: Install Vulkan toolchain (Linux)
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake glslc glslang-tools spirv-headers libvulkan-dev
@@ -57,7 +57,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          vulkan_version: 1.3.275.0
+          vulkan_version: latest
           install_runtime: true
           cache: true
 

--- a/.github/workflows/build-stt-accel.yml
+++ b/.github/workflows/build-stt-accel.yml
@@ -147,6 +147,7 @@ jobs:
       - name: Upload manifest
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}  # manifest job has no checkout → tell gh the repo
           INPUT_TAG: ${{ github.event.inputs.tag }}
           REF_NAME: ${{ github.ref_name }}
         run: |

--- a/.github/workflows/build-stt-accel.yml
+++ b/.github/workflows/build-stt-accel.yml
@@ -70,11 +70,15 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          git clone --depth 1 https://github.com/ggml-org/whisper.cpp src
-          cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=1
-          cmake --build src/build --config Release --target whisper-cli
+          # Clone into RUNNER_TEMP, NOT "src" — the repo (checked out here) already
+          # has its own src/ directory, so `git clone ... src` would collide.
+          $wc = Join-Path $env:RUNNER_TEMP 'whispercpp'
+          git clone --depth 1 https://github.com/ggml-org/whisper.cpp $wc
+          if (-not (Test-Path "$wc/CMakeLists.txt")) { throw "whisper.cpp clone failed" }
+          cmake -S $wc -B $wc/build -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=1
+          cmake --build $wc/build --config Release --target whisper-cli
           New-Item -ItemType Directory -Force "dist/${{ matrix.key }}" | Out-Null
-          Copy-Item "src/build/bin/Release/*" "dist/${{ matrix.key }}/" -Recurse -Force
+          Copy-Item "$wc/build/bin/Release/*" "dist/${{ matrix.key }}/" -Recurse -Force
 
       - name: Package + checksum
         shell: bash

--- a/scripts/build-whispercpp.sh
+++ b/scripts/build-whispercpp.sh
@@ -21,6 +21,11 @@ case "$BACKEND" in
   *) echo "unknown backend: $BACKEND (expected vulkan|metal)" >&2; exit 1 ;;
 esac
 
+# Resolve OUT to an absolute path BEFORE cd-ing into the temp workdir — a relative
+# OUT would otherwise land inside $WORK and be deleted by the trap below.
+mkdir -p "$OUT"
+OUT="$(cd "$OUT" && pwd)"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 git clone --depth 1 --branch "$REF" https://github.com/ggml-org/whisper.cpp "$WORK/src" \


### PR DESCRIPTION
Fixes the new `Build STT accelerator` workflow so it builds + publishes whisper.cpp Vulkan/Metal binaries (verified green on stt-accel-v1):
- build-whispercpp.sh: resolve OUT to absolute before cd into temp workdir (relative OUT was deleted by the cleanup trap → empty dist).
- Linux runner ubuntu-24.04 (glslc has no apt package on 22.04).
- Windows Vulkan SDK `latest` (pinned 1.3.275.0 404'd on LunarG).
- Windows: clone whisper.cpp into RUNNER_TEMP, not `src` (collides with the repo's own src/).
- manifest job: set GH_REPO (job has no checkout).

Verified: linux-x64-vulkan, macos-arm64-metal, windows-x64-vulkan all green; manifest published; in-app manifest URL returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)