### PR TITLE
fix(electronic): axis title no longer overlaps tick labels at large font

### DIFF
--- a/src/lib/electronic/BandPlot.svelte
+++ b/src/lib/electronic/BandPlot.svelte
@@ -254,6 +254,7 @@
         ticktext: tick_labels,
         range: [distance[0] ?? 0, distance[distance.length - 1] ?? 1],
         zeroline: false,
+        automargin: true,
         ...grid_props,
         showgrid: false,  // No horizontal grid for band plots
         ...line_props,
@@ -263,6 +264,7 @@
         title: { text: `E \u2013 E<sub>f</sub> (eV)`, font: { size: title_size } },
         range: [emin, emax],
         zeroline: false,
+        automargin: true,
         ...grid_props,
         ...line_props,
         ...tick_props_obj,

--- a/src/lib/electronic/CohpPlot.svelte
+++ b/src/lib/electronic/CohpPlot.svelte
@@ -263,6 +263,7 @@
     const energy_axis = {
       title: { text: `E \u2013 E<sub>f</sub> (eV)`, font: { size: title_size } },
       zeroline: false,
+      automargin: true,
       range: is_horizontal ? (y_range ?? undefined) : (x_range ?? undefined),
       ...grid_props,
       ...line_props,
@@ -271,6 +272,7 @@
     const cohp_axis = {
       title: { text: cohp_label, font: { size: title_size } },
       zeroline: true,
+      automargin: true,
       range: is_horizontal ? (x_range ?? undefined) : (y_range ?? undefined),
       ...grid_props,
       ...line_props,

--- a/src/lib/electronic/DosPlot.svelte
+++ b/src/lib/electronic/DosPlot.svelte
@@ -235,6 +235,7 @@
     const energy_axis = {
       title: { text: `E \u2013 E<sub>f</sub> (eV)`, font: { size: title_size } },
       zeroline: false,
+      automargin: true,
       range: is_horizontal ? (y_range ?? undefined) : (x_range ?? undefined),
       ...grid_props,
       ...line_props,
@@ -243,6 +244,7 @@
     const dos_axis = {
       title: { text: `DOS (states/eV)`, font: { size: title_size } },
       zeroline: true,
+      automargin: true,
       range: is_horizontal ? (x_range ?? undefined) : (y_range ?? undefined),
       ...grid_props,
       ...line_props,


### PR DESCRIPTION
## Problem

Enlarging the axis-title font (标题字号, configurable up to ~30) in the electronic-structure plots made the axis title overlap / cover the tick labels behind it. Reported for DOS; the same bug affected Band and COHP plots.

## Cause

All three Plotly plots used a hard-coded layout `margin: { l: 60, r: 10, t: 10, b: 45 }` with no `automargin` or title `standoff`. The title font scaled with `title_size`, but the margin band stayed fixed, so a big title was drawn into the same 60px-left / 45px-bottom band as the tick labels.

## Fix

Add `automargin: true` to both axis objects in:
- `DosPlot.svelte` (energy_axis + dos_axis)
- `BandPlot.svelte` (xaxis + yaxis)
- `CohpPlot.svelte` (energy_axis + cohp_axis)

Plotly now expands the margin to fit ticks + title at any font size. No shared chart component exists, so the fix is applied per file.

## Test

User verified in the running desktop app: cranking 标题字号 to 30 no longer covers the tick labels. `pnpm check` introduces no new errors (the 9 pre-existing errors are in unrelated whisper test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)