### PR TITLE
fix: load Claude settings env for agent bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,11 @@ each user's own memory, not here.
 ## Review gates (default human-in-the-loop)
 - Don't auto-submit a freshly built workflow/campaign; show inputs, confirm, then submit.
   Skip only on explicit user opt-in ("go as you set" / "yolo" / "always skip").
+
+## Agent Bridge Notes
+
+### [2026-06-23] Claude settings env fallback
+**Category**: bug
+**Context**: Desktop CatBot Claude Code provider returned blank replies when users configured proxy env only in `~/.claude/settings.json`.
+**Discovery**: The sidecar disabled Claude global setting sources and inherited only OS env, so `ANTHROPIC_BASE_URL` / auth env in Claude settings were invisible.
+**Solution/Note**: Claude adapter now loads only the `env` map from `settings.json` / `settings.local.json` as fallback, without enabling global MCP/settings loading.

--- a/src/lib/server/agent-bridge/adapters/__tests__/claude.test.ts
+++ b/src/lib/server/agent-bridge/adapters/__tests__/claude.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { assistant_text_fallback } from '../claude.js'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  apply_claude_settings_env,
+  assistant_text_fallback,
+  read_claude_settings_env,
+} from '../claude.js'
 
 const assistant = (blocks: unknown[]) => ({ type: 'assistant', message: { content: blocks } })
 
@@ -38,5 +45,53 @@ describe('assistant_text_fallback — text-loss guard for cold-start turns', () 
     expect(assistant_text_fallback({ type: 'assistant' }, 0)).toEqual([])
     expect(assistant_text_fallback(null, 0)).toEqual([])
     expect(assistant_text_fallback(assistant([{ type: 'text', text: '' }]), 0)).toEqual([])
+  })
+})
+
+describe('Claude settings env fallback', () => {
+  function writeSettings(home: string, name: string, env: Record<string, string>): void {
+    const dir = join(home, '.claude')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, name), JSON.stringify({ env }), 'utf8')
+  }
+
+  it('reads env from ~/.claude/settings.json', () => {
+    const home = mkdtempSync(join(tmpdir(), 'catgo-claude-env-'))
+    writeSettings(home, 'settings.json', {
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:15721',
+      ANTHROPIC_AUTH_TOKEN: 'PROXY_MANAGED',
+    })
+
+    expect(read_claude_settings_env(home)).toEqual({
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:15721',
+      ANTHROPIC_AUTH_TOKEN: 'PROXY_MANAGED',
+    })
+  })
+
+  it('lets settings.local.json override settings.json', () => {
+    const home = mkdtempSync(join(tmpdir(), 'catgo-claude-env-'))
+    writeSettings(home, 'settings.json', {
+      ANTHROPIC_BASE_URL: 'http://old-proxy',
+    })
+    writeSettings(home, 'settings.local.json', {
+      ANTHROPIC_BASE_URL: 'http://new-proxy',
+    })
+
+    expect(read_claude_settings_env(home).ANTHROPIC_BASE_URL).toBe('http://new-proxy')
+  })
+
+  it('fills missing process env without overriding explicit env', () => {
+    const home = mkdtempSync(join(tmpdir(), 'catgo-claude-env-'))
+    writeSettings(home, 'settings.json', {
+      ANTHROPIC_BASE_URL: 'http://settings-proxy',
+      ANTHROPIC_AUTH_TOKEN: 'PROXY_MANAGED',
+    })
+    const env: NodeJS.ProcessEnv = {
+      ANTHROPIC_BASE_URL: 'http://explicit-proxy',
+    }
+
+    expect(apply_claude_settings_env(env, home)).toEqual(['ANTHROPIC_AUTH_TOKEN'])
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://explicit-proxy')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('PROXY_MANAGED')
   })
 })

