### PR TITLE
docs(ios): App Store submission runbook + reusable scripts (no Mac)

### DIFF
--- a/deploy/ios/APPSTORE.md
+++ b/deploy/ios/APPSTORE.md
@@ -1,0 +1,150 @@
+# Shipping CatGo iOS to the App Store (no Mac)
+
+The iOS app is the **STATIC_ONLY web build** in a WKWebView (`ios-build.yml` sets
+`VITE_STATIC_ONLY=1`). It builds, signs, and uploads to TestFlight from GitHub's
+macOS runners — **no local Mac needed**. This is the runbook for taking a build
+from TestFlight to a public App Store release, done entirely from Linux + the
+App Store Connect API.
+
+First public release: **CatGo: HPC & Chemistry** (`org.catgo.app`), app id
+`6777090974`, submitted as **1.4.0** on 2026-06-26.
+
+---
+
+## 0. Signing certificates (one-time, already done)
+
+iOS and macOS desktop need **different** certificate types and must use
+**different** GitHub secrets — sharing one breaks the other:
+
+| Pipeline | Cert type | Secrets |
+|---|---|---|
+| `ios-build.yml` | **Apple Distribution** | `APPLE_CERTIFICATE` / `_PASSWORD` / `_SIGNING_IDENTITY` |
+| `tauri-build.yml` (macOS) | **Developer ID Application** | `MACOS_CERTIFICATE` / `_PASSWORD` / `_SIGNING_IDENTITY` |
+
+Both certs can be created on **Linux with OpenSSL** (no Keychain): `openssl
+genrsa` → `openssl req` (CSR) → upload CSR at developer.apple.com → download
+`.cer` → `openssl pkcs12 -export -legacy` to a `.p12`. Notarization (macOS) +
+TestFlight upload (iOS) both use the App Store Connect API key
+(`APPLE_API_KEY_ID` / `APPLE_API_ISSUER_ID` / `APPLE_API_KEY_P8`).
+
+## 1. Build + upload to TestFlight
+
+```bash
+gh workflow run ios-build.yml -R Hello-QM/catgo-LRG -r main -f signed=true -f upload=true
+gh run watch <run_id> -R Hello-QM/catgo-LRG --exit-status
+```
+
+The build's `CFBundleVersion` = `github.run_number`; its **marketing version**
+(`CFBundleShortVersionString`) comes from `src-tauri/tauri.conf.json`. The App
+Store version string **must match that marketing version** to attach the build —
+so submit `1.4.0` against a `1.4.0` build; a different number needs a fresh
+build (bump tauri.conf first).
+
+Pre-submission gate: make sure no backend-only surface is reachable in the
+STATIC_ONLY UI (it 503s / shows a "download desktop" prompt → App Store
+rejection, Guideline 2.1). See the Analysis-button / Doping-tab gating in
+`StructureToolbar.svelte` + `BuildPane.svelte`.
+
+## 2. App Store Connect API key (local)
+
+Build the JSON deliver/scripts expect from the `.p8` + the two IDs. **Keep it out
+of git.**
+
+```bash
+python3 - <<'PY'
+import json
+open('/path/to/asc_api_key.json','w').write(json.dumps({
+  "key_id": "<APPLE_API_KEY_ID>",
+  "issuer_id": "<APPLE_API_ISSUER_ID>",      # appstoreconnect.apple.com/access/integrations/api
+  "key": open('/path/to/AuthKey_<KEYID>.p8').read(),
+  "in_house": False,
+}))
+PY
+chmod 600 /path/to/asc_api_key.json
+```
+
+## 3. Screenshots → exact App Store sizes
+
+App Store Connect validates by **exact pixel size**. Device captures are usually
+wrong (6.1" iPhone, 11" iPad). Pad them (no distortion):
+
+```bash
+python3 deploy/ios/scripts/pad_screenshots.py <src>/Mobile <out>/Mobile iphone67   # 1290x2796
+python3 deploy/ios/scripts/pad_screenshots.py <src>/Pad    <out>/Pad    ipad129    # 2048x2732
+```
+
+Max **10 per device**; portrait only. Stage all into one folder
+`fastlane/screenshots/en-US/` — `deliver` detects device by image size.
+
+## 4. Push metadata + screenshots
+
+Text metadata lives in `fastlane/metadata/en-US/*.txt` (name, subtitle,
+description, keywords, promotional_text, marketing_url, support_url,
+primary/secondary_category). Limits: name ≤30, subtitle ≤30, keywords ≤100,
+promo ≤170, description ≤4000.
+
+```bash
+export PATH="$HOME/.local/share/gem/ruby/<ver>/bin:$PATH"   # if fastlane is user-installed
+
+# Screenshots — deliver works fine for these:
+fastlane deliver --api_key_path ./asc_api_key.json --app_identifier org.catgo.app \
+  --screenshots_path ./fastlane/screenshots --skip_binary_upload true \
+  --skip_metadata true --overwrite_screenshots true \
+  --submit_for_review false --run_precheck_before_submit false --force
+
+# Text metadata — deliver 2.236 crashes here (fetch_app_store_review_detail "No data"),
+# so use the API directly instead:
+ASC_API_KEY=./asc_api_key.json \
+PRIVACY_URL="https://github.com/Hello-QM/catgo-LRG/blob/main/PRIVACY.md" \
+python3 deploy/ios/scripts/asc_push_metadata.py org.catgo.app ./fastlane/metadata
+```
+
+Gotchas baked into the script: **don't** set `name` (globally unique — "CatGo"
+is taken; the registered name is "CatGo: HPC & Chemistry"); **don't** set
+`whatsNew` on a first release (not editable → 409).
+
+## 5. Version string + attach the build (API)
+
+If the editable version was auto-created with the wrong number, rename it and
+attach the VALID build whose marketing version matches:
+
+```python
+# PATCH /v1/appStoreVersions/{id}  {"attributes":{"versionString":"1.4.0"}}
+# PATCH /v1/appStoreVersions/{id}/relationships/build  {"data":{"type":"builds","id":<build_id>}}
+```
+
+(Find the build via `/v1/builds?filter[app]=<id>&sort=-uploadedDate`; its
+`/preReleaseVersion` gives the marketing version. `CFBundleVersion` == the
+`github.run_number` of the build run.)
+
+## 6. The web-only steps (must be done in App Store Connect by you)
+
+Everything above is scriptable; these are not (legal / declarations / final
+submit). From `https://appstoreconnect.apple.com/apps/6777090974/distribution`:
+
+1. **Agreements** (`/agreements`) — accept the updated Apple Developer Program
+   License Agreement (the yellow banner). Free app → ignore the Paid Apps
+   Agreement. DSA: declare **non-trader** (no EU, keeps your address private) or
+   **trader** (EU, contact shown).
+2. **Contact Information** (App Review Information on the version page).
+3. **App Privacy** → "No, we do not collect data" (**Data Not Collected** — no
+   analytics/accounts/backend; SSH creds + API keys stay on-device).
+4. **Content Rights** (App Information) → "does not contain third-party content".
+5. **Pricing** → **Free**.
+6. **Age Rating** → all None → **4+**.
+7. **Add for Review** → Export Compliance → **Exempt** (standard HTTPS/SSH) →
+   **Submit**.
+
+Verify state any time:
+
+```bash
+ASC_API_KEY=./asc_api_key.json python3 - <<'PY'
+import jwt,time,json,os,requests
+k=json.load(open(os.environ["ASC_API_KEY"]))
+t=jwt.encode({"iss":k["issuer_id"],"iat":int(time.time()),"exp":int(time.time())+600,"aud":"appstoreconnect-v1"},k["key"],algorithm="ES256",headers={"kid":k["key_id"]})
+H={"Authorization":f"Bearer {t}"}; B="https://api.appstoreconnect.apple.com/v1"
+a=requests.get(f"{B}/apps",headers=H,params={"filter[bundleId]":"org.catgo.app"}).json()["data"][0]
+v=requests.get(f"{B}/apps/{a['id']}/appStoreVersions",headers=H).json()["data"][0]["attributes"]
+print(a["attributes"]["name"], v["versionString"], v["appStoreState"])
+PY
+```

