### PR TITLE
feat(import): show electronic-structure metadata in database previews

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -38,6 +38,13 @@
   import type { AppTab } from './TabBar.svelte'
   import OptimadeSearchModal from '$lib/structure/OptimadeSearchModal.svelte'
   import OptimadePreviewModal from '$lib/structure/OptimadePreviewModal.svelte'
+  import {
+    electronic_props_from_mp,
+    electronic_props_from_optimade,
+    type ElectronicProps,
+  } from '$lib/structure/electronic_preview'
+  import { extract_provider_details } from '$lib/api/optimade'
+  import type { MPSummaryData } from '$lib/api/materials-project'
   import PasteContentModal from '$lib/structure/PasteContentModal.svelte'
   import MonacoEditorPanel from '$lib/structure/MonacoEditorPanel.svelte'
   import type { PymatgenStructure } from '$lib/structure'
@@ -149,7 +156,10 @@
   import CloseAllModal from './components/CloseAllModal.svelte'
   import DownloadManager from './components/DownloadManager.svelte'
 
-  init_i18n().then(() => load_i18n_module(`app`))
+  init_i18n().then(() => {
+    load_i18n_module(`app`)
+    load_i18n_module(`structure`)
+  })
 
   // ========== Tab Management (extracted to ./lib/tab-manager.svelte.ts) ==========
   const tm = create_tab_manager()
@@ -1069,7 +1079,11 @@
     }
   }
 
-  function handle_optimade_preview(optimade_struct: any, structure: PymatgenStructure) {
+  function handle_optimade_preview(
+    optimade_struct: any,
+    structure: PymatgenStructure,
+    mp_summary: MPSummaryData | null = null,
+  ) {
     modal.db_preview_pymatgen = structure
     const attrs = optimade_struct?.attributes ?? {}
     const provider = attrs.database_provider ?? `OPTIMADE`
@@ -1078,6 +1092,20 @@
     const sites =
       attrs.n_sites ??
       (Array.isArray(attrs.cartesian_site_positions) ? attrs.cartesian_site_positions.length : 0)
+
+    // Build electronic-structure props: prefer the MP REST summary (rich
+    // surface — cbm/vbm/efermi/has_props/ordering); otherwise extract whatever
+    // the OPTIMADE adapter exposed under `_<provider>_*`.
+    let elec: ElectronicProps
+    if (mp_summary) {
+      elec = electronic_props_from_mp(mp_summary)
+    } else {
+      const pd = extract_provider_details(attrs as Record<string, unknown>)
+      elec = electronic_props_from_optimade(pd)
+    }
+    // Stash on the pending pymatgen so the metadata rides through Confirm
+    // into the loaded structure (consumed by StructureInfoPane / overlays).
+    ;(structure as any)._electronic_props = elec
 
     modal.db_preview_title = t(`app.preview_structure_import`)
     modal.db_preview_formula = formula
@@ -1088,6 +1116,7 @@
       { label: t(`app.field_sites`), value: String(sites) },
       { label: t(`app.field_database`), value: provider },
     ]
+    modal.db_preview_electronic = elec
     modal.db_preview_visible = true
   }
 
@@ -1120,6 +1149,7 @@
     modal.db_preview_formula = formula
     modal.db_preview_lattice = null
     modal.db_preview_details = rows
+    modal.db_preview_electronic = null // PubChem is molecular — no band/Fermi
     modal.db_preview_visible = true
   }
 
@@ -1135,6 +1165,7 @@
     modal.db_preview_visible = false
     modal.db_preview_pymatgen = null
     modal.db_preview_details = []
+    modal.db_preview_electronic = null
     modal.db_preview_formula = ``
     modal.db_preview_lattice = null
   }
@@ -2748,6 +2779,24 @@
   title={modal.db_preview_title}
   formula={modal.db_preview_formula}
   details={modal.db_preview_details}
+  electronic_props={modal.db_preview_electronic}
+  electronic_labels={{
+    band_gap: t(`structure.preview_band_gap`),
+    is_metal: t(`structure.preview_is_metal`),
+    efermi: t(`structure.preview_efermi`),
+    cbm: t(`structure.preview_cbm`),
+    vbm: t(`structure.preview_vbm`),
+    dos_available: t(`structure.preview_dos_available`),
+    bands_available: t(`structure.preview_bands_available`),
+    magnetic_ordering: t(`structure.preview_magnetic_ordering`),
+    yes: t(`structure.preview_yes`),
+    no: t(`structure.preview_no`),
+    available: t(`structure.preview_available`),
+    not_available: t(`structure.preview_not_available`),
+    metallic: t(`structure.preview_metallic`),
+    missing: t(`structure.preview_missing`),
+  }}
+  electronic_heading={t(`structure.preview_electronic_heading`)}
   lattice_params={modal.db_preview_lattice}
 />
 

--- a/desktop/state/modal-state.svelte.ts
+++ b/desktop/state/modal-state.svelte.ts
@@ -2,6 +2,8 @@
  * Modal reactive state — extracted from App.svelte.
  */
 
+import type { ElectronicProps } from '$lib/structure/electronic_preview'
+
 interface PreviewDetailRow {
   label: string
   value: string
@@ -31,6 +33,7 @@ class ModalState {
   db_preview_formula = $state(``)
   db_preview_details = $state<PreviewDetailRow[]>([])
   db_preview_lattice = $state<PreviewLatticeParams | null>(null)
+  db_preview_electronic = $state<ElectronicProps | null>(null)
   // Close-all dialog
   close_all_visible = $state(false)
   close_all_entries = $state<CloseAllEntry[]>([])

--- a/server/catgo/routers/materials_project.py
+++ b/server/catgo/routers/materials_project.py
@@ -90,6 +90,11 @@ async def search_structures(
             "band_gap",
             "is_stable",
             "is_metal",
+            "efermi",
+            "cbm",
+            "vbm",
+            "ordering",
+            "has_props",
         ]),
         "_limit": str(request.limit),
     }
@@ -159,6 +164,11 @@ async def get_structure(
             "band_gap",
             "is_stable",
             "is_metal",
+            "efermi",
+            "cbm",
+            "vbm",
+            "ordering",
+            "has_props",
         ]),
     }
 

--- a/server/catgo/routers/optimade.py
+++ b/server/catgo/routers/optimade.py
@@ -190,12 +190,20 @@ async def get_providers():
 
 
 @router.get("/structure/{provider_id}/{structure_id:path}")
-async def get_structure(provider_id: str, structure_id: str):
+async def get_structure(
+    provider_id: str,
+    structure_id: str,
+    response_fields: Optional[str] = Query(None),
+):
     """Fetch a single structure from an OPTIMADE provider.
 
     Args:
         provider_id: Provider identifier (e.g., 'mp', 'mc3d')
         structure_id: Structure identifier within the provider
+        response_fields: Optional comma-separated OPTIMADE response_fields.
+            MP's OPTIMADE adapter only returns `_mp_*` extras when these are
+            listed explicitly; without it the response carries only standard
+            fields. Forwarded verbatim to the provider.
     """
     # Get provider base URL
     providers_response = await get_providers()
@@ -207,9 +215,9 @@ async def get_structure(provider_id: str, structure_id: str):
 
     base_url = await resolve_provider_url(provider["attributes"]["base_url"])
 
-    # Build query params - don't restrict response_fields so providers
-    # return all available extended fields (providers ignore unknown fields)
     params = {}
+    if response_fields:
+        params["response_fields"] = response_fields
 
     query_string = urlencode(params) if params else ""
 

