### PR TITLE
fix(hpc): binary dotfile no longer drops the SSH session ("session expired")

### DIFF
--- a/server/catgo/routers/hpc.py
+++ b/server/catgo/routers/hpc.py
@@ -587,10 +587,22 @@ async def read_many_file_content(request: FileReadManyRequest) -> FileReadManyRe
                     "printf '0\\n{m}_CONTENT_{i}\\n\\n{m}_END_{i}\\n'; "
                     "fi".format(m=marker, i=idx, p=safe, n=max_bytes)
                 )
-            result = await hpc.conn.run(" ; ".join(parts), check=False)
+            # encoding=None -> asyncssh returns raw bytes instead of UTF-8-decoding
+            # the channel. A dotfile with non-UTF-8 bytes (e.g. a binary .pid /
+            # VESTA lock / a .bak) otherwise makes asyncssh fail to decode the
+            # channel and DISCONNECT the whole SSH connection mid-read - which
+            # surfaced as "session expired" the instant a home with such a file
+            # was browsed. Decode defensively here instead.
+            result = await hpc.conn.run(" ; ".join(parts), check=False, encoding=None)
             if result.exit_status not in (0, None):
-                raise RuntimeError(result.stderr or f"read-many failed ({result.exit_status})")
-            return result.stdout or ""
+                stderr = result.stderr
+                if isinstance(stderr, bytes):
+                    stderr = stderr.decode("utf-8", errors="replace")
+                raise RuntimeError(stderr or f"read-many failed ({result.exit_status})")
+            stdout = result.stdout or b""
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode("utf-8", errors="replace")
+            return stdout
 
         raw = await hpc.run_on_owner(_read_many_remote)
         items = []


### PR DESCRIPTION
## Problem
Connecting to a remote whose home contains a non-UTF-8 dotfile (e.g. a binary `.pid` / VESTA lock / `.bak`) showed **会话已过期 / "session expired"** the instant the file browser loaded — but only on some clusters. Reported by a user: lab connects then "秒过期"; Expanse is fine.

## Root cause
On connect, the read-many prefetch runs `head -c N <file>` across a batch of dotfiles in one command. `asyncssh` decodes the command channel as UTF-8; a byte like `0xfd` makes that decode raise, so asyncssh sends a protocol disconnect and tears down the **entire** SSH connection. `connection_lost` marks the session dead, and the next directory listing 404s as "Session not found or expired". Homes that are all-text (Expanse) never hit it — hence it looked connection-specific.

Backend log at the moment of failure:
```
Auth for user … succeeded
Connected to <host>
Command: …head -c 65536 …/.VESTA3-…  (read-many over dotfiles)
Sending disconnect: 'utf-8' codec can't decode byte 0xfd … invalid start byte
SSH connection lost … Marked session … as dead (connection_lost)
```

## Fix
Run the read-many command with `encoding=None` (raw bytes) and decode the output in Python with `errors='replace'`. A binary dotfile now yields replacement chars in that one file's preview instead of killing the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)