### PR TITLE
fix(mobile): Android insets + CJK terminal input + voice transcript edits

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -112,6 +112,15 @@ jobs:
         # is backend-free.
         run: pnpm tauri android init
 
+      - name: Re-apply Android native inset patches
+        # `tauri android init` regenerates gen/android from stock templates,
+        # DROPPING MainActivity.kt's window-inset listener and the manifest's
+        # windowSoftInputMode. Without this the released APK draws under the
+        # status bar (clock/battery overlap the header) and the soft keyboard
+        # covers the terminal keybar / AI-chat composer. Idempotent.
+        # See deploy/android/README.md and plan/mobile-input-issues.md.
+        run: bash deploy/android/apply-native-patches.sh
+
       - name: Generate app icons (CatGo cat)
         run: pnpm tauri icon desktop/logo.png
 

--- a/deploy/android/README.md
+++ b/deploy/android/README.md
@@ -114,6 +114,16 @@ pnpm tauri android init
 
 ## 2b. Post-init native patches (REQUIRED — re-apply after every `init`)
 
+> **Automated:** run `bash deploy/android/apply-native-patches.sh` after every
+> `tauri android init` (and before `tauri android build`). It is idempotent and
+> applies BOTH edits below: it copies `deploy/android/overrides/MainActivity.kt`
+> into the generated project and inserts `windowSoftInputMode` into the manifest.
+> CI does this automatically (`.github/workflows/android-build.yml`). Edit the
+> canonical `deploy/android/overrides/MainActivity.kt`, NOT the generated copy.
+> The manual steps below are kept for reference / to understand what the script
+> does. (Skipping it ships an APK whose header is hidden under the status bar and
+> whose keyboard covers the terminal keybar / AI-chat composer.)
+
 `tauri android init` regenerates the native project from the CLI templates, so
 the two edits below must be re-applied after each `init`. Without them the soft
 keyboard covers the terminal's input line on a real device (the desktop/emulator

--- a/deploy/android/apply-native-patches.sh
+++ b/deploy/android/apply-native-patches.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Re-apply the Android native patches that `tauri android init` drops.
+#
+# `src-tauri/gen/android/` is gitignored and regenerated from stock Tauri
+# templates on every `pnpm tauri android init`. Two edits required for correct
+# window-inset behaviour (status bar not covering the top, soft keyboard not
+# covering the terminal keybar / chat composer) live in that generated tree and
+# are therefore lost on each init:
+#
+#   1. AndroidManifest.xml — `android:windowSoftInputMode="adjustResize"` on
+#      the .MainActivity <activity>.
+#   2. MainActivity.kt — enableEdgeToEdge() + a WindowInsets listener that pads
+#      the content view by the status-bar (top) and IME/nav-bar (bottom) insets.
+#
+# Run this AFTER `tauri android init` and BEFORE `tauri android build`. It is
+# idempotent. See deploy/android/README.md and plan/mobile-input-issues.md.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GEN="$REPO_ROOT/src-tauri/gen/android/app/src/main"
+MANIFEST="$GEN/AndroidManifest.xml"
+ACTIVITY="$GEN/java/com/catgo/app/MainActivity.kt"
+OVERRIDE="$REPO_ROOT/deploy/android/overrides/MainActivity.kt"
+
+if [ ! -d "$GEN" ]; then
+  echo "::error::$GEN not found — run 'pnpm tauri android init' first." >&2
+  exit 1
+fi
+
+# (1) MainActivity.kt — full replace with the canonical copy.
+cp "$OVERRIDE" "$ACTIVITY"
+echo "patched: MainActivity.kt (inset listener)"
+
+# (2) AndroidManifest.xml — insert windowSoftInputMode if absent (idempotent).
+if grep -q 'windowSoftInputMode' "$MANIFEST"; then
+  echo "skip: AndroidManifest.xml already has windowSoftInputMode"
+else
+  # Insert the attribute immediately before the unique .MainActivity name attr.
+  sed -i.bak 's#\(android:name=".MainActivity"\)#android:windowSoftInputMode="adjustResize"\n            \1#' "$MANIFEST"
+  rm -f "$MANIFEST.bak"
+  grep -q 'windowSoftInputMode' "$MANIFEST" || {
+    echo "::error::failed to insert windowSoftInputMode into AndroidManifest.xml" >&2
+    exit 1
+  }
+  echo "patched: AndroidManifest.xml (windowSoftInputMode=adjustResize)"
+fi
+
+echo "Android native patches applied."

--- a/deploy/android/overrides/MainActivity.kt
+++ b/deploy/android/overrides/MainActivity.kt
@@ -1,0 +1,51 @@
+package com.catgo.app
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+// CANONICAL copy. `tauri android init` regenerates src-tauri/gen/android/ from
+// stock templates and overwrites MainActivity.kt with a bare
+// `class MainActivity : TauriActivity()`, DROPPING the inset handling below.
+// `deploy/android/apply-native-patches.sh` copies this file back into the
+// generated project after every init (run by .github/workflows/android-build.yml
+// and documented for local builds in deploy/android/README.md). Edit THIS file,
+// not the generated one — the generated one is gitignored and ephemeral.
+//
+// NOTE on camera: do NOT call requestPermissions() here. wry's
+// RustWebChromeClient.onPermissionRequest already requests + grants the CAMERA
+// permission when the page calls getUserMedia() (gesture mode); requesting it
+// ourselves too makes the result get delivered to wry's handler as well, which
+// then calls grant()/deny() twice and crashes ("Either grant() or deny() has
+// been already called"). The manifest CAMERA permission is all that's needed.
+class MainActivity : TauriActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
+    super.onCreate(savedInstanceState)
+
+    // `windowSoftInputMode="adjustResize"` (manifest) is the official Tauri fix
+    // for the soft keyboard (tauri-apps/tauri PR #13277), but `enableEdgeToEdge()`
+    // calls `setDecorFitsSystemWindows(false)`, so the window no longer resizes
+    // for the IME — the keyboard is drawn OVER the WebView and covers the
+    // terminal's input line (tauri-apps/tauri #7868 / #10631). Consume the IME
+    // inset (or the nav-bar inset when the keyboard is hidden) as bottom padding
+    // on the content view so the WebView shrinks above the keyboard;
+    // `visualViewport` then updates and MobileTerminal re-fits xterm above it.
+    val content = findViewById<View>(android.R.id.content)
+    ViewCompat.setOnApplyWindowInsetsListener(content) { v, insets ->
+      val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      val ime = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+      // Pad TOP by the status bar (so the app header is not drawn under the
+      // clock/battery) and BOTTOM by the larger of the IME or nav-bar inset (so
+      // the keyboard does not cover the terminal keybar / chat composer). This
+      // native padding is what actually keeps the keyboard from covering content
+      // on this WebView (its window.visualViewport does NOT shrink for the IME).
+      // The frontend must NOT also shrink to visualViewport or it double-counts
+      // and leaves a black gap.
+      v.setPadding(0, bars.top, 0, maxOf(ime, bars.bottom))
+      insets
+    }
+  }
+}