--- a/src/lib/api/materials-project.ts
+++ b/src/lib/api/materials-project.ts
@@ -150,6 +150,14 @@ export interface MPSummaryData {
   band_gap?: number
   is_stable?: boolean
   is_metal?: boolean
+  efermi?: number
+  cbm?: number
+  vbm?: number
+  ordering?: string
+  // Availability map MP returns at `has_props`: { dos: bool, bandstructure: bool, ... }.
+  // We only read .dos / .bandstructure for the preview — the full payloads are huge
+  // and would defeat the point of "preview before import".
+  has_props?: Record<string, boolean>
 }
 
 /**
@@ -172,7 +180,7 @@ export async function search_mp_structures(
   if (vscode_api || direct_api()) {
     // Direct Materials Project API call (relay-routed in the web build)
     const params = new URLSearchParams({
-      _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal`,
+      _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal,efermi,cbm,vbm,ordering,has_props`,
       _limit: String(limit),
     })
 
@@ -233,7 +241,7 @@ export async function get_mp_structure_summary(material_id: string): Promise<MPS
     if (vscode_api || direct_api()) {
       // Direct API call (relay-routed in the web build)
       const params = new URLSearchParams({
-        _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal`,
+        _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal,efermi,cbm,vbm,ordering,has_props`,
       })
       url = `https://api.materialsproject.org/materials/summary/${material_id}?${params}`
       data = await fetch_json_smart(url, api_key) as typeof data

--- a/src/lib/api/optimade.ts
+++ b/src/lib/api/optimade.ts
@@ -150,6 +150,12 @@ export interface OptimadeStructure {
     // Electronic properties
     _mp_band_gap?: number // eV
     _mp_is_metal?: boolean
+    _mp_efermi?: number // eV
+    _mp_cbm?: number // eV
+    _mp_vbm?: number // eV
+    _mp_ordering?: string // 'FM' | 'AFM' | 'NM' | 'FiM' | 'Unknown'
+    _mp_magnetism?: Record<string, unknown> // nested dict { ordering, total_magnetization, ... }
+    _mp_has_props?: Record<string, boolean>
     // Alternative naming conventions
     _exmpl_band_gap?: number
     _odbx_band_gap?: number
@@ -259,6 +265,13 @@ export async function fetch_optimade_structure(
 ): Promise<OptimadeStructure | null> {
   const encoded_id = encode_structure_id(structure_id)
 
+  // Request the same provider-specific extras the list-search asks for —
+  // MP's OPTIMADE adapter (and several others) only return `_<provider>_*`
+  // fields when explicitly listed via response_fields. Without this, the
+  // full-record fetch comes back with standard OPTIMADE fields only, so
+  // band_gap / is_metal / efermi / etc. would never reach the preview.
+  const response_fields = build_response_fields(provider)
+
   const is_static = (typeof __CATGO_STATIC_ONLY__ !== `undefined` && __CATGO_STATIC_ONLY__) || isMobile()
   let url: string
   if (vscode_api || is_static) {
@@ -272,19 +285,36 @@ export async function fetch_optimade_structure(
     if (provider === `mp` || provider === `mpdd`) {
       base_url = `https://optimade.materialsproject.org`
     }
-    // Try common endpoint patterns
     url = `${base_url}/v1/structures/${encoded_id}`
+    if (response_fields) url += `?response_fields=${encodeURIComponent(response_fields)}`
   } else {
     // Backend proxy
     url = `${API_BASE}/optimade/structure/${provider}/${encoded_id}`
+    if (response_fields) url += `?response_fields=${encodeURIComponent(response_fields)}`
   }
 
   try {
-    const data = await fetch_json_smart(url) as { data?: OptimadeStructure }
+    let data = await fetch_json_smart(url) as { data?: OptimadeStructure }
+    // Some providers reject unknown response_fields with 400; retry without
+    // it so the import path still works even if extras are unavailable.
+    if (!data?.data && response_fields) {
+      const fallback_url = url.replace(/[?&]response_fields=[^&]*/, ``)
+      data = await fetch_json_smart(fallback_url) as { data?: OptimadeStructure }
+    }
     return data.data || null
   } catch (error) {
     if (error instanceof Error && error.message.includes(`404`)) {
       return null
+    }
+    // 400 from a provider that rejects response_fields — retry plain
+    if (
+      error instanceof Error
+      && response_fields
+      && (error.message.includes(`400`) || error.message.includes(`Bad Request`))
+    ) {
+      const fallback_url = url.replace(/[?&]response_fields=[^&]*/, ``)
+      const data = await fetch_json_smart(fallback_url) as { data?: OptimadeStructure }
+      return data.data || null
     }
     throw error
   }
