### PR TITLE
feat(workflow): adsorbate-only freeze for frequency calcs (C1)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-c1-adsorbate-only-freeze.md
+++ b/docs/superpowers/plans/2026-06-23-c1-adsorbate-only-freeze.md
@@ -1,0 +1,332 @@
+# C1 — Adsorbate-Only Freeze Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make frequency calculations physically correct — fix the entire slab and vibrate only the adsorbate — by tagging adsorbate atoms and adding a `freeze_mode: adsorbate`.
+
+**Architecture:** `run_adsorbate_place` writes an `is_adsorbate` boolean site property on every output structure. A new `adsorbate` freeze mode (backend `vasp.py` + frontend `freeze.ts`) freezes every atom whose `is_adsorbate` is not True. The freq node defaults to this mode and the editor offers a one-click preset.
+
+**Tech Stack:** Python (pymatgen, pytest), Svelte 5 / TypeScript (vitest).
+
+## Global Constraints
+
+- Python style: type hints, docstrings, specific exceptions, module logger (no `print`).
+- Frontend style (enforced by `deno fmt`, do by hand — no deno here): single quotes, no semicolons, 2-space indent, 90-col.
+- Tests: pytest under `server/tests/` run via `uv run pytest` (pytest-asyncio NOT installed — drive coroutines with `asyncio.run`). Frontend vitest via `pnpm test`.
+- `is_adsorbate` is a per-site boolean stored under each site's `properties` (pymatgen `site_properties`), True on adsorbate atoms, False on slab atoms.
+
+---
+
+### Task 1: Tag adsorbate atoms in `run_adsorbate_place`
+
+**Files:**
+- Modify: `server/catgo/workflow/builtins_impl.py` (ferrox path `463-477`, pymatgen fallback `345-352`)
+- Test: `server/tests/test_adsorbate_tagging.py`
+
+**Interfaces:**
+- Produces: `run_adsorbate_place(...)` output `{"structure": <json>}` where the parsed pymatgen Structure has site property `is_adsorbate: list[bool]` (len == n_atoms), False for the first `n_slab` slab atoms and True for the appended adsorbate atoms.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_adsorbate_tagging.py
+"""run_adsorbate_place must tag adsorbate atoms with is_adsorbate=True."""
+import json
+from pymatgen.core import Lattice, Structure
+from catgo.workflow.builtins_impl import run_adsorbate_place
+
+
+def _slab_json() -> str:
+    lat = Lattice.from_parameters(3, 3, 20, 90, 90, 90)
+    s = Structure(lat, ["Pt"] * 4, [[0, 0, 0.2], [0, 0, 0.3], [0, 0, 0.4], [0, 0, 0.5]])
+    s.add_site_property("selective_dynamics", [[False] * 3, [False] * 3, [True] * 3, [True] * 3])
+    return json.dumps(s.as_dict())
+
+
+def test_adsorbate_atoms_are_tagged():
+    out = run_adsorbate_place(structure=_slab_json(), species="OH", site="ontop", height=2.0)
+    s = Structure.from_dict(json.loads(out["structure"]))
+    tag = s.site_properties.get("is_adsorbate")
+    assert tag is not None, "is_adsorbate property missing"
+    assert len(tag) == len(s)
+    assert tag[:4] == [False, False, False, False]   # slab
+    assert all(tag[4:]) and len(tag) > 4              # adsorbate (OH = 2 atoms)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && uv run pytest tests/test_adsorbate_tagging.py -q`
+Expected: FAIL — `is_adsorbate property missing` (ferrox absent here → fallback path runs).
+
+- [ ] **Step 3: Implement — pymatgen fallback path**
+
+In `builtins_impl.py`, replace the fallback return (currently lines ~345-352):
+
+```python
+        new_slab = slab.copy()
+        for elem, off in zip(elements, coords):
+            new_slab.append(
+                elem,
+                [chosen_3d[0] + off[0], chosen_3d[1] + off[1], chosen_3d[2] + off[2]],
+                coords_are_cartesian=True,
+            )
+        n_slab = len(slab)
+        new_slab.add_site_property(
+            "is_adsorbate", [i >= n_slab for i in range(len(new_slab))]
+        )
+        return {"structure": json.dumps(new_slab.as_dict())}
+```
+
+- [ ] **Step 4: Implement — ferrox path**
+
+In the ferrox `out_sites` loop (lines ~464-477), tag each site. Change the loop body so `props` always carries the flag:
+
+```python
+        if i < n_slab:
+            props = dict(slab_dict["sites"][i].get("properties") or {})
+        else:
+            props = {"selective_dynamics": [True, True, True]} if slab_has_sd else {}
+        props["is_adsorbate"] = i >= n_slab
+        out_sites.append({
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && uv run pytest tests/test_adsorbate_tagging.py -q`
+Expected: PASS (fallback path here; ferrox path covered by code review since ferrox is unavailable in this env).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/catgo/workflow/builtins_impl.py server/tests/test_adsorbate_tagging.py
+git commit -m "feat(workflow): tag adsorbate atoms with is_adsorbate in adsorbate_place"
+```
+
+---
+
+### Task 2: Backend `freeze_mode: adsorbate` in VASP freq generation
+
+**Files:**
+- Modify: `server/workflow/engines/vasp.py` (freq freeze block `289-349`)
+- Test: `server/tests/test_freq_adsorbate_freeze.py`
+
+**Interfaces:**
+- Consumes: structures carrying `is_adsorbate` site property (Task 1).
+- Produces: when `params["freeze_mode"] == "adsorbate"`, `generate_vasp_input_files("freq", params, structure_str)` returns a POSCAR whose adsorbate atoms (is_adsorbate True) are `T T T` and all other atoms `F F F`. When no `is_adsorbate` tag is present, it logs a warning and freezes nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_freq_adsorbate_freeze.py
+"""freeze_mode=adsorbate fixes the whole slab, frees only tagged adsorbate atoms."""
+import json
+from pymatgen.core import Lattice, Structure
+from workflow.engines.vasp import generate_vasp_input_files
+
+
+def _tagged_structure() -> str:
+    lat = Lattice.from_parameters(3, 3, 20, 90, 90, 90)
+    s = Structure(lat, ["Pt", "Pt", "Pt", "O", "H"],
+                  [[0, 0, 0.2], [0, 0, 0.3], [0, 0, 0.4], [0, 0, 0.6], [0, 0, 0.65]])
+    s.add_site_property("is_adsorbate", [False, False, False, True, True])
+    return json.dumps(s.as_dict())
+
+
+def _counts(poscar: str):
+    lines = poscar.splitlines()
+    fff = sum(1 for l in lines if "F F F" in l)
+    ttt = sum(1 for l in lines if "T T T" in l)
+    hdr = any("elective" in l for l in lines[:9])
+    return hdr, fff, ttt
+
+
+def test_adsorbate_mode_freezes_slab_frees_adsorbate():
+    files, _, _ = generate_vasp_input_files("freq", {"freeze_mode": "adsorbate"}, _tagged_structure())
+    hdr, fff, ttt = _counts(files["POSCAR"])
+    assert hdr and fff == 3 and ttt == 2   # 3 slab fixed, 2 adsorbate free
+
+
+def test_adsorbate_mode_without_tag_warns_and_freezes_nothing():
+    lat = Lattice.from_parameters(3, 3, 20, 90, 90, 90)
+    s = Structure(lat, ["Pt", "O"], [[0, 0, 0.2], [0, 0, 0.6]])
+    files, _, _ = generate_vasp_input_files("freq", {"freeze_mode": "adsorbate"}, json.dumps(s.as_dict()))
+    _, fff, _ = _counts(files["POSCAR"])
+    assert fff == 0   # no tag -> nothing frozen
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && uv run pytest tests/test_freq_adsorbate_freeze.py -q`
+Expected: FAIL — `adsorbate` mode not handled, frozen_set empty → `fff == 0` (first test fails).
+
+- [ ] **Step 3: Implement the adsorbate branch**
+
+In `vasp.py`, inside the `if node_type in ("freq", "frequency"):` block, add a branch alongside the others (after the `element` branch, before `layers/bottom`):
+
+```python
+        elif freeze_mode == "adsorbate" and struct:
+            tags = struct.site_properties.get("is_adsorbate")
+            if not tags or not any(tags):
+                logger.warning(
+                    "[FREEZE] freeze_mode=adsorbate but structure has no is_adsorbate "
+                    "tag (%d atoms) — freezing nothing", n_atoms)
+            else:
+                for idx, is_ads in enumerate(tags):
+                    if not is_ads:
+                        frozen_set.add(idx)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && uv run pytest tests/test_freq_adsorbate_freeze.py -q`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/workflow/engines/vasp.py server/tests/test_freq_adsorbate_freeze.py
+git commit -m "feat(vasp): add freeze_mode=adsorbate for frequency calcs"
+```
+
+---
+
+### Task 3: Frontend `freeze.ts` adsorbate mode (parity)
+
+**Files:**
+- Modify: `src/lib/workflow/freeze.ts` (mode handling `31-70`)
+- Test: `src/lib/workflow/__tests__/freeze.test.ts`
+
+**Interfaces:**
+- Consumes: a structure object whose sites carry `properties.is_adsorbate` (or top-level `site_properties.is_adsorbate`).
+- Produces: `apply_freeze_to_structure(struct, { freeze_mode: 'adsorbate' })` returns the structure with `selective_dynamics` = `[false,false,false]` for non-adsorbate sites, `[true,true,true]` for adsorbate sites.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// add to src/lib/workflow/__tests__/freeze.test.ts
+import { describe, it, expect } from 'vitest'
+import { apply_freeze_to_structure } from '../freeze'
+
+describe('freeze_mode adsorbate', () => {
+  it('fixes non-adsorbate atoms, frees adsorbate', () => {
+    const struct = {
+      sites: [
+        { properties: { is_adsorbate: false } },
+        { properties: { is_adsorbate: false } },
+        { properties: { is_adsorbate: true } },
+      ],
+    }
+    const out = apply_freeze_to_structure(struct as never, { freeze_mode: 'adsorbate' } as never)
+    const sd = out.sites.map((s: never) => (s as { properties: { selective_dynamics: boolean[] } }).properties.selective_dynamics)
+    expect(sd[0]).toEqual([false, false, false])
+    expect(sd[1]).toEqual([false, false, false])
+    expect(sd[2]).toEqual([true, true, true])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- freeze`
+Expected: FAIL — adsorbate mode unhandled (no selective_dynamics set / wrong values).
+
+- [ ] **Step 3: Implement the adsorbate branch in `freeze.ts`**
+
+In `apply_freeze_to_structure`, add a branch where the other modes are handled (mirror the structure of the `element`/`layers` branches). Read each site's `properties.is_adsorbate` (fall back to `site_properties.is_adsorbate[i]`), and freeze where it is not true:
+
+```ts
+  } else if (mode === 'adsorbate') {
+    const tag = (i: number): boolean => {
+      const per = struct.sites[i]?.properties?.is_adsorbate
+      if (typeof per === 'boolean') return per
+      const top = struct.site_properties?.is_adsorbate
+      return Array.isArray(top) ? !!top[i] : false
+    }
+    frozen = new Set(struct.sites.map((_s, i) => i).filter(i => !tag(i)))
+```
+
+(Match the exact local variable names/shape used by the surrounding branches — read `freeze.ts:20-70` first and adapt; the test above pins the observable behaviour.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- freeze`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/workflow/freeze.ts src/lib/workflow/__tests__/freeze.test.ts
+git commit -m "feat(workflow): add adsorbate freeze mode to frontend freeze helper"
+```
+
+---
+
+### Task 4: freq node default + editor preset
+
+**Files:**
+- Modify: `src/lib/workflow/node-defs/calculation/freq.ts` (default `28-31`, options `50-61`, help `60`)
+- Modify: `src/lib/workflow/NodeConfigPanel.svelte` (freq freeze quick-buttons `404-414`)
+
+**Interfaces:**
+- Consumes: `freeze_mode: 'adsorbate'` handled by Task 3.
+- Produces: new freq nodes default to `freeze_mode: 'adsorbate'`; the editor shows a "Fix slab, vibrate adsorbate only" quick-button and an `adsorbate` option in the Freeze Mode select.
+
+- [ ] **Step 1: freq default + select option**
+
+In `freq.ts`, change the default `freeze_mode: 'none'` → `freeze_mode: 'adsorbate'`, and add to the `freeze_mode` select options:
+
+```ts
+        { label: `Adsorbate only (fix slab)`, value: `adsorbate` },
+```
+
+Update the help text to note this is the recommended surface-frequency setting.
+
+- [ ] **Step 2: Editor quick-button**
+
+In `NodeConfigPanel.svelte` freq freeze quick-buttons block, add (matching the surrounding button markup/style):
+
+```svelte
+          <button class="freeze-quick-btn" onclick={() => emit({ ...node.params, freeze_mode: `adsorbate` })}>
+            Fix slab, vibrate adsorbate only
+          </button>
+```
+
+- [ ] **Step 3: Type-check + manual sanity**
+
+Run: `pnpm check`
+Expected: no new type errors in the two files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/workflow/node-defs/calculation/freq.ts src/lib/workflow/NodeConfigPanel.svelte
+git commit -m "feat(workflow): default freq to adsorbate-only freeze + editor preset"
+```
+
+---
+
+### Task 5: Patch the paused ORR workflow's freq nodes (operational)
+
+**Files:** none (data edit via running backend API at `http://127.0.0.1:8000`).
+
+- [ ] **Step 1: Set the 3 freq nodes to adsorbate mode**
+
+After Tasks 1-4 are merged and the backend restarted on the merged code, set
+`freeze_mode: adsorbate` (remove `freeze_mode: bottom`, `freeze_n_layers`) on
+`freq_OOH`, `freq_O`, `freq_OH` by re-saving the workflow graph (same
+graph-edit + `POST /api/workflow/` pattern used for the parallel re-wire), then
+`reset`. The adsorbate_place nodes will re-run and emit `is_adsorbate`-tagged
+structures the freq nodes consume.
+
+- [ ] **Step 2: Verify**
+
+Re-run; confirm each freq preview POSCAR fixes the whole slab and frees only the
+adsorbate (slab atoms `F F F`, adsorbate `T T T`).
+
+---
+
+## Self-Review
+
+- **Spec coverage (C1):** adsorbate tagging (Task 1), backend adsorbate mode (Task 2), frontend parity (Task 3), freq default + preset (Task 4), running-workflow patch (Task 5). ✓ C2/C3/C4 are separate plans.
+- **Placeholders:** Task 3 Step 3 intentionally defers to the surrounding `freeze.ts` variable shape; the test pins behaviour. Acceptable (UI-helper internals vary).
+- **Type consistency:** `is_adsorbate` (bool per site) is produced in Task 1 and consumed by name in Tasks 2/3. `freeze_mode: 'adsorbate'` consistent across Tasks 2-4.

--- a/docs/superpowers/specs/2026-06-23-workflow-freeze-correctness-design.md
+++ b/docs/superpowers/specs/2026-06-23-workflow-freeze-correctness-design.md
@@ -1,0 +1,120 @@
+# Workflow Freeze Correctness — Design
+
+**Date:** 2026-06-23
+**Status:** Approved (design), pending implementation plan
+
+## Problem
+
+Generated and edited catalysis workflows produce physically-incorrect DFT
+setups, silently sending wrong jobs to HPC:
+
+1. **freq uses the wrong constraint.** Frequency calculations on adsorbate/slab
+   systems must fix the *entire slab* and vibrate *only the adsorbate* (the
+   standard harmonic-adsorbate approximation). Today both the editor default and
+   CatBot's quickbuild `vasp_freq` preset use `freeze_mode: bottom, 2 layers`
+   (same as geo_opt) — so the top slab layers get vibrated. Physically wrong ZPE
+   / entropy.
+2. **CatBot's batch (LLM-authored) path applies no freeze at all.** The
+   `_NODE_DEFAULTS` for `geo_opt`/`freq`/`slab_gen` carry no freeze keys, so a
+   slab built that way is fully free.
+3. **No parameter validation.** Nothing checks that freeze-layer count ≤ slab
+   layers, or that VASP params (ENCUT/EDIFF/IBRION) are sane. `_get_layer_z_threshold`
+   silently clamps an over-count to "freeze everything".
+4. **No review nudge.** After CatBot builds a workflow the message just says
+   "adjust or Run" — nothing tells the user to verify freeze/params.
+
+Root enabler for #1: the adsorbate atoms are **not identifiable downstream**.
+`adsorbate_placement.py` computes `adsorbate_indices` but `run_adsorbate_place`
+discards them; the emitted structure carries no `is_adsorbate` marker.
+
+## Approved decisions
+
+- **Adsorbate identification: tag atoms** (Approach A). `run_adsorbate_place`
+  persists an `is_adsorbate` site property. A new `freeze_mode: adsorbate` fixes
+  every atom not tagged.
+- **Validation severity: warn-mostly, block on severe.** Most issues are
+  non-blocking warnings; hard errors (freeze layers > slab layers) block.
+
+## Components
+
+### C1 — Adsorbate-only freeze (physics core)
+
+The one fix that makes freq correct and unblocks the paused ORR workflow.
+
+- **Tag adsorbate atoms.** `run_adsorbate_place`
+  (`server/catgo/workflow/builtins_impl.py`) writes a per-site boolean
+  `is_adsorbate` site property (True on appended adsorbate atoms, False on slab)
+  in **both** paths: ferrox (`~456-483`, uses the placement engine's
+  `adsorbate_indices`/`n_slab`) and the pymatgen fallback (`~285-352`, the
+  appended atoms). Stop discarding `adsorbate_placement.py:335-347`'s indices.
+- **New `freeze_mode: adsorbate`** in backend `server/workflow/engines/vasp.py`
+  freq block (`~289-349`) and frontend `src/lib/workflow/freeze.ts`: freeze every
+  site whose `is_adsorbate` is not True → all-slab fixed, adsorbate free.
+  - Fallback: if no `is_adsorbate` property is present on the structure, emit a
+    **warning** and leave atoms free (do not silently mis-freeze); validation
+    (C3) flags it.
+- **freq node default** (`src/lib/workflow/node-defs/calculation/freq.ts:28`):
+  `freeze_mode: adsorbate`.
+- **Frontend preset**: `NodeConfigPanel.svelte` freq freeze quick-buttons gain
+  "Fix slab, vibrate adsorbate only" → sets `freeze_mode: adsorbate`. Keep the
+  existing freeze-warning (`:396-411`) but point its default fix at the new preset.
+- **Running-workflow patch**: once C1 lands, set the 3 freq nodes in the paused
+  ORR workflow to `freeze_mode: adsorbate` (they will get tagged structures from
+  the re-run adsorbate_place).
+
+### C2 — CatBot generation freeze defaults
+
+- **Quickbuild** (`server/catgo/mcp_tools/server_claude_code.py:2339-2341`):
+  `vasp_freq` preset → `freeze_mode: adsorbate` (drop `bottom`/`freeze_n_layers`).
+  `vasp_opt` keeps `freeze_mode: bottom, freeze_n_layers: 2` (correct for geo_opt).
+  Fix the `DOS` recipe geo_opt (`:2504`) to carry the same geo_opt freeze.
+- **workflow_builder skill**
+  (`server/catgo/workflow/skills/workflow_builder/SKILL.md`): update the freq
+  examples (`L44, L139, L155, L159`) to `freeze_mode: adsorbate`; document the
+  geo_opt-vs-freq freeze distinction.
+- **Batch path** (`workflow_tools.py` `_NODE_DEFAULTS`): do **not** force freeze
+  defaults (a molecular geo_opt must not freeze). Instead rely on the skill
+  guidance + C3 validation warning for un-frozen slabs.
+
+### C3 — Validation (warn-mostly, block-severe)
+
+A shared validator invoked from `dry_run_graph`
+(`server/catgo/routers/workflow_engine.py:319-376`, per-node with params +
+upstream structure) and surfaced through `_validate_graph`
+(`workflow_tools.py:959`) so all build paths see it.
+
+- **Block (error):** freeze-layer count > slab's distinct-z layer count.
+- **Warn:** slab/adsorbate `geo_opt` with no freeze; `freq` on a tagged-adsorbate
+  structure that is not `freeze_mode: adsorbate`; VASP params out of sane range
+  (e.g. ENCUT ∉ [200, 900], EDIFF > 1e-3, IBRION invalid for the calc type).
+- Replace the silent clamp in `_get_layer_z_threshold` (`vasp.py:46-52`) with a
+  surfaced warning/error.
+
+### C4 — Post-generation reminder
+
+- Quickbuild return (`server_claude_code.py:2639-2645`) and batch summary
+  (`workflow_tools.py:1592-1604`) append a review nudge: "⚠️ Review freeze
+  settings and key params (ENCUT/IBRION/frozen layers) before Run" plus any C3
+  warnings.
+
+## Sequencing & isolation
+
+C1 → C2 → C3 → C4, each a separate PR. C1 is the physics core and unblocks the
+paused workflow; C2 depends on C1's `adsorbate` mode; C3 and C4 are additive.
+
+## Testing
+
+- C1: `run_adsorbate_place` tags `is_adsorbate` (ferrox + fallback); `vasp.py`
+  freq with `freeze_mode: adsorbate` → POSCAR fixes all slab, frees adsorbate;
+  end-to-end slab→adsorbate→freq POSCAR (all-slab F F F, adsorbate T T T);
+  missing-tag fallback warns.
+- C2: quickbuild ORR/OER/HER recipes emit `freeze_mode: adsorbate` on freq;
+  geo_opt keeps bottom-N.
+- C3: validator blocks freeze-layers > slab-layers; warns on un-frozen slab
+  geo_opt / non-adsorbate freq / out-of-range ENCUT.
+- C4: quickbuild + batch responses contain the review nudge.
+
+## Out of scope
+
+- Re-architecting the workflow engine or the freeze UI beyond the new preset.
+- Non-VASP engines' freeze handling (CP2K/ORCA) — follow-up if needed.

--- a/server/catgo/workflow/builtins_impl.py
+++ b/server/catgo/workflow/builtins_impl.py
@@ -349,6 +349,12 @@ def run_adsorbate_place(
                 [chosen_3d[0] + off[0], chosen_3d[1] + off[1], chosen_3d[2] + off[2]],
                 coords_are_cartesian=True,
             )
+        # Tag adsorbate atoms so downstream freq can fix the slab and vibrate
+        # only the adsorbate (freeze_mode=adsorbate).
+        n_slab = len(slab)
+        new_slab.add_site_property(
+            "is_adsorbate", [i >= n_slab for i in range(len(new_slab))]
+        )
         return {"structure": json.dumps(new_slab.as_dict())}
 
     import numpy as np
@@ -468,6 +474,9 @@ def run_adsorbate_place(
             props = dict(slab_dict["sites"][i].get("properties") or {})
         else:
             props = {"selective_dynamics": [True, True, True]} if slab_has_sd else {}
+        # Tag adsorbate atoms so downstream freq can fix the slab and vibrate
+        # only the adsorbate (freeze_mode=adsorbate).
+        props["is_adsorbate"] = i >= n_slab
         out_sites.append({
             "species": [{"element": sym, "occu": 1}],
             "abc": abc,

--- a/server/tests/test_adsorbate_tagging.py
+++ b/server/tests/test_adsorbate_tagging.py
@@ -1,0 +1,23 @@
+"""run_adsorbate_place must tag adsorbate atoms with is_adsorbate=True."""
+import json
+
+from pymatgen.core import Lattice, Structure
+
+from catgo.workflow.builtins_impl import run_adsorbate_place
+
+
+def _slab_json() -> str:
+    lat = Lattice.from_parameters(3, 3, 20, 90, 90, 90)
+    s = Structure(lat, ["Pt"] * 4, [[0, 0, 0.2], [0, 0, 0.3], [0, 0, 0.4], [0, 0, 0.5]])
+    s.add_site_property("selective_dynamics", [[False] * 3, [False] * 3, [True] * 3, [True] * 3])
+    return json.dumps(s.as_dict())
+
+
+def test_adsorbate_atoms_are_tagged():
+    out = run_adsorbate_place(structure=_slab_json(), species="OH", site="ontop", height=2.0)
+    s = Structure.from_dict(json.loads(out["structure"]))
+    tag = s.site_properties.get("is_adsorbate")
+    assert tag is not None, "is_adsorbate property missing"
+    assert len(tag) == len(s)
+    assert tag[:4] == [False, False, False, False]   # slab
+    assert all(tag[4:]) and len(tag) > 4              # adsorbate (OH = 2 atoms)

--- a/server/tests/test_freq_adsorbate_freeze.py
+++ b/server/tests/test_freq_adsorbate_freeze.py
@@ -1,0 +1,36 @@
+"""freeze_mode=adsorbate fixes the whole slab, frees only tagged adsorbate atoms."""
+import json
+
+from pymatgen.core import Lattice, Structure
+
+from workflow.engines.vasp import generate_vasp_input_files
+
+
+def _tagged_structure() -> str:
+    lat = Lattice.from_parameters(3, 3, 20, 90, 90, 90)
+    s = Structure(lat, ["Pt", "Pt", "Pt", "O", "H"],
+                  [[0, 0, 0.2], [0, 0, 0.3], [0, 0, 0.4], [0, 0, 0.6], [0, 0, 0.65]])
+    s.add_site_property("is_adsorbate", [False, False, False, True, True])
+    return json.dumps(s.as_dict())
+
+
+def _counts(poscar: str):
+    lines = poscar.splitlines()
+    fff = sum(1 for l in lines if "F F F" in l)
+    ttt = sum(1 for l in lines if "T T T" in l)
+    hdr = any("elective" in l for l in lines[:9])
+    return hdr, fff, ttt
+
+
+def test_adsorbate_mode_freezes_slab_frees_adsorbate():
+    files, _, _ = generate_vasp_input_files("freq", {"freeze_mode": "adsorbate"}, _tagged_structure())
+    hdr, fff, ttt = _counts(files["POSCAR"])
+    assert hdr and fff == 3 and ttt == 2   # 3 slab fixed, 2 adsorbate free
+
+
+def test_adsorbate_mode_without_tag_warns_and_freezes_nothing():
+    lat = Lattice.from_parameters(3, 3, 20, 90, 90, 90)
+    s = Structure(lat, ["Pt", "O"], [[0, 0, 0.2], [0, 0, 0.6]])
+    files, _, _ = generate_vasp_input_files("freq", {"freeze_mode": "adsorbate"}, json.dumps(s.as_dict()))
+    _, fff, _ = _counts(files["POSCAR"])
+    assert fff == 0   # no tag -> nothing frozen

--- a/server/workflow/engines/vasp.py
+++ b/server/workflow/engines/vasp.py
@@ -304,6 +304,20 @@ def generate_vasp_input_files(
                 if str(site.specie) in elems:
                     frozen_set.add(idx)
 
+        elif freeze_mode == "adsorbate" and struct:
+            # Surface-frequency methodology: fix the entire slab, vibrate only the
+            # adsorbate. Adsorbate atoms are tagged is_adsorbate=True by
+            # run_adsorbate_place; everything else is frozen.
+            tags = struct.site_properties.get("is_adsorbate")
+            if not tags or not any(tags):
+                logger.warning(
+                    "[FREEZE] freeze_mode=adsorbate but structure has no is_adsorbate "
+                    "tag (%d atoms) — freezing nothing", n_atoms)
+            else:
+                for idx, is_ads in enumerate(tags):
+                    if not is_ads:
+                        frozen_set.add(idx)
+
         elif freeze_mode in ("indices", "manual"):
             idx_str = str(params.get("freeze_indices", ""))
             for part in idx_str.split(","):

--- a/src/lib/i18n/en/workflow.ts
+++ b/src/lib/i18n/en/workflow.ts
@@ -135,6 +135,7 @@ const workflow: Record<string, string> = {
   config_incar_preset: `INCAR Preset`,
   config_manual: `Manual`,
   config_freeze_warning: `For surface calculations, freeze bulk atoms so only surface + adsorbate vibrate.`,
+  config_freeze_adsorbate_only: `Fix slab, vibrate adsorbate only`,
   config_freeze_by_layers: `Freeze by Layers`,
   config_freeze_by_height: `Freeze by Height`,
   config_select_in_3d: `Select in 3D`,

--- a/src/lib/i18n/zh/workflow.ts
+++ b/src/lib/i18n/zh/workflow.ts
@@ -135,6 +135,7 @@ const workflow: Record<string, string> = {
   config_incar_preset: `INCAR 预设`,
   config_manual: `手动`,
   config_freeze_warning: `对于表面计算，请冻结体相原子，仅让表面和吸附物参与振动。`,
+  config_freeze_adsorbate_only: `固定 slab，仅吸附物振动`,
   config_freeze_by_layers: `按层冻结`,
   config_freeze_by_height: `按高度冻结`,
   config_select_in_3d: `在 3D 中选择`,

--- a/src/lib/workflow/NodeConfigPanel.svelte
+++ b/src/lib/workflow/NodeConfigPanel.svelte
@@ -402,6 +402,9 @@
           {t('workflow.config_freeze_warning')}
         </span>
         <div class="freeze-quick-actions">
+          <button class="freeze-quick-btn" onclick={() => emit({ ...node.params, freeze_mode: `adsorbate` })}>
+            {t('workflow.config_freeze_adsorbate_only')}
+          </button>
           <button class="freeze-quick-btn" onclick={() => emit({ ...node.params, freeze_mode: `layers`, freeze_layers: node.params.freeze_layers || 4 })}>
             {t('workflow.config_freeze_by_layers')}
           </button>

--- a/src/lib/workflow/__tests__/freeze.test.ts
+++ b/src/lib/workflow/__tests__/freeze.test.ts
@@ -15,6 +15,33 @@ import { apply_freeze_to_structure } from '../freeze'
  * node" leak stays fixed.
  */
 
+describe(`freeze_mode adsorbate`, () => {
+  function tagged(): string {
+    return JSON.stringify({
+      lattice: { matrix: [[5, 0, 0], [0, 5, 0], [0, 0, 20]] },
+      sites: [
+        { species: [{ element: `Pt`, occu: 1 }], xyz: [0, 0, 0], label: `Pt`, properties: { is_adsorbate: false } },
+        { species: [{ element: `Pt`, occu: 1 }], xyz: [0, 0, 1], label: `Pt`, properties: { is_adsorbate: false } },
+        { species: [{ element: `O`, occu: 1 }], xyz: [0, 0, 3], label: `O`, properties: { is_adsorbate: true } },
+      ],
+    })
+  }
+
+  it(`fixes non-adsorbate atoms, frees adsorbate`, () => {
+    const out = JSON.parse(apply_freeze_to_structure(tagged(), { freeze_mode: `adsorbate` })!)
+    expect(out.sites[0].properties.selective_dynamics).toEqual([false, false, false])
+    expect(out.sites[1].properties.selective_dynamics).toEqual([false, false, false])
+    expect(out.sites[2].properties.selective_dynamics).toEqual([true, true, true])
+  })
+
+  it(`freezes nothing when no atom is tagged`, () => {
+    const untagged = JSON.parse(tagged())
+    untagged.sites.forEach((s: { properties: Record<string, unknown> }) => { s.properties = {} })
+    const out = JSON.parse(apply_freeze_to_structure(JSON.stringify(untagged), { freeze_mode: `adsorbate` })!)
+    for (const s of out.sites) expect(s.properties.selective_dynamics).toEqual([true, true, true])
+  })
+})
+
 /** A 4-atom slab spread across 4 distinct z-layers (z = 0, 1, 2, 3). */
 function make_slab(): string {
   return JSON.stringify({

--- a/src/lib/workflow/freeze.ts
+++ b/src/lib/workflow/freeze.ts
@@ -52,6 +52,16 @@ export function apply_freeze_to_structure(struct_json: string | null, params: Re
           if (!isNaN(v)) frozen.add(v)
         }
       }
+    } else if (mode === `adsorbate`) {
+      // Surface-frequency methodology: fix the whole slab, free only the
+      // adsorbate. Adsorbate atoms carry properties.is_adsorbate=true (set by
+      // adsorbate_place). If nothing is tagged, freeze nothing (mirror backend).
+      const any_tag = struct.sites.some((s: any) => s.properties?.is_adsorbate === true)
+      if (any_tag) {
+        for (let i = 0; i < n; i++) {
+          if (struct.sites[i].properties?.is_adsorbate !== true) frozen.add(i)
+        }
+      }
     } else if (mode === `layers` || mode === `bottom`) {
       const n_layers = n_bottom > 0 ? n_bottom : Number(params.freeze_layers ?? 0)
       if (n_layers > 0) {

--- a/src/lib/workflow/node-defs/calculation/freq.ts
+++ b/src/lib/workflow/node-defs/calculation/freq.ts
@@ -25,7 +25,7 @@ export const FREQ_NODE: NodeDefinition = {
     NPAR: 0, KPAR: 0, NCORE: 0,
     IVDW: 0, LDIPOL: false, IDIPOL: 3,
     NBANDS: 0, NEDOS: 301, ISTART: 0, ICHARG: 0,
-    freeze_mode: `none`,
+    freeze_mode: `adsorbate`,
     freeze_z_below: 0,
     freeze_elements: ``, freeze_indices: ``,
     freeze_layers: 0, freeze_invert: false,
@@ -47,9 +47,10 @@ Combine with E_DFT from upstream geo_opt/single_point: **G = E_DFT + G_corr**
       help: `Name for this system (e.g. "slab+OH"). Propagated to downstream Gibbs Energy node for the free energy diagram.`,
     },
     {
-      key: `freeze_mode`, label: `Freeze Mode`, type: `select`, default: `none`,
+      key: `freeze_mode`, label: `Freeze Mode`, type: `select`, default: `adsorbate`,
       group: `Freeze Atoms`,
       options: [
+        { label: `Adsorbate only (fix slab) — recommended`, value: `adsorbate` },
         { label: `None (all atoms vibrate)`, value: `none` },
         { label: `Manual (select in 3D)`, value: `manual` },
         { label: `By Height (z range)`, value: `z_range` },
@@ -57,7 +58,7 @@ Combine with E_DFT from upstream geo_opt/single_point: **G = E_DFT + G_corr**
         { label: `By Index`, value: `indices` },
         { label: `By Layers (bottom N)`, value: `layers` },
       ],
-      help: `Select which atoms to freeze (F F F in POSCAR). Frozen atoms are excluded from vibrational analysis. For surface calculations, freeze bulk atoms and only vibrate surface + adsorbate.`,
+      help: `Select which atoms to freeze (F F F in POSCAR). Frozen atoms are excluded from vibrational analysis. For an adsorbate on a slab, use "Adsorbate only" — it fixes the entire slab and vibrates only the adsorbate (the standard harmonic-adsorbate approximation). Requires the structure to come through an Adsorbate node (which tags the adsorbate atoms).`,
     },
     {
       key: `freeze_z_below`, label: `Freeze z below (Å)`, type: `number`, default: 0,


### PR DESCRIPTION
First slice (C1) of the **workflow freeze correctness** effort — spec at `docs/superpowers/specs/2026-06-23-workflow-freeze-correctness-design.md`.

## Why

Frequency calcs on adsorbate/slab systems must **fix the entire slab and vibrate only the adsorbate** (harmonic-adsorbate approximation). Today freq nodes default to bottom-N-layer freezing (same as geo_opt), so top slab layers get vibrated — physically wrong ZPE/entropy. The enabler bug: adsorbate atoms aren't identifiable downstream (`adsorbate_placement.py` computes the indices but `run_adsorbate_place` discards them).

## What

1. **Tag adsorbate atoms** — `run_adsorbate_place` writes an `is_adsorbate` site property (True on adsorbate, False on slab) in both the ferrox and pymatgen-fallback paths.
2. **New `freeze_mode: adsorbate`** (backend `vasp.py` freq block + frontend `freeze.ts`) — fixes every non-tagged atom, frees only the adsorbate; warns + freezes nothing when no tag is present (no silent mis-freeze).
3. **freq node defaults to `adsorbate`** + editor quick-button "Fix slab, vibrate adsorbate only" (en/zh i18n).

## Verification

- `test_adsorbate_tagging.py`, `test_freq_adsorbate_freeze.py` (incl. no-tag fallback), `freeze.test.ts` (+2 adsorbate cases) — **all pass**.
- End-to-end on the real ORR slab params: slab(36) → adsorbate → freq POSCAR = **36 slab atoms `F F F`, 3 OOH atoms `T T T`**.
- i18n en/zh parity test passes.

## Follow-ups (separate PRs, per spec)

- C2: CatBot generation freeze defaults (quickbuild `vasp_freq` → adsorbate, etc.)
- C3: param/freeze validation (warn-mostly, block freeze-layers > slab-layers)
- C4: post-generation "review the workflow" reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)