### PR TITLE
fix(workflow): adsorbate-only freeze for freq in catalysis recipes + templates (C2)

### DIFF
--- a/server/catgo/mcp_tools/server_claude_code.py
+++ b/server/catgo/mcp_tools/server_claude_code.py
@@ -2338,7 +2338,11 @@ def _quickbuild_recipes() -> dict[str, dict]:
     build on top of the auto-added `structure_input` node from `create`."""
     vasp_opt = {"software": "vasp", "encut": 520, "ediffg": -0.03,
                 "freeze_mode": "bottom", "freeze_n_layers": 2}
-    vasp_freq = {"software": "vasp", "freeze_mode": "bottom", "freeze_n_layers": 2}
+    # Frequency on an adsorbate/slab system must fix the ENTIRE slab and vibrate
+    # only the adsorbate (harmonic-adsorbate approximation). freeze_mode=adsorbate
+    # freezes every atom not tagged is_adsorbate by adsorbate_place. Bottom-N
+    # freezing (like geo_opt) would wrongly let the top slab layers vibrate.
+    vasp_freq = {"software": "vasp", "freeze_mode": "adsorbate"}
 
     return {
         "HER": {

--- a/server/tests/test_recipe_freq_freeze.py
+++ b/server/tests/test_recipe_freq_freeze.py
@@ -1,0 +1,33 @@
+"""Quickbuild catalysis recipes must use adsorbate-only freeze for freq nodes.
+
+A freq calc on an adsorbate/slab system must fix the whole slab and vibrate only
+the adsorbate (freeze_mode=adsorbate). The recipes previously used freeze_mode=
+bottom (like geo_opt), which wrongly lets the top slab layers vibrate → wrong
+ZPE/entropy in the free-energy diagram.
+"""
+
+from catgo.mcp_tools.server_claude_code import _quickbuild_recipes
+
+_ADSORBATE_RECIPES = {"HER", "OER", "ORR", "NRR", "CO2RR_2e"}
+
+
+def test_adsorbate_recipe_freq_nodes_use_adsorbate_freeze():
+    recipes = _quickbuild_recipes()
+    for name in _ADSORBATE_RECIPES:
+        g = recipes[name]
+        freq_nodes = [n for n in g["nodes"] if n["type"] == "freq"]
+        assert freq_nodes, f"{name} has no freq node"
+        for n in freq_nodes:
+            assert n["params"].get("freeze_mode") == "adsorbate", (
+                f"{name} freq node freeze_mode={n['params'].get('freeze_mode')} (want adsorbate)"
+            )
+
+
+def test_geo_opt_keeps_bottom_layer_freeze():
+    # geo_opt relaxation should still freeze the bottom layers (not adsorbate mode).
+    recipes = _quickbuild_recipes()
+    for name in _ADSORBATE_RECIPES:
+        for n in recipes[name]["nodes"]:
+            if n["type"] == "geo_opt":
+                fm = n["params"].get("freeze_mode")
+                assert fm in ("bottom", "layers"), f"{name} geo_opt freeze_mode={fm}"

--- a/src/lib/workflow/graph-model.ts
+++ b/src/lib/workflow/graph-model.ts
@@ -594,8 +594,8 @@ export const TEMPLATES: Record<string, { name: string; desc: string; nodes: WfNo
       { id: `t3`, type: `slab_gen`, x: 500, y: 160, params: { miller: `1,1,1`, layers: 4, vacuum: 15 } },
       { id: `t4`, type: `geo_opt`, x: 720, y: 160, params: { software: `vasp`, ENCUT: 520, EDIFF: `1e-5`, ISIF: 2, NSW: 200, LDIPOL: true, frozen_layers: 2, kpoints: `3\u00D73\u00D71` } },
       { id: `t5`, type: `adsorbate_place`, x: 940, y: 160, params: { adsorbate: `N2` } },
-      { id: `t6`, type: `geo_opt`, x: 1160, y: 160, params: { software: `vasp`, ENCUT: 520, EDIFF: `1e-5`, ISIF: 2, NSW: 200, LDIPOL: true, kpoints: `3\u00D73\u00D71` } },
-      { id: `t7`, type: `freq`, x: 1380, y: 160, params: { software: `vasp`, ENCUT: 520, EDIFF: `1e-6`, IBRION: 5, NFREE: 2, kpoints: `3\u00D73\u00D71` } },
+      { id: `t6`, type: `geo_opt`, x: 1160, y: 160, params: { software: `vasp`, ENCUT: 520, EDIFF: `1e-5`, ISIF: 2, NSW: 200, LDIPOL: true, frozen_layers: 2, kpoints: `3\u00D73\u00D71` } },
+      { id: `t7`, type: `freq`, x: 1380, y: 160, params: { software: `vasp`, ENCUT: 520, EDIFF: `1e-6`, IBRION: 5, NFREE: 2, freeze_mode: `adsorbate`, kpoints: `3\u00D73\u00D71` } },
       { id: `t8`, type: `free_energy`, x: 1600, y: 160, params: { temperature: 298.15 } },
     ],
     edges: [


### PR DESCRIPTION
## What

A deterministic physics audit of all **32 built-in templates + quickbuild recipes** (all pass mechanical dry-run) flagged **6** with the same methodology bug — and 26 clean.

The 6: `HER`, `OER`, `ORR`, `NRR`, `CO2RR_2e` recipes + the `Full Catalysis Pipeline` template. Their **freq** nodes on adsorbate/slab systems used `freeze_mode=bottom` (or none) instead of `adsorbate`, so the top slab layers vibrate → wrong ZPE/entropy in the free-energy diagram.

## Fix

- **Quickbuild `vasp_freq` preset** (`server_claude_code.py`): `freeze_mode: bottom` → `adsorbate`. Fixes all 5 catalysis recipes at once. `vasp_opt` keeps bottom-N (correct for geo_opt).
- **Full Catalysis Pipeline** (`graph-model.ts`): adsorbate `geo_opt` gains `frozen_layers: 2`; `freq` gains `freeze_mode: adsorbate`.

Builds on `freeze_mode=adsorbate` (#407).

## Test

`test_recipe_freq_freeze.py` — every adsorbate recipe's freq node uses `adsorbate`; geo_opt keeps bottom-layer freeze. **Passes.**

## Audit coverage

26/32 templates clean (bulk/molecular ones correctly have no freeze; freq-bearing adsorbate ones now all `adsorbate`). 0 broken. Audit was rule-based (slab-geo_opt-no-freeze / adsorbate-freq-not-adsorbate / ENCUT-IBRION-ISIF sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)