### PR TITLE
fix(build): sync pnpm-lock specifier to ~2.9.0 (frozen-lockfile)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         specifier: ^2.3.4
         version: 2.3.4
       '@tauri-apps/plugin-updater':
-        specifier: ^2.9.0
+        specifier: ~2.9.0
         version: 2.9.0
       '@threlte/core':
         specifier: ^8.1.8


### PR DESCRIPTION
Follow-up to #437: lockfile still had `^2.9.0` while package.json is `~2.9.0`, breaking `pnpm install --frozen-lockfile` in CI (ERR_PNPM_OUTDATED_LOCKFILE). One-line lockfile resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)