### PR TITLE
fix(release): wire macOS notarization via App Store Connect API key

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -181,6 +181,15 @@ jobs:
       - name: Build agent sidecar (Bun-compiled Node binary)
         run: pnpm build:agent
 
+      - name: Prepare Apple API key for notarization (macOS)
+        if: runner.os == 'macOS'
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
+          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0.6
         env:
@@ -189,14 +198,18 @@ jobs:
           # which GitHub runners lack → "failed to run linuxdeploy". Make all
           # AppImage tooling extract-and-run instead of FUSE-mounting.
           APPIMAGE_EXTRACT_AND_RUN: 1
-          # NOTE: macOS code-signing + notarization is intentionally NOT wired
-          # here yet. The repo's Apple credentials are App Store Connect API-key
-          # based (used by the iOS workflow: APPLE_API_KEY_ID / APPLE_API_ISSUER_ID
-          # / APPLE_API_KEY_P8); the Apple-ID + app-specific-password method this
-          # action's signing path expects isn't configured, so enabling it failed
-          # notarization (401). Ship unsigned this release (right-click → Open),
-          # and wire API-key notarization (write the .p8 to a file →
-          # APPLE_API_ISSUER / APPLE_API_KEY / APPLE_API_KEY_PATH) in a follow-up.
+          # macOS code-signing + notarization. Signing uses the Developer-ID cert
+          # (APPLE_CERTIFICATE/_PASSWORD/_SIGNING_IDENTITY + team); notarization
+          # uses the App Store Connect API key (the repo's existing secrets, also
+          # used by ios-build.yml). APPLE_API_KEY_PATH is written by the step
+          # above. NOT the Apple-ID/app-specific-password method (those secrets
+          # don't exist → would 401). All empty on win/linux → no-op there.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'CatGo ${{ github.ref_name }}'


### PR DESCRIPTION
v1.4.0 shipped macOS **unsigned** because tauri-action's Apple-ID/app-specific-password notarization path 401'd — those secrets don't exist. The repo's Apple creds are **App Store Connect API-key** based (`APPLE_API_KEY_ID` / `APPLE_API_ISSUER_ID` / `APPLE_API_KEY_P8`, already used by `ios-build.yml`).

This writes the `.p8` to a file on the macOS runner and passes `APPLE_API_ISSUER` / `APPLE_API_KEY` / `APPLE_API_KEY_PATH` to tauri-action (plus the Developer-ID signing cert + `APPLE_DEVELOPMENT_TEAM`). No-op on Windows/Linux.

**Caveat to verify on the build**: notarization requires a **Developer ID Application** cert. If the repo's `APPLE_CERTIFICATE` is an *Apple Distribution* cert (iOS/App-Store type), the macOS build will fail and a Developer ID cert must be added. The `v1.4.0` tag was moved to this commit to test it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)