### PR TITLE
fix(workflow): scanner resolves generic 'analysis' node so teaching templates run

### DIFF
--- a/server/catgo/workflow/engine/scanner.py
+++ b/server/catgo/workflow/engine/scanner.py
@@ -633,9 +633,12 @@ class WorkflowEngine:
             task_type = task["task_type"]
             params = json.loads(task.get("params_json", "{}") or "{}")
 
-            # Resolve unified calc types (geo_opt+mlp → mlp_relax)
+            # Resolve unified calc types (geo_opt+mlp → mlp_relax) and the
+            # generic `analysis` node (analysis+type=elastic → elastic_analysis).
+            # _resolve_software returns the type unchanged for everything else,
+            # so calling it for both keeps a single resolution point.
             resolved_type = task_type
-            if task_type in UNIFIED_CALC_NODES:
+            if task_type in UNIFIED_CALC_NODES or task_type == "analysis":
                 resolved_type, _ = _resolve_software(task_type, params)
 
             # --- MLP local execution (when execution_mode == "local") ---


### PR DESCRIPTION
Completes the analysis-node wiring (#413). The scanner only ran `_resolve_software` for UNIFIED_CALC_NODES, so a generic `analysis` node (with `params.type`) was never resolved to its specific handler — it stayed `analysis`, missed ANALYSIS_NODES routing, hit the submitter, and failed with 'No engine registered for analysis'. Now resolves `analysis` too.

**Verified end-to-end** on an isolated local backend: the MLP MD pipeline template (structure_input → MLP MD → md_analysis → export_data) runs **4/4 complete, 0 failed** with MACE on CPU — no HPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)