@@ -384,6 +414,12 @@ const PROVIDER_EXTRA_FIELDS: Record<string, string[]> = {
     `_mp_band_gap`,
     `_mp_is_stable`,
     `_mp_is_metal`,
+    `_mp_efermi`,
+    `_mp_cbm`,
+    `_mp_vbm`,
+    `_mp_ordering`,
+    `_mp_magnetism`,
+    `_mp_has_props`,
     `_mp_crystal_system`,
     `_mp_spacegroup_symbol`,
     `_mp_spacegroup_number`,
@@ -711,6 +747,12 @@ export interface ProviderDetails {
   formation_energy?: number
   is_stable?: boolean
   is_metal?: boolean
+  efermi?: number
+  cbm?: number
+  vbm?: number
+  magnetic_ordering?: string
+  has_dos?: boolean
+  has_bandstructure?: boolean
   /** Any other interesting extended fields keyed by display label. */
   extra: Record<string, string | number | boolean>
 }
@@ -732,6 +774,11 @@ const DETAIL_PATTERNS: {
   { key: `formation_energy`, regex: /^_\w+_(formation|enthalpy_formation|delta_e)/ },
   { key: `is_stable`, regex: /^_\w+_is_stable$/ },
   { key: `is_metal`, regex: /^_\w+_is_metal$/ },
+  // Electronic-structure scalars (typically MP-only on OPTIMADE today).
+  { key: `efermi`, regex: /^_\w+_(efermi|fermi_energy)$/i },
+  { key: `cbm`, regex: /^_\w+_cbm$/i },
+  { key: `vbm`, regex: /^_\w+_vbm$/i },
+  { key: `magnetic_ordering`, regex: /^_\w+_(ordering|magnetic_ordering)$/i },
 ]
 
 /**
@@ -767,6 +814,27 @@ export function extract_provider_details(
       continue
     }
 
+    // MP nests magnetism data: { ordering: 'FM'|'AFM'|'NM'|..., total_magnetization, ... }.
+    if (attr_key === `_mp_magnetism` && typeof attr_val === `object`) {
+      const mag = attr_val as Record<string, unknown>
+      if (typeof mag.ordering === `string` && details.magnetic_ordering === undefined) {
+        details.magnetic_ordering = mag.ordering
+      }
+      continue
+    }
+
+    // MP availability flags: { dos: true, bandstructure: true, ... }.
+    if (attr_key === `_mp_has_props` && typeof attr_val === `object` && attr_val !== null) {
+      const props = attr_val as Record<string, unknown>
+      if (typeof props.dos === `boolean` && details.has_dos === undefined) {
+        details.has_dos = props.dos
+      }
+      if (typeof props.bandstructure === `boolean` && details.has_bandstructure === undefined) {
+        details.has_bandstructure = props.bandstructure
+      }
+      continue
+    }
+
     let matched = false
     for (const { key, regex } of DETAIL_PATTERNS) {
       if (regex.test(attr_key) && details[key] === undefined) {
@@ -777,6 +845,9 @@ export function extract_provider_details(
           `energy_above_hull`,
           `formation_energy`,
           `spacegroup_number`,
+          `efermi`,
+          `cbm`,
+          `vbm`,
         ]
         if (numeric_keys.includes(key) && typeof attr_val !== `number`) continue
         ;(details as unknown as Record<string, unknown>)[key] = attr_val

--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -1651,5 +1651,24 @@ const structure: Record<string, string> = {
   trajectory_format_compressed: `Compressed files (.gz)`,
   bio_open_in_native: `Open in native viewer`,
   bio_open_in_molstar: `Open in Mol*`,
+
+  // Preview modal — electronic-structure subsection (database imports)
+  preview_electronic_heading: `Electronic structure`,
+  preview_band_gap: `Band gap:`,
+  preview_is_metal: `Metal:`,
+  preview_efermi: `Fermi energy:`,
+  preview_cbm: `CBM:`,
+  preview_vbm: `VBM:`,
+  preview_dos_available: `DOS:`,
+  preview_bands_available: `Bands:`,
+  preview_magnetic_ordering: `Magnetic order:`,
+  preview_yes: `Yes`,
+  preview_no: `No`,
+  preview_available: `available`,
+  preview_not_available: `not available`,
+  preview_metallic: `metallic`,
+  preview_missing: `—`,
+  result_mag: `Mag`,
+  result_bands: `Bands`,
 }
 export default structure

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -1651,5 +1651,24 @@ const structure: Record<string, string> = {
   trajectory_format_compressed: `压缩文件 (.gz)`,
   bio_open_in_native: `用原生查看器打开`,
   bio_open_in_molstar: `在 Mol* 中打开`,
+
+  // 预览弹窗 — 电子结构子区域（数据库导入）
+  preview_electronic_heading: `电子结构`,
+  preview_band_gap: `带隙：`,
+  preview_is_metal: `金属性：`,
+  preview_efermi: `费米能：`,
+  preview_cbm: `导带底 (CBM)：`,
+  preview_vbm: `价带顶 (VBM)：`,
+  preview_dos_available: `态密度 (DOS)：`,
+  preview_bands_available: `能带：`,
+  preview_magnetic_ordering: `磁有序：`,
+  preview_yes: `是`,
+  preview_no: `否`,
+  preview_available: `可用`,
+  preview_not_available: `不可用`,
+  preview_metallic: `金属性`,
+  preview_missing: `—`,
+  result_mag: `磁`,
+  result_bands: `能带`,
 }
 export default structure

--- a/src/lib/structure/ElectronicInfoPanel.svelte
+++ b/src/lib/structure/ElectronicInfoPanel.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  // Single rendering surface for the "Electronic structure" preview block.
+  // Used by import preview modals, the loaded-structure info pane, the 3D
+  // StructurePreview overlay, and workflow previews — so all four read like
+  // the same widget. Pass `props` (ElectronicProps) and optional labels; an
+  // empty `props` collapses the panel rather than showing 8 em-dashes.
+
+  import { buildElectronicRows, type ElectronicProps, type ElectronicLabels } from './electronic_preview'
+
+  interface Props {
+    props: ElectronicProps | null | undefined
+    labels?: Partial<ElectronicLabels>
+    heading?: string | null // null/empty → no heading rendered (compact mode)
+    compact?: boolean // tighter rows for use inside cards or overlays
+    hide_when_empty?: boolean // default true: don't render at all if all values are missing
+  }
+
+  let {
+    props,
+    labels = {},
+    heading = `Electronic structure`,
+    compact = false,
+    hide_when_empty = true,
+  }: Props = $props()
+
+  // Empty means every queryable field is null/undefined; we don't bother
+  // taking screen real estate to display 8 em-dashes.
+  let is_empty = $derived(() => {
+    if (!props) return true
+    const keys: (keyof ElectronicProps)[] = [
+      'band_gap', 'is_metal', 'efermi', 'cbm', 'vbm',
+      'has_dos', 'has_bandstructure', 'magnetic_ordering',
+    ]
+    return keys.every((k) => props[k] === undefined || props[k] === null)
+  })
+
+  let rows = $derived(buildElectronicRows(props ?? {}, labels))
+</script>
+
+{#if !(hide_when_empty && is_empty())}
+  <div class="electronic-panel" class:compact>
+    {#if heading}
+      <span class="sublabel">{heading}</span>
+    {/if}
+    {#each rows as row (row.label + row.value)}
+      <div class="info-item">
+        <span class="label">{row.label}</span>
+        <span class="value" class:mono={row.mono}>{row.value}</span>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .electronic-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 0;
+    min-width: 0;
+  }
+
+  .sublabel {
+    color: var(--text-color-muted, #999);
+    font-size: 0.85rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .info-item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 0.9rem;
+    min-width: 0;
+  }
+
+  .label {
+    color: var(--text-color-muted, #999);
+    min-width: 90px;
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+
+  .value {
+    color: inherit;
+    flex: 1;
+    word-break: break-all;
+    min-width: 0;
+  }
+
+  .value.mono {
+    font-family: monospace;
+    font-size: 0.8rem;
+  }
+
+  .electronic-panel.compact {
+    gap: 2px;
+    padding: 4px 0;
+  }
+
+  .electronic-panel.compact .info-item {
+    font-size: 0.78rem;
+  }
+
+  .electronic-panel.compact .label {
+    min-width: 72px;
+    font-size: 0.75rem;
+  }
+
+  .electronic-panel.compact .sublabel {
+    font-size: 0.72rem;
+  }
+</style>

--- a/src/lib/structure/OptimadePreviewModal.svelte
+++ b/src/lib/structure/OptimadePreviewModal.svelte
@@ -4,6 +4,8 @@
   import { Composition } from '$lib/composition'
   import type { PymatgenStructure } from './index'
   import StructurePreview from './StructurePreview.svelte'
+  import ElectronicInfoPanel from './ElectronicInfoPanel.svelte'
+  import type { ElectronicProps, ElectronicLabels } from './electronic_preview'
 
   export interface PreviewDetailRow {
     label: string
@@ -29,6 +31,11 @@
     title?: string
     formula?: string
     details?: PreviewDetailRow[]
+    // Optional electronic-structure data rendered under its own subheader.
+    // Kept separate from `details` so the section is visually distinct.
+    electronic_props?: ElectronicProps | null
+    electronic_labels?: Partial<ElectronicLabels>
+    electronic_heading?: string
     lattice_params?: PreviewLatticeParams | null
     // Legacy OPTIMADE mode (back-compat): if optimade_structure is provided
     // and `details` is not, the modal computes the rows from it.
@@ -44,6 +51,9 @@
     title = `Preview Structure Import`,
     formula: formula_prop,
     details: details_prop,
+    electronic_props = null,
+    electronic_labels = {},
+    electronic_heading = `Electronic structure`,
     lattice_params: lattice_params_prop,
     optimade_structure = null,
     provider_name = `OPTIMADE`,
@@ -168,6 +178,14 @@
                   <span class="value" class:mono={row.mono}>{row.value}</span>
                 </div>
               {/each}
+
+              {#if electronic_props}
+                <ElectronicInfoPanel
+                  props={electronic_props}
+                  labels={electronic_labels}
+                  heading={electronic_heading}
+                />
+              {/if}
 
               {#if lattice_params}
                 <div class="info-subsection">

--- a/src/lib/structure/OptimadeSearchModal.svelte
+++ b/src/lib/structure/OptimadeSearchModal.svelte
@@ -12,6 +12,7 @@
     set_mp_api_key,
     has_mp_api_key,
     search_mp_structures,
+    get_mp_structure_summary,
     validate_mp_api_key,
     type MPSummaryData,
   } from '$lib/api/materials-project'
@@ -51,7 +52,14 @@
     visible: boolean
     onclose: () => void
     onimport: (structure: PymatgenStructure) => void
-    onpreview?: (optimade_struct: OptimadeStructure, pymatgen_struct: PymatgenStructure) => void
+    onpreview?: (
+      optimade_struct: OptimadeStructure,
+      pymatgen_struct: PymatgenStructure,
+      // Optional: MP REST summary when MP is the active provider. Carries
+      // electronic-structure fields (cbm/vbm/efermi/has_props/ordering) that
+      // MP's OPTIMADE adapter doesn't always expose.
+      mp_summary?: MPSummaryData | null,
+    ) => void
     onpubchem_preview?: (
       compound: PubChemCompound,
       search_result: PubChemSearchCompound | null,
@@ -565,6 +573,13 @@
         providers,
       )
       if (full_structure) {
+        // Annotate with the resolved provider name so downstream previews
+        // can show "Materials Project" / "Alexandria" etc. instead of the
+        // generic "OPTIMADE" fallback. (OPTIMADE responses don't carry the
+        // provider id in their attributes by spec.)
+        const prov_obj = providers.find((p) => p.id === selected_provider)
+        ;(full_structure.attributes as Record<string, unknown>).database_provider =
+          prov_obj?.attributes?.name ?? selected_provider
         let pymatgen_structure = optimade_to_pymatgen(full_structure)
         if (pymatgen_structure) {
           // OPTIMADE APIs often return non-standard lattice orientations
@@ -581,7 +596,36 @@
 
           // If onpreview is provided, call it instead of onimport
           if (onpreview) {
-            onpreview(full_structure, pymatgen_structure)
+            // Prefer cached MP REST summary (richer surface than MP's OPTIMADE
+            // adapter). Mirror the result-card lookup pattern: primary lookup
+            // by struct.id, fallback to structure-fingerprint map for MP IDs
+            // that have been renumbered between the OPTIMADE adapter and the
+            // REST API. Last resort: fetch the single-record summary on
+            // demand (handles the race where fetch_mp_summaries hasn't
+            // resolved yet when the user clicks Import).
+            let mp_summary: MPSummaryData | null = null
+            if (selected_provider === `mp` && mp_has_key) {
+              const attrs = struct.attributes ?? {}
+              const prov = extract_provider_details(attrs as Record<string, unknown>)
+              const comp = computed_details.get(struct.id)
+              const fp_key = struct_key(
+                attrs.chemical_formula_reduced,
+                attrs.nsites ?? attrs.n_sites,
+                prov.spacegroup_symbol ?? comp?.spacegroup_symbol,
+              )
+              mp_summary = mp_summaries.get(struct.id)
+                ?? mp_summaries_by_key.get(fp_key)
+                ?? null
+              if (!mp_summary) {
+                try {
+                  mp_summary = await get_mp_structure_summary(struct.id)
+                  if (mp_summary) mp_summaries.set(struct.id, mp_summary)
+                } catch (err) {
+                  console.warn(`[MP ENRICH] on-demand fetch failed for`, struct.id, err)
+                }
+              }
+            }
+            onpreview(full_structure, pymatgen_structure, mp_summary)
             // Keep modal open - don't call onclose()
           } else {
             // Fallback to direct import if no preview callback
@@ -941,6 +985,13 @@
                     {@const e_above_hull = mp_data?.energy_above_hull ?? prov.energy_above_hull}
                     {@const formation_energy = mp_data?.formation_energy_per_atom ?? prov.formation_energy ?? attrs._mp_formation_energy_per_atom}
                     {@const band_gap = mp_data?.band_gap ?? prov.band_gap ?? attrs._mp_band_gap ?? attrs._odbx_band_gap ?? attrs._exmpl_band_gap}
+                    {@const is_metal = mp_data?.is_metal ?? prov.is_metal}
+                    {@const efermi = mp_data?.efermi ?? prov.efermi}
+                    {@const cbm = mp_data?.cbm ?? prov.cbm}
+                    {@const vbm = mp_data?.vbm ?? prov.vbm}
+                    {@const magnetic_ordering = mp_data?.ordering ?? prov.magnetic_ordering}
+                    {@const has_dos = mp_data?.has_props?.dos ?? prov.has_dos}
+                    {@const has_bandstructure = mp_data?.has_props?.bandstructure ?? prov.has_bandstructure}
                     {@const is_stable = mp_data?.is_stable ?? prov.is_stable}
                     {@const volume = comp?.volume}
                     {@const density = comp?.density}
@@ -999,6 +1050,41 @@
                           {#if band_gap !== undefined && band_gap !== null}
                             <span class="result-detail" title={t('structure.band_gap_ev')}>
                               <span class="detail-label">{t('structure.result_gap')}:</span> {band_gap.toFixed(2)} eV
+                            </span>
+                          {/if}
+                          {#if is_metal === true}
+                            <span class="result-detail" title={t('structure.preview_is_metal')}>
+                              <span class="detail-label">{t('structure.preview_metallic')}</span>
+                            </span>
+                          {/if}
+                          {#if typeof efermi === `number`}
+                            <span class="result-detail" title={t('structure.preview_efermi')}>
+                              <span class="detail-label">E<sub>F</sub>:</span> {efermi.toFixed(2)} eV
+                            </span>
+                          {/if}
+                          {#if typeof cbm === `number`}
+                            <span class="result-detail" title={t('structure.preview_cbm')}>
+                              <span class="detail-label">CBM:</span> {cbm.toFixed(2)} eV
+                            </span>
+                          {/if}
+                          {#if typeof vbm === `number`}
+                            <span class="result-detail" title={t('structure.preview_vbm')}>
+                              <span class="detail-label">VBM:</span> {vbm.toFixed(2)} eV
+                            </span>
+                          {/if}
+                          {#if magnetic_ordering}
+                            <span class="result-detail" title={t('structure.preview_magnetic_ordering')}>
+                              <span class="detail-label">{t('structure.result_mag')}:</span> {magnetic_ordering}
+                            </span>
+                          {/if}
+                          {#if has_dos === true}
+                            <span class="result-detail" title={t('structure.preview_dos_available')}>
+                              <span class="detail-label">DOS</span>
+                            </span>
+                          {/if}
+                          {#if has_bandstructure === true}
+                            <span class="result-detail" title={t('structure.preview_bands_available')}>
+                              <span class="detail-label">{t('structure.result_bands')}</span>
                             </span>
                           {/if}
                           {#if !comp && computing_details}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -149,6 +149,14 @@
   import { scale_structure_geometry } from '$lib/trajectory/operations'
   import OptimadeSearchModal from './OptimadeSearchModal.svelte'
   import OptimadePreviewModal from './OptimadePreviewModal.svelte'
+  import {
+    buildElectronicRows,
+    electronic_props_from_mp,
+    electronic_props_from_optimade,
+    type ElectronicProps,
+  } from './electronic_preview'
+  import { extract_provider_details } from '$lib/api/optimade'
+  import type { MPSummaryData } from '$lib/api/materials-project'
   import PasteContentModal from './PasteContentModal.svelte'
   import VacuumBoxModal from './VacuumBoxModal.svelte'
   import { translate_sites } from './manipulation'
@@ -751,6 +759,7 @@
   let optimade_pending_pymatgen = $state<PymatgenStructure | null>(null) // Pending PymatgenStructure for preview
   let optimade_pending_provider = $state<string | null>(null) // Provider name for preview
   let optimade_preview_details = $state<Array<{ label: string; value: string; mono?: boolean }>>([])
+  let optimade_preview_electronic = $state<ElectronicProps | null>(null)
   let optimade_preview_formula = $state<string>(``)
   let optimade_preview_lattice = $state<{ a: number; b: number; c: number; alpha: number; beta: number; gamma: number } | null>(null)
   let optimade_preview_title = $state<string>(`Preview Structure Import`)
@@ -1371,7 +1380,16 @@
     }
     untrack(() => {
       const aligned = align_to_principal_axes(structure!)
-      structure = { ...aligned, _aligned: true } as any as typeof structure
+      // Preserve session-local annotations stamped onto the imported structure
+      // (e.g. `_electronic_props` from a database import). `align_to_principal_axes`
+      // returns a fresh object that doesn't carry these forward, so the spread
+      // would otherwise silently drop them.
+      const prior_elec = (structure as any)?._electronic_props
+      structure = {
+        ...aligned,
+        _aligned: true,
+        ...(prior_elec ? { _electronic_props: prior_elec } : {}),
+      } as any as typeof structure
       structure_aligned_id = structure_id
       // The scene may have already locked its rotation pivot from the raw
       // imported coordinates. Recenter once after this automatic load-time
@@ -2950,7 +2968,11 @@
   }
 
   // Handle OPTIMADE structure preview
-  function handle_optimade_preview(optimade_struct: any, pymatgen_struct: PymatgenStructure) {
+  function handle_optimade_preview(
+    optimade_struct: any,
+    pymatgen_struct: PymatgenStructure,
+    mp_summary: MPSummaryData | null = null,
+  ) {
     optimade_pending_structure = optimade_struct
     optimade_pending_pymatgen = pymatgen_struct
 
@@ -2964,6 +2986,19 @@
       attrs.n_sites ??
       (Array.isArray(attrs.cartesian_site_positions) ? attrs.cartesian_site_positions.length : 0)
 
+    // Electronic-structure block: prefer the MP REST summary (richer surface);
+    // fall back to whatever the OPTIMADE adapter put under `_<provider>_*`.
+    let elec: ElectronicProps
+    if (mp_summary) {
+      elec = electronic_props_from_mp(mp_summary)
+    } else {
+      const pd = extract_provider_details(attrs as Record<string, unknown>)
+      elec = electronic_props_from_optimade(pd)
+    }
+    // Stash on the pending pymatgen so the metadata rides through Confirm
+    // into the loaded structure (consumed by StructureInfoPane / overlays).
+    ;(pymatgen_struct as any)._electronic_props = elec
+
     optimade_preview_title = `Preview Structure Import`
     optimade_preview_formula = formula
     optimade_preview_lattice = null // let modal compute from optimade_structure (legacy fallback)
@@ -2973,6 +3008,7 @@
       { label: `Sites:`, value: String(sites) },
       { label: `Database:`, value: provider },
     ]
+    optimade_preview_electronic = elec
 
     optimade_preview_visible = true
   }
@@ -3009,6 +3045,7 @@
     optimade_preview_formula = formula
     optimade_preview_lattice = null // molecules — no crystallographic lattice
     optimade_preview_details = rows
+    optimade_preview_electronic = null // PubChem is molecular — no band/Fermi data
 
     optimade_preview_visible = true
   }
@@ -3025,6 +3062,7 @@
       optimade_pending_pymatgen = null
       optimade_pending_provider = null
       optimade_preview_details = []
+      optimade_preview_electronic = null
       optimade_preview_formula = ``
       optimade_preview_lattice = null
     }
@@ -3037,8 +3075,30 @@
     optimade_pending_pymatgen = null
     optimade_pending_provider = null
     optimade_preview_details = []
+    optimade_preview_electronic = null
     optimade_preview_formula = ``
     optimade_preview_lattice = null
+  }
+
+  // i18n labels for ElectronicInfoPanel — shared by the import-preview modal
+  // and any other surface that reads localized labels off this component.
+  function electronic_i18n_labels() {
+    return {
+      band_gap: t(`structure.preview_band_gap`),
+      is_metal: t(`structure.preview_is_metal`),
+      efermi: t(`structure.preview_efermi`),
+      cbm: t(`structure.preview_cbm`),
+      vbm: t(`structure.preview_vbm`),
+      dos_available: t(`structure.preview_dos_available`),
+      bands_available: t(`structure.preview_bands_available`),
+      magnetic_ordering: t(`structure.preview_magnetic_ordering`),
+      yes: t(`structure.preview_yes`),
+      no: t(`structure.preview_no`),
+      available: t(`structure.preview_available`),
+      not_available: t(`structure.preview_not_available`),
+      metallic: t(`structure.preview_metallic`),
+      missing: t(`structure.preview_missing`),
+    }
   }
 
   // Handle molecule import file selection
@@ -4792,6 +4852,9 @@
     title={optimade_preview_title}
     formula={optimade_preview_formula}
     details={optimade_preview_details}
+    electronic_props={optimade_preview_electronic}
+    electronic_labels={electronic_i18n_labels()}
+    electronic_heading={t(`structure.preview_electronic_heading`)}
     lattice_params={optimade_preview_lattice}
   />
 

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -8,6 +8,8 @@
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteSet } from 'svelte/reactivity'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import ElectronicInfoPanel from './ElectronicInfoPanel.svelte'
+  import type { ElectronicProps } from './electronic_preview'
 
   // Lazy-load structure translations
   load_i18n_module('structure')
@@ -35,6 +37,31 @@
 
   let copied_items = new SvelteSet<string>()
   let sites_expanded = $state(false)
+
+  // Read electronic-structure metadata stashed on the structure at import
+  // (Structure.svelte:handle_optimade_preview attaches `_electronic_props`).
+  // Untyped because PymatgenStructure / AnyStructure don't declare it —
+  // it's a session-local annotation that doesn't survive serialization.
+  let electronic_props = $derived(
+    (structure as unknown as { _electronic_props?: ElectronicProps })?._electronic_props ?? null,
+  )
+
+  let electronic_labels = $derived({
+    band_gap: t(`structure.preview_band_gap`),
+    is_metal: t(`structure.preview_is_metal`),
+    efermi: t(`structure.preview_efermi`),
+    cbm: t(`structure.preview_cbm`),
+    vbm: t(`structure.preview_vbm`),
+    dos_available: t(`structure.preview_dos_available`),
+    bands_available: t(`structure.preview_bands_available`),
+    magnetic_ordering: t(`structure.preview_magnetic_ordering`),
+    yes: t(`structure.preview_yes`),
+    no: t(`structure.preview_no`),
+    available: t(`structure.preview_available`),
+    not_available: t(`structure.preview_not_available`),
+    metallic: t(`structure.preview_metallic`),
+    missing: t(`structure.preview_missing`),
+  })
 
   async function copy_to_clipboard(label: string, value: string, key: string) {
     try {
@@ -310,6 +337,18 @@
   {...rest}
 >
   <h4 style="margin-top: 0">{t('structure.structure_info')}</h4>
+  {#if electronic_props}
+    <section class="electronic-section">
+      <h4>{t('structure.preview_electronic_heading')}</h4>
+      <ElectronicInfoPanel
+        props={electronic_props}
+        labels={electronic_labels}
+        heading={null}
+        hide_when_empty={true}
+      />
+    </section>
+    <hr />
+  {/if}
   {#each pane_data as section, sec_idx (section.title)}
     {#if sec_idx > 0}<hr />{/if}
     <section>

--- a/src/lib/structure/StructurePreview.svelte
+++ b/src/lib/structure/StructurePreview.svelte
@@ -5,15 +5,43 @@
   import { Canvas } from '@threlte/core'
   import { SvelteMap } from 'svelte/reactivity'
   import StructureScene from './StructureScene.svelte'
+  import ElectronicInfoPanel from './ElectronicInfoPanel.svelte'
+  import type { ElectronicProps, ElectronicLabels } from './electronic_preview'
 
   interface Props {
     structure: PymatgenStructure | null
     onselect?: (index: number) => void
     adsorption_sites?: AdsorptionSite[]
     on_adsorption_site_click?: (site_idx: number) => void
+    // Optional electronic-structure metadata. If omitted, falls back to
+    // `structure._electronic_props` (stashed by import handlers); pass
+    // `null` explicitly to suppress the overlay even when stashed data
+    // would otherwise show.
+    electronic_props?: ElectronicProps | null
+    electronic_labels?: Partial<ElectronicLabels>
+    /** Corner position of the overlay; set to `none` to hide. */
+    electronic_overlay?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'none'
   }
 
