### PR TITLE
perf(release): use zstd compression for the RPM bundle

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -77,6 +77,10 @@
       "rpm": {
         "files": {
           "/usr/bin/catgo-cli": "../deploy/cli/catgo-cli"
+        },
+        "compression": {
+          "type": "zstd",
+          "level": 3
         }
       }
     },


### PR DESCRIPTION
Tauri's RPM bundler defaults to gzip-6; the ~240MB bundled backend made the rpm step the Linux build's long pole (~1.5h vs ~15s for .deb). Switch to zstd level 3 (faster, comparable ratio). Applies next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)