--- a/deploy/ios/scripts/asc_push_metadata.py
+++ b/deploy/ios/scripts/asc_push_metadata.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Push App Store listing metadata via the App Store Connect API.
+
+Used instead of `fastlane deliver` for text metadata because deliver 2.236 + an
+API key crashes on `fetch_app_store_review_detail` ("No data") while uploading.
+The raw API PATCHes are simple and avoid that path. Screenshots still go through
+`fastlane deliver --skip_metadata true` (its multipart upload works fine).
+
+Credentials come from an App Store Connect API key JSON (NEVER commit it):
+    {"key_id": "...", "issuer_id": "...", "key": "<AuthKey .p8 contents>"}
+
+Usage:
+    ASC_API_KEY=/path/to/asc_api_key.json \
+    asc_push_metadata.py <bundle_id> <metadata_dir>
+
+<metadata_dir> holds fastlane-style files (en-US/description.txt, keywords.txt,
+promotional_text.txt, marketing_url.txt, support_url.txt, subtitle.txt). It edits
+the single editable App Store version's en-US localization and sets the privacy
+policy URL. It does NOT set name (globally unique — leave it), does NOT set
+whatsNew (not editable on a first release), and does NOT submit.
+
+Set PRIVACY_URL env to also write the privacy policy URL.
+"""
+import jwt, time, json, os, sys, requests
+
+BASE = "https://api.appstoreconnect.apple.com/v1"
+EDITABLE = {"PREPARE_FOR_SUBMISSION", "DEVELOPER_REJECTED", "REJECTED",
+            "METADATA_REJECTED", "INVALID_BINARY"}
+
+
+def load_key():
+    p = os.environ.get("ASC_API_KEY")
+    if not p or not os.path.exists(p):
+        sys.exit("set ASC_API_KEY=/path/to/asc_api_key.json")
+    return json.load(open(p))
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    bundle, md = sys.argv[1], sys.argv[2]
+    loc_dir = os.path.join(md, "en-US")
+    k = load_key()
+
+    def tok():
+        return jwt.encode(
+            {"iss": k["issuer_id"], "iat": int(time.time()),
+             "exp": int(time.time()) + 1100, "aud": "appstoreconnect-v1"},
+            k["key"], algorithm="ES256", headers={"kid": k["key_id"]})
+
+    def H():
+        return {"Authorization": f"Bearer {tok()}", "Content-Type": "application/json"}
+
+    def rd(name):
+        p = os.path.join(loc_dir, name)
+        return open(p, encoding="utf-8").read() if os.path.exists(p) else None
+
+    def patch(url, attrs, typ, rid):
+        r = requests.patch(url, headers=H(),
+                           data=json.dumps({"data": {"type": typ, "id": rid, "attributes": attrs}}))
+        if r.status_code >= 300:
+            print("  PATCH FAIL", r.status_code, r.text[:300])
+        else:
+            print("  set:", list(attrs.keys()))
+        return r
+
+    apps = requests.get(f"{BASE}/apps", headers=H(),
+                        params={"filter[bundleId]": bundle}).json()["data"]
+    assert apps, "app not found: " + bundle
+    aid = apps[0]["id"]
+    print("app:", apps[0]["attributes"]["name"], "| id", aid)
+
+    vers = requests.get(f"{BASE}/apps/{aid}/appStoreVersions", headers=H()).json()["data"]
+    ed = [v for v in vers if v["attributes"]["appStoreState"] in EDITABLE]
+    assert ed, "no editable App Store version (create one first)"
+    vid = ed[0]["id"]
+    print("version:", ed[0]["attributes"]["versionString"], ed[0]["attributes"]["appStoreState"])
+
+    locs = requests.get(f"{BASE}/appStoreVersions/{vid}/appStoreVersionLocalizations",
+                        headers=H()).json()["data"]
+    vloc = ([l for l in locs if l["attributes"]["locale"] == "en-US"] or locs)[0]
+    vattr = {k2: v2 for k2, v2 in {
+        "description": rd("description.txt"), "keywords": rd("keywords.txt"),
+        "promotionalText": rd("promotional_text.txt"),
+        "marketingUrl": rd("marketing_url.txt"), "supportUrl": rd("support_url.txt"),
+    }.items() if v2}
+    print("version localization:")
+    patch(f"{BASE}/appStoreVersionLocalizations/{vloc['id']}", vattr,
+          "appStoreVersionLocalizations", vloc["id"])
+
+    info_id = requests.get(f"{BASE}/apps/{aid}/appInfos", headers=H()).json()["data"][0]["id"]
+    ilocs = requests.get(f"{BASE}/appInfos/{info_id}/appInfoLocalizations",
+                         headers=H()).json()["data"]
+    iloc = ([l for l in ilocs if l["attributes"]["locale"] == "en-US"] or ilocs)[0]
+    iattr = {k2: v2 for k2, v2 in {
+        "subtitle": rd("subtitle.txt"),
+        "privacyPolicyUrl": os.environ.get("PRIVACY_URL"),
+    }.items() if v2}
+    print("app info localization:")
+    patch(f"{BASE}/appInfoLocalizations/{iloc['id']}", iattr,
+          "appInfoLocalizations", iloc["id"])
+    print("\nDONE — metadata pushed, no submit.")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/ios/scripts/pad_screenshots.py
+++ b/deploy/ios/scripts/pad_screenshots.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Pad iOS screenshots to exact App Store dimensions (no distortion).
+
+App Store Connect validates screenshots by *exact* pixel size and rejects
+anything else. Device captures are often the wrong size (e.g. a 6.1" iPhone or
+an 11" iPad). This scales each image to fit the target canvas preserving aspect
+ratio, then pads the remainder with the image's own edge colour so the border is
+invisible on same-aspect devices and unobtrusive otherwise.
+
+Usage:
+    pad_screenshots.py <src_dir> <out_dir> iphone67   # -> 1290x2796
+    pad_screenshots.py <src_dir> <out_dir> ipad129    # -> 2048x2732
+
+Targets (portrait):
+    iphone67  1290x2796   (iPhone 6.7")      iphone69  1320x2868  (6.9")
+    ipad129   2048x2732   (iPad 12.9")       ipad13    2064x2752  (13")
+
+Notes:
+    - Drops landscape inputs (App Store wants one orientation; keep portrait).
+    - App Store max is 10 screenshots per device — trim the source set yourself.
+    - Output is RGB PNG (no alpha; App Store rejects alpha).
+"""
+import sys, os, glob
+from PIL import Image
+
+TARGETS = {
+    "iphone67": (1290, 2796), "iphone69": (1320, 2868),
+    "ipad129": (2048, 2732), "ipad13": (2064, 2752),
+}
+
+
+def bg_color(im):
+    w, h = im.size
+    px = im.load()
+    s = []
+    step = max(1, h // 60)
+    for y in range(0, h, step):
+        s.append(px[1, y]); s.append(px[w - 2, y])
+    s.sort()
+    return s[len(s) // 2]
+
+
+def pad_to(src, dst, TW, TH):
+    im = Image.open(src).convert("RGB")
+    w, h = im.size
+    scale = min(TW / w, TH / h)
+    nw, nh = int(round(w * scale)), int(round(h * scale))
+    canvas = Image.new("RGB", (TW, TH), bg_color(im))
+    canvas.paste(im.resize((nw, nh), Image.LANCZOS), ((TW - nw) // 2, (TH - nh) // 2))
+    canvas.save(dst, "PNG")
+
+
+def main():
+    if len(sys.argv) != 4 or sys.argv[3] not in TARGETS:
+        sys.exit(__doc__)
+    src_dir, out_dir, target = sys.argv[1:4]
+    TW, TH = TARGETS[target]
+    os.makedirs(out_dir, exist_ok=True)
+    n = 0
+    for f in sorted(glob.glob(os.path.join(src_dir, "*"))):
+        try:
+            w, h = Image.open(f).size
+        except Exception:
+            continue
+        if w > h:
+            print(f"skip landscape {os.path.basename(f)}"); continue
+        out = os.path.join(out_dir, os.path.splitext(os.path.basename(f))[0] + ".png")
+        pad_to(f, out, TW, TH); n += 1
+        print(f"{(w, h)} -> {(TW, TH)}  {os.path.basename(out)}")
+    print(f"{n} screenshots -> {out_dir}  (App Store max 10/device)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Mac-free flow used to ship CatGo 1.4.0 to the App Store + two reusable scripts (screenshot padding, metadata push via ASC API). Captures the gotchas: cert/secret split (Apple Distribution vs Developer ID), fastlane deliver's review-detail crash → API workaround, globally-unique app name, whatsNew not editable on first release, version-must-match-build. No credentials committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)