### PR TITLE
fix(desktop): popout structure windows had no Tauri ACL capability

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "terminal",
     "terminal-*",
     "doping-pt-*",
+    "structure-*",
     "catgo-docs"
   ],
   "permissions": [

--- a/src/lib/update/UpdateBanner.svelte
+++ b/src/lib/update/UpdateBanner.svelte
@@ -14,10 +14,18 @@
   load_i18n_module('app')
 
   // Check shortly after launch (desktop only). The delay lets the window settle
-  // and the backend come up before we hit the network.
+  // and the backend come up before we hit the network. Only the MAIN window
+  // checks: popouts (structure-*, terminal-*, …) load this same app root, and
+  // each would otherwise fire its own duplicate check 4s after opening.
   $effect(() => {
     if (!is_desktop_tauri()) return
-    const id = setTimeout(() => {
+    const id = setTimeout(async () => {
+      try {
+        const { getCurrentWindow } = await import(`@tauri-apps/api/window`)
+        if (getCurrentWindow().label !== `main`) return
+      } catch {
+        return
+      }
       check_for_updates()
     }, 4000)
     return () => clearTimeout(id)


### PR DESCRIPTION
## Symptom

Opening a structure in a new window (popout) on desktop showed, ~4s later:

> Update failed: Command plugin:app|version not allowed by ACL

## Root cause

Popout structure windows are created with label `structure-<stamp>` (`desktop/lib/popout-manager.ts`), but `src-tauri/capabilities/default.json` did not include that pattern in its `windows` list — so **no capability matched the popout and every Tauri IPC from it was ACL-denied**. The popout loads the same app root, so `UpdateBanner`'s post-launch `check_for_updates()` → `getVersion()` (`plugin:app|version`) was the first denied call the user sees. The `catgo-reload-structure` event listener ("Window + Overwrite" reuse) was silently dead for the same reason.

## Fix

- `capabilities/default.json`: add `structure-*` to the `windows` list (same pattern as the existing `terminal-*` / `doping-pt-*` entries).
- `UpdateBanner.svelte`: gate the post-launch auto-check on `getCurrentWindow().label === 'main'` — popouts shouldn't each fire a duplicate update check anyway.

## Verification

- `vitest run`: 2043 tests pass (file-level failures identical on main — sandbox network noise).
- Capability JSON validated. ACL takes effect at build time — live confirmation lands with the next desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)