### PR TITLE
feat(cli): expose the catgo CLI from the bundled app (no pip needed)

### DIFF
--- a/deploy/cli/catgo-cli
+++ b/deploy/cli/catgo-cli
@@ -1,0 +1,8 @@
+#!/bin/sh
+# CatGo CLI — thin wrapper. The bundled `catgo-server` sidecar contains the full
+# `catgo` Python package and dispatches CLI subcommands (dos/band/cohp/freq/
+# slab/supercell/reticular/convert/inspect/push/pull/submit/campaign/…) to
+# catgo.cli. This exposes them as `catgo-cli <subcommand>` so an app-only
+# install (no pip) still has the CLI. The desktop app binary is `catgo` (GUI),
+# hence the distinct `catgo-cli` name to avoid the collision.
+exec /usr/bin/catgo-server "$@"

--- a/deploy/cli/catgo-cli.cmd
+++ b/deploy/cli/catgo-cli.cmd
@@ -1,0 +1,4 @@
+@echo off
+REM CatGo CLI wrapper (Windows) — forwards to the bundled catgo-server, which
+REM dispatches CLI subcommands to catgo.cli. Place next to catgo-server.exe.
+"%~dp0catgo-server.exe" %*

--- a/server/main.py
+++ b/server/main.py
@@ -856,6 +856,24 @@ if __name__ == "__main__":
     import argparse
     import uvicorn
 
+    # ── catgo CLI passthrough ──────────────────────────────────────────────
+    # The packaged sidecar bundles the whole `catgo` package, so it can ALSO
+    # serve as the `catgo` CLI without shipping a second ~500 MB PyInstaller
+    # binary. When invoked as `catgo-server <subcommand>` (or via a `catgo-cli`
+    # wrapper/symlink) where <subcommand> is a catgo CLI command, delegate to
+    # `catgo.cli:main`. The desktop app spawns this sidecar with NO arguments
+    # (tauri `shell.sidecar("catgo-server").spawn()`), so the server path below
+    # is unaffected. `serve` is intentionally NOT delegated — server lifecycle
+    # stays here / with the app.
+    _CLI_PASSTHROUGH = {
+        "setup", "status", "stop", "campaign", "freq-inputs", "slab",
+        "supercell", "reticular", "convert", "inspect", "dos", "band",
+        "cohp", "freq", "push", "pull", "submit",
+    }
+    if len(sys.argv) > 1 and sys.argv[1] in _CLI_PASSTHROUGH:
+        from catgo.cli import main as _cli_main
+        raise SystemExit(_cli_main())
+
     parser = argparse.ArgumentParser(description="CatGo Computation Server")
     parser.add_argument("--daemon", action="store_true",
                         help="Run as a background daemon (Unix only)")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,6 +50,18 @@
     "macOS": {
       "minimumSystemVersion": "10.15"
     },
+    "linux": {
+      "deb": {
+        "files": {
+          "/usr/bin/catgo-cli": "../deploy/cli/catgo-cli"
+        }
+      },
+      "rpm": {
+        "files": {
+          "/usr/bin/catgo-cli": "../deploy/cli/catgo-cli"
+        }
+      }
+    },
     "iOS": {
       "minimumSystemVersion": "17.0",
       "infoPlist": "Info.ios.plist"


### PR DESCRIPTION
**Problem:** an app-only install has no Python `catgo` CLI. The desktop package ships `catgo-server` (PyInstaller bundle of the whole catgo package) + `catgo` (the GUI binary) + `catgo-agent` — but not the CLI, and `catgo` is the GUI, so `catgo dos/submit/...` isn't available without `pip install`.

**Fix (option B — reuse the existing bundle, no second ~500 MB binary):** `server/main.py` dispatches `catgo-server <subcommand>` (dos/band/cohp/freq/slab/supercell/reticular/convert/inspect/push/pull/submit/campaign/freq-inputs/setup/status/stop) to `catgo.cli:main`. The app spawns the sidecar with **no args** (`shell.sidecar("catgo-server").spawn()`), so the server path is unchanged; `serve` is deliberately not delegated.

Ergonomics: a thin `catgo-cli` wrapper (forwards to catgo-server) wired into the Linux **deb/rpm** at `/usr/bin/catgo-cli` (avoids the `catgo`=GUI name collision); a Windows `.cmd` is provided in `deploy/cli/`. Universal form `catgo-server <subcommand>` works on every platform.

`catgo.cli` is already fully collected by `catgo_server.spec` (collect_submodules('catgo'), 70 refs).

Verified: `catgo-server inspect --help` → catgo CLI; `catgo-server --help` → server argparse (unchanged); tauri.conf.json valid.

Follow-ups (noted, not in this PR): CLI subcommands import the server app module first (works, slightly wasteful); macOS .dmg has no `catgo-cli` wrapper yet (use `catgo-server <cmd>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)