-  let { structure, onselect, adsorption_sites = [], on_adsorption_site_click }: Props = $props()
+  let {
+    structure,
+    onselect,
+    adsorption_sites = [],
+    on_adsorption_site_click,
+    electronic_props,
+    electronic_labels = {},
+    electronic_overlay = 'none',
+  }: Props = $props()
+
+  // Prefer explicit prop; fall back to anything stashed on the structure at import.
+  let resolved_electronic = $derived(
+    electronic_props === null
+      ? null
+      : (electronic_props
+        ?? (structure as unknown as { _electronic_props?: ElectronicProps } | null)
+          ?._electronic_props
+        ?? null),
+  )
 
   // Pass the structure through as-is. Previously this called
   // `get_pbc_image_sites()` unconditionally to add PBC image atoms,
@@ -125,6 +153,16 @@
           bind:initial_computed_zoom
         />
       </Canvas>
+      {#if resolved_electronic && electronic_overlay !== 'none'}
+        <div class="electronic-overlay" data-corner={electronic_overlay}>
+          <ElectronicInfoPanel
+            props={resolved_electronic}
+            labels={electronic_labels}
+            heading={null}
+            compact={true}
+          />
+        </div>
+      {/if}
     </div>
   {/if}
 {:else}
@@ -154,6 +192,25 @@
     padding: 0 !important;
     border: none !important;
   }
