### PR TITLE
fix(mobile): hide backend-only Analysis + Doping surfaces in STATIC_ONLY builds

### DIFF
--- a/src/lib/structure/BuildPane.svelte
+++ b/src/lib/structure/BuildPane.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { DraggablePane } from '$lib'
+  import { STATIC_ONLY } from '$lib/api/config'
   import type { Snippet } from 'svelte'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
@@ -8,7 +9,14 @@
 
   export type BuildTab = 'lattice' | 'slab_cutter' | 'adsorption' | 'adsorbate' | 'water_layer' | 'pseudo_h' | 'moire' | 'nanotube' | 'nanoparticle' | 'nanoscroll' | 'heterostructure' | 'doping' | 'pathway' | 'reticular'
 
-  const tab_defs: { id: BuildTab; label: () => string }[] = [
+  // Build tabs that have NO client-side (WASM/TS) path and only work via the
+  // Python backend. On STATIC_ONLY (web + the iOS build) they'd 503, so they are
+  // hidden entirely rather than shown-then-broken (App Store completeness). Every
+  // other build tab runs offline; doping (combinatorial/random substitution) is
+  // the lone backend-only one.
+  const STATIC_HIDDEN_TABS: ReadonlySet<BuildTab> = new Set<BuildTab>(['doping'])
+
+  const all_tab_defs: { id: BuildTab; label: () => string }[] = [
     { id: 'lattice', label: () => t('structure.lattice_tab') },
     { id: 'slab_cutter', label: () => t('structure.slab') },
     { id: 'adsorption', label: () => t('structure.sites') },
@@ -24,6 +32,10 @@
     { id: 'pathway', label: () => t('structure.pathway') },
     { id: 'reticular', label: () => t('structure.reticular') },
   ]
+
+  const tab_defs = STATIC_ONLY
+    ? all_tab_defs.filter((tab) => !STATIC_HIDDEN_TABS.has(tab.id))
+    : all_tab_defs
 
   let {
     show = $bindable(false),

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -8,7 +8,7 @@
   import { DosAnalysisPane, DosPlot, CohpAnalysisPane, CohpPlot, BandAnalysisPane, BandPlot, FreqAnalysisPane, ChargeAnalysisPane } from '$lib/electronic'
   import type { DOSSessionInfo, DosViewState, CohpViewState, BandViewState } from '$lib/electronic'
   import ExportDpiControl from '$lib/electronic/ExportDpiControl.svelte'
-  import { API_BASE } from '$lib/api/config'
+  import { API_BASE, STATIC_ONLY } from '$lib/api/config'
   import { elem_symbols } from '$lib/labels'
 
   import { DEFAULTS, type ShowBonds } from '$lib/settings'
@@ -3607,7 +3607,7 @@
               {on_save_to_database}
               {on_export_to_hpc}
             />
-          {:else if build.active_build_tab === `doping` && structure && `lattice` in structure}
+          {:else if build.active_build_tab === `doping` && !STATIC_ONLY && structure && `lattice` in structure}
             <DopingPane
               bind:this={build.doping_pane_ref}
               bind:structure={structure as PymatgenStructure}

--- a/src/lib/structure/StructureToolbar.svelte
+++ b/src/lib/structure/StructureToolbar.svelte
@@ -455,7 +455,12 @@
         <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.build_tools')}</span>
       </span>
 
+      {#if !hidden_toolbar_items.includes('analysis') && !STATIC_ONLY}
       <!-- === Analysis Tools === -->
+      <!-- Gated like workflow/server below: AnalysisPane's DOS/band/COHP/freq/charge
+           sub-tabs are backend-only (no WASM fallback), so on STATIC_ONLY (web + the
+           iOS build) they'd 503. MobileWorkspace also lists 'analysis' in
+           HIDDEN_TOOLBAR — this is the check that actually honours it. -->
       <span class="struct-toolbar-tooltip-wrap">
         <button
           type="button"
@@ -467,6 +472,7 @@
         </button>
         <span class="struct-toolbar-tooltip" role="tooltip">{t('structure.analysis_tools')}</span>
       </span>
+      {/if}
 
       {#if on_open_in_molstar}
       <!-- === Open current structure in the Mol* bio viewer === -->


### PR DESCRIPTION
Pre-submission audit of the iOS (`VITE_STATIC_ONLY=1`) build found two reviewer-reachable surfaces that hit the **"requires the CatGo desktop app" 503 / download-desktop prompt** — App Store **Guideline 2.1 (App Completeness)** rejection risks. Everything else (view/edit/parse structures, WASM bonds, offline builders, OPTIMADE/PubChem search, local optimizer) already works without a backend.

### Fixed
- **Analysis toolbar button** was ungated, unlike its workflow/server/chat/terminal neighbours — stayed live on mobile despite `MobileWorkspace` listing `'analysis'` in `HIDDEN_TOOLBAR`. Its DOS/band/COHP/freq/charge sub-tabs are backend-only (no WASM fallback) → 503 on tap. Now gated `!hidden_toolbar_items.includes('analysis') && !STATIC_ONLY`.
- **Doping build tab** — the only build sub-tab with no client-side path (combinatorial/random substitution → backend); it rendered `DesktopRequiredNotice` with the literal "download desktop / github.com" text. Hidden from `BuildPane`'s tab list on `STATIC_ONLY`, with a defensive guard on the `DopingPane` render in `Structure.svelte`.

Desktop (non-STATIC_ONLY) unchanged. `svelte-check` clean on the 3 files.

Source: background audit of `src/lib/mobile/` + every `STATIC_ONLY` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)