### PR TITLE
fix(build): pin @tauri-apps/plugin-updater to 2.9.x (match Rust crate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.4",
-    "@tauri-apps/plugin-updater": "^2.10.1",
+    "@tauri-apps/plugin-updater": "~2.9.0",
     "@threlte/core": "^8.1.8",
     "@threlte/extras": "^9.5.5",
     "@types/d3-force": "^3.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: ^2.3.4
         version: 2.3.4
       '@tauri-apps/plugin-updater':
-        specifier: ^2.10.1
-        version: 2.10.1
+        specifier: ^2.9.0
+        version: 2.9.0
       '@threlte/core':
         specifier: ^8.1.8
         version: 8.3.1(svelte@5.48.0)(three@0.181.2(patch_hash=135875ae2386a6ee9ff9516832e12ff0e50270b82597b4a26a8a70e725b5ea60))
@@ -1481,8 +1481,8 @@ packages:
   '@tauri-apps/plugin-shell@2.3.4':
     resolution: {integrity: sha512-ktsRWf8wHLD17aZEyqE8c5x98eNAuTizR1FSX475zQ4TxaiJnhwksLygQz+AGwckJL5bfEP13nWrlTNQJUpKpA==}
 
-  '@tauri-apps/plugin-updater@2.10.1':
-    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
+  '@tauri-apps/plugin-updater@2.9.0':
+    resolution: {integrity: sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5356,7 +5356,7 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.9.1
 
-  '@tauri-apps/plugin-updater@2.10.1':
+  '@tauri-apps/plugin-updater@2.9.0':
     dependencies:
       '@tauri-apps/api': 2.9.1
 


### PR DESCRIPTION
iOS build failed: `Found version mismatched Tauri packages` — npm `@tauri-apps/plugin-updater@2.10.1` vs Rust `tauri-plugin-updater@2.9.0` (latest on crates.io). Tauri CLI requires matching major/minor per plugin. Pin npm to `~2.9.0`. Also unblocks desktop `tauri-build` (same check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)