--- a/plan/mobile-input-issues.md
+++ b/plan/mobile-input-issues.md
@@ -1,0 +1,99 @@
+# Mobile input issues — root-cause log (2026-06-19)
+
+Triage pass while user tests on-device (iOS + Android). Code paths verified
+against current source. "Needs device evidence" = can't reproduce in agent env;
+needs a screenshot or event log to close.
+
+## A. Voice input — can't delete CJK after dictation (chat + terminal, multi-platform, NOT iOS-only)
+
+Mechanism: speech transcript application overwrites/blocks user edits.
+
+| Surface | Location | Mechanism |
+|---|---|---|
+| Desktop chat | `src/lib/chat/ChatPane.svelte:661-667` | `recognition.onresult` → `input_text = transcript` whole-value replace each event; recognizer auto-restarts on silence → overwrites user deletions |
+| Mobile chat | `src/lib/mobile/MobileChat.svelte:389-395` | `apply_transcript` → `input = mic_base + sep + text` whole-value replace, no edit guard |
+| Engine | `src/lib/gesture/voice-engine.ts:178` | `continuous = true` + auto-restart on silence |
+| Desktop terminal | `src/lib/structure/TerminalPanel.svelte:449,567-576` | composition guard `IME_CONFIRM_KEYS` includes `\x7f` (DEL); 80ms post-compose window SWALLOWS Backspace after CJK commit |
+| Terminal voice | `src/lib/structure/terminal-voice.svelte.ts:145` | final-only, `send_keys(text + space)` straight to PTY |
+
+Two sub-causes:
+- **A-chat**: whole-text replace + recognizer never stops → deletions回写. Fix = stop/freeze transcript application on user edit (`oninput`/edit → `stop_listening`; base from live value, not frozen `mic_base`).
+- **A-terminal**: 80ms window treats DEL as a confirm key. Fix = drop `\x7f` from `IME_CONFIRM_KEYS` (suppress only space/enter, never Backspace).
+
+## A2. iOS app-mic — second sentence overwrites first (CJK)
+
+Native truth (`src-tauri/plugins/tauri-plugin-ios-speech/ios/Sources/SpeechPlugin.swift`):
+- `bestTranscription.formattedString` cumulative WITHIN one task (:145)
+- `isFinal` → emit `final` + `teardown()` (:149-151) → session ENDS, no auto-continue
+- JS `mic_base` frozen at mic-start; `apply_transcript` whole-replace (`MobileChat.svelte:395`)
+
+Root: design supports only ONE utterance per tap. Second sentence's text arrives
+with `mic_base` still = start value → `input = "" + sentence2` → wipes sentence1.
+No segment-commit / continuation.
+
+Open unknown (needs device log of `partial`/`final` sequence): after `final`+teardown,
+how does sentence 2 even emit events? Either (a) on-device partial regression after
+pause, or (b) a restart. Fix below covers both.
+
+Fix: `apply_transcript` → segment-commit + monotonic anti-regression:
+- maintain `committed` buffer; continuation (longer/prefix) → `input = mic_base + committed + text`
+- regression (shorter/diverged) → fold prev into `committed`, append new
+- on native `final`: commit segment; if user hasn't stopped, `start_listening()` again
+  to continue; do NOT flip `mic_listening` off except on user-stop/error
+
+Product decision needed: continuous multi-sentence dictation (auto-continue) vs one-shot.
+
+## B. Android — soft keyboard covers chat input + terminal keybar
+
+Native patch IS in current source: `MainActivity.kt:29-39` `setOnApplyWindowInsetsListener`
+pads `content` `(0, bars.top, 0, max(ime, bars.bottom))`; `AndroidManifest.xml:15`
+`adjustResize`. (Gitignored — `deploy/android/README.md:115-171` documents required
+re-apply after `tauri android init`.)
+
+| Element | Handling | Verdict |
+|---|---|---|
+| Terminal keybar `MobileTerminal.svelte:679-695` | reads `visualViewport` → `position:fixed`, floats above kb when `kb_inset>0`, z=50 | has float logic; still covered on device → see hypothesis below |
+| Chat composer `MobileChat.svelte:1150-1159` | ONLY `env(safe-area-inset-bottom)`, no visualViewport, no float | **genuine gap — will be covered** |
+
+- **B1 chat composer**: real frontend bug. Fix = mirror terminal `kb_inset` float onto `.ai-composer`.
+- **B2 keybar covered + C below**: likely same root → see hypothesis.
+
+## C. Android — top overlaps status bar (time/signal/battery cover top of app)
+
+Current source SHOULD be fine: `MainActivity.kt:37` pads top by `bars.top`; frontend
+top bars use `env(safe-area-inset-top)` (`MobileChat.svelte:802`, etc.). With native
+top padding, webview sits below status bar.
+
+## CONFIRMED root cause for B2 + C: CI never re-applies the gitignored native inset patches
+
+Device evidence (RMX2111, installed 1.2.1, lastUpdate 2026-06-19 04:22):
+- Workspace + terminal top toolbar draws UNDER the status bar (time/battery/signal overlap) → C
+- Terminal keybar fully hidden behind soft keyboard (no float above IME) → B2
+- Landing screen top is fine (its own layout spacing), so it masked the issue
+
+`.github/workflows/android-build.yml`:
+- `:113 pnpm tauri android init` regenerates `gen/android` from STOCK templates
+- `:126 pnpm tauri android build`
+- **NO step between re-applies `MainActivity.kt` (inset listener) or `AndroidManifest.xml`
+  (`windowSoftInputMode`)** → released APK ships a STOCK MainActivity with zero inset
+  handling. `deploy/android/README.md` documents these as manual post-init patches; CI
+  never runs them. Every released APK is broken on insets. The "validated on RMX2111"
+  memory was a LOCAL build where the patch was hand-applied.
+
+Fix: commit override copies of `MainActivity.kt` + `AndroidManifest.xml` (e.g.
+`deploy/android/overrides/`) and a script that copies them into `gen/android` AFTER
+`tauri android init`, BEFORE `android build` — invoked in CI and documented for local.
+B1 (chat composer) is independent frontend work.
+
+## Status
+
+| Issue | State | Action |
+|---|---|---|
+| A-chat delete | confirmed | edit-stops-transcript fix |
+| A-terminal delete | confirmed | drop `\x7f` from IME_CONFIRM_KEYS |
+| A2 overwrite | confirmed + 1 unknown | segment-commit; need product decision + device log |
+| B1 chat covered | confirmed | float composer on visualViewport |
+| B2 keybar covered | needs device evidence | verify APK has patch |
+| C status-bar overlap | needs device evidence | verify APK has patch |
+
+No code changed yet — awaiting user test results + decisions.

--- a/plan/mobile-input-issues.md
+++ b/plan/mobile-input-issues.md
@@ -91,7 +91,7 @@ B1 (chat composer) is independent frontend work.
 |---|---|---|
 | A-chat delete | confirmed | edit-stops-transcript fix |
 | A-terminal delete | confirmed | drop `\x7f` from IME_CONFIRM_KEYS |
-| A2 overwrite | confirmed + 1 unknown | segment-commit; need product decision + device log |
+| A2 overwrite | WONTFIX | iOS SFSpeech only; built-in OS dictation is enough — whisper.cpp dropped, in-app mic left as-is (see plan/whisper-on-mobile.md) |
 | B1 chat covered | confirmed | float composer on visualViewport |
 | B2 keybar covered | needs device evidence | verify APK has patch |
 | C status-bar overlap | needs device evidence | verify APK has patch |