--- a/src/lib/server/agent-bridge/adapters/claude.ts
+++ b/src/lib/server/agent-bridge/adapters/claude.ts
@@ -1,6 +1,6 @@
 import { query, listSessions as sdkListSessions } from '@anthropic-ai/claude-agent-sdk'
 import { execSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import type { AgentAdapter } from '../adapter.js'
@@ -31,6 +31,9 @@ import type { AgentEvent, PermissionRequest, SessionInfo, StreamParams } from '.
 // ---------------------------------------------------------------------------
 
 let _claudePath: string | null | undefined
+let _claudeEnvLoaded = false
+
+type ClaudeEnvMap = Record<string, string>
 
 // Given any resolved `claude` path (possibly an npm `.cmd`/`.ps1`/sh shim),
 // prefer the real vendored native binary the shim ultimately execs.
@@ -104,6 +107,57 @@ function resolveClaudeExecutable(): string | undefined {
 
   _claudePath = null
   return undefined
+}
+
+function readJsonEnv(file: string): ClaudeEnvMap {
+  if (!existsSync(file)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as unknown
+    if (!parsed || typeof parsed !== 'object') return {}
+    const env = (parsed as { env?: unknown }).env
+    if (!env || typeof env !== 'object' || Array.isArray(env)) return {}
+    const out: ClaudeEnvMap = {}
+    for (const [key, value] of Object.entries(env)) {
+      if (!key || typeof value !== 'string') continue
+      out[key] = value
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+export function read_claude_settings_env(home: string = homedir()): ClaudeEnvMap {
+  return {
+    ...readJsonEnv(join(home, '.claude', 'settings.json')),
+    ...readJsonEnv(join(home, '.claude', 'settings.local.json')),
+  }
+}
+
+export function apply_claude_settings_env(
+  target: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): string[] {
+  const env = read_claude_settings_env(home)
+  const applied: string[] = []
+  for (const [key, value] of Object.entries(env)) {
+    // Keep explicit system/user environment variables authoritative. The
+    // settings.json fallback only fills gaps for desktop sidecars launched
+    // outside an interactive shell.
+    if (target[key]) continue
+    target[key] = value
+    applied.push(key)
+  }
+  return applied
+}
+
+function ensureClaudeSettingsEnv(): void {
+  if (_claudeEnvLoaded) return
+  _claudeEnvLoaded = true
+  const applied = apply_claude_settings_env()
+  if (applied.length > 0) {
+    console.info(`[agent-bridge] loaded Claude settings env: ${applied.join(', ')}`)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +397,7 @@ export function createClaudeAdapter(): AgentAdapter {
         }
       }
 
+      ensureClaudeSettingsEnv()
       const claudeExe = resolveClaudeExecutable()
 
       const q = query({


### PR DESCRIPTION
## Summary
Fixes a blank CatBot reply issue when users select the Claude Code provider in the desktop app and rely on Claude Code proxy credentials configured in `~/.claude/settings.json`.

This PR makes the Claude agent bridge load only the `env` map from Claude settings as a fallback, so desktop sidecars can see values such as `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` without requiring users to manually duplicate them into Windows system/user environment variables.

## Problem
Some desktop users configure Claude Code to use a local/API proxy through `~/.claude/settings.json`, for example:

{
  "env": {
    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
    "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED"
  }
}

When CatBot uses the Claude Code provider, the request may return no visible error but produce an empty assistant bubble / blank reply. Logs can show symptoms such as the Claude connection closing immediately or no token data being received.

## Root Cause
The CatGo desktop agent sidecar launches independently from the user shell. It inherits OS process environment variables, but it does not automatically inherit the `env` block stored in Claude’s settings files.

At the same time, the Claude adapter intentionally uses `settingSources: []`. This prevents loading global Claude MCP/settings that could conflict with CatGo’s own HTTP MCP bridge, but it also means Claude settings env values are not loaded by the SDK path.

So if proxy/auth configuration only exists in `~/.claude/settings.json`, the spawned Claude CLI cannot see `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`, fails to authenticate/connect, and CatBot ends up with a blank reply.

## Fix
This PR adds a narrow fallback in the Claude adapter:

- Reads `env` from `~/.claude/settings.json`.
- Reads `env` from `~/.claude/settings.local.json`.
- Applies those values to the agent bridge process environment only when the variable is not already set.
- Keeps existing OS/user environment variables authoritative.
- Keeps `settingSources: []`, so CatGo still avoids loading unrelated global Claude settings/MCP configuration.

In short: CatGo now loads Claude settings env, but not the rest of Claude global settings.

## Safety Notes
This intentionally does not enable full Claude settings loading.

Only the `env` object is read, which avoids pulling in user-defined MCP servers or other global Claude Code configuration that could interfere with CatGo’s controlled agent bridge setup.

## Tests
Added unit coverage for the fallback behavior:

- Reads env values from `~/.claude/settings.json`.
- Allows `settings.local.json` to override `settings.json`.
- Does not overwrite explicitly provided process environment variables.

Verified with:

pnpm vitest run src/lib/server/agent-bridge/adapters/__tests__/claude.test.ts

Result:

Test Files  1 passed
Tests       8 passed

Also checked:

git diff --check

No whitespace errors were reported, only Windows CRLF conversion warnings.