### PR TITLE
feat(terminal): Ctrl+click a directory navigates the Files panel

### DIFF
--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -7,6 +7,7 @@
   import { theme_state, terminal_font_state, save_terminal_font_state, TERMINAL_FONT_FAMILIES } from '$lib/state.svelte'
   import { register_terminal, unregister_terminal, mark_terminal_active } from './terminal-registry.svelte'
   import { next_marker, wrap_command, extract_result, strip_ansi } from './terminal-capture'
+  import { open_terminal_click } from './terminal-path-nav'
 
   let {
     layout = `horizontal`,
@@ -320,7 +321,20 @@
                     if (!_event.ctrlKey && !_event.metaKey) return
                     // Resolve relative paths using tracked CWD
                     const resolved = text.startsWith(`/`) || text.startsWith(`~/`) ? text : (current_cwd ? `${current_cwd}/${text}` : text)
-                    on_open_file!(resolved)
+                    // Directory → move the Files panel there (reuse the same
+                    // `catgo-terminal-cwd` bus the Directory-Sync feature listens
+                    // on, regardless of the sync_cwd toggle — a Ctrl+click is an
+                    // explicit jump); file → open it. dir-detection is async so it
+                    // can't run inside xterm's synchronous activate().
+                    void open_terminal_click(resolved, session_id ?? ``, {
+                      open_file: (p) => on_open_file?.(p),
+                      navigate_dir: (p, sid) => {
+                        const seq = ++_cwd_seq
+                        window.dispatchEvent(
+                          new CustomEvent(`catgo-terminal-cwd`, { detail: { path: p, session_id: sid, seq } }),
+                        )
+                      },
+                    })
                   },
                 })
               }

