### PR TITLE
fix: route SDK permission approvals through backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,11 @@ each user's own memory, not here.
 ## Review gates (default human-in-the-loop)
 - Don't auto-submit a freshly built workflow/campaign; show inputs, confirm, then submit.
   Skip only on explicit user opt-in ("go as you set" / "yolo" / "always skip").
+
+## Agent Bridge Notes
+
+### [2026-06-24] SDK permission cards must resolve through backend
+**Category**: bug
+**Context**: CatBot Claude/SDK tool permission cards appeared allowed but the stream stayed stuck on Thinking.
+**Discovery**: Passing `onResolve` to SDK PermissionCards short-circuits `/api/agent/permission`; only client-direct entries have `pb.resolve`.
+**Solution/Note**: Pass `onResolve` only when `pb.resolve` exists; SDK permissions must use PermissionCard's backend `resolve_permission()` path.

--- a/src/lib/chat/ChatPane.svelte
+++ b/src/lib/chat/ChatPane.svelte
@@ -1590,12 +1590,16 @@ import { is_client_direct, normalize_provider_base_url, relay_fetch } from './pr
                     input={pb.input}
                     suggestions={pb.suggestions}
                     decisionReason={pb.decisionReason}
-                    onResolve={(approved, session) => {
-                      // "Allow for session": flip the session-scoped bypass so
-                      // subsequent mutating tools auto-approve (no re-prompt).
-                      if (session) slice.skip_permission.value = true
-                      pb.resolve?.(approved)
-                    }}
+                    onResolve={pb.resolve
+                      ? (approved, session) => {
+                        // Client-direct permissions are local promises. SDK
+                        // permissions have no pb.resolve and must use the
+                        // backend /api/agent/permission path inside
+                        // PermissionCard.
+                        if (session) slice.skip_permission.value = true
+                        pb.resolve?.(approved)
+                      }
+                      : undefined}
                   />
                 {/each}
                 <ThinkingSummary tools={slice.active_tool_blocks.entries}>


### PR DESCRIPTION
## Summary
Fixes a CatBot SDK-agent permission hang where the user clicks "Allow" on a tool permission card, the card appears to be accepted, but the assistant stays stuck on `Thinking...` and does not continue streaming.

This was reproduced by a user and confirmed fixed in a Windows minimal test build.

## Problem
When CatBot uses an SDK-backed provider such as Claude Code, tool permission requests are created by the backend agent bridge. The backend waits for the frontend to call `/api/agent/permission` so the pending permission promise can be resolved and the SDK can continue tool execution.

However, after the user clicked "Allow" / "Allow for session", the frontend card could visually transition, while the backend-side SDK permission request remained unresolved. The result was a stalled conversation: the UI stayed on `Thinking...`, but no further output arrived.

## Root Cause
`ChatPane.svelte` always passed an `onResolve` callback to `PermissionCard`.

`PermissionCard` treats the presence of `onResolve` as the client-direct path. In that mode it resolves an in-browser permission promise and intentionally skips the backend `resolve_permission()` round-trip.

That is correct for client-direct tool execution, where `pb.resolve` exists.

But SDK-agent permission entries do not have `pb.resolve`; they must go through the backend `/api/agent/permission` endpoint. Because `onResolve` was still being passed, SDK permission cards short-circuited the backend resolution path, leaving the SDK waiting forever.

## Fix
Only pass `onResolve` when the permission entry actually has `pb.resolve`.

- Client-direct permissions still use the local `pb.resolve` callback.
- SDK-agent permissions no longer receive `onResolve`, so `PermissionCard` falls back to its existing backend `resolve_permission()` path.
- This lets Claude/SDK permission approvals correctly release the backend pending permission promise and continue streaming.

## User Impact
Before:
- User clicks "Allow".
- Permission card appears handled.
- CatBot remains stuck on `Thinking...`.
- Tool execution never resumes.

After:
- User clicks "Allow".
- SDK backend receives the permission decision.
- Tool execution resumes.
- CatBot continues output normally.

## Verification
User validation:
- A Windows minimal test build containing this fix was sent to the affected user.
- User confirmed the issue is fixed.

Automated / local checks:
```bash
pnpm vitest run src/lib/server/agent-bridge/adapters/__tests__/claude.test.ts

