### PR TITLE
fix(dos): parse adjacent signed PROCAR floats

### DIFF
--- a/extensions/dos-analysis/catgo_dos/io.py
+++ b/extensions/dos-analysis/catgo_dos/io.py
@@ -37,6 +37,16 @@ def _parse_float_fields(text: str) -> list[float]:
     return [float(match.group(0)) for match in _FLOAT_RE.finditer(text)]
 
 
+def _normalize_adjacent_signed_floats(text: str) -> str:
+    """Insert whitespace between adjacent floats while preserving exponents.
+
+    VASP can emit fixed-width values without a separating space when the next
+    value is signed, e.g. ``0.30000000-0.10000000``. Add a space before that
+    sign globally, but do not touch exponent signs such as ``1.25E-03``.
+    """
+    return re.sub(r"(?<=[0-9])([+-])(?=[0-9.])", r" \1", text)
+
+
 def _decode(x: object) -> str:
     if isinstance(x, (bytes, np.bytes_)):
         return x.decode()
@@ -315,6 +325,8 @@ def read_procar(
     -------
     VaspData
     """
+    procar_text = _normalize_adjacent_signed_floats(procar_text)
+
     # --- Step 1: Parse header ---
     # Line 2: "# of k-points:  N   # of bands:  M   # of ions:  K"
     header_match = re.search(
@@ -331,7 +343,7 @@ def read_procar(
 
     # --- Step 2: Parse k-points and weights ---
     kpoint_pattern = re.compile(
-        r"k-point\s+(\d+)\s*:\s+([-.\d\s]+?)weight\s*=\s*([-.\d]+)"
+        r"k-point\s+(\d+)\s*:\s+([-+.\d\sEe]+?)weight\s*=\s*([-+.\dEe]+)"
     )
     kp_matches = kpoint_pattern.findall(procar_text)
 
@@ -354,9 +366,11 @@ def read_procar(
     kpoints = np.zeros((nkpts, 3))
     kweights = np.zeros(nkpts)
     for i in range(nkpts):
-        coords = kp_matches[i][1].split()
-        kpoints[i] = [float(c) for c in coords[:3]]
-        kweights[i] = float(kp_matches[i][2])
+        coords = _parse_float_fields(kp_matches[i][1])
+        if len(coords) < 3:
+            raise ValueError(f"Could not parse k-point coordinates from PROCAR entry {i + 1}")
+        kpoints[i] = coords[:3]
+        kweights[i] = _parse_float_fields(kp_matches[i][2])[0]
 
     # Normalize weights to sum to 1
     wsum = kweights.sum()

--- a/server/tests/test_procar_parser.py
+++ b/server/tests/test_procar_parser.py
@@ -4,6 +4,16 @@ from catgo.cli._extpath import ensure_extension
 def test_procar_parser_splits_adjacent_signed_floats():
     mod = ensure_extension("dos-analysis", "catgo_dos.io")
 
-    values = mod._parse_float_fields("0.00000000-0.00000000 1.25E-03-2.50E+01")
+    values = mod._parse_float_fields("0.00000000-0.00000000 0.30000000-0.10000000 1.25E-03-2.50E+01")
 
-    assert values == [0.0, -0.0, 1.25e-3, -25.0]
+    assert values == [0.0, -0.0, 0.3, -0.1, 1.25e-3, -25.0]
+
+
+def test_procar_normalizer_preserves_exponent_signs():
+    mod = ensure_extension("dos-analysis", "catgo_dos.io")
+
+    text = "0.30000000-0.10000000 1.25E-03-2.50E+01 3.0e+02+4.0"
+
+    assert mod._normalize_adjacent_signed_floats(text) == (
+        "0.30000000 -0.10000000 1.25E-03 -2.50E+01 3.0e+02 +4.0"
+    )


### PR DESCRIPTION
## Summary

This PR fixes a PROCAR parsing bug in DOS/PDOS analysis when VASP outputs adjacent signed floating-point values without whitespace.

Author: XCai@JXNU  
Email: 690857@163.com

## Problem

Some PROCAR files contain numeric fields where two float values are directly connected, for example:

0.00000000-0.00000000
0.00000000-0.40000000
0.30000000-0.10000000
1.25E-03-2.50E+01

The previous parser relied mainly on whitespace splitting. When values were concatenated like this, Python tried to parse the whole string as one float and failed with errors such as:

could not convert string to float: '0.00000000-0.00000000'

## Root Cause

VASP PROCAR output can use fixed-width numeric formatting. In some cases, especially for negative values or scientific notation, adjacent float fields may be printed without a separating space.

This is valid PROCAR-style output, but the parser treated whitespace as the only field boundary.

## Solution

This PR adds two layers of protection:

1. Normalize adjacent signed float fields before parsing by inserting missing whitespace between connected numbers.
2. Use regex-based float extraction for sensitive PROCAR sections, including k-point coordinates and projection rows.

The normalization preserves exponent signs, so values like 1.25E-03 are not incorrectly split.

## Verification

The following checks were performed locally:

git diff --check
py -m py_compile extensions/dos-analysis/catgo_dos/io.py

A manual parser assertion was also tested with adjacent signed floats and scientific notation, including:

0.30000000-0.10000000
1.25E-03-2.50E+01
3.0e+02+4.0

All checks passed.

Note: pytest was not run locally because pytest is not installed in the current Python environment.
