### PR TITLE
fix(workflow): JobScriptParams accepts potcar_root (fixes dropped POTCAR config)

### DIFF
--- a/server/catgo/models/workflow_run.py
+++ b/server/catgo/models/workflow_run.py
@@ -14,6 +14,13 @@ class JobScriptParams(BaseModel):
     partition: Optional[str] = "workq"
     memory: Optional[str] = None
     account: Optional[str] = None
+    # POTCAR location for VASP. Kept here (not only on ClusterConfig) so a
+    # workflow run that sets potcar_root in default_job_params is not silently
+    # dropped by validation — the scanner copies default_job_params into
+    # hpc.job_defaults, where the submitter reads it. Without this, VASP jobs
+    # die on a missing POTCAR.
+    potcar_root: Optional[str] = None
+    potcar_functional: Optional[str] = None
 
 
 class ClusterConfig(BaseModel):

--- a/server/tests/test_runconfig_potcar_root.py
+++ b/server/tests/test_runconfig_potcar_root.py
@@ -1,0 +1,26 @@
+"""default_job_params must keep potcar_root through WorkflowRunConfig validation.
+
+Regression: potcar_root set in default_job_params was silently dropped because
+JobScriptParams had no such field. The scanner then had no potcar_root to put in
+hpc.job_defaults, the submitter skipped POTCAR generation, and the VASP job died
+with "file not found ... POTCAR".
+"""
+
+from catgo.models.workflow_run import JobScriptParams, WorkflowRunConfig
+
+
+def test_jobscriptparams_keeps_potcar_root():
+    p = JobScriptParams(ntasks=32, partition="shared", potcar_root="/pots", potcar_functional="potpaw_PBE")
+    assert p.potcar_root == "/pots"
+    assert p.potcar_functional == "potpaw_PBE"
+
+
+def test_runconfig_keeps_potcar_root_in_default_job_params():
+    cfg = WorkflowRunConfig(default_job_params={"ntasks": 32, "potcar_root": "/home/u/pot"})
+    assert cfg.default_job_params.potcar_root == "/home/u/pot"
+
+
+def test_potcar_root_defaults_to_none():
+    p = JobScriptParams()
+    assert p.potcar_root is None
+    assert p.potcar_functional is None


### PR DESCRIPTION
## Bug

VASP workflow jobs died with `severe (29): file not found ... POTCAR`. A `potcar_root` set in the run config's `default_job_params` never reached the submitter.

## Root cause

`default_job_params` is typed as `JobScriptParams`, which only declared `nodes/ntasks/cpus_per_task/walltime/partition/memory/account` — **no `potcar_root`**. So Pydantic silently dropped `potcar_root`/`potcar_functional` on every `/run`. The scanner then had no potcar_root to copy into `hpc.job_defaults`, the submitter's `_resolve_potcar_settings` returned `""`, and POTCAR generation was skipped → VASP failed.

(Pairs with the companion fix where the submitter reads potcar_root from `hpc.job_defaults`, not just hpc-root.)

## Fix

Add `potcar_root: Optional[str] = None` and `potcar_functional: Optional[str] = None` to `JobScriptParams`. Purely **additive + backward compatible** — no existing field or default changed; frontend submissions that don't set potcar_root here are unaffected.

## Test

`test_runconfig_potcar_root.py` — potcar_root survives both `JobScriptParams` and `WorkflowRunConfig` validation; defaults to None. **3 passed.**

## Verified live

With this fix, the run config's `potcar_root` survives `/run`, the submitter generates a 228 KB POTCAR remotely, and a real VASP geo_opt job ran on Expanse (no longer dies in 6 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)