### PR TITLE
fix(release): regenerate updater signing key (v1.4.1 build failed)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
       "endpoints": [
         "https://github.com/Hello-QM/catgo-LRG/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFDQjM4OTlEMjRGREVGNkUKUldSdTcvMGtuWW16SE80M2ZMdVZqT1FqbjJPbnU2S3RNZGxEMnBrMTZ5NGRiSlo2akNFQjZ3SVAK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK",
       "windows": {
         "installMode": "passive"
       }


### PR DESCRIPTION
v1.4.1 build failed at updater signing on all platforms: `incorrect updater private key password: Wrong password for that key`. The original key was encrypted but the password secret was empty. Regenerated the keypair (verified it signs), swapped the public key in `tauri.conf.json`. Safe to rotate — no updater-enabled release shipped yet.

Needs secrets updated: `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)