### PR TITLE
feat(cli,release): `catgo view` on packaged installs + v1.4.0

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -189,6 +189,20 @@ jobs:
           # which GitHub runners lack → "failed to run linuxdeploy". Make all
           # AppImage tooling extract-and-run instead of FUSE-mounting.
           APPIMAGE_EXTRACT_AND_RUN: 1
+          # macOS code-signing + notarization. tauri-action signs & notarizes the
+          # .app/.dmg only when these are set; if the secrets are absent the build
+          # still succeeds (unsigned). Add them in repo Settings → Secrets:
+          #   APPLE_CERTIFICATE          base64 of the Developer ID .p12
+          #   APPLE_CERTIFICATE_PASSWORD .p12 password
+          #   APPLE_SIGNING_IDENTITY     "Developer ID Application: NAME (TEAMID)"
+          #   APPLE_ID / APPLE_PASSWORD  Apple ID + app-specific password
+          #   APPLE_TEAM_ID              10-char team id
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'CatGo ${{ github.ref_name }}'
@@ -203,9 +217,12 @@ jobs:
             - **Linux** — `.deb` (and `.rpm`)
 
             ### Installation
-            - **Windows** — run the `.msi` installer
+            - **Windows** — run the **`-setup.exe`** installer (recommended; it puts the `catgo` CLI on your PATH so `catgo view` works). The `.msi` installs the app but not the CLI.
+              - Unsigned this release: if Windows SmartScreen warns, click **More info → Run anyway**. (Code signing is coming in a later build.)
             - **macOS** — open the `.dmg` and drag CatGo to Applications
             - **Linux** — `sudo dpkg -i CatGo_*_amd64.deb` (or `sudo rpm -i`)
