### PR TITLE
fix(hpc): durable SSH sessions + file-browser session recovery

### DIFF
--- a/server/catgo/utils/connection_pool.py
+++ b/server/catgo/utils/connection_pool.py
@@ -68,13 +68,24 @@ def _delete_persisted_session(session_id: str) -> None:
 class HPCConnectionPool:
     """Manages SSH connections with reuse, keepalive, and idle cleanup."""
 
-    IDLE_TIMEOUT = 3600  # 1 hour
+    # Reap a connection only after this many seconds IDLE. Generous by default
+    # (24h) so a session survives normal work gaps like a plain `ssh`/kitty
+    # session — the keepalive below holds the TCP open meanwhile. Set
+    # CATGO_HPC_IDLE_TIMEOUT=0 to never reap on idle. (Was 1h, which silently
+    # dropped connections the user still considered "open".)
+    IDLE_TIMEOUT = int(os.environ.get("CATGO_HPC_IDLE_TIMEOUT", 86400))  # 24h
     OTP_TIMEOUT = 120  # 2 minutes for user to enter OTP
     CLEANUP_INTERVAL = 120  # Check every 2 minutes (keep HPC firewalls from dropping idle TCP)
+    # Mark a connection dead only after this many CONSECUTIVE keepalive failures.
+    # A single failed/slow `echo` on a busy login node is a transient blip, not a
+    # dead connection — requiring a streak avoids killing a session the user is
+    # actively relying on (it would otherwise expire on one hiccup).
+    KEEPALIVE_DEAD_AFTER = int(os.environ.get("CATGO_HPC_KEEPALIVE_DEAD_AFTER", 3))
 
     def __init__(self) -> None:
         self.connections: dict[str, HPCConnection] = {}
         self._dead_connections: dict[str, HPCConnection] = {}  # Keeps metadata for auto-reconnect
+        self._keepalive_fails: dict[str, int] = {}  # consecutive keepalive failures per session
         self._cleanup_task: Optional[asyncio.Task[None]] = None
         # Register always-available local filesystem connection
         self.connections[LOCAL_SESSION_ID] = LocalFileConnection()
@@ -92,7 +103,9 @@ class HPCConnectionPool:
             expired = [
                 sid
                 for sid, hpc in self.connections.items()
-                if sid != LOCAL_SESSION_ID and now - hpc.last_used > self.IDLE_TIMEOUT
+                if sid != LOCAL_SESSION_ID
+                and self.IDLE_TIMEOUT > 0
+                and now - hpc.last_used > self.IDLE_TIMEOUT
             ]
             for sid in expired:
                 logger.info(f"Closing idle connection: {sid}")
@@ -111,12 +124,24 @@ class HPCConnectionPool:
                         hpc.conn.run("echo __catgo_keepalive__", check=False),
                         timeout=15,
                     )
-                    if "__catgo_keepalive__" not in (result.stdout or ""):
-                        logger.warning(f"Keepalive failed for {sid}, marking dead")
-                        hpc._alive = False
+                    if "__catgo_keepalive__" in (result.stdout or ""):
+                        self._keepalive_fails.pop(sid, None)  # healthy — reset streak
+                    else:
+                        self._note_keepalive_failure(sid, hpc, "no echo reply")
                 except Exception as exc:
-                    logger.warning(f"Keepalive error for {sid}: {exc}, marking dead")
-                    hpc._alive = False
+                    self._note_keepalive_failure(sid, hpc, str(exc))
+
+    def _note_keepalive_failure(self, sid: str, hpc: "HPCConnection", reason: str) -> None:
+        """Record a keepalive miss; mark the connection dead only after a STREAK
+        of KEEPALIVE_DEAD_AFTER consecutive failures (transient blips tolerated)."""
+        n = self._keepalive_fails.get(sid, 0) + 1
+        self._keepalive_fails[sid] = n
+        if n >= self.KEEPALIVE_DEAD_AFTER:
+            logger.warning(f"Keepalive failed {n}x for {sid} ({reason}), marking dead")
+            hpc._alive = False
+            self._keepalive_fails.pop(sid, None)
+        else:
+            logger.info(f"Keepalive miss {n}/{self.KEEPALIVE_DEAD_AFTER} for {sid} ({reason})")
 
     async def connect(
         self,
@@ -190,7 +215,11 @@ class HPCConnectionPool:
                     "port": config.jump_port,
                     "username": jump_username,
                     "known_hosts": None,
+                    # SSH-level keepalive (like ssh ServerAliveInterval). count_max
+                    # raised from asyncssh's default 3 so a slow login node needs
+                    # ~3min of silence (6×30s) — not 90s — before SSH drops it.
                     "keepalive_interval": 30,
+                    "keepalive_count_max": 6,
                 }
                 if tunnel:
                     jump_kwargs["tunnel"] = tunnel
@@ -243,7 +272,11 @@ class HPCConnectionPool:
                 "username": config.username,
                 "known_hosts": None,
                 "tunnel": tunnel,
+                # SSH-level keepalive (like ssh ServerAliveInterval). count_max
+                # raised from asyncssh's default 3 so a slow login node needs
+                # ~3min of silence (6×30s) — not 90s — before SSH drops it.
                 "keepalive_interval": 30,
+                "keepalive_count_max": 6,
             }
 
             is_password_auth = config.auth_method in (AuthMethod.PASSWORD, AuthMethod.PASSWORD_OTP)

