### PR TITLE
fix(structure): default toon lighting to az 25 / el 20

### DIFF
--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -31,8 +31,8 @@ export const LIGHTING_PROFILE_DEFAULTS: Readonly<Record<RenderStyle, LightingPro
     highlight_strength: 0.0,
   },
   toon: {
-    light_azimuth: 35,
-    light_elevation: 45,
+    light_azimuth: 25,
+    light_elevation: 20,
     directional_light: 0.3,
     ambient_light: 0.7,
     highlight_strength: 0.0,


### PR DESCRIPTION
Lower the **toon** (cel/cartoon) render style's default headlamp direction to **azimuth 25°, elevation 20°** (was 35° / 45°). `glossy` and `matte` profiles are unchanged.

One-line change in `LIGHTING_PROFILE_DEFAULTS` (`src/lib/settings/config.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)