### PR TITLE
fix(workflow): reset clears stale hpc_job_id + work_dir (re-run submits fresh)

### DIFF
--- a/server/catgo/workflow/engine/lifecycle.py
+++ b/server/catgo/workflow/engine/lifecycle.py
@@ -151,7 +151,13 @@ def resume_workflow(db: WorkflowDB, workflow_id: str) -> None:
 
 
 def reset_workflow(db: WorkflowDB, workflow_id: str) -> None:
-    """Reset all tasks to WAITING. Does NOT clear work_dir/hpc_job_id.
+    """Reset all tasks to WAITING and clear their HPC job binding.
+
+    Clears hpc_job_id and work_dir so a re-run submits FRESH jobs. Previously a
+    reset left the old hpc_job_id in place: on the next run the engine polled
+    that (now-finished or cancelled) job, saw it gone, and marked the task
+    FAILED instead of resubmitting — the whole workflow then failed without ever
+    launching a new calculation.
 
     Sets workflow status to 'resetting' so the scanner skips it,
     then resets all task states with retry logic for DB lock contention.
@@ -180,6 +186,8 @@ def reset_workflow(db: WorkflowDB, workflow_id: str) -> None:
                         error_message=None,
                         error_type=None,
                         retry_count=0,
+                        hpc_job_id=None,
+                        work_dir=None,
                     )
                 db.update_workflow(workflow_id, status="draft")
                 logger.info("Workflow %s reset (%d tasks)", workflow_id, len(tasks))

--- a/server/tests/test_reset_clears_job.py
+++ b/server/tests/test_reset_clears_job.py
@@ -1,0 +1,39 @@
+"""reset_workflow must clear hpc_job_id/work_dir so a re-run submits fresh.
+
+Regression: after a reset, tasks kept their old hpc_job_id. On the next run the
+engine polled that finished/cancelled job, found it gone, and marked the task
+FAILED instead of resubmitting — the whole workflow failed without launching a
+new calculation.
+"""
+
+import pytest
+
+from catgo.workflow.db import WorkflowDB
+from catgo.workflow.states import TaskState
+from catgo.workflow.engine.lifecycle import reset_workflow
+
+
+@pytest.fixture
+def db(tmp_path):
+    return WorkflowDB(str(tmp_path / "test.db"))
+
+
+def test_reset_clears_hpc_job_id_and_work_dir(db):
+    wf_id = db.create_workflow("test")
+    t1 = db.create_task(wf_id, "geo_opt", params={})
+    # Simulate a prior run: task finished/cancelled with a stale job binding.
+    db.update_task(
+        t1,
+        status=TaskState.FAILED.value,
+        hpc_job_id="51381735",
+        work_dir="/expanse/.../old",
+        error_message="job vanished",
+    )
+
+    reset_workflow(db, wf_id)
+
+    task = db.get_task(t1)
+    assert task["status"] == TaskState.WAITING.value
+    assert not task.get("hpc_job_id"), "stale hpc_job_id not cleared"
+    assert not task.get("work_dir"), "stale work_dir not cleared"
+    assert not task.get("error_message")


### PR DESCRIPTION
## Bug

After resetting a workflow, each task kept its **old `hpc_job_id`**. On the next run the engine polled that (now finished/cancelled) job, saw it was gone, and marked the task **FAILED** — the whole workflow failed without ever submitting a new calculation. `reset_workflow`'s docstring even said *"Does NOT clear work_dir/hpc_job_id."*

Found live: a reset ORR workflow kept `hpc_job_id=51381735` (a cancelled job); every re-run immediately failed.

## Fix

`reset_workflow` (`server/catgo/workflow/engine/lifecycle.py`) now clears `hpc_job_id` and `work_dir` when resetting tasks to WAITING, so a re-run submits fresh jobs and re-resolves the work dir against the current config.

## Test

`test_reset_clears_job.py`: a FAILED task with a stale `hpc_job_id`/`work_dir` is cleared by `reset_workflow`. **Passes.** Verified live: after the fix, reset reported no steps holding a stale job id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)