+            - **Android** — install `CatGo-v*-android-universal.apk`
+            - **iOS** — join the [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
 
             ### Highlights
             - **Reads ~30 formats** — VASP, Quantum ESPRESSO, CP2K, ABACUS, ORCA, Gaussian, CASTEP, SIESTA, OpenMX, LAMMPS, ASE `.traj`, phonopy, HDF5, CIF, XYZ/extXYZ, mol2, PDB, cube/CHGCAR — inputs **and** outputs
@@ -216,7 +233,12 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
-            ### What's New
+            ### New in 1.4.0
+            - **`catgo view` / `catgo gui` CLI** — open structures & trajectories like `ase gui`: `catgo view */POSCAR` stacks files into one trajectory, per-file `@SLICE` frame selection, `--interpolate` (IDPP), and headless `-g/-t` convergence plots. On a packaged install, running `catgo view` with no app open **launches CatGo** and shows the structure.
+            - **Nanoparticle / cluster builder** — Wulff, octahedron, icosahedron, decahedron (via `ase.cluster`), in the Build panel, the CLI (`catgo nanoparticle`), and the `catgo_nanoparticle` MCP tool.
+            - **Random concentration doping** — substitute N of a host element with a dopant mix at random sites, with seed & dedup.
+            - **Web "Get the App"** — the browser build now surfaces a one-click download (Windows/macOS/Linux/Android + iOS TestFlight) instead of a bare GitHub link.
+
             See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for the full list.
           releaseDraft: true
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2026-06-25
+
+### Added
+- **`catgo view` / `catgo gui` CLI** — open structure & trajectory files like `ase gui`. `catgo view */POSCAR` stacks single-frame files into one trajectory (natural-sorted); per-file `filename@SLICE` and global `-n/--image-number` frame selection; `--interpolate N` between two endpoints (IDPP, linear fallback); headless `-g/--graph` + `-t/--terminal` per-frame convergence dump/plot. Reuses the existing viewer push channel.
+- **Nanoparticle / cluster builder** — finite metal clusters via `ase.cluster` (Wulff equilibrium shape, octahedron, icosahedron, decahedron), centred in a vacuum box. Exposed in the Build panel, the CLI (`catgo nanoparticle`), and the `catgo_nanoparticle` MCP tool — all backed by one `/api/build/nanoparticle` route.
+- **Random concentration-based doping** — randomly substitute N of a host element with a dopant mix at random sites, with optional seed and dedup.
+- **Web "Get the App" download flow** — the static web build surfaces an OS-picker download (Windows/macOS/Linux/Android via the GitHub releases API, iOS via TestFlight) inline at the "desktop required" notice and as a persistent badge, instead of a raw GitHub URL.
+
+### Fixed
+- **`catgo view` works after a packaged install** — the frozen `catgo-server` now dispatches `view`/`gui`/`nanoparticle` subcommands; the server records `~/.catgo/server.port` so the CLI attaches to the running app backend on any port; the Windows `-setup.exe` installer puts a `catgo` CLI shim on PATH; and `catgo view` with no app open launches the desktop app.
+
 ## [1.3.2] - 2026-06-21
 
 ### Added

--- a/citation.cff
+++ b/citation.cff
@@ -12,4 +12,4 @@ license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license
 repository-code: https://github.com/Hello-QM/catgo-LRG
 type: software
 url: https://github.com/Hello-QM/catgo-LRG
-version: 1.3.1
+version: 1.4.0

--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.3.4";
+  const VERSION = "1.4.0";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/server/catgo/cli/_autostart.py
+++ b/server/catgo/cli/_autostart.py
@@ -15,9 +15,16 @@ def spawn_daemon_and_wait(timeout: float = 20.0) -> ServerLink:
     Raises OpError on spawn failure or timeout. Does NOT kill the spawned
     process on timeout (port may already be in use by another service).
     """
+    # In a PyInstaller build `sys.executable` is the frozen `catgo-server`
+    # binary, which does NOT honor `-m catgo`; launching it bare starts the
+    # server directly (and records ~/.catgo/server.port for discovery).
+    if getattr(sys, "frozen", False):
+        cmd = [sys.executable]
+    else:
+        cmd = [sys.executable, "-m", "catgo", "serve", "--daemon"]
     try:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "catgo", "serve", "--daemon"],
+            cmd,
             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
             start_new_session=True,
         )

--- a/server/catgo/cli/server_link.py
+++ b/server/catgo/cli/server_link.py
@@ -54,7 +54,17 @@ class ServerLink:
             if base.endswith("/api"):
                 base = base[: -len("/api")]
             return cls(base_url=base) if _ping(f"{base}/health") else None
-        for port in (8000, 33413):
+        # The desktop app's sidecar can bind a non-default / auto-assigned port,
+        # which it records in ~/.catgo/server.port. Try that first so the CLI
+        # attaches to the running app backend, then fall back to well-known ports.
+        candidates: list[int] = []
+        try:
+            from pathlib import Path
+            port_txt = (Path.home() / ".catgo" / "server.port").read_text().strip()
+            candidates.append(int(port_txt))
+        except (OSError, ValueError):
+            pass
+        for port in candidates + [8000, 33413]:
             url = f"http://localhost:{port}"
             if _ping(f"{url}/health"):
                 return cls(base_url=url)

--- a/server/catgo/cli/view_cmd.py
+++ b/server/catgo/cli/view_cmd.py
@@ -305,6 +305,49 @@ def _is_local(base_url: str) -> bool:
     return "localhost" in base_url or "127.0.0.1" in base_url
 
 
+def _find_gui_app() -> "Path | None":
+    """Locate the installed CatGo desktop GUI executable.
+
+    Only meaningful in a packaged build: the frozen ``catgo-server`` backend
+    sits next to the GUI binary (``CatGo.exe`` / ``CatGo`` / the .app's MacOS
+    dir). Returns None for a dev / pip install (no bundled GUI to launch).
+    """
+    if not getattr(sys, "frozen", False):
+        return None
+    exe = Path(sys.executable)
+    me = exe.name.lower()
+    for name in ("CatGo.exe", "CatGo", "catgo.exe", "catgo"):
+        cand = exe.parent / name
+        if cand.exists() and cand.name.lower() != me:
+            return cand
+    # macOS .app: backend in CatGo.app/Contents/MacOS next to the GUI binary,
+    # or one level up in the bundle.
+    for up in (exe.parent, exe.parent.parent):
+        for name in ("CatGo", "catgo"):
+            cand = up / name
+            if cand.exists() and cand.is_file() and cand.name.lower() != me:
+                return cand
+    return None
+
+
+def _wait_for_backend(timeout: float = 40.0):
+    """Poll ServerLink.discover() until a backend answers, or timeout → None."""
+    import time
+
+    from catgo.cli.server_link import ServerLink
+
+    delay = 0.3
+    waited = 0.0
+    while waited < timeout:
+        link = ServerLink.discover()
+        if link is not None:
+            return link
+        time.sleep(delay)
+        waited += delay
+        delay = min(delay * 1.5, 2.0)
+    return None
+
+
 def cmd_view(args) -> int:
     from catgo.cli.adapter import OpError
     from catgo.cli.server_link import ServerLink
@@ -369,9 +412,12 @@ def cmd_view(args) -> int:
             print(f"wrote {out}")
         return 0
 
-    # Discover a running server; otherwise auto-start the backend daemon.
+    # Discover a running server; otherwise bring one up. Prefer launching the
+    # full desktop app (so the structure shows in the real GUI) when packaged;
+    # fall back to a headless backend + browser for a dev / pip install.
     link = ServerLink.discover()
-    started = False
+    started_headless = False
+    launched_gui = False
     if link is None:
         if getattr(args, "no_autostart", False):
             print(
@@ -380,14 +426,32 @@ def cmd_view(args) -> int:
                 file=sys.stderr,
             )
             return 2
-        try:
-            from catgo.cli._autostart import spawn_daemon_and_wait
+        gui = _find_gui_app()
+        if gui is not None:
+            import subprocess
+            try:
+                subprocess.Popen([str(gui)], start_new_session=True)
+            except OSError as exc:
+                print(f"error: failed to launch CatGo: {exc}", file=sys.stderr)
+                return 2
+            print("Launching CatGo…")
+            link = _wait_for_backend()
+            launched_gui = True
+            if link is None:
+                print(
+                    "error: launched CatGo but its backend didn't come up in time",
+                    file=sys.stderr,
+                )
+                return 2
+        else:
+            try:
+                from catgo.cli._autostart import spawn_daemon_and_wait
 
-            link = spawn_daemon_and_wait()
-            started = True
-        except OpError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            return 2
+                link = spawn_daemon_and_wait()
+                started_headless = True
+            except OpError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
 
     panel = getattr(args, "panel", "") or None
 
@@ -415,11 +479,13 @@ def cmd_view(args) -> int:
             except OSError:
                 pass
 
-    # If we just started the backend there is no window yet — open the served
-    # web UI (the prebuilt SPA at the server root) so the push is actually seen.
-    if started and _is_local(link.base_url):
+    # Headless backend we spawned → no window; open the served web UI so the
+    # push is visible. GUI we launched → it IS the window, don't open a browser.
+    if started_headless and _is_local(link.base_url):
         webbrowser.open(link.base_url + "/")
         print(f"opened {summary} -> {link.base_url}/")
+    elif launched_gui:
+        print(f"launched CatGo — opened {summary}")
     else:
         print(f"opened {summary} -> CatGo viewer ({link.base_url})")
     return 0

--- a/server/main.py
+++ b/server/main.py
@@ -887,7 +887,8 @@ if __name__ == "__main__":
     _CLI_PASSTHROUGH = {
         "setup", "status", "stop", "campaign", "freq-inputs", "slab",
         "supercell", "reticular", "convert", "inspect", "dos", "band",
-        "cohp", "freq", "push", "pull", "submit",
+        "cohp", "freq", "push", "pull", "submit", "nanoparticle",
+        "view", "gui",
     }
     if len(sys.argv) > 1 and sys.argv[1] in _CLI_PASSTHROUGH:
         from catgo.cli import main as _cli_main
@@ -926,6 +927,14 @@ if __name__ == "__main__":
         print(_json.dumps({"port": run_port}), flush=True)
 
         print(f"Starting CatGo server on port {run_port}")
+        # Advertise the live port so the `catgo`/`catgo-cli` CLI (e.g.
+        # `catgo view`) can attach to this already-running backend even when it
+        # picked a non-default / auto-assigned port. ServerLink.discover() reads
+        # this file. (Previously only the --daemon path wrote it.)
+        try:
+            _write_pid_port(os.getpid(), run_port)
+        except OSError:
+            pass
         uvicorn.run(
             "main:app",
             host="0.0.0.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.3.4"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.3.4"
+version = "1.4.0"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",
@@ -45,6 +45,9 @@
     "windows": {
       "wix": {
         "language": "en-US"
+      },
+      "nsis": {
+        "installerHooks": "./windows/installer-hooks.nsh"
       }
     },
     "macOS": {

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -1,0 +1,30 @@
+; CatGo NSIS installer hooks — expose the `catgo` CLI on PATH so commands like
+; `catgo view structure.cif` work from a terminal after installing the app.
+;
+; The bundled `catgo-server.exe` sidecar contains the full `catgo` Python
+; package and dispatches CLI subcommands (view/gui/slab/dos/…) to catgo.cli.
+; We drop a tiny `catgo.cmd` shim that forwards to it, in a dedicated `cli`
+; subdirectory that we add to the per-user PATH. The shim lives in its own
+; folder (NOT $INSTDIR) so its name never collides with the GUI `CatGo.exe`
+; that sits in $INSTDIR (Windows PATH resolves `.exe` before `.cmd`).
+;
+; Only the NSIS (`-setup.exe`) installer runs these hooks; the `.msi` (WiX)
+; build does not, so the release notes point CLI users at the `.exe`.
+
+!macro NSIS_HOOK_POSTINSTALL
+  CreateDirectory "$INSTDIR\cli"
+  FileOpen $9 "$INSTDIR\cli\catgo.cmd" w
+  FileWrite $9 "@echo off$\r$\n"
+  FileWrite $9 '"%~dp0..\catgo-server.exe" %*$\r$\n'
+  FileClose $9
+  ; Add the shim folder to the current user's PATH (EnVar ships with Tauri NSIS).
+  EnVar::SetHKCU
+  EnVar::AddValue "Path" "$INSTDIR\cli"
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  EnVar::SetHKCU
+  EnVar::DeleteValue "Path" "$INSTDIR\cli"
+  Delete "$INSTDIR\cli\catgo.cmd"
+  RMDir "$INSTDIR\cli"
+!macroend


### PR DESCRIPTION
## Summary

Makes `catgo view` (merged in #425) actually work for users who **installed the desktop app** (no Python / no pip), and cuts the **1.4.0** release across all platforms.

### `catgo view` on a packaged install — 3 blockers fixed
1. **Frozen exe didn't route `view`** → added `view`/`gui`/`nanoparticle` to `_CLI_PASSTHROUGH` in `main.py`, so `catgo-server.exe view …` dispatches to the CLI.
2. **CLI couldn't find the app's backend** (auto-assigned port, not 8000) → the server now writes `~/.catgo/server.port` on **every** startup (was daemon-only) and `ServerLink.discover()` reads it. `_autostart` is also frozen-aware (`-m catgo` fails in PyInstaller).
3. **No `catgo` on Windows PATH** → the NSIS `-setup.exe` installer writes a `catgo` shim into a `cli\` subfolder and adds it to PATH (separate folder so it never collides with the GUI `CatGo.exe`, which Windows resolves first).

Plus: with **no app open**, a packaged `catgo view` now **launches the desktop app** and shows the structure, instead of only spawning a headless backend + browser. (Dev/pip installs keep the headless+browser behaviour.)

### Release 1.4.0
- Version bumped across `tauri.conf.json`, `Cargo.toml`/`Cargo.lock`, `package.json`, download page.
- macOS code-signing + notarization wired into `tauri-build.yml` (reads `APPLE_*` secrets; builds unsigned if absent — you have the Apple Developer account, so add the secrets to enable it).
- Release notes: per-platform install (Windows `-setup.exe` for CLI support + SmartScreen "Run anyway" note, Android APK, iOS TestFlight), 1.4.0 highlights. CHANGELOG entry added.

## Verified
- `catgo view` end-to-end against a backend on a **non-default port (:8765)** found purely via `~/.catgo/server.port` → pushed (79 sites). Dev path unchanged (`_find_gui_app()` → None when not frozen).
- JSON config valid; Python compiles; all version surfaces synced to 1.4.0.

## Needs verification on the built artifact (can't test installers locally)
- The Windows NSIS PATH hook + shim (uses the EnVar plugin Tauri ships) — verify `catgo view` from a fresh terminal after installing the `-setup.exe`.
- macOS signing only activates once the `APPLE_*` secrets are added.

## Note on platforms
Tagging `v1.4.0` builds **Windows/macOS/Linux** (tauri-build.yml). **Android** and **iOS** are separate `workflow_dispatch` workflows — trigger them after tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)