### PR TITLE
fix(hpc): support conn.run(input=) on subprocess SSH + local runners

### DIFF
--- a/server/catgo/utils/local_connection.py
+++ b/server/catgo/utils/local_connection.py
@@ -36,21 +36,29 @@ class SubprocessSSHRunner:
     def __init__(self, ssh_alias: str) -> None:
         self.ssh_alias = ssh_alias
 
-    async def run_raw(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
+    async def run_raw(
+        self, cmd: str, check: bool = False, timeout: float = 60, input: str | None = None
+    ) -> SubprocessCompletedProcess:
         """Run a command through ssh without forcing a login shell.
 
         File operations should not pay for user profile/module startup. Some
         HPC profiles print large oneAPI/module banners from login shells, which
         can both delay simple file commands and pollute stdout parsing.
+
+        `input`, when given, is piped to the remote command's stdin (matches the
+        asyncssh `conn.run(..., input=...)` interface — used to upload file
+        content via `cat > file`).
         """
         proc = await asyncio.create_subprocess_exec(
             "ssh", "-o", "BatchMode=yes", self.ssh_alias, cmd,
+            stdin=asyncio.subprocess.PIPE if input is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout
+                proc.communicate(input.encode() if input is not None else None),
+                timeout=timeout,
             )
         except (asyncio.TimeoutError, TimeoutError):
             try:
@@ -70,7 +78,9 @@ class SubprocessSSHRunner:
             raise RuntimeError(f"Command failed ({result.exit_status}): {result.stderr}")
         return result
 
-    async def run(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
+    async def run(
+        self, cmd: str, check: bool = False, timeout: float = 60, input: str | None = None
+    ) -> SubprocessCompletedProcess:
         # Wrap in login shell so module-managed tools (sbatch, squeue, etc.) are in PATH
         login_cmd = f"bash -l -c {shlex.quote(cmd)}"
         proc = await asyncio.create_subprocess_exec(
@@ -80,12 +90,14 @@ class SubprocessSSHRunner:
             # /usr/bin/ssh-askpass and dies with "Connection closed ... port 65535"
             # instead of a clean "Permission denied / master not active" error.
             "ssh", "-o", "BatchMode=yes", self.ssh_alias, login_cmd,
+            stdin=asyncio.subprocess.PIPE if input is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout
+                proc.communicate(input.encode() if input is not None else None),
+                timeout=timeout,
             )
         except (asyncio.TimeoutError, TimeoutError):
             try:
@@ -120,14 +132,18 @@ class LocalCommandRunner:
     (conn.run("cat ..."), conn.run("head -c ..."), etc.) work transparently.
     """
 
-    async def run(self, cmd: str, check: bool = False, timeout: float = 60) -> SubprocessCompletedProcess:
+    async def run(
+        self, cmd: str, check: bool = False, timeout: float = 60, input: str | None = None
+    ) -> SubprocessCompletedProcess:
         proc = await asyncio.create_subprocess_shell(
             cmd,
+            stdin=asyncio.subprocess.PIPE if input is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout
+            proc.communicate(input.encode() if input is not None else None),
+            timeout=timeout,
         )
         result = SubprocessCompletedProcess(
             exit_status=proc.returncode or 0,

--- a/server/tests/test_local_connection_input.py
+++ b/server/tests/test_local_connection_input.py
@@ -1,0 +1,43 @@
+"""conn.run(..., input=...) must pipe stdin on the subprocess SSH/local runners.
+
+Regression: job submit failed with
+``SubprocessSSHRunner.run() got an unexpected keyword argument 'input'`` —
+the submitter uploads (possibly user-edited) preview files via
+``conn.run("cat > file", input=content)``, which the asyncssh backend supports
+but the system-ssh / local subprocess backends did not.
+"""
+
+import asyncio
+import inspect
+
+from catgo.utils.local_connection import LocalCommandRunner, SubprocessSSHRunner
+
+# pytest-asyncio is not installed in this repo; drive coroutines via asyncio.run
+# so the tests actually execute (a bare `async def test_` would be a false pass).
+
+
+def test_local_runner_pipes_input_to_stdin(tmp_path):
+    target = tmp_path / "INCAR"
+    runner = LocalCommandRunner()
+    result = asyncio.run(runner.run(f"cat > {target}", input="ENCUT = 520\n", check=True))
+    assert result.exit_status == 0
+    assert target.read_text() == "ENCUT = 520\n"
+
+
+def test_local_runner_without_input_still_works():
+    runner = LocalCommandRunner()
+    result = asyncio.run(runner.run("echo hi", check=True))
+    assert result.exit_status == 0
+    assert result.stdout.strip() == "hi"
+
+
+def test_subprocess_ssh_runner_accepts_input_kwarg():
+    # The exact failure mode: the kwarg must exist on both run() and run_raw().
+    for name in ("run", "run_raw"):
+        params = inspect.signature(getattr(SubprocessSSHRunner, name)).parameters
+        assert "input" in params, f"SubprocessSSHRunner.{name} missing 'input'"
+
+
+def test_local_runner_accepts_input_kwarg():
+    params = inspect.signature(LocalCommandRunner.run).parameters
+    assert "input" in params


### PR DESCRIPTION
## Symptom

Running a workflow on HPC (Expanse, system-ssh/ControlMaster connection) — a Geometry Optimization step goes **FAILED** with:

> Submit failed: SubprocessSSHRunner.run() got an unexpected keyword argument 'input'

## Root cause

The submitter uploads (possibly user-edited) **preview** input files to the cluster via `conn.run("cat > {file}", input=content)` (`submitter.py:256`). The asyncssh connection backend accepts `input=` (pipes to stdin), but the two subprocess backends — `SubprocessSSHRunner` (system `ssh` + ControlMaster) and `LocalCommandRunner` — did **not** define the kwarg, so any task whose connection used them crashed the moment it tried to upload reviewed files.

## Fix

Add `input: str | None = None` to `SubprocessSSHRunner.run` / `run_raw` and `LocalCommandRunner.run`. When provided, open `stdin=PIPE` and feed it via `communicate(input.encode())` — matching the asyncssh `conn.run(..., input=...)` interface the caller expects.

## Verification

- `test_local_connection_input.py`: `LocalCommandRunner.run("cat > f", input=...)` writes the file end-to-end (real subprocess); the no-input path still works; both runners expose the `input` kwarg. **4 passed.**
- Note: pytest-asyncio is not installed in this repo (the `asyncio_mode` ini is ignored and bare `async def test_` are silent no-ops), so the new tests drive coroutines via `asyncio.run()` and actually execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)