--- a/src/lib/structure/FileTree.svelte
+++ b/src/lib/structure/FileTree.svelte
@@ -28,6 +28,7 @@
     on_move_file,
     on_upload,
     on_analyze_report,
+    on_session_expired,
     merging_dir = null,
     merge_status = null,
   }: {
@@ -50,6 +51,9 @@
     on_upload?: (files: File[], dest_path: string) => Promise<void>
     /** Analyze a REPORT file for slow-growth post-processing. */
     on_analyze_report?: (file: RemoteFile) => void
+    /** Fired when a file op reports the session expired/gone, so the parent can
+     *  recover a live session and remount (the terminal self-heals; files did not). */
+    on_session_expired?: () => void
     /** Directory name currently being merged (null = idle). */
     merging_dir?: string | null
     /** Status message after merge attempt (null = idle). */
@@ -425,7 +429,13 @@
     try {
       const result = await listFiles(session_id, path)
       if (!result.success) {
-        root_error = result.message || t('common.operation_failed')
+        const m = result.message || ``
+        if (m.includes(`not found`) || m.includes(`expired`)) {
+          root_error = t('sidebar.session_expired')
+          on_session_expired?.() // let the parent recover a live session + remount
+          return { files: [], current_path: path }
+        }
+        root_error = m || t('common.operation_failed')
         return { files: [], current_path: path }
       }
       if (result.files) {
@@ -438,9 +448,10 @@
     } catch (e: any) {
       const msg = e?.message || String(e)
       console.error(`Failed to list ${path}:`, e)
-      // Don't retry on session errors
+      // Don't retry here — hand off to the parent to recover a live session.
       if (msg.includes(`not found`) || msg.includes(`expired`)) {
         root_error = t('sidebar.session_expired')
+        on_session_expired?.()
         return { files: [], current_path: path }
       }
       root_error = msg

--- a/src/lib/structure/ServerPane.svelte
+++ b/src/lib/structure/ServerPane.svelte
@@ -260,6 +260,28 @@
   // FileTree refresh trigger (increment to force remount after upload)
   let file_tree_key = $state(0)
 
+  // When a FILE op reports the session expired, recover like the terminal does.
+  // pty.ts already finds a live replacement session for the terminal; the file
+  // browser had no recovery, so it kept querying the dead id (green dot + "Session
+  // expired" + refresh that never helped). Re-sync with the live backend
+  // connections and, if one exists for this host, adopt its id and remount.
+  let last_recovered_sid = $state(``)
+  async function recover_file_session(): Promise<void> {
+    const sess = active_session
+    if (!sess || sess.session_id === LOCAL_SESSION_ID) return
+    const stale = sess.session_id
+    if (stale === last_recovered_sid) return // already tried for this id — avoid a loop
+    last_recovered_sid = stale
+    await refresh_hpc_sessions()
+    const live = hpc_session_store.sessions.find(
+      (s) => s.host === sess.host && s.username === sess.username && s.session_id !== stale,
+    )
+    if (live) {
+      sess.session_id = live.session_id
+      file_tree_key++ // remount FileTree → reloads against the live session
+    }
+  }
+
   /** Find session by stable _id through the reactive array (returns proxy). */
   function get_session(id: string): HPCSession | undefined {
     return sessions.find((s) => s._id === id)
@@ -1858,6 +1880,7 @@
               on_preview_file={(file, type) => open_remote_preview(file, type)}
               on_load_trajectory={(dir, pattern) => merge_dir_as_trajectory(dir, pattern)}
               on_analyze_report={on_analyze_report ? (file) => analyze_remote_report(file) : undefined}
+              on_session_expired={recover_file_session}
               on_navigate={(path) => { if (active_session) active_session.current_path = path }}
               on_download={(file) => download_remote_file(file)}
               on_copy_path={(file) => copy_remote_path(file)}


### PR DESCRIPTION
## Problem
An HPC connection that was still usable (terminal worked, dot green) showed "Session expired" in the Files tab, and refresh didn't help. The user noted CatGo sessions die far sooner than a plain `ssh`/kitty session.

## Causes & fixes

**Durability** — the backend reaped connections aggressively:
- `IDLE_TIMEOUT` was **1h** → idle connections silently closed. Raised to **24h** (`CATGO_HPC_IDLE_TIMEOUT`, `0` = never reap).
- App-level `echo` keepalive marked a connection **dead on a single** failed/slow ping → over-killed on busy login nodes. Now needs a **streak** (`KEEPALIVE_DEAD_AFTER=3`).
- SSH-level keepalive already ran (`keepalive_interval=30`) but used asyncssh's default `keepalive_count_max=3` (90s). Raised to **6** (~3min) so a slow node isn't dropped.

**Recovery** — the terminal self-heals (`pty.ts` finds a live replacement session) but the file browser had none: it kept calling `listFiles()` with the dead id, and refresh re-used it. `FileTree` now fires `on_session_expired`; `ServerPane` re-syncs with the live backend connections, adopts a live session for the same host, and remounts the tree.

## Why it was designed the aggressive way
Resource hygiene (the backend may hold many SSH connections; HPC login nodes cap concurrent sessions and kill idle ones) + fast dead-connection detection so the UI doesn't show zombies. The fixes keep both (keepalive for firewalls, dead-detection) but stop over-reaping sessions the user still relies on.

Type-check clean for changed files; connection_pool.py syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)