### PR TITLE
fix(optimade): retry providers on cold start so Search-Database isn't PubChem-only

### DIFF
--- a/src/lib/api/__tests__/optimade.test.ts
+++ b/src/lib/api/__tests__/optimade.test.ts
@@ -141,3 +141,71 @@ describe(`MP nested _mp_stability extraction + stability sort`, () => {
     ])
   })
 })
+
+// Cold-start race: on desktop the Python sidecar that serves
+// /api/optimade/providers boots a few seconds after the webview. If the user
+// opens Search-Database immediately, the first providers fetch is refused at
+// the socket level — the dialog then degrades to PubChem-only (the modal injects
+// PubChem client-side; the OPTIMADE list needs the backend). fetch_optimade_providers
+// must retry the backend instead of giving up on the first failure, and must
+// never cache an empty result (so a later open still recovers).
+describe(`fetch_optimade_providers cold-start retry`, () => {
+  let mod: typeof import('../optimade')
+
+  beforeEach(async () => {
+    delete (globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__
+    vi.resetModules()
+    vi.useFakeTimers()
+    mod = await import(`../optimade`)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  const providers_response = (ids: string[]) =>
+    new Response(
+      JSON.stringify({ data: ids.map((id) => ({ id, type: `links`, attributes: { name: id, base_url: `https://x/${id}` } })) }),
+      { status: 200, headers: { 'Content-Type': `application/vnd.api+json` } },
+    )
+
+  it(`retries the backend and succeeds when the sidecar comes up late`, async () => {
+    let calls = 0
+    vi.spyOn(globalThis, `fetch`).mockImplementation(() => {
+      calls++
+      // First two attempts: sidecar not listening yet (connection refused).
+      if (calls < 3) return Promise.reject(new TypeError(`Failed to fetch`))
+      return Promise.resolve(providers_response([`mp`, `alexandria`]))
+    })
+
+    const promise = mod.fetch_optimade_providers()
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(calls).toBe(3)
+    expect(result.map((p) => p.id)).toEqual([`mp`, `alexandria`])
+  })
+
+  it(`returns an empty, UN-cached list when the backend never comes up`, async () => {
+    vi.spyOn(globalThis, `fetch`).mockImplementation(() =>
+      Promise.reject(new TypeError(`Failed to fetch`)),
+    )
+
+    const promise = mod.fetch_optimade_providers()
+    await vi.runAllTimersAsync()
+    const first = await promise
+    expect(first).toEqual([])
+
+    // Not cached as empty: a subsequent open re-attempts the backend, and now
+    // the sidecar is up, so the real list loads (no stale empty cache wins).
+    vi.restoreAllMocks()
+    vi.spyOn(globalThis, `fetch`).mockImplementation(() =>
+      Promise.resolve(providers_response([`mp`])),
+    )
+    const promise2 = mod.fetch_optimade_providers()
+    await vi.runAllTimersAsync()
+    const second = await promise2
+    expect(second.map((p) => p.id)).toEqual([`mp`])
+  })
+})

--- a/src/lib/api/optimade.ts
+++ b/src/lib/api/optimade.ts
@@ -184,6 +184,18 @@ let cached_providers: OptimadeProvider[] | null = null
 let providers_cache_time = 0
 const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
 
+// Cold-start retry budget. On the desktop build the Python sidecar (which
+// serves /api/optimade/providers) is spawned by Tauri and takes a few seconds
+// to boot — PyInstaller unpack + heavy eager imports. If the user opens the
+// Search-Database dialog before it is listening, the very first providers fetch
+// is refused at the socket level. PubChem still appears (the modal injects it
+// client-side, no backend needed), so the dialog degrades to "only PubChem".
+// Retry with backoff so the first open self-heals instead of sticking.
+const PROVIDERS_FETCH_RETRIES = 3 // total attempts
+const PROVIDERS_RETRY_BASE_MS = 400 // backoff: 0ms, 400ms, 800ms
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
 // URL encode/decode utilities for structure IDs with special characters
 export const encode_structure_id = (id: string) =>
   encodeURIComponent(id).replace(/\./g, `%2E`).replace(/\//g, `%2F`)
@@ -233,26 +245,39 @@ export async function fetch_optimade_providers(): Promise<OptimadeProvider[]> {
     return cached_providers
   }
 
-  try {
-    // Always go through the catgo-server backend when one is available
-    // (the VSCode extension bundles a sidecar at API_BASE = http://127.0.0.1:<port>/api).
-    // Extension host's undici fetch occasionally fails on providers.optimade.org
-    // with a bare "fetch failed" — routing through the Python backend's
-    // /optimade/providers endpoint sidesteps that entire failure mode and also
-    // gives us the same provider filtering that the desktop app gets.
-    const url = `${API_BASE}/optimade/providers`
+  // Always go through the catgo-server backend when one is available
+  // (the VSCode extension bundles a sidecar at API_BASE = http://127.0.0.1:<port>/api).
+  // Extension host's undici fetch occasionally fails on providers.optimade.org
+  // with a bare "fetch failed" — routing through the Python backend's
+  // /optimade/providers endpoint sidesteps that entire failure mode and also
+  // gives us the same provider filtering that the desktop app gets.
+  //
+  // The backend always answers with at least a fallback list once its router is
+  // mounted (and the router mounts before uvicorn binds), so an empty/failed
+  // result here means the backend itself was unreachable — i.e. a cold-start
+  // race. Retry with backoff before giving up.
+  const url = `${API_BASE}/optimade/providers`
+  let last_error: unknown = null
+  for (let attempt = 0; attempt < PROVIDERS_FETCH_RETRIES; attempt++) {
+    if (attempt > 0) await sleep(PROVIDERS_RETRY_BASE_MS * attempt)
+    try {
+      const data = await fetch_json_smart(url) as { data?: OptimadeProvider[] }
+      const providers = data.data || []
+      // A reachable backend returns a non-empty list; an empty one means it is
+      // still booting (or wedged) — keep retrying rather than caching nothing.
+      if (providers.length === 0) continue
 
-    const data = await fetch_json_smart(url) as { data?: OptimadeProvider[] }
-    const providers = data.data || []
-
-    cached_providers = providers
-    providers_cache_time = now
-    return cached_providers ?? []
-  } catch (error) {
-    console.warn(`Failed to fetch OPTIMADE providers from backend:`, error)
-    // Return cached providers if available, otherwise empty array
-    return cached_providers ?? []
+      cached_providers = providers
+      providers_cache_time = now
+      return providers
+    } catch (error) {
+      last_error = error
+    }
   }
+
+  console.warn(`Failed to fetch OPTIMADE providers from backend:`, last_error)
+  // Never cache an empty/failed result — the next dialog open must retry.
+  return cached_providers ?? []
 }
 
 /**

--- a/src/lib/structure/OptimadeSearchModal.svelte
+++ b/src/lib/structure/OptimadeSearchModal.svelte
@@ -90,6 +90,10 @@
   // Elements selected via the periodic table (used for 'only' and 'at_least' modes)
   let selected_elements = $state<string[]>([])
   let loading_providers = $state(false)
+  // Whether the OPTIMADE provider list (not just the client-side PubChem entry)
+  // has actually loaded. A cold-start backend race can leave us with PubChem
+  // only; this flag drives a retry on every reopen until the real list arrives.
+  let optimade_loaded = $state(false)
   let providers_error = $state<string | null>(null)
   let loading_search = $state(false)
   let loading_import = $state(false)
@@ -131,9 +135,13 @@
   let computed_details = $state<Map<string, ComputedDetails>>(new Map())
   let computing_details = $state(false)
 
-  // Load providers on mount
+  // Load providers on mount, and retry on every reopen until the real OPTIMADE
+  // list has loaded. Guarding on `optimade_loaded` (not `providers.length`) is
+  // deliberate: a cold-start backend race degrades the list to PubChem-only
+  // (length 1), and the old `providers.length === 0` guard would never retry
+  // that state — the user was stuck until a full reload.
   $effect(() => {
-    if (visible && providers.length === 0) {
+    if (visible && !optimade_loaded) {
       load_providers()
     }
   })
@@ -194,6 +202,9 @@
   })
 
   async function load_providers() {
+    // The reload effect can fire while a load is already in flight (visible
+    // toggling, reactive deps changing). Guard so we don't issue parallel fetches.
+    if (loading_providers) return
     loading_providers = true
     providers_error = null
     try {
@@ -213,7 +224,12 @@
         selected_provider = mp?.id ?? providers[0].id
       }
       if (fetched.length === 0) {
+        // Only PubChem made it in — the OPTIMADE list is still missing (cold-start
+        // race, backend not ready). Leave `optimade_loaded` false so reopening the
+        // dialog retries instead of sticking on PubChem-only.
         providers_error = t('structure.optimade_no_providers')
+      } else {
+        optimade_loaded = true
       }
     } catch (err) {
       console.error(`Failed to load OPTIMADE providers:`, err)


### PR DESCRIPTION
## 问题

冷启动后立即打开 Fetch Structure → Search Database，弹窗只显示 PubChem，所有 OPTIMADE 数据库（MP / Alexandria / MC3D / 2DMatpedia …）不显示。关闭再开则全部正常。100% 复现（Windows 桌面 full backend）。

## 根因（与上报分析不同）

上报推测「OPTIMADE router 比 PubChem router 晚注册 ~12s」。**代码层面不成立**：

- `optimade_router` 与 `pubchem_router` 都是 eager import，在 `server/main.py:574-575` **连续、模块加载期**注册，早于 uvicorn 绑定端口。无注册时序差。
- PubChem 能显示是因为弹窗**客户端硬编码**了一个 PubChem 合成条目（`OptimadeSearchModal.svelte`），不需要后端；OPTIMADE 列表需后端往返。这才是真正的不对称。
- 后端 `/optimade/providers` 一旦挂载，任何异常都返回 `FALLBACK_PROVIDERS`，不会报错。

**真正触发**：桌面冷启动时 Python sidecar（Tauri 拉起，PyInstaller 解包 + 重导入）还没监听，用户已点开弹窗 → 前端 `fetch_optimade_providers()` 被 socket 拒绝 → catch → 返回 `[]` → 只剩硬编码 PubChem。旧的重载守卫 `providers.length === 0` 此时长度为 1 → **永不重试**，降级状态卡死。

（`relay_fetch` 注释里记录过一次「只剩 PubChem」——那是**移动端 CORS** 场景，早已修复。同症状，不同触发。）

## 修复（前端自愈，对应上报 6.2）

1. **`fetch_optimade_providers`**：后端拉取加退避重试（3 次，0/400/800ms），首次失败不再放弃；失败/空结果绝不缓存，下次打开可恢复。
2. **`OptimadeSearchModal`**：新增 `optimade_loaded` 标志，重载 `$effect` 守卫改为 `!optimade_loaded`（而非 `providers.length`），降级成只剩 PubChem 时**每次重开都会重试**直到真列表到；并加并发拉取守卫。
3. **测试**：冷启动重试成功 + 空结果不缓存可恢复。

未采纳上报 6.1（后端 readiness 探针）：其前提（router 时序）不成立，且 sidecar 启动延迟不可消除，前端自愈是正确层。

## 验证

- `optimade.test.ts` 套件 10/10 通过
- 全量 vitest **4356 通过 / 0 失败**（真实 CI 门槛）
- 未真机冷启动复现（开发机为 Linux，跑不了 Windows 桌面冷启动）；已对死代码路径逐条确认逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)