--- a/plan/whisper-on-mobile.md
+++ b/plan/whisper-on-mobile.md
@@ -1,0 +1,366 @@
+# Native whisper.cpp on-device STT for CatGo mobile — design + implementation plan (2026-06-19)
+
+Replace the iOS-only `SFSpeechRecognizer` voice input with **whisper.cpp linked
+as a native library** (iOS Metal, Android NDK), on the **same JS event contract**
+so the chat consumer barely changes. Grounded against current source; cited
+`file:line` throughout. No production code written yet — this is the spec.
+
+## A. Goal + why
+
+**What:** dictation in the mobile AI chat (and later terminal voice) powered by
+whisper.cpp running natively on the device, not SFSpeech, not WASM-in-webview.
+
+**Why:**
+- **Chinese quality.** SFSpeechRecognizer is weak on Mandarin/code-mixed CN-EN;
+  the team already overrides `zh-HK`/`yue-CN` labels by hand because Apple's
+  locale handling is lossy (`src/lib/mobile/ios-speech.ts:46-50`). Whisper
+  `small`/`medium` multilingual is materially better on zh.
+- **Unify with desktop, conceptually.** Desktop already fled WASM Whisper to a
+  native backend (`server/catgo/routers/stt.py:1-15`: "WebKit webviews leak
+  ~0.8 GB of unreclaimable WASM memory per inference and OOM"). Mobile has the
+  *same* WKWebView, so the *same* rule applies — but mobile is **backend-free**
+  (`src-tauri/tauri.ios.conf.json:4` / `tauri.android.conf.json:4`
+  `"externalBin": []`), so it can't reach a Python sidecar. The native-library
+  route is the mobile analogue of the desktop native backend.
+- **Offline, no API key, audio never leaves the phone** — same privacy posture
+  as today's SFSpeech on-device mode (`SpeechPlugin.swift:114-118`).
+
+**Non-goal / forbidden:** WASM Whisper (transformers.js) in the webview. This is
+the exact bug the team escaped; do not reintroduce it on mobile. See
+`MEMORY: webkit-wasm-memory-leak-native-stt`.
+
+## B. Hard constraints (verified against source)
+
+| Constraint | Evidence |
+|---|---|
+| Mobile is backend-free — no faster-whisper sidecar | `tauri.ios.conf.json:4`, `tauri.android.conf.json:4` `externalBin:[]`; build uses `VITE_STATIC_ONLY=1` |
+| WASM-in-webview forbidden (OOM) | `server/catgo/routers/stt.py:3-6`; MEMORY note |
+| iOS sandbox can't spawn CLI sidecars | so whisper.cpp must be a **linked library**, not the `whisper-cli` binary the desktop accelerator ships |
+| Existing whisper.cpp build emits a **CLI + dylibs**, NOT iOS static libs | `scripts/build-whispercpp.sh:36-48` builds `--target whisper-cli`, copies `*.so/*.dylib/*.dll`; no `xcframework`, no `-DBUILD_SHARED_LIBS=OFF` static `.a`, no iOS toolchain (`-DCMAKE_SYSTEM_NAME=iOS`). The accelerator is **desktop-only** (`build-stt-accel.yml:24-37`: ubuntu/macos-x64/windows runners, `os-arch-api` keys, never an iOS slice). |
+
+**Conclusion:** the existing Metal build output is **not reusable as-is for iOS**.
+It is an x86-or-arm64 *macOS desktop* `whisper-cli` + dylibs. For the phone we need
+a *new* compile: whisper.cpp built for the iOS arm64 device + simulator, Metal
+backend, packaged as an **`.xcframework`** (or static `.a` + headers) and linked
+into the Swift plugin. whisper.cpp upstream ships an iOS example and supports
+`xcframework` packaging, so the toolchain exists; we just don't invoke it yet.
+
+## C. Architecture
+
+### C.1 Plugin shape — extend, don't fork
+
+The current iOS plugin (`src-tauri/plugins/tauri-plugin-ios-speech/`) is the
+proven pattern: a path-dependency Cargo crate
+(`src-tauri/Cargo.toml:97`), registered iOS-only at
+`src-tauri/src/lib.rs:217-218`. Its Swift `SpeechPlugin` already solves the hard
+parts we need to **reuse verbatim**:
+
+- AVAudioEngine mic tap + serial `DispatchQueue` teardown discipline
+  (`SpeechPlugin.swift:35-53,99-191`). The comment block at `:11-20` is
+  load-bearing: engine `stop()`/session `setActive(false)` **block** and freeze
+  the WKWebView if run on main — keep all audio work on `queue`.
+- `installTap`/`removeTap` reentrancy guard via `isTapInstalled`
+  (`SpeechPlugin.swift:50-53,128-185`).
+- `trigger("partial"/"final"/"error", ...)` event emission
+  (`SpeechPlugin.swift:150-163`) — the JS side (`ios-speech.ts:123-137`) listens
+  on exactly these names.
+
+**Decision:** rather than a brand-new `tauri-plugin-mobile-whisper`, **add a
+whisper engine inside the existing plugin** and keep the SFSpeech engine as a
+fallback (see §H Migration). The Rust command surface and JS bridge stay; only
+the Swift gains a `WhisperEngine` alongside the SFSpeech path, switched by a
+`engine` arg on `start_listening`. This minimizes the `gen/apple` regeneration
+surface (one plugin, not two) and keeps `MobileChat.svelte` untouched.
+
+> If Android forces a clean split (different language/build), we can rename to
+> `tauri-plugin-mobile-speech` and host both platforms' native code under it.
+> Keep the crate/JS names stable to avoid touching `lib.rs` and capabilities.
+
+### C.2 Audio → inference dataflow (the streaming problem)
+
+SFSpeech is natively streaming: it hands back a growing `formattedString` each
+callback (`SpeechPlugin.swift:144-154`). **whisper.cpp is NOT streaming** — it
+transcribes a *complete* PCM buffer in one shot. We must synthesize the
+`partial`/`final` contract on top of a batch transcriber:
+
+```
+mic (AVAudioEngine tap, 16 kHz mono f32)         [reuse SpeechPlugin tap]
+  → ring buffer (PCM, accumulating)
+  → VAD-segmented OR sliding-window scheduler
+     · partial: every ~1.0–1.5 s, run whisper on [start..now] of the
+       current utterance → trigger("partial", full text so far)
+     · final:   on VAD silence (~600–800 ms) OR stop_listening() →
+       run whisper on the whole utterance → trigger("final", text); reset buffer
+  → whisper.cpp full(ctx, params, pcm) on a background queue (Metal)
+```
+
+Two viable strategies (recommend starting with **sliding re-decode**, simplest):
+
+1. **Sliding re-decode (recommend for v1).** Keep the whole current utterance in
+   a buffer; on a timer (or on every N samples) re-run whisper on the entire
+   utterance-so-far and emit the result as `partial`. On silence/stop, the last
+   decode is the `final`. Simple, matches the "full running transcript each
+   event" contract `apply_transcript` already assumes
+   (`MobileChat.svelte:380-395`). Cost: O(utterance²) compute as it grows — fine
+   for short chat utterances (a few seconds), bad for long dictation. Cap
+   utterance length (e.g. force a `final`+segment-commit at ~15 s).
+2. **VAD-segmented commit.** Run a lightweight VAD (whisper.cpp ships an energy
+   VAD; or port the desktop Silero approach noted in `stt.py:13-14`), decode each
+   speech segment once on its trailing edge, emit `final` per segment. Lower CPU,
+   but partials within a segment need a separate timer. This is the better
+   long-term design and aligns with desktop (browser runs Silero VAD, POSTs
+   segments — `stt.py:12-14`).
+
+**Latency tradeoff vs SFSpeech (be honest in the UX):** SFSpeech partials feel
+instant. whisper partials lag by the decode time of the model on the phone CPU/GPU
+(tiny ~real-time on A-series Metal; small noticeably slower). Set expectations:
+partials may update every ~1 s, not per-word. If that feels bad, keep SFSpeech as
+the default for English and offer Whisper as the "better Chinese" option (§H).
+
+### C.3 JS contract — unchanged
+
+`src/lib/mobile/ios-speech.ts` stays the public surface: `start_listening`,
+`stop_listening`, `supported_locales`, `on_transcript({on_partial,on_final,
+on_error})` (`ios-speech.ts:93-159`). `MobileChat.svelte:407-442 toggle_mic` and
+`:389-400 apply_transcript` need **no change** for the happy path — whisper just
+becomes the engine behind the same events.
+
+One addition: an **engine selector**. Add an optional `engine?: 'sfspeech' |
+'whisper'` (and `model?` for whisper size) to `start_listening`, defaulting per
+§H. `supported_locales()` for whisper returns whisper's multilingual set (a fixed
+list, not Apple's), so the picker (`MobileChat.svelte:343-360`) keys off the
+active engine.
+
+## D. iOS implementation
+
+### D.1 Build whisper.cpp for iOS (the missing artifact)
+
+New script `scripts/build-whispercpp-ios.sh` (sibling to the existing
+`build-whispercpp.sh`). It must:
+- clone whisper.cpp at a **pinned ref** (the desktop script already pins via the
+  3rd arg — `build-whispercpp.sh:15-16`; reuse the same ref for parity).
+- build **static** libs for `arm64` device + `arm64`/`x86_64` simulator with
+  `-DGGML_METAL=1 -DBUILD_SHARED_LIBS=OFF` and the iOS toolchain
+  (`-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0` — matches
+  `Package.swift:8` `.iOS(.v13)`), or invoke whisper.cpp's own
+  `build-xcframework.sh` if present at the pinned ref.
+- package as `whisper.xcframework` (libwhisper + libggml + libggml-metal +
+  `default.metallib` + headers) staged into the plugin's `ios/` tree.
+
+> Metal note: whisper.cpp's Metal backend needs `ggml-metal.metal`/`default.metallib`
+> bundled and loadable at runtime. The plugin must add the metallib as a bundle
+> resource and point GGML at it. This is the #1 iOS-Metal footgun.
+
+### D.2 Link into the Swift plugin
+
+`tauri-plugin-ios-speech/ios/Package.swift` currently has one target depending on
+`Tauri` (`Package.swift:19-26`). Add:
+- a **binary target** for `whisper.xcframework`:
+  `.binaryTarget(name: "whisper", path: "whisper.xcframework")`, and add `whisper`
+  to the plugin target's `dependencies`.
+- the metallib + GGML model resources via `.copy(...)` in the target's
+  `resources:` (or bundle them through the Xcode project — see §G regeneration).
+
+The committed-source boundary is favorable: the plugin's `.gitignore` only
+ignores regenerated bindings (`.tauri/`, `ios/.build/`, `Package.resolved`,
+`permissions/autogenerated/`) — **hand-authored Swift + Package.swift +
+default.toml are committed**. So we *can* commit a checked-in `Package.swift` that
+references the xcframework. The xcframework binary itself (~tens of MB) should be
+fetched/built rather than committed (see §G + §F download decision).
+
+### D.3 Swift `WhisperEngine`
+
+New `ios/Sources/WhisperEngine.swift`, mirroring `SpeechPlugin`'s threading:
+- reuse the AVAudioEngine tap (factor the audio capture out of `SpeechPlugin` so
+  both engines share it; tap delivers 16 kHz mono f32 — note SFSpeech uses the
+  input node's native format `SpeechPlugin.swift:127`, whisper needs a
+  **resample to 16 kHz mono** via `AVAudioConverter`).
+- own a `whisper_context` loaded from the GGML model (lazy, once).
+- run the sliding/VAD scheduler (§C.2) on the serial `queue`; call
+  `whisper_full` on a **dedicated inference queue** so a long decode doesn't stall
+  the mic tap.
+- emit `trigger("partial"/"final"/"error", ["text": ...])` — identical to
+  `SpeechPlugin.swift:150-163`, so JS is unchanged.
+
+### D.4 Permissions — simpler than today
+
+whisper does **not** use Apple's Speech framework, so
+`NSSpeechRecognitionUsageDescription` is **not required** for the whisper path
+(only `NSMicrophoneUsageDescription`). Today both are declared
+(`src-tauri/Info.ios.plist:22-25`). Keep both while SFSpeech remains a fallback;
+if we ever fully drop SFSpeech, the speech-recognition string can go. The plugin's
+`requestPermission` (`SpeechPlugin.swift:65-72`) currently AND-gates mic+speech —
+add a mic-only path for the whisper engine so denial of speech auth doesn't block
+whisper.
+
+## E. Android implementation (greenfield — flag the effort)
+
+**There is no existing Android native plugin.** `src-tauri/plugins/` holds only
+`tauri-plugin-bg-grace` and `tauri-plugin-ios-speech`, both iOS-only
+(`grep` confirmed: zero `.kt`, zero `android/` plugin dirs). So Android voice
+input **does not exist today at all** — this is net-new, the larger of the two
+phases.
+
+Shape (Tauri mobile Android plugin = Kotlin + JNI):
+- add an `android/` source set to the plugin (Kotlin `@TauriPlugin` class with
+  `@Command` methods mirroring the iOS `@objc` commands), registered through the
+  same Rust `init()` (`src/lib.rs` gains an Android-cfg `register_android_plugin`
+  branch alongside the iOS one at `:217-218`).
+- mic capture via `AudioRecord` (16 kHz mono PCM16) → same ring-buffer/VAD
+  scheduler.
+- whisper.cpp built via the **NDK** (`-DCMAKE_SYSTEM_NAME=Android`,
+  ABIs `arm64-v8a` + optionally `x86_64` for emulator), producing
+  `libwhisper.so`/`libggml*.so` under `jniLibs/<abi>/`. CPU backend first;
+  **Vulkan optional** (whisper.cpp supports `-DGGML_VULKAN=1` — the desktop script
+  already does Vulkan, `build-whispercpp.sh:19`, so the shader build is known, but
+  Android Vulkan driver coverage is uneven — make it opt-in).
+- JNI bridge (small C shim or `whisper.cpp`'s bundled `whisper_android` JNI) so
+  Kotlin can call `whisper_full` and stream text back via the same
+  `trigger(...)` event names.
+
+**Effort flag:** Android is roughly 2× the iOS work — new Kotlin plugin
+scaffolding, NDK cross-compile in CI, JNI, AudioRecord, AND it must survive the
+`gen/android` regeneration problem (§G) which is *already* biting released APKs
+(`plan/mobile-input-issues.md:67-86`).
+
+## F. Model management
+
+| Question | Recommendation |
+|---|---|
+| Which model | **`ggml-small`** multilingual for zh quality, or **distil-small** if a GGML build exists, as the default. Offer `tiny`/`base` as a "fast" option for low-end devices. Use **quantized** GGML (`q5_0`/`q8_0`) to cut size & memory. |
+| Size impact | tiny ≈ 75 MB, base ≈ 142 MB, small ≈ 466 MB (q5 ≈ 180 MB), medium ≈ 1.5 GB. small-q5 (~180 MB) is the sweet spot for zh. **Do NOT bundle** a 180 MB+ model in the IPA/APK. |
+| Bundle vs download | **Download-on-demand**, mirroring the desktop accelerator exactly (`stt.py:248-277` `/accel/install` + `/accel/model`; `deploy/stt-accel/README.md:17` "Everything lands in `~/.catgo/stt-accel/{bin,models}` — never the app bundle"). On mobile there's no backend, so the **plugin** (Swift/Kotlin) downloads the GGML from a pinned URL (GitHub Release, same as `stt-accel-manifest.json`) into app-support storage, sha256-verified. |
+| Storage path | iOS: `Application Support/whisper/ggml-<size>.bin`. Android: `filesDir/whisper/`. Mirror the desktop `accel.model_path` naming `ggml-<size>.bin` (`stt.py:57-61`) for cross-surface consistency. |
+| First-run UX | First mic tap with whisper engine + no model → emit a `partial`/`error` or a dedicated `model_required` event; the chat shows a one-time "Download voice model (~180 MB, Wi-Fi recommended)" sheet, then a progress indicator. Reuse the language-sheet pattern (`MobileChat.svelte:338,356-360`). Offer Wi-Fi-only gating. |
+| Offline | Once downloaded, fully offline (the whole point). |
+
+Optionally tiny/base **could** be bundled (75–142 MB) so voice works out-of-box
+with a "download small for better Chinese" upsell. Decide per IPA/APK size budget
+(open question §K).
+
+## G. Build / CI impact — surviving `gen/{apple,android}` regeneration
+
+This is the highest-risk operational concern, and it's a **known active bug**:
+`plan/mobile-input-issues.md:67-86` documents that CI's `tauri android init`
+regenerates `gen/android` from stock templates and **never re-applies** the
+committed `MainActivity.kt`/`AndroidManifest.xml` patches, so **every released APK
+ships broken inset handling**. Native whisper linking must not fall into the same
+trap.
+
+**iOS is mostly safe by construction.** The plugin lives *outside* `gen/apple` —
+it's a path-dependency crate with **committed Swift + Package.swift**
+(`.gitignore` only sheds `.tauri/`, `.build/`, `Package.resolved`). `tauri ios
+init`/`build` regenerates `gen/apple` but pulls the plugin in via Cargo +
+`register_ios_plugin` (`lib.rs:176`), so the Swift survives. **What does NOT
+survive automatically:** Xcode project settings that must live in `gen/apple`
+(e.g. embedding the metallib/model as bundle resources, extra framework search
+paths if not expressed via Package.swift). Prefer expressing **everything**
+through `Package.swift` `resources:`/`binaryTarget` so it's plugin-local and
+regeneration-proof; anything that can't be must be re-applied by a committed
+override + post-init script — the same fix `mobile-input-issues.md:83-85`
+prescribes for Android.
+
+**Android is NOT safe by construction.** The Kotlin plugin source can live in the
+committed plugin dir, but `jniLibs` placement, NDK ABI config, and Gradle deps may
+land in `gen/android`. **Action:** extend the override mechanism the input-issues
+plan already calls for (`deploy/android/overrides/` + a post-`init` copy script
+run in CI) to also stage `jniLibs/*` and any Gradle snippets. Build the whisper
+`.so`s in a CI step (NDK) before `tauri android build`, copy into the regenerated
+`gen/android/app/src/main/jniLibs/`.
+
+**New CI:** add iOS-arm64 + Android-NDK whisper.cpp build jobs. Model these on
+`build-stt-accel.yml` but with **mobile toolchains** (the existing matrix is
+desktop-only — `build-stt-accel.yml:24-37`). Output an `xcframework` artifact and
+per-ABI `.so` artifacts; publish GGML models + a mobile manifest to a Release
+(reuse the `stt-accel-manifest.json` assembler pattern,
+`build-stt-accel.yml:115-154`).
+
+## H. Migration — keep SFSpeech, add an engine toggle
+
+**Recommend: do NOT hard-replace SFSpeech.** Add an **engine abstraction** in
+`ios-speech.ts` and a user toggle:
+- `engine: 'sfspeech' | 'whisper'`, persisted next to `voice_locale`
+  (`ios-speech.ts:74-91` `localStorage` pattern). Default `sfspeech` for English
+  locales (instant partials, zero download), `whisper` offered/auto for zh.
+- `start_listening(locale, {engine, model})`; the Swift plugin routes to
+  `SpeechPlugin` (existing) or `WhisperEngine` (new). Same events out.
+- `supported_locales()` returns Apple's set for sfspeech (`SpeechPlugin.swift:58-61`)
+  vs whisper's multilingual set for whisper.
+- Fallback chain: whisper selected but model missing/download-declined → fall back
+  to sfspeech (iOS) with a notice; Android has no sfspeech, so whisper is the only
+  engine there and the model download is mandatory before first use.
+
+This makes the change **additive** (preserve-existing-functionality), keeps
+`MobileChat.svelte` ~unchanged, and lets us ship iOS-whisper as opt-in before
+trusting it as default.
+
+## I. Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| iOS memory — but **native**, not webview | low | This is the whole point: native whisper has no JSC/WASM leak (`stt.py:3-6`). Still cap utterance length & free `whisper_context` on teardown. |
+| Inference latency on phone | **high** | tiny/base near real-time on Metal; small lags. Sliding re-decode is O(n²). Default to smaller model for partials, decode `small` only for `final`; or VAD-segment (§C.2). Set UX expectations. |
+| Binary size (xcframework + libggml-metal) | med | Static libs add several MB to the IPA; acceptable. Models are the real weight → download-on-demand (§F). |
+| Model download bandwidth (~180 MB) | med | Wi-Fi-only default, progress UI, resumable, sha256-verified; one-time. |
+| Battery / thermal during long dictation | med | whisper on Metal/CPU is heavier than SFSpeech. Cap session length; stop engine promptly on teardown (reuse `SpeechPlugin` teardown discipline `:176-191`). |
+| App Store / Play review | low | On-device ML is fine; no ITSAppUsesNonExemptEncryption surprises. Downloading a model post-install is allowed (it's data, not executable code) — keep it data-only, never download executable binaries on iOS. |
+| `gen/{apple,android}` regeneration losing native linking | **high** (already biting Android) | §G: express via Package.swift on iOS; committed overrides + post-init script + CI build step on Android. |
+| Android greenfield scope | high | Phase it after iOS (§J); it's a new Kotlin/JNI/NDK plugin from zero. |
+
+**Single biggest risk: inference latency / streaming UX** — whisper isn't
+streaming, so matching SFSpeech's instant per-word partials on a phone is the hard
+part; the sliding-window/VAD design and model-size choices in §C.2/§F are the
+whole ballgame.
+
+## J. Phased rollout + task breakdown
+
+### Phase 0 — spike (validate the unknown)
+- [ ] `scripts/build-whispercpp-ios.sh`: build whisper.cpp `xcframework` (Metal,
+      static, arm64 device+sim) at the pinned ref. **Verify the metallib loads on
+      a real device.** (highest-uncertainty step — do first)
+- [ ] Throwaway Swift harness: load `ggml-tiny`, transcribe a bundled wav,
+      measure decode latency on an actual iPhone. Decide sliding vs VAD.
+
+### Phase 1 — iOS whisper engine (reuses existing plugin + Metal toolchain)
+- [ ] Factor shared AVAudioEngine capture out of `SpeechPlugin.swift` into a
+      `MicCapture` helper (16 kHz mono f32 via `AVAudioConverter`).
+- [ ] `ios/Sources/WhisperEngine.swift`: context load, scheduler, `trigger` events.
+- [ ] `ios/Package.swift`: add `whisper` binaryTarget + metallib resource
+      (`Package.swift:19-26`).
+- [ ] `src/lib.rs` Swift plugin: add `start_listening` `engine`/`model` args; route.
+- [ ] `tauri-plugin-ios-speech/src/lib.rs`: thread `engine`/`model` through
+      `StartArgs` (`lib.rs:61-64,97-101`).
+- [ ] Model download in Swift (app-support, sha256, progress events) + a
+      `model_required`/progress event.
+- [ ] `ios-speech.ts`: engine field, persisted toggle, whisper locale set
+      (`ios-speech.ts:74-101`).
+- [ ] `MobileChat.svelte`: engine picker in the language sheet (`:338,356-360`);
+      `model_required` → download sheet. Keep `apply_transcript` (`:389-400`) and
+      `toggle_mic` (`:407-442`) otherwise intact.
+- [ ] CI: iOS-arm64 whisper build job; publish xcframework + GGML + manifest.
+- [ ] Permissions: mic-only path for whisper (`SpeechPlugin.swift:65-72`).
+
+### Phase 2 — Android (greenfield)
+- [ ] Kotlin `@TauriPlugin` under the plugin's `android/` source set; Rust
+      `register_android_plugin` branch in `src/lib.rs` (mirror `:217-218`).
+- [ ] `AudioRecord` capture → same scheduler.
+- [ ] NDK whisper.cpp build (`arm64-v8a` CPU, optional Vulkan) → `jniLibs/`.
+- [ ] JNI bridge to `whisper_full`; emit same `trigger` events.
+- [ ] Extend `deploy/android/overrides/` + post-`init` script (per
+      `mobile-input-issues.md:83-85`) to stage `jniLibs` + Gradle; wire into
+      `android-build.yml` BEFORE `android build`.
+- [ ] Model download in Kotlin (`filesDir/whisper/`), mandatory before first use.
+
+## K. Open questions for the user
+1. **Default engine on iOS:** SFSpeech for EN + Whisper for zh (auto by locale),
+   or Whisper-everywhere? (latency vs quality)
+2. **Model size default:** `small-q5` (~180 MB, best zh) vs `base` (~140 MB) vs
+   ship `tiny` bundled + upsell small?
+3. **Bundle a tiny model in the IPA/APK** for out-of-box voice, or pure
+   download-on-demand (zero size cost, but first voice needs a download)?
+4. **Android priority:** is Android voice input wanted now (greenfield, ~2× the
+   work), or iOS-first and defer Android?
+5. **Terminal voice on mobile too?** Desktop terminal voice exists
+   (`terminal-voice.svelte.ts`); should the mobile terminal keybar also get
+   whisper dictation, or chat-only for v1?
+6. **Vulkan on Android** worth the extra build/driver-coverage risk, or CPU-only?

--- a/plan/whisper-on-mobile.md
+++ b/plan/whisper-on-mobile.md
@@ -1,3 +1,13 @@
+> **DECISION (2026-06-19): NOT pursuing.** The built-in OS keyboard dictation
+> (Android Gboard / iOS 听写) is already strong enough for CJK and other input,
+> and it feeds text fields as ordinary input — the terminal CJK `insertText` fix
+> (commit d4a7db3) already covers dictation into the terminal. Building/shipping
+> a whisper.cpp engine + model download was judged not worth the size/battery/
+> maintenance cost. This document is retained for the analysis (esp. why
+> WASM-in-WebView is forbidden — the WebKit OOM leak) should the decision be
+> revisited. The in-app SFSpeech mic button (iOS) stays as-is; its multi-sentence
+> "second sentence overwrites first" quirk (A2) is left unfixed.
+
 # Native whisper.cpp on-device STT for CatGo mobile — design + implementation plan (2026-06-19)
 
 Replace the iOS-only `SFSpeechRecognizer` voice input with **whisper.cpp linked

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -632,6 +632,10 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
   let voice_recording = $state(false)
   let voice_supported = $state(false)
   let recognition: any = null
+  // Set once the user edits the box while recording. onresult rewrites the whole
+  // input_text each event, so without this a deletion/edit is instantly clobbered
+  // by the next interim result (Chinese feels un-deletable while the mic is live).
+  let voice_edited = $state(false)
 
   $effect(() => {
     voice_supported = typeof window !== `undefined` &&
@@ -659,6 +663,7 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
     recognition.lang = voice_language
 
     recognition.onresult = (event: any) => {
+      if (voice_edited) return // user took over the box — don't clobber their edit
       let transcript = ``
       for (let i = 0; i < event.results.length; i++) {
         transcript += event.results[i][0].transcript
@@ -674,6 +679,7 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
     }
     recognition.onerror = () => { voice_recording = false }
 
+    voice_edited = false // fresh session — transcripts may drive the box again
     voice_recording = true
     recognition.start()
   }
@@ -879,6 +885,17 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
     if (!textarea_el) return
     textarea_el.style.height = `auto`
     textarea_el.style.height = `${Math.min(textarea_el.scrollHeight, 120)}px`
+  }
+
+  // Real user edit on the composer. A programmatic `input_text = transcript`
+  // assignment does NOT fire `input`, so this only trips on genuine typing/
+  // deletion — at which point we stop voice from overwriting the box.
+  function on_input_edit() {
+    auto_resize()
+    if (voice_recording && !voice_edited) {
+      voice_edited = true
+      stop_voice()
+    }
   }
 
   $effect(() => {
@@ -1820,7 +1837,7 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
           bind:value={input_text}
           bind:this={textarea_el}
           onkeydown={handle_keydown}
-          oninput={auto_resize}
+          oninput={on_input_edit}
           onpaste={handle_attach_paste}
           onfocus={(e) => { const w = (e.target as HTMLElement).closest(`.input-wrapper`); w?.classList.add(`focused`) }}
           onblur={(e) => { const w = (e.target as HTMLElement).closest(`.input-wrapper`); w?.classList.remove(`focused`) }}

--- a/src/lib/mobile/MobileChat.svelte
+++ b/src/lib/mobile/MobileChat.svelte
@@ -317,6 +317,12 @@
   // ios-speech.ts). Mic is offered only on the native shell; in a plain browser
   // the plugin commands don't exist.
   let mic_listening = $state(false)
+  // Set true once the user manually edits the box during/after dictation. The
+  // recognizer streams the FULL running transcript each event, so apply_transcript
+  // reassigns `input` outright — which would clobber a user's deletion/edit (and
+  // make Chinese feel un-deletable while the mic is live). Once the user takes
+  // over the box we freeze transcript application until the next mic tap.
+  let mic_edited = $state(false)
   // Guards toggle_mic against re-entry: a rapid double-tap could otherwise fire a
   // new start_listening before the previous stop_listening IPC resolved, colliding
   // two sessions at the native plugin.
@@ -369,6 +375,45 @@
     mic_unlisten = null
   })
 
+  // The user typed/deleted in the box. If the mic is live, freeze transcript
+  // application (so the recognizer can't overwrite the edit) and end the session.
+  // bind:value assignments do NOT fire `input`, so this only catches real edits.
+  function on_user_edit(): void {
+    if (mic_listening && !mic_edited) {
+      mic_edited = true
+      mic_listening = false
+      void stop_listening().catch(() => {})
+    }
+  }
+
+  // ── Soft-keyboard inset (B1) ──
+  // On iOS WKWebView the keyboard shrinks window.visualViewport but NOT the
+  // layout viewport, so the bottom-anchored composer (.ai-overlay is
+  // position:absolute inset:0) stays behind the keyboard. Pad the overlay bottom
+  // by the keyboard overlap so the composer floats above it. On Android the
+  // native MainActivity inset listener already shrinks the WebView and
+  // visualViewport does NOT shrink for the IME, so this computes ~0 and we don't
+  // double-count. Mirrors MobileTerminal's kb_inset.
+  let kb_inset = $state(0)
+  $effect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    let last = -1
+    const update = () => {
+      const next = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop))
+      if (next === last) return
+      last = next
+      kb_inset = next
+    }
+    update()
+    vv.addEventListener(`resize`, update)
+    vv.addEventListener(`scroll`, update)
+    return () => {
+      vv.removeEventListener(`resize`, update)
+      vv.removeEventListener(`scroll`, update)
+    }
+  })
+
   // TODO(you): apply a streamed transcript to the composer.
   //
   // Called for every recognizer event: `text` is the FULL transcript so far,
