### PR TITLE
fix(desktop): terminal Ctrl+click honors the open target when no structure tab exists

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -206,6 +206,7 @@
     tab_states,
     get tabs() { return tm.tabs },
     set_active_tab_id: (id) => { tm.active_tab_id = id },
+    open_new_structure_tab,
   }
   const pane_deps: PaneManagerDeps = {
     tab_states,

--- a/desktop/lib/sidebar-handlers.ts
+++ b/desktop/lib/sidebar-handlers.ts
@@ -27,6 +27,8 @@ export interface SidebarHandlerDeps {
   tab_states: Record<string, StructureTabState>
   tabs: { id: string; type: string }[]
   set_active_tab_id: (id: string) => void
+  /** Create a fresh structure tab and return its ids (App owns the side effect). */
+  open_new_structure_tab: () => { tab_id: string; leaf_id: string }
 }
 
 export function handle_sidebar_load(deps: SidebarHandlerDeps, content: string | ArrayBuffer, filename: string, file_path?: string, session_id?: string) {
@@ -89,13 +91,31 @@ export async function handle_terminal_open_file(deps: SidebarHandlerDeps, file_p
       const { readRemoteFile } = await import(`$lib/api/hpc`)
       const result = await readRemoteFile(session_id, file_path)
       if (result.success && result.content !== undefined) {
-        // Switch to first structure tab, or open new window if none exists
+        // Switch to the first structure tab and route by the open target.
         const struct_tab = deps.tabs.find(t => t.type === `structure`)
         if (struct_tab) {
           deps.set_active_tab_id(struct_tab.id)
           handle_sidebar_load(deps, result.content, filename, file_path, session_id)
         } else {
-          await parse_and_open_structure_window(result.content, filename, deps.is_tauri)
+          // No structure tab exists (e.g. a terminal-only tab is active).
+          // Honor the user's open target: only an explicit Window choice pops
+          // out; Tab/Split get a fresh structure tab (there is nothing to
+          // split, so both collapse to "new tab").
+          const target = resolve_open_target(deps.get_open_target(), false)
+          if (target.kind === `window`) {
+            await parse_and_open_structure_window(result.content, filename, deps.is_tauri, target.mode === `overwrite`)
+            return
+          }
+          const n = deps.open_new_structure_tab()
+          const made = deps.tabs.find(t => t.id === n.tab_id)
+          if (n.leaf_id && made?.type === `structure`) {
+            const origin = session_id ? { session_id, file_path } : null
+            const local_path = session_id ? null : file_path
+            await deps.process_file_content(n.tab_id, result.content, filename, n.leaf_id, origin, local_path)
+          } else {
+            // Tab cap reached (create_tab no-oped) — popout as a last resort.
+            await parse_and_open_structure_window(result.content, filename, deps.is_tauri)
+          }
         }
       }
       return

--- a/tests/vitest/desktop/terminal-open-target.test.ts
+++ b/tests/vitest/desktop/terminal-open-target.test.ts
@@ -1,0 +1,126 @@
+// Terminal Ctrl+click on a structure file must honor the "Open files in"
+// target when NO structure tab exists (e.g. a terminal-only tab is active).
+// Regression: this case always popped out a new window, ignoring Tab/Split —
+// and on desktop builds where popout windows were ACL-dead the file appeared
+// to simply not open.
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const popout = vi.fn()
+
+vi.mock(`../../../desktop/lib/popout-manager`, () => ({
+  parse_and_open_structure_window: (...args: unknown[]) => popout(...args),
+  open_doc_window: vi.fn(),
+}))
+vi.mock(`$lib/api/hpc`, () => ({
+  readRemoteFile: vi.fn().mockResolvedValue({ success: true, content: `POSCAR-content` }),
+}))
+vi.mock(`$lib/structure/parse`, () => ({ is_structure_file: () => true }))
+vi.mock(`$lib/trajectory/parse`, () => ({ is_trajectory_file: () => false }))
+vi.mock(`$lib/state.svelte`, () => ({
+  resolve_open_target: (t: unknown) => t,
+}))
+vi.mock(`$lib/toast-state.svelte`, () => ({ show_toast: vi.fn() }))
+
+import {
+  handle_terminal_open_file,
+  type SidebarHandlerDeps,
+} from '../../../desktop/lib/sidebar-handlers'
+import type { OpenTarget } from '$lib/state.svelte'
+
+function make_deps(target: OpenTarget, opts: { cap?: boolean; with_structure_tab?: boolean } = {}) {
+  const tabs = [{ id: `term-1`, type: `terminal` }]
+  if (opts.with_structure_tab) tabs.push({ id: `s0`, type: `structure` })
+  const deps = {
+    get_active_ts: () => (opts.with_structure_tab ? { active_leaf_id: `L0` } : null),
+    get_active_tab_id: () => `term-1`,
+    get_active_tab_type: () => `terminal`,
+    get_open_target: () => target,
+    process_file_content: vi.fn().mockResolvedValue(undefined),
+    place_single: vi.fn().mockResolvedValue(undefined),
+    update_tab_label: vi.fn(),
+    is_tauri: true,
+    set_is_loading: vi.fn(),
+    set_loading_text: vi.fn(),
+    tab_states: {},
+    tabs,
+    set_active_tab_id: vi.fn(),
+    open_new_structure_tab: vi.fn(() => {
+      if (opts.cap) return { tab_id: `term-1`, leaf_id: `` } // create_tab no-oped
+      tabs.push({ id: `s1`, type: `structure` })
+      return { tab_id: `s1`, leaf_id: `leaf-1` }
+    }),
+  }
+  return deps as unknown as SidebarHandlerDeps & typeof deps
+}
+
+beforeEach(() => {
+  popout.mockClear()
+})
+
+describe(`handle_terminal_open_file with no structure tab`, () => {
+  test(`split target creates a structure tab instead of a popout window`, async () => {
+    const deps = make_deps({ kind: `split`, mode: `overwrite` } as OpenTarget)
+    await handle_terminal_open_file(deps, `/tmp/POSCAR`, `POSCAR`, ``)
+    expect(deps.open_new_structure_tab).toHaveBeenCalledOnce()
+    expect(deps.process_file_content).toHaveBeenCalledOnce()
+    // Local shell (blank session): the path travels as local_path, no origin.
+    expect(deps.process_file_content).toHaveBeenCalledWith(
+      `s1`,
+      `POSCAR-content`,
+      `POSCAR`,
+      `leaf-1`,
+      null,
+      `/tmp/POSCAR`,
+    )
+    expect(popout).not.toHaveBeenCalled()
+  })
+
+  test(`tab target also lands in a fresh structure tab`, async () => {
+    const deps = make_deps({ kind: `tab`, mode: `new` } as OpenTarget)
+    await handle_terminal_open_file(deps, `/tmp/POSCAR`, `POSCAR`, ``)
+    expect(deps.open_new_structure_tab).toHaveBeenCalledOnce()
+    expect(popout).not.toHaveBeenCalled()
+  })
+
+  test(`remote file keeps its session origin`, async () => {
+    const deps = make_deps({ kind: `split`, mode: `new` } as OpenTarget)
+    await handle_terminal_open_file(deps, `/remote/POSCAR`, `POSCAR`, `sess-9`)
+    expect(deps.process_file_content).toHaveBeenCalledWith(
+      `s1`,
+      `POSCAR-content`,
+      `POSCAR`,
+      `leaf-1`,
+      { session_id: `sess-9`, file_path: `/remote/POSCAR` },
+      null,
+    )
+  })
+
+  test(`window target still opens a popout (overwrite → reuse)`, async () => {
+    const deps = make_deps({ kind: `window`, mode: `overwrite` } as OpenTarget)
+    await handle_terminal_open_file(deps, `/tmp/POSCAR`, `POSCAR`, ``)
+    expect(popout).toHaveBeenCalledOnce()
+    expect(popout).toHaveBeenCalledWith(`POSCAR-content`, `POSCAR`, true, true)
+    expect(deps.open_new_structure_tab).not.toHaveBeenCalled()
+  })
+
+  test(`falls back to a popout when the tab cap blocks a new tab`, async () => {
+    const deps = make_deps({ kind: `split`, mode: `overwrite` } as OpenTarget, { cap: true })
+    await handle_terminal_open_file(deps, `/tmp/POSCAR`, `POSCAR`, ``)
+    expect(deps.open_new_structure_tab).toHaveBeenCalledOnce()
+    expect(deps.process_file_content).not.toHaveBeenCalled()
+    expect(popout).toHaveBeenCalledOnce()
+  })
+})
+
+describe(`handle_terminal_open_file with an existing structure tab`, () => {
+  test(`switches to it and places via the open target (unchanged behavior)`, async () => {
+    const deps = make_deps({ kind: `split`, mode: `overwrite` } as OpenTarget, {
+      with_structure_tab: true,
+    })
+    await handle_terminal_open_file(deps, `/tmp/POSCAR`, `POSCAR`, ``)
+    expect(deps.set_active_tab_id).toHaveBeenCalledWith(`s0`)
+    expect(deps.place_single).toHaveBeenCalledOnce()
+    expect(deps.open_new_structure_tab).not.toHaveBeenCalled()
+    expect(popout).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Symptom

Active tab is a terminal-only tab (terminal fills the panel), open mode set to **Split + Overwrite**. Ctrl+clicking a structure file in the terminal doesn't open the structure.

## Root cause

`handle_terminal_open_file`'s structure branch only honors the open target when a structure tab already exists. With no structure tab it unconditionally called `parse_and_open_structure_window` — a popout window — ignoring the user's Tab/Split choice. On installed builds where popout windows had no ACL capability (fixed in #453) that window was broken, so the click appeared to do nothing.

## Fix

When no structure tab exists, resolve the open target and route:

- **Window** → popout as before (reuse on overwrite).
- **Tab / Split** → create a fresh structure tab (`open_new_structure_tab`, newly exposed as a sidebar-handler dep) and load into it. A terminal tab has nothing to split, so both collapse to "new tab".
- Tab cap reached (create_tab no-ops) → popout fallback.

Existing structure-tab behavior unchanged.

## Tests

+6 vitest (`tests/vitest/desktop/terminal-open-target.test.ts`): split/tab → new structure tab (popout NOT called), remote origin vs local path plumbing, window target → popout with reuse, tab-cap fallback, existing-structure-tab path unchanged. Full suite: 2049 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)