### PR TITLE
fix(workflow): read potcar_root from hpc.job_defaults (fixes missing POTCAR → VASP fail)

### DIFF
--- a/server/catgo/workflow/engine/submitter.py
+++ b/server/catgo/workflow/engine/submitter.py
@@ -148,6 +148,23 @@ def _resolve_cluster_config(wf_config: dict, session_id: str) -> dict:
     return {}
 
 
+def _resolve_potcar_settings(config: dict) -> tuple[str, str]:
+    """Return (potcar_root, potcar_functional) for VASP POTCAR generation.
+
+    Reads from ``config["hpc"]["potcar_root"]`` first, then falls back to
+    ``config["hpc"]["job_defaults"]["potcar_root"]``. The scanner only promotes
+    potcar_root to the hpc root when a per-session cluster_config supplies it;
+    when it comes from default_job_params it lands only in job_defaults. Reading
+    just the root level silently skipped POTCAR generation and the VASP job died
+    with "file not found ... POTCAR".
+    """
+    hpc_cfg = config.get("hpc", {}) or {}
+    jd = hpc_cfg.get("job_defaults", {}) or {}
+    root = hpc_cfg.get("potcar_root") or jd.get("potcar_root") or ""
+    func = hpc_cfg.get("potcar_functional") or jd.get("potcar_functional") or "potpaw_PBE"
+    return root, func
+
+
 async def _submit_one(
     db: WorkflowDB, task: dict, workflow_id: str,
     params: dict, config: dict,
@@ -330,10 +347,14 @@ async def _submit_one(
 
     # 8. Generate POTCAR on remote (for VASP)
     if engine_key == "vasp":
-        potcar_root = config.get("hpc", {}).get("potcar_root", "")
-        potcar_func = config.get("hpc", {}).get("potcar_functional", "potpaw_PBE")
+        potcar_root, potcar_func = _resolve_potcar_settings(config)
         if potcar_root:
             await _generate_potcar(hpc, work_dir, potcar_root, potcar_func)
+        else:
+            logger.warning(
+                "Task %s: VASP node but no potcar_root in config (hpc root or "
+                "job_defaults) — POTCAR NOT generated, the job will fail on a "
+                "missing POTCAR", task_id)
 
     success, message, job_id = await _submit_job(
         hpc, work_dir, resolved_type, job_script, params, config,

--- a/server/tests/test_potcar_root_resolution.py
+++ b/server/tests/test_potcar_root_resolution.py
@@ -1,0 +1,37 @@
+"""POTCAR root must be found whether it sits at hpc-root or hpc.job_defaults.
+
+Regression: VASP jobs died with `severe (29): file not found ... POTCAR`. The
+submitter read `config["hpc"]["potcar_root"]`, but when potcar_root comes from
+default_job_params it lands in `config["hpc"]["job_defaults"]` (the scanner only
+promotes it to hpc-root when a cluster_config exists for the session). With an
+empty cluster_config the submitter read "" and silently skipped POTCAR
+generation.
+"""
+
+from catgo.workflow.engine.submitter import _resolve_potcar_settings
+
+
+def test_reads_from_job_defaults_when_root_absent():
+    cfg = {"hpc": {"job_defaults": {"potcar_root": "/pots", "potcar_functional": "potpaw_PBE_54"}}}
+    root, func = _resolve_potcar_settings(cfg)
+    assert root == "/pots"
+    assert func == "potpaw_PBE_54"
+
+
+def test_reads_from_hpc_root():
+    cfg = {"hpc": {"potcar_root": "/r", "potcar_functional": "potpaw_LDA"}}
+    root, func = _resolve_potcar_settings(cfg)
+    assert root == "/r"
+    assert func == "potpaw_LDA"
+
+
+def test_hpc_root_takes_precedence_over_job_defaults():
+    cfg = {"hpc": {"potcar_root": "/root", "job_defaults": {"potcar_root": "/jd"}}}
+    root, _ = _resolve_potcar_settings(cfg)
+    assert root == "/root"
+
+
+def test_defaults_when_absent():
+    root, func = _resolve_potcar_settings({"hpc": {}})
+    assert root == ""
+    assert func == "potpaw_PBE"


### PR DESCRIPTION
## Bug

VASP jobs submitted by the workflow engine died in ~6 seconds with:
> `forrtl: severe (29): file not found, unit 10, file .../POTCAR`

The job ran (read POSCAR correctly) but no POTCAR was in the work dir.

## Root cause

`_submit_one` read POTCAR settings only from the hpc **root**:
```python
potcar_root = config.get("hpc", {}).get("potcar_root", "")   # often ""
```
But when `potcar_root` comes from `default_job_params`, the scanner lands it in `config["hpc"]["job_defaults"]` and only promotes it to the hpc root **when a per-session `cluster_config` supplies it** (`scanner.py:392`). For a workflow with an empty `cluster_configs` (the common case), the root value is `""`, so `if potcar_root:` was false and **POTCAR generation was silently skipped** — VASP then failed on the missing POTCAR.

## Fix

`_resolve_potcar_settings(config)` reads `hpc.potcar_root` first, then falls back to `hpc.job_defaults.potcar_root` (same for `potcar_functional`). When neither is present it logs a warning instead of silently producing a doomed job.

## Test

`test_potcar_root_resolution.py` — job_defaults-only, hpc-root, precedence, and absent (defaults). **4 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)