+
+  .electronic-overlay {
+    position: absolute;
+    z-index: 5;
+    pointer-events: none;
+    max-width: 220px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: rgba(20, 20, 20, 0.75);
+    color: #eee;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    font-size: 0.75rem;
+  }
+  .electronic-overlay[data-corner='top-left'] { top: 8px; left: 8px; }
+  .electronic-overlay[data-corner='top-right'] { top: 8px; right: 8px; }
+  .electronic-overlay[data-corner='bottom-left'] { bottom: 8px; left: 8px; }
+  .electronic-overlay[data-corner='bottom-right'] { bottom: 8px; right: 8px; }
 
   .no-structure {
     width: 100%;

--- a/src/lib/structure/__tests__/electronic_preview.test.ts
+++ b/src/lib/structure/__tests__/electronic_preview.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildElectronicRows,
+  electronic_props_from_mp,
+  electronic_props_from_optimade,
+} from '../electronic_preview'
+
+const by_label = (rows: { label: string; value: string }[]) =>
+  Object.fromEntries(rows.map((r) => [r.label, r.value]))
+
+describe('buildElectronicRows', () => {
+  it('renders all 8 rows in stable order even when empty', () => {
+    const rows = buildElectronicRows({})
+    expect(rows.map((r) => r.label)).toEqual([
+      'Band gap:',
+      'Metal:',
+      'Fermi energy:',
+      'CBM:',
+      'VBM:',
+      'DOS:',
+      'Bands:',
+      'Magnetic order:',
+    ])
+    // All values fall back to em-dash when the database supplies nothing.
+    for (const r of rows) expect(r.value).toBe('—')
+  })
+
+  it('formats a full MP-style payload with eV units and ordering enum', () => {
+    const rows = buildElectronicRows({
+      band_gap: 1.234,
+      is_metal: false,
+      efermi: 4.5,
+      cbm: 5.1,
+      vbm: 3.87654,
+      has_dos: true,
+      has_bandstructure: true,
+      magnetic_ordering: 'AFM',
+    })
+    const b = by_label(rows)
+    expect(b['Band gap:']).toBe('1.234 eV')
+    expect(b['Metal:']).toBe('No')
+    expect(b['Fermi energy:']).toBe('4.5 eV')
+    expect(b['CBM:']).toBe('5.1 eV')
+    expect(b['VBM:']).toBe('3.877 eV') // trailing zero trimmed after rounding
+    expect(b['DOS:']).toBe('available')
+    expect(b['Bands:']).toBe('available')
+    expect(b['Magnetic order:']).toBe('Antiferromagnetic')
+  })
+
+  it('shows "metallic" in the band-gap slot when is_metal=true', () => {
+    const rows = buildElectronicRows({ is_metal: true, band_gap: 0 })
+    const b = by_label(rows)
+    expect(b['Band gap:']).toBe('metallic')
+    expect(b['Metal:']).toBe('Yes')
+  })
+
+  it('renders partial payload with mixed missing fields', () => {
+    const rows = buildElectronicRows({
+      band_gap: 0.5,
+      is_metal: false,
+      has_dos: false, // explicit "not available"
+      // efermi/cbm/vbm/has_bandstructure/ordering all missing
+    })
+    const b = by_label(rows)
+    expect(b['Band gap:']).toBe('0.5 eV')
+    expect(b['Metal:']).toBe('No')
+    expect(b['Fermi energy:']).toBe('—')
+    expect(b['CBM:']).toBe('—')
+    expect(b['VBM:']).toBe('—')
+    expect(b['DOS:']).toBe('not available')
+    expect(b['Bands:']).toBe('—')
+    expect(b['Magnetic order:']).toBe('—')
+  })
+
+  it('honours custom label overrides (i18n path)', () => {
+    const rows = buildElectronicRows(
+      { is_metal: true, has_dos: true, magnetic_ordering: 'FM' },
+      {
+        band_gap: '带隙：',
+        is_metal: '金属性：',
+        dos_available: '态密度：',
+        magnetic_ordering: '磁有序：',
+        metallic: '金属性',
+        yes: '是',
+        no: '否',
+        available: '可用',
+        not_available: '不可用',
+        missing: '—',
+      },
+    )
+    const b = by_label(rows)
+    expect(b['带隙：']).toBe('金属性')
+    expect(b['金属性：']).toBe('是')
+    expect(b['态密度：']).toBe('可用')
+    expect(b['磁有序：']).toBe('Ferromagnetic') // ordering enum is provider data, not localized
+  })
+
+  it('passes through unknown ordering values verbatim', () => {
+    const rows = buildElectronicRows({ magnetic_ordering: 'SomeNewOrdering' })
+    expect(by_label(rows)['Magnetic order:']).toBe('SomeNewOrdering')
+  })
+
+  it('treats null/undefined and NaN as missing, never crashes', () => {
+    const rows = buildElectronicRows({
+      band_gap: null as any,
+      is_metal: null as any,
+      efermi: Number.NaN,
+      cbm: undefined,
+      vbm: Infinity, // not finite → missing
+    })
+    const b = by_label(rows)
+    expect(b['Band gap:']).toBe('—')
+    expect(b['Metal:']).toBe('—')
+    expect(b['Fermi energy:']).toBe('—')
+    expect(b['CBM:']).toBe('—')
+    expect(b['VBM:']).toBe('—')
+  })
+})
+
+describe('electronic_props_from_mp', () => {
+  it('extracts dos/bandstructure from has_props', () => {
+    const props = electronic_props_from_mp({
+      band_gap: 1.1,
+      is_metal: false,
+      efermi: 5.0,
+      cbm: 5.6,
+      vbm: 4.5,
+      ordering: 'NM',
+      has_props: { dos: true, bandstructure: true, magnetism: false },
+    })
+    expect(props.band_gap).toBe(1.1)
+    expect(props.efermi).toBe(5.0)
+    expect(props.has_dos).toBe(true)
+    expect(props.has_bandstructure).toBe(true)
+    expect(props.magnetic_ordering).toBe('NM')
+  })
+
+  it('returns empty object for null/undefined input', () => {
+    expect(electronic_props_from_mp(null)).toEqual({})
+    expect(electronic_props_from_mp(undefined)).toEqual({})
+  })
+})
+
+describe('electronic_props_from_optimade', () => {
+  it('passes ProviderDetails fields straight through', () => {
+    const props = electronic_props_from_optimade({
+      band_gap: 2.3,
+      is_metal: false,
+      efermi: 3.1,
+      magnetic_ordering: 'FM',
+    })
+    expect(props.band_gap).toBe(2.3)
+    expect(props.efermi).toBe(3.1)
+    expect(props.magnetic_ordering).toBe('FM')
+  })
+
+  it('returns empty object for null/undefined input', () => {
+    expect(electronic_props_from_optimade(null)).toEqual({})
+    expect(electronic_props_from_optimade(undefined)).toEqual({})
+  })
+})
+
+describe('end-to-end: OPTIMADE attrs → ElectronicProps → rows', () => {
+  // Lock in the realistic shape MP's OPTIMADE adapter returns when the
+  // search/fetch endpoint requests _mp_* extras (the bug we just fixed).
+  it('renders Band gap / Metal rows for a metallic MP structure (Mg, mp-1056702)', async () => {
+    const { extract_provider_details } = await import('../../api/optimade')
+    const mp_mg_attrs = {
+      chemical_formula_reduced: 'Mg',
+      chemical_formula_descriptive: 'Mg',
+      nsites: 1,
+      _mp_band_gap: 0,
+      _mp_is_metal: true,
+    }
+    const pd = extract_provider_details(mp_mg_attrs as Record<string, unknown>)
+    const elec = electronic_props_from_optimade(pd)
+    const rows = buildElectronicRows(elec)
+    const b = by_label(rows)
+    expect(b['Band gap:']).toBe('metallic')
+    expect(b['Metal:']).toBe('Yes')
+    // Fields MP's OPTIMADE adapter doesn't expose should fall through to —.
+    expect(b['Fermi energy:']).toBe('—')
+    expect(b['CBM:']).toBe('—')
+    expect(b['VBM:']).toBe('—')
+  })
+
+  it('renders a richer row set when MP REST summary is available', () => {
+    const elec = electronic_props_from_mp({
+      band_gap: 1.234,
+      is_metal: false,
+      efermi: 4.5,
+      cbm: 5.1,
+      vbm: 3.877,
+      ordering: 'AFM',
+      has_props: { dos: true, bandstructure: true },
+    })
+    const b = by_label(buildElectronicRows(elec))
+    expect(b['Band gap:']).toBe('1.234 eV')
+    expect(b['Metal:']).toBe('No')
+    expect(b['Fermi energy:']).toBe('4.5 eV')
+    expect(b['Magnetic order:']).toBe('Antiferromagnetic')
+    expect(b['DOS:']).toBe('available')
+    expect(b['Bands:']).toBe('available')
+  })
+})

