### PR TITLE
release: v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2026-06-21
+
+### Added
+- **Viewer render styles** (`render_style`): a per-material shading mode — **Glossy** (specular), **Matte** (diffuse), **Toon** (3-band cel/cartoon with silhouette outline) — orthogonal to the colour scheme. Lives in the controls pane (中文: 光泽 / 哑光 / 卡通).
+- **Per-material lighting controls**: a Lighting group with light **azimuth + elevation** (direction), **directional + ambient** intensity and **highlight (specular) strength** — all update live. Each render style keeps its own lighting profile (remembered per material). Also corrects the viewer headlamp, which was lit from the lower-left, to light from above.
+- **Bond-order perception in the 3D viewer** (`Bond orders` / 键级, off by default): perceives double / triple / aromatic bond orders across the whole structure — molecular adsorbates **and** carbon-framework catalysts (graphene, C₃N₄, h-BN, COF). Doubles/triples render as offset multi-cylinders; aromatic rings render as a single inscribed ring per hexagon (PBC-aware: cross-cell hexagons are detected, deduped and wrapped into the cell). Metals stay single-bonded.
+- **CatBot atom-selection DSL**: agents can select atoms by query — `elem:O AND frac:c>0.9`, `label:O1`, `bonded:@i`, `sphere:@i;r`, with `AND`/`OR`/`NOT` and parentheses — via the `catgo_view` `select` action (no manual UI; nobody memorises a DSL).
+- **DOS/COHP/BANDS plots**: customizable per-series line colours, Nature-style colour presets, and publication DPI × width PNG export.
+- **CatGo CLI from the bundled app**: the `catgo` command is exposed by the packaged build (no `pip install` needed).
+- **CatBot workflow editing**: client-direct chat providers can now build and edit workflows.
+
+### Fixed
+- **Electronic-structure DB previews** and assorted import/review fixes.
+
 ## [1.3.1] - 2026-06-20
 
 ### Fixed

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures, molecules and MD / optimization trajectories — reads the file formats of VASP, Quantum ESPRESSO, CP2K, ABACUS, ORCA, Gaussian, CASTEP, SIESTA, OpenMX, LAMMPS and ASE: POSCAR/CONTCAR · CIF · XYZ/extXYZ · mol2 · PDB · vasprun.xml · OUTCAR · XDATCAR · .traj · HDF5 · cube/CHGCAR isosurfaces. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, trajectory scrubbing with energy/force overlays, themes that follow VS Code. Right-click → Render, or Ctrl/Cmd+Shift+V.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.3.1"
+version = "1.3.2"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump to **1.3.2** across all manifests + CHANGELOG.

Bundles the features merged since v1.3.1 (#392–#398): render styles (Glossy/Matte/Toon) + per-material lighting, whole-structure bond orders (double/triple/aromatic, incl. graphene/C3N4), CatBot selection DSL, DOS/COHP/BANDS colors + Nature presets + DPI export, catgo CLI from the bundle.

Merging + tagging v1.3.2 triggers the desktop / HPC-bundle / VSCode-sidecar / VSIX builds; iOS + Android dispatched after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)