@@ -387,6 +432,11 @@
   // Keep it ~6-10 lines. Helpers in scope: `input` ($state, bound to the
   // textarea), `mic_base`, `mic_listening` ($state), `send()`.
   function apply_transcript(text: string, is_final: boolean): void {
+    // The user grabbed the box mid-dictation (edited/deleted) — stop overwriting
+    // it. Without this, every streamed transcript (incl. the final emitted by
+    // stop_listening) reassigns `input` and wipes the user's edit, so deleting
+    // Chinese while the mic is live feels impossible.
+    if (mic_edited) return
     // Preserve anything typed before the mic started. The recognizer streams the
     // FULL running transcript each event, so set `input` outright — concatenating
     // would duplicate ("show show the…"). Add a space only when joining onto
@@ -419,6 +469,7 @@
         return
       }
       mic_base = input
+      mic_edited = false // fresh session — transcripts may drive the box again
       // Subscribe before starting so no early partial is missed; reuse one set of
       // listeners across sessions (re-tapping mic just re-arms start_listening).
       if (!mic_unlisten) {
@@ -510,7 +561,7 @@
   }
 </script>
 
-<div class="ai-overlay">
+<div class="ai-overlay" style="padding-bottom: {kb_inset}px">
   <header class="ai-head">
     <!-- Chat tab strip: tap = switch, long-press = close sheet, + = new (capped
          at MAX_CHAT_TABS). Mirrors the terminal tab bar. -->
