### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -238,7 +238,7 @@ jobs:
             ### Installation
             - **Windows** — run the **`-setup.exe`** installer (recommended; it puts the `catgo` CLI on your PATH so `catgo view` works). The `.msi` installs the app but not the CLI.
               - Unsigned this release: if Windows SmartScreen warns, click **More info → Run anyway**. (Code signing is coming in a later build.)
-            - **macOS** — open the `.dmg` and drag CatGo to Applications. Unsigned this release: the first launch needs **right-click → Open → Open** (signing/notarization is coming next).
+            - **macOS** — open the `.dmg` and drag CatGo to Applications. **Signed & notarized** (Apple Silicon) — it opens normally, no right-click workaround.
             - **Linux** — `sudo dpkg -i CatGo_*_amd64.deb` (or `sudo rpm -i`)
             - **Android** — install `CatGo-v*-android-universal.apk`
             - **iOS** — join the [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
@@ -251,6 +251,16 @@ jobs:
             - **Builders** — slabs, adsorbates, moiré, nanotubes, heterostructures, MOFs, doping, passivation
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
+
+            ### New in 1.4.1
+            - **In-app auto-update** — Windows & macOS notice new releases and update with one click (download the signed bundle → relaunch); Linux gets a "new version" banner linking to the download page. The banner only shows when a newer release exists.
+            - **Signed & notarized macOS** — the `.dmg`/`.app` now open without the Gatekeeper right-click workaround.
+            - **Bonds preserved when adding a lattice** — adding a periodic box to a molecule (Build → Lattice) no longer drops the bonds (correct fractional coords, incl. non-orthogonal cells).
+            - **Search Database fixed** — OPTIMADE providers retry on cold start, so it's no longer PubChem-only.
+            - **VS Code extension** — trajectory playback no longer janks (off-thread bond recompute); **plots** — axis titles no longer overlap tick labels at large fonts.
+            - **iOS** — CatGo is now on the App Store (static viewer build); the web "Get the App" button is embedded in the landing page.
+
+            See the [CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md) for the full list.
 
             ### New in 1.4.0
             - **`catgo view` / `catgo gui` CLI** — open structures & trajectories like `ase gui`: `catgo view */POSCAR` stacks files into one trajectory, per-file `@SLICE` frame selection, `--interpolate` (IDPP), and headless `-g/-t` convergence plots. On a packaged install, running `catgo view` with no app open **launches CatGo** and shows the structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2026-06-26
+
+### Added
+- **In-app auto-update** — installed desktop builds now notice new releases and update from inside the app. Windows/macOS download the signed bundle and relaunch with one click; Linux (`.deb`/`.rpm`) shows a "new version" banner that opens the download page. A bottom-centre banner appears only when a newer version exists. Web and mobile builds are unaffected.
+- **Signed & notarized macOS builds** — the `.dmg`/`.app` are now code-signed with a Developer ID certificate and notarized via the App Store Connect API key, so macOS no longer needs the right-click → Open Gatekeeper workaround.
+
+### Changed
+- **Web "Get the App" button** is now embedded in the landing page (next to *Star on GitHub*) instead of floating over the editor after a structure loads.
+- **Toon render style** default headlamp lowered to azimuth 25° / elevation 20°.
+
+### Fixed
+- **Bonds no longer disappear** after adding a periodic lattice to a molecule (Build Tools → Lattice): fractional coordinates are now recomputed correctly, including non-orthogonal boxes.
+- **Search Database is no longer PubChem-only** — OPTIMADE providers are retried on cold start so the full provider list loads.
+- **VS Code extension trajectory playback** no longer recomputes `solid_angle` bonds on the main thread every frame (jank fixed).
+- **Electronic-structure plots** — axis titles no longer overlap tick labels at large font sizes.
+- **iOS (App Store) build** hides backend-only surfaces (Analysis tools, Doping builder) that would otherwise show a "requires the desktop app" error in the static build.
+
 ## [1.4.0] - 2026-06-25
 
 ### Added

--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.4.0";
+  const VERSION = "1.4.1";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.0"
+version = "1.4.1"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump to **1.4.1** across desktop surfaces + refreshed release notes.

**Highlights**: in-app auto-update (Win/macOS one-click, Linux notify) · signed & notarized macOS · bonds preserved when adding a lattice · Search-Database OPTIMADE cold-start fix · VS Code trajectory perf + plot axis-label fixes · iOS App Store build.

Surfaces bumped: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` (+lock), `deploy/download/index.html`. Updated `tauri-build.yml` releaseBody (macOS now signed; New-in-1.4.1) + `CHANGELOG.md`. Tagging `v1.4.1` after merge triggers the signed/notarized/auto-update desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)