--- a/src/lib/structure/__tests__/terminal-path-nav.test.ts
+++ b/src/lib/structure/__tests__/terminal-path-nav.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { open_terminal_click } from '../terminal-path-nav'
+
+describe('open_terminal_click', () => {
+  it('navigates the Files panel when the path is a directory', async () => {
+    const open_file = vi.fn()
+    const navigate_dir = vi.fn()
+    await open_terminal_click(
+      '/home/u/proj/iso_search',
+      '',
+      { open_file, navigate_dir },
+      async () => true, // is_directory
+    )
+    expect(navigate_dir).toHaveBeenCalledWith('/home/u/proj/iso_search', '')
+    expect(open_file).not.toHaveBeenCalled()
+  })
+
+  it('opens the file when the path is NOT a directory', async () => {
+    const open_file = vi.fn()
+    const navigate_dir = vi.fn()
+    await open_terminal_click(
+      '/home/u/proj/ir20_bare_distinct.extxyz',
+      '',
+      { open_file, navigate_dir },
+      async () => false, // is_directory
+    )
+    expect(open_file).toHaveBeenCalledWith('/home/u/proj/ir20_bare_distinct.extxyz')
+    expect(navigate_dir).not.toHaveBeenCalled()
+  })
+
+  it('forwards the remote session_id to navigate_dir for remote terminals', async () => {
+    const open_file = vi.fn()
+    const navigate_dir = vi.fn()
+    await open_terminal_click(
+      '/scratch/run42',
+      'sess-abc',
+      { open_file, navigate_dir },
+      async () => true,
+    )
+    expect(navigate_dir).toHaveBeenCalledWith('/scratch/run42', 'sess-abc')
+  })
+
+  it('treats a detection failure as a file (safe fallback)', async () => {
+    const open_file = vi.fn()
+    const navigate_dir = vi.fn()
+    await open_terminal_click(
+      '/maybe/gone',
+      '',
+      { open_file, navigate_dir },
+      async () => false, // path_is_directory swallows errors → false
+    )
+    expect(open_file).toHaveBeenCalledWith('/maybe/gone')
+    expect(navigate_dir).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/structure/terminal-path-nav.ts
+++ b/src/lib/structure/terminal-path-nav.ts
@@ -1,0 +1,50 @@
+/**
+ * Terminal Ctrl+click path resolution: a clicked DIRECTORY navigates the Files
+ * panel (reusing the existing `catgo-terminal-cwd` window-event bus that the
+ * Directory-Sync feature already listens on — see desktop/sidebar/cwd-sync.svelte.ts),
+ * while a clicked FILE opens in the viewer/editor via the existing on_open_file path.
+ *
+ * Split out of TerminalPanel.svelte so the dir-vs-file branch is unit-testable
+ * without a DOM/xterm harness.
+ */
+import { API_BASE } from '$lib/api/config'
+import { listFiles } from '$lib/api/hpc'
+
+/** True if `path` is a directory. Local terminal (empty session_id) → the local
+ * `/workflow/files/browse` endpoint (200 = dir, 404 = not). Remote terminal →
+ * `listFiles` over that session's SSH (success = dir). Any error → false, so the
+ * caller safely falls back to treating it as a file (the prior behaviour). */
+export async function path_is_directory(path: string, session_id: string): Promise<boolean> {
+  try {
+    if (session_id) {
+      const res = await listFiles(session_id, path)
+      return res.success
+    }
+    const res = await fetch(`${API_BASE}/workflow/files/browse?dir=${encodeURIComponent(path)}`)
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export interface TerminalClickHandlers {
+  /** Open a file path (structure/editor/preview) — the pre-existing behaviour. */
+  open_file: (path: string) => void
+  /** Navigate the Files panel for this session to `path` (a directory). */
+  navigate_dir: (path: string, session_id: string) => void
+}
+
+/** Route a Ctrl+clicked, already-resolved terminal path: directory → navigate the
+ * Files panel; file → open it. `is_directory` is injectable for testing. */
+export async function open_terminal_click(
+  path: string,
+  session_id: string,
+  handlers: TerminalClickHandlers,
+  is_directory: (path: string, session_id: string) => Promise<boolean> = path_is_directory,
+): Promise<void> {
+  if (await is_directory(path, session_id)) {
+    handlers.navigate_dir(path, session_id)
+  } else {
+    handlers.open_file(path)
+  }
+}


### PR DESCRIPTION
## What

In CatGo's embedded terminal, Ctrl+click on a **file** path already opens it in the viewer/editor. Ctrl+click on a **directory** now moves the **Files panel** to that directory instead of trying to open it as a file.

## How

Reuses the existing **Directory-Sync** infrastructure rather than building a new channel:

- The click dispatches the same `catgo-terminal-cwd` window event the OSC7 `sync_cwd` path already emits, so the listener in `desktop/sidebar/cwd-sync.svelte.ts` navigates the active Files panel — **Local Files** for a local terminal, the matching **SSH session** for a remote one.
- It fires **regardless of the `sync_cwd` toggle** — a Ctrl+click is an explicit jump, not passive CWD following.

Dir-vs-file detection is async (can't run inside xterm's synchronous link `activate()`):

| Terminal | Detection | dir = |
|---|---|---|
| local (no session_id) | `GET /workflow/files/browse?dir=…` | `200` (404 = file) |
| remote (SSH) | `listFiles(session_id, path)` | `success` |

Any error falls back to opening the path as a file — the prior behaviour.

The dir-vs-file branch is split into `src/lib/structure/terminal-path-nav.ts` so it is unit-testable without a DOM/xterm harness; `TerminalPanel.svelte`'s link `activate()` just calls into it.

## Tests

- **+4 vitest** (`src/lib/structure/__tests__/terminal-path-nav.test.ts`): directory → navigate, file → open, remote `session_id` forwarded, detection-failure → safe file fallback. All pass.
- `svelte-check` clean on the changed files (the repo's 13 pre-existing errors are unrelated).

## Notes

- Same-window only by design (mirrors the existing CWD-sync: a popped-out terminal must not move the origin window's files — no cross-window BroadcastChannel).
- No change to the file-click path; only directories take the new branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)