@@ -683,6 +734,7 @@
         placeholder={t(`mobile.ai_message_placeholder`)}
         bind:value={input}
         onkeydown={on_input_keydown}
+        oninput={on_user_edit}
       ></textarea>
       {#if mic_supported}
         {#if voice_locale}
@@ -791,6 +843,9 @@
     display: flex;
     flex-direction: column;
     background: var(--page-bg, #0e1117);
+    /* padding-bottom is set inline to the soft-keyboard inset (B1) so the
+       composer floats above the keyboard on iOS; glide it to avoid a jump. */
+    transition: padding-bottom 0.18s ease;
   }
   .ai-head {
     display: flex;

--- a/src/lib/mobile/__tests__/terminal-ime.test.ts
+++ b/src/lib/mobile/__tests__/terminal-ime.test.ts
@@ -73,6 +73,22 @@ describe(`createImeGuard`, () => {
     expect(g.should_suppress(` `)).toBe(false)
   })
 
+  it(`never swallows Backspace (DEL) — not as residue, not mid-composition`, () => {
+    // Regression: on iOS/Android WKWebView, compositionend for CJK is
+    // unreliable, so std_composing could stick true and eat EVERY backspace —
+    // the user could not delete Chinese characters they had just typed. A DEL
+    // reaching onData is always a real edit intent; honor it unconditionally.
+    let t = 1000
+    const g = createImeGuard({ write: vi.fn(), now: () => t })
+    // In the post-compose residue window: space is dropped, Backspace is NOT.
+    g.on_composition_end(`字`)
+    expect(g.should_suppress(` `)).toBe(true)
+    expect(g.should_suppress(`\x7f`)).toBe(false)
+    // Even while a composition is (stuck) open, Backspace passes through.
+    g.on_composition_start()
+    expect(g.should_suppress(`\x7f`)).toBe(false)
+  })
+
   it(`never arms the residue window for pure Latin typing`, () => {
     const g = createImeGuard({ write: vi.fn(), now: () => 0 })
     // No composition has happened, so a typed space is never suppressed.

--- a/src/lib/mobile/__tests__/terminal-ime.test.ts
+++ b/src/lib/mobile/__tests__/terminal-ime.test.ts
@@ -73,6 +73,30 @@ describe(`createImeGuard`, () => {
     expect(g.should_suppress(` `)).toBe(false)
   })
 
+  it(`flushes a buffered WK composition on compositionend, even when it carries no data`, () => {
+    // Regression ("会少最新的输入" — the latest CJK word is dropped): a word
+    // buffered via the WK beforeinput path waits for a flush trigger. The LAST
+    // word has no trailing keydown, so compositionend must flush the buffer.
+    // Some platforms deliver an EMPTY compositionend after the real text already
+    // arrived via beforeinput, so fall back to the buffered partial.
+    const write = vi.fn()
+    const g = createImeGuard({ write, now: () => 0 })
+    expect(g.on_before_input(`insertReplacementText`, `你好`)).toBe(true)
+    expect(write).not.toHaveBeenCalled()
+    g.on_composition_end(null) // empty/dataless end — the bug's trigger
+    expect(write).toHaveBeenCalledWith(`你好`)
+    expect(write).toHaveBeenCalledTimes(1)
+  })
+
+  it(`does not double-write when compositionend carries the committed text`, () => {
+    const write = vi.fn()
+    const g = createImeGuard({ write, now: () => 0 })
+    g.on_before_input(`insertReplacementText`, `你好`)
+    g.on_composition_end(`你好`) // committed data present — must not also flush buffer
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledWith(`你好`)
+  })
+
   it(`never swallows Backspace (DEL) — not as residue, not mid-composition`, () => {
     // Regression: on iOS/Android WKWebView, compositionend for CJK is
     // unreliable, so std_composing could stick true and eat EVERY backspace —
@@ -113,5 +137,21 @@ describe(`createImeGuard`, () => {
     // The second is still pending until a real key flushes it.
     g.on_keydown(13)
     expect(write).toHaveBeenLastCalledWith(`나`)
+  })
+
+  it(`writes a Chinese insertText word immediately (no stranded last word)`, () => {
+    // Android WebView (observed on-device) delivers each committed Chinese word
+    // as a collapsed `insertText` with NO composition events. Buffering it (as we
+    // must for Korean jamo, which rebuild via insertReplacementText) stranded the
+    // LAST word — it flushed only on the NEXT event ("会少最新的输入"). A complete
+    // CJK ideograph is final, so write it on arrival.
+    const write = vi.fn()
+    const g = createImeGuard({ write, now: () => 0 })
+    expect(g.on_before_input(`insertText`, `你好`)).toBe(true)
+    expect(write).toHaveBeenNthCalledWith(1, `你好`)
+    expect(g.on_before_input(`insertText`, `朋友`)).toBe(true)
+    expect(write).toHaveBeenNthCalledWith(2, `朋友`)
+    // No trailing keydown/compositionend needed — both already written.
+    expect(write).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/lib/mobile/terminal-ime.ts
+++ b/src/lib/mobile/terminal-ime.ts
@@ -30,6 +30,20 @@ export function isCJK(text: string): boolean {
   )
 }
 
+/** Hangul (Korean) on the first code point. A Hangul jamo/syllable typed as a
+ *  standalone insertText may be REBUILT by a following insertReplacementText, so
+ *  it must be buffered; non-Hangul CJK (Chinese/Japanese) insertText is final. */
+export function isHangul(text: string): boolean {
+  const cp = text.codePointAt(0) ?? 0
+  return (
+    (cp >= 0x1100 && cp <= 0x11ff) || // Hangul Jamo
+    (cp >= 0x3130 && cp <= 0x318f) || // Hangul Compatibility Jamo
+    (cp >= 0xac00 && cp <= 0xd7af) || // Hangul Syllables
+    (cp >= 0xa960 && cp <= 0xa97f) || // Hangul Jamo Extended-A
+    (cp >= 0xd7b0 && cp <= 0xd7ff) //    Hangul Jamo Extended-B
+  )
+}
+
 // After a composition commits, xterm's deferred _finalizeComposition (and the
 // textarea clear we do) can emit a stray space/enter. Swallow those for a brief
 // window. The window is armed ONLY by a composition ending, so pure Latin typing
@@ -89,12 +103,23 @@ export function createImeGuard(opts: {
         wk_pending = data
         return true
       }
-      // A standalone CJK character may start a new composition (Korean jamo):
-      // flush the previous buffer, then buffer this one.
       if (input_type === `insertText` && data && isCJK(data)) {
-        flush()
-        wk_composing = true
-        wk_pending = data
+        flush() // emit any prior buffered partial first
+        if (isHangul(data)) {
+          // A standalone Hangul jamo/syllable may be REBUILT by a following
+          // insertReplacementText (ㅎ → 하 → 한, or 가 → 각) — buffer it so the
+          // rebuild replaces rather than appends.
+          wk_composing = true
+          wk_pending = data
+        } else {
+          // Chinese / Japanese: the committed word arrives as a collapsed
+          // insertText with NO composition events on this WebView (observed on
+          // Android). It is final and never rebuilt, so write it on arrival.
+          // Buffering it would strand the LAST word — it would flush only on the
+          // NEXT event, dropping the latest input ("会少最新的输入").
+          opts.write(data)
+          post_compose_until = now() + POST_COMPOSE_MS
+        }
         return true
       }
       return false
@@ -106,7 +131,15 @@ export function createImeGuard(opts: {
     on_composition_end(committed) {
       std_composing = false
       post_compose_until = now() + POST_COMPOSE_MS
-      if (committed) opts.write(committed)
+      // The composition is over: emit the final text and CLEAR the WK buffer so
+      // the last CJK word is never stranded waiting for a keydown that won't come
+      // ("会少最新的输入" — the latest word dropped). Prefer the event's committed
+      // data; fall back to the buffered partial when the platform delivers the
+      // text via beforeinput and sends a dataless compositionend.
+      const text = committed || wk_pending
+      wk_composing = false
+      wk_pending = ``
+      if (text) opts.write(text)
     },
     on_keydown(key_code) {
       // keyCode 229 = "IME is processing" — don't flush mid-composition.

--- a/src/lib/mobile/terminal-ime.ts
+++ b/src/lib/mobile/terminal-ime.ts
@@ -31,13 +31,14 @@ export function isCJK(text: string): boolean {
 }
 
 // After a composition commits, xterm's deferred _finalizeComposition (and the
-// textarea clear we do) can emit a stray space/enter/DEL. Swallow those for a
-// brief window. The window is armed ONLY by a composition ending, so pure Latin
-// typing never enters it (a deliberately-typed space/Enter is never eaten).
+// textarea clear we do) can emit a stray space/enter. Swallow those for a brief
+// window. The window is armed ONLY by a composition ending, so pure Latin typing
+// never enters it (a deliberately-typed space/Enter is never eaten).
 // `\u00a0` (non-breaking space) is included because some IMEs/keyboards emit NBSP
 // rather than a plain space as the confirmation key after a composition.
+// DEL (`\x7f`, Backspace) is deliberately NOT in this set \u2014 see should_suppress.
 const POST_COMPOSE_MS = 80
-const IME_CONFIRM_KEYS = new Set([` `, `\n`, `\r`, `\x7f`, `\u00a0`])
+const IME_CONFIRM_KEYS = new Set([` `, `\n`, `\r`, `\u00a0`])
 
 export interface ImeGuard {
   /** From `beforeinput`. Returns true if this was a CJK-composition event the
@@ -112,6 +113,11 @@ export function createImeGuard(opts: {
       if (wk_composing && key_code !== 229) flush()
     },
     should_suppress(data) {
+      // A Backspace/DEL reaching onData is always a real edit intent — never
+      // swallow it. WKWebView fires compositionend unreliably for CJK, so
+      // std_composing can stick `true` and would otherwise eat every backspace,
+      // leaving the user unable to delete Chinese they just typed.
+      if (data === `\x7f`) return false
       if (std_composing || wk_composing) return true
       if (post_compose_until > 0) {
         if (now() < post_compose_until && IME_CONFIRM_KEYS.has(data)) return true

--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -446,7 +446,10 @@
         let post_compose_until = 0     // suppress confirmation-key residue until this time
 
         const POST_COMPOSE_MS = 80
-        const IME_CONFIRM_KEYS = new Set([` `, `\n`, `\r`, `\x7f`, `\u00a0`])
+        // DEL (`\x7f`, Backspace) is deliberately NOT here \u2014 it is never IME
+        // residue, and WebKit's unreliable CJK compositionend can otherwise
+        // leave std_composing stuck and eat every backspace (see onData below).
+        const IME_CONFIRM_KEYS = new Set([` `, `\n`, `\r`, `\u00a0`])
 
         // ─── IME event tracing (enable: window.__CATGO_IME_DEBUG = true) ───
         const ime_log = (...args: any[]) => {
@@ -564,6 +567,14 @@
         // Suppress onData during any form of IME composition, and suppress
         // confirmation-key residue (space/enter) briefly after composition ends.
         term.onData((data: string) => {
+          // A Backspace/DEL is always a real edit intent — never swallow it.
+          // WebKit fires compositionend unreliably for CJK, so std_composing can
+          // stick `true` and would otherwise eat every backspace, leaving the
+          // user unable to delete Chinese they just typed.
+          if (data === `\x7f`) {
+            pty_session?.write(data).catch(() => {})
+            return
+          }
           if (std_composing || wk_composing) {
             ime_log(`onData SUPPRESS (composing)`, { data, hex: [...data].map(c => c.codePointAt(0)!.toString(16)) })
             return

--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -498,8 +498,13 @@
           xt_textarea.addEventListener(`compositionend`, (e: CompositionEvent) => {
             ime_log(`compositionend`, { data: e.data, textarea: xt_textarea.value })
             std_composing = false
-            const committed = e.data
             post_compose_until = performance.now() + POST_COMPOSE_MS
+            // Prefer the event's committed data; fall back to the buffered WK
+            // partial and CLEAR the buffer so the last CJK word is never stranded
+            // waiting for a keydown that won't come ("会少最新的输入").
+            const committed = e.data || wk_pending
+            wk_composing = false
+            wk_pending = ``
             if (committed) {
               ime_log(`compositionend → PTY write`, { data: committed })
               pty_session?.write(committed).catch(() => {})
@@ -540,13 +545,29 @@
               return
             }
 
-            // insertText with CJK character: may be WKWebView starting a new
-            // composition (especially Korean jamo). Flush previous, buffer new.
+            // insertText with a CJK character. Flush any previous partial first.
             if (e.inputType === `insertText` && data && isCJK(data)) {
               wkFlush()
-              wk_composing = true
-              wk_pending = data
-              ime_log(`beforeinput insertText CJK → buffer`, { data })
+              const cp0 = data.codePointAt(0) ?? 0
+              const isHangul = (cp0 >= 0x1100 && cp0 <= 0x11FF) ||
+                (cp0 >= 0x3130 && cp0 <= 0x318F) || (cp0 >= 0xAC00 && cp0 <= 0xD7AF) ||
+                (cp0 >= 0xA960 && cp0 <= 0xA97F) || (cp0 >= 0xD7B0 && cp0 <= 0xD7FF)
+              if (isHangul) {
+                // Korean jamo/syllable may be REBUILT by a following
+                // insertReplacementText (ㅎ→하→한, 가→각) — buffer it.
+                wk_composing = true
+                wk_pending = data
+                ime_log(`beforeinput insertText Hangul → buffer`, { data })
+              } else {
+                // Chinese/Japanese: the committed word arrives as a collapsed
+                // insertText with NO composition events. It is final and never
+                // rebuilt — write it on arrival. Buffering it would strand the
+                // LAST word (flushed only on the NEXT event), dropping the latest
+                // input ("会少最新的输入").
+                pty_session?.write(data).catch(() => {})
+                post_compose_until = performance.now() + POST_COMPOSE_MS
+                ime_log(`beforeinput insertText CJK → PTY write`, { data })
+              }
               e.preventDefault()
               e.stopPropagation()
               return


### PR DESCRIPTION
Fixes a batch of mobile input bugs reported on-device (RMX2111, Android), several cross-platform. Verified on-device where marked ✅.

## Bugs fixed

### Android window insets — `d36356e` ✅ device-verified
Every released APK (incl. 1.2.1) shipped a **stock** `MainActivity` because CI's `tauri android init` regenerates the gitignored `gen/android/` from stock templates and **never re-applied** the inset patch. Result: header drawn under the status bar (clock/battery overlap) and the soft keyboard covering the terminal keybar / AI-chat composer.
- `deploy/android/overrides/MainActivity.kt` (canonical, committed) + `deploy/android/apply-native-patches.sh` (idempotent) run by `android-build.yml` after init, before build.

### Terminal CJK input — last word dropped — `d4a7db3` ✅ device-verified
On-device trace showed each committed Chinese word arrives as a collapsed `insertText` with **no composition events**. The IME guard buffered every CJK `insertText` and flushed only on the *next* event, so the **last word was silently dropped** ("type 你好你好 → only one 你好"). A complete CJK ideograph delivered as collapsed `insertText` is final → write it on arrival; keep buffering only for Hangul (Korean jamo rebuild). Mobile + desktop, 3 regression tests.

### Terminal — Backspace swallowed by the CJK IME guard — `f850e50`
WebKit fires `compositionend` unreliably for CJK, so `std_composing` could stick and the guard ate every DEL — couldn't delete Chinese. Backspace now always passes through; dropped `\x7f` from `IME_CONFIRM_KEYS`. Mobile + desktop, regression test.

### Voice transcript clobbered edits — `293e5b6` (mobile) / `361e954` (desktop)
Speech `onresult`/`apply_transcript` rewrote the whole input each event, wiping a user edit/deletion. First real edit now freezes transcript application. Mobile composer also floats above the iOS keyboard via `visualViewport` (B1).

### whisper.cpp on mobile — dropped — `0bd75e2`
Built-in OS keyboard dictation is sufficient; design doc retained with the decision recorded. In-app iOS SFSpeech mic left as-is (multi-sentence overwrite = WONTFIX).

## Verification
- Unit tests green (terminal-ime: 14); type-check clean for changed files.
- On-device (RMX2111): status-bar overlap fixed, keybar floats above keyboard, full CJK phrase "你好 朋友 你好 朋友" renders.
- A-chat / B1 verified by code + shared mechanism (composer float uses the same native inset as the verified keybar); live chat needs an API key to view the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)