--- a/src/lib/structure/electronic_preview.ts
+++ b/src/lib/structure/electronic_preview.ts
@@ -1,0 +1,173 @@
+// Build the "Electronic structure" rows shown in import preview modals,
+// from whatever electronic-property fields a database happens to expose.
+// One source of truth so MP, OPTIMADE, and any future provider render the
+// same way (and degrade to "—" identically when fields are missing).
+
+import type { PreviewDetailRow } from './OptimadePreviewModal.svelte'
+
+export interface ElectronicProps {
+  band_gap?: number | null
+  is_metal?: boolean | null
+  efermi?: number | null
+  cbm?: number | null
+  vbm?: number | null
+  has_dos?: boolean | null
+  has_bandstructure?: boolean | null
+  magnetic_ordering?: string | null
+}
+
+export interface ElectronicLabels {
+  band_gap: string
+  is_metal: string
+  efermi: string
+  cbm: string
+  vbm: string
+  dos_available: string
+  bands_available: string
+  magnetic_ordering: string
+  /** Yes/no for the "Metal:" row. */
+  yes: string
+  no: string
+  /** Available/not available for "DOS:" and "Bands:" rows. */
+  available: string
+  not_available: string
+  metallic: string
+  missing: string
+}
+
+const DEFAULT_LABELS: ElectronicLabels = {
+  band_gap: `Band gap:`,
+  is_metal: `Metal:`,
+  efermi: `Fermi energy:`,
+  cbm: `CBM:`,
+  vbm: `VBM:`,
+  dos_available: `DOS:`,
+  bands_available: `Bands:`,
+  magnetic_ordering: `Magnetic order:`,
+  yes: `Yes`,
+  no: `No`,
+  available: `available`,
+  not_available: `not available`,
+  metallic: `metallic`,
+  missing: `—`, // em dash
+}
+
+function fmt_eV(v: number | null | undefined): string | null {
+  if (typeof v !== `number` || !Number.isFinite(v)) return null
+  // 3 decimals is the MP convention; trim trailing zeros for readability.
+  return `${v.toFixed(3).replace(/\.?0+$/, ``)} eV`
+}
+
+function fmt_bool_available(v: boolean | null | undefined, labels: ElectronicLabels): string | null {
+  if (v === true) return labels.available
+  if (v === false) return labels.not_available
+  return null
+}
+
+// MP's `ordering` enum → human label. Pass anything else through verbatim so
+// providers with their own vocabulary (or future MP additions) aren't lost.
+function fmt_magnetic_ordering(v: string | null | undefined): string | null {
+  if (!v) return null
+  const map: Record<string, string> = {
+    FM: `Ferromagnetic`,
+    AFM: `Antiferromagnetic`,
+    FiM: `Ferrimagnetic`,
+    NM: `Nonmagnetic`,
+    Unknown: `Unknown`,
+  }
+  return map[v] ?? v
+}
+
+/**
+ * Build preview rows for the electronic-structure block.
+ *
+ * Always returns the same 8 rows in the same order so the modal layout is
+ * stable across databases. Missing fields render as labels.missing ("—").
+ */
+export function buildElectronicRows(
+  props: ElectronicProps,
+  labels: Partial<ElectronicLabels> = {},
+): PreviewDetailRow[] {
+  const L = { ...DEFAULT_LABELS, ...labels }
+
+  // band_gap row: if the material is metallic show "metallic" (band gap of 0
+  // is conventionally reported but "metallic" reads better in a preview).
+  let gap_value: string
+  if (props.is_metal === true) {
+    gap_value = L.metallic
+  } else {
+    gap_value = fmt_eV(props.band_gap ?? null) ?? L.missing
+  }
+
+  return [
+    { label: L.band_gap, value: gap_value },
+    {
+      label: L.is_metal,
+      value: props.is_metal === true ? L.yes : props.is_metal === false ? L.no : L.missing,
+    },
+    { label: L.efermi, value: fmt_eV(props.efermi ?? null) ?? L.missing },
+    { label: L.cbm, value: fmt_eV(props.cbm ?? null) ?? L.missing },
+    { label: L.vbm, value: fmt_eV(props.vbm ?? null) ?? L.missing },
+    { label: L.dos_available, value: fmt_bool_available(props.has_dos ?? null, L) ?? L.missing },
+    {
+      label: L.bands_available,
+      value: fmt_bool_available(props.has_bandstructure ?? null, L) ?? L.missing,
+    },
+    {
+      label: L.magnetic_ordering,
+      value: fmt_magnetic_ordering(props.magnetic_ordering ?? null) ?? L.missing,
+    },
+  ]
+}
+
+// Adapters: normalize a payload from a specific database into ElectronicProps
+// so callers don't sprinkle field-name knowledge across the codebase.
+
+export function electronic_props_from_mp(
+  summary: {
+    band_gap?: number
+    is_metal?: boolean
+    efermi?: number
+    cbm?: number
+    vbm?: number
+    ordering?: string
+    has_props?: Record<string, boolean>
+  } | null | undefined,
+): ElectronicProps {
+  if (!summary) return {}
+  return {
+    band_gap: summary.band_gap,
+    is_metal: summary.is_metal,
+    efermi: summary.efermi,
+    cbm: summary.cbm,
+    vbm: summary.vbm,
+    has_dos: summary.has_props?.dos,
+    has_bandstructure: summary.has_props?.bandstructure,
+    magnetic_ordering: summary.ordering,
+  }
+}
+
+export function electronic_props_from_optimade(
+  details: {
+    band_gap?: number
+    is_metal?: boolean
+    efermi?: number
+    cbm?: number
+    vbm?: number
+    has_dos?: boolean
+    has_bandstructure?: boolean
+    magnetic_ordering?: string
+  } | null | undefined,
+): ElectronicProps {
+  if (!details) return {}
+  return {
+    band_gap: details.band_gap,
+    is_metal: details.is_metal,
+    efermi: details.efermi,
+    cbm: details.cbm,
+    vbm: details.vbm,
+    has_dos: details.has_dos,
+    has_bandstructure: details.has_bandstructure,
+    magnetic_ordering: details.magnetic_ordering,
+  }
+}

--- a/src/lib/workflow/CalcStructurePreview.svelte
+++ b/src/lib/workflow/CalcStructurePreview.svelte
@@ -52,7 +52,7 @@
   <div class="calc-preview">
     <div class="preview-viewport">
       {#if structure}
-        <StructurePreview {structure} />
+        <StructurePreview {structure} electronic_overlay="top-left" />
         {#if on_expand}
           <button class="viewport-expand-btn" onclick={on_expand} title={t('workflow.calc_open_full_viewer')}>&#x26F6;</button>
         {/if}

--- a/src/lib/workflow/MultiStructurePreview.svelte
+++ b/src/lib/workflow/MultiStructurePreview.svelte
@@ -190,7 +190,7 @@
   <!-- 3D Preview -->
   <div class="preview-viewport" style:height="{height}px">
     {#if current_structure}
-      <StructurePreview structure={current_structure} />
+      <StructurePreview structure={current_structure} electronic_overlay="top-left" />
       {#if on_expand}
         <button class="viewport-expand-btn" onclick={on_expand} title={t('workflow.calc_open_full_viewer')}>&#x26F6;</button>
       {/if}

--- a/src/lib/workflow/SlabGenPreview.svelte
+++ b/src/lib/workflow/SlabGenPreview.svelte
@@ -231,7 +231,7 @@
         <span>{error_msg}</span>
       </div>
     {:else if preview_structure}
-      <StructurePreview structure={preview_structure} />
+      <StructurePreview structure={preview_structure} electronic_overlay="top-left" />
       {#if on_expand}
         <button class="viewport-expand-btn" onclick={on_expand} title={t(`workflow.calc_open_full_viewer`)}>&#x26F6;</button>
       {/if}

--- a/src/lib/workflow/StructureInputDialog.svelte
+++ b/src/lib/workflow/StructureInputDialog.svelte
@@ -8,6 +8,13 @@
   import OptimadeSearchModal from '$lib/structure/OptimadeSearchModal.svelte'
   import OptimadePreviewModal from '$lib/structure/OptimadePreviewModal.svelte'
   import PubchemSearchModal from '$lib/structure/PubchemSearchModal.svelte'
+  import {
+    electronic_props_from_mp,
+    electronic_props_from_optimade,
+    type ElectronicProps,
+  } from '$lib/structure/electronic_preview'
+  import { extract_provider_details } from '$lib/api/optimade'
+  import type { MPSummaryData } from '$lib/api/materials-project'
   import { is_trajectory_file, parse_trajectory_async, MAX_BIN_FILE_SIZE, MAX_TEXT_FILE_SIZE } from '$lib/trajectory/parse'
   import type { TrajectoryType } from '$lib/trajectory'
   import type { PymatgenStructure } from '$lib/structure'
@@ -77,6 +84,7 @@
   let db_preview_formula = $state(``)
   let db_preview_details = $state<Array<{ label: string; value: string; mono?: boolean }>>([])
   let db_preview_lattice = $state<{ a: number; b: number; c: number; alpha: number; beta: number; gamma: number } | null>(null)
+  let db_preview_electronic = $state<ElectronicProps | null>(null)
 
   // ─── Trajectory state ───
   // IMPORTANT: trajectory stored as non-reactive to avoid Svelte proxifying
@@ -537,7 +545,11 @@
     }
   }
 
-  function handle_optimade_preview(optimade_struct: any, structure: PymatgenStructure) {
+  function handle_optimade_preview(
+    optimade_struct: any,
+    structure: PymatgenStructure,
+    mp_summary: MPSummaryData | null = null,
+  ) {
     db_preview_pymatgen = structure
     const attrs = optimade_struct?.attributes ?? {}
     const provider = attrs.database_provider ?? `OPTIMADE`
@@ -546,6 +558,15 @@
     const sites =
       attrs.n_sites ??
       (Array.isArray(attrs.cartesian_site_positions) ? attrs.cartesian_site_positions.length : 0)
+
+    let elec: ElectronicProps
+    if (mp_summary) {
+      elec = electronic_props_from_mp(mp_summary)
+    } else {
+      const pd = extract_provider_details(attrs as Record<string, unknown>)
+      elec = electronic_props_from_optimade(pd)
+    }
+    ;(structure as any)._electronic_props = elec
 
     db_preview_title = `Preview Structure Import`
     db_preview_formula = formula
@@ -556,6 +577,7 @@
       { label: `Sites:`, value: String(sites) },
       { label: `Database:`, value: provider },
     ]
+    db_preview_electronic = elec
     show_db_preview = true
   }
 
@@ -587,6 +609,7 @@
     db_preview_formula = formula
     db_preview_lattice = null
     db_preview_details = rows
+    db_preview_electronic = null // PubChem is molecular — no band/Fermi
     show_db_preview = true
   }
 
@@ -599,6 +622,7 @@
     show_db_preview = false
     db_preview_pymatgen = null
     db_preview_details = []
+    db_preview_electronic = null
     db_preview_formula = ``
     db_preview_lattice = null
     // Close the underlying search modal too
@@ -610,6 +634,7 @@
     show_db_preview = false
     db_preview_pymatgen = null
     db_preview_details = []
+    db_preview_electronic = null
     db_preview_formula = ``
     db_preview_lattice = null
     // Leave the search modal open so the user can pick a different result
@@ -963,6 +988,24 @@
   title={db_preview_title}
   formula={db_preview_formula}
   details={db_preview_details}
+  electronic_props={db_preview_electronic}
+  electronic_labels={{
+    band_gap: t(`structure.preview_band_gap`),
+    is_metal: t(`structure.preview_is_metal`),
+    efermi: t(`structure.preview_efermi`),
+    cbm: t(`structure.preview_cbm`),
+    vbm: t(`structure.preview_vbm`),
+    dos_available: t(`structure.preview_dos_available`),
+    bands_available: t(`structure.preview_bands_available`),
+    magnetic_ordering: t(`structure.preview_magnetic_ordering`),
+    yes: t(`structure.preview_yes`),
+    no: t(`structure.preview_no`),
+    available: t(`structure.preview_available`),
+    not_available: t(`structure.preview_not_available`),
+    metallic: t(`structure.preview_metallic`),
+    missing: t(`structure.preview_missing`),
+  }}
+  electronic_heading={t(`structure.preview_electronic_heading`)}
   lattice_params={db_preview_lattice}
 />
 


### PR DESCRIPTION
Adds band_gap, is_metal, efermi, cbm, vbm, magnetic ordering, and DOS / bandstructure availability to every structure-preview surface that imports from a database (Materials Project via OPTIMADE + REST, OPTIMADE providers generally). The same shared ElectronicInfoPanel is reused in the import preview modal, the loaded-structure info pane, the search-result cards, the 3D viewer corner overlay, and the workflow structure previews.

Backend
- materials_project.py: request cbm/vbm/efermi/ordering/has_props on MP REST.
- optimade.py: forward response_fields query param on per-structure fetch so MP's OPTIMADE adapter actually returns _mp_* extras (it omits them unless asked).

Frontend
- electronic_preview.ts: pure helper that normalises MP / OPTIMADE payloads into a stable ElectronicProps shape and renders 8 rows with i18n-aware formatting (eV units, metallic badge, ordering enum, em-dash fallback).
- ElectronicInfoPanel.svelte: single presentational component used everywhere.
- OptimadeSearchModal: per-card chips for the new fields; handle_import now mirrors the chip's two-tier mp_summaries lookup (primary id + structure fingerprint) and falls back to an on-demand MP REST fetch — fixes a race where the bulk enrichment hadn't resolved by click time.
- OptimadePreviewModal: takes ElectronicProps directly, renders the panel between Details and Lattice.
- Structure.svelte / desktop/App.svelte / workflow/StructureInputDialog: all three OptimadePreviewModal callers stash the metadata on the pending pymatgen and pass props through to the modal. Provider name now resolved from the providers list rather than hardcoded "OPTIMADE".
- align_on_load preserves the _electronic_props annotation across the spread that would otherwise drop session-local fields.
- StructureInfoPane: new Electronic-structure section at the top when the loaded structure carries metadata.
- StructurePreview: optional electronic_props prop + corner overlay (off by default; workflow previews opt in).

i18n
- 15 new keys in en/zh structure.ts (parity test green).

Tests
- 13 new vitest cases covering builder formatting, label overrides, MP and OPTIMADE adapters, NaN/null safety, and end-to-end extraction from realistic MP-via-OPTIMADE attrs.