### PR TITLE
fix(desktop): Split+Overwrite aimed at a terminal leaf escalates instead of no-op

### DIFF
--- a/desktop/lib/open-dispatch.ts
+++ b/desktop/lib/open-dispatch.ts
@@ -9,7 +9,7 @@
 
 import type { OpenTarget } from '$lib/state.svelte'
 import type { PaneNode } from '../pane-tree'
-import { buildPreset, escalateForImport } from '../pane-tree'
+import { buildPreset, escalateForImport, isTerminalLeaf, leaves } from '../pane-tree'
 
 export type OpenPlan =
   | { action: 'window' }
@@ -24,7 +24,10 @@ export type OpenPlan =
  * - tab + overwrite   → collapse the whole tab to one fresh leaf, load there.
  * - split + new       → reuse first empty leaf, else split the active leaf,
  *                       else (at CAP) fall back to a new tab.
- * - split + overwrite → load into the active leaf in place.
+ * - split + overwrite → load into the active leaf in place — unless that leaf
+ *                       is a terminal (it can't host a structure, so an
+ *                       in-place overwrite silently shows nothing); escalate
+ *                       like `new` instead.
  */
 export function plan_open(root: PaneNode, activeLeafId: string, target: OpenTarget): OpenPlan {
   if (target.kind === 'window') return { action: 'window' }
@@ -36,7 +39,11 @@ export function plan_open(root: PaneNode, activeLeafId: string, target: OpenTarg
   }
 
   // kind === 'split'
-  if (target.mode === 'overwrite') return { action: 'pane', root, leafId: activeLeafId }
+  if (target.mode === 'overwrite') {
+    const active = leaves(root).find((l) => l.id === activeLeafId)
+    if (!active || !isTerminalLeaf(active)) return { action: 'pane', root, leafId: activeLeafId }
+    // fall through: overwrite aimed at a terminal leaf escalates like `new`
+  }
 
   const esc = escalateForImport(root, activeLeafId)
   if (!esc) return { action: 'new-tab' }

--- a/tests/desktop/open-target.test.ts
+++ b/tests/desktop/open-target.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { resolve_open_target, type OpenTarget } from '../../src/lib/state.svelte'
 import { plan_open } from '../../desktop/lib/open-dispatch'
-import { buildPreset, findFirstEmptyLeaf } from '../../desktop/pane-tree'
+import {
+  buildPreset,
+  create_terminal_leaf,
+  findFirstEmptyLeaf,
+  leaves,
+} from '../../desktop/pane-tree'
 
 const t = (kind: OpenTarget['kind'], mode: OpenTarget['mode']): OpenTarget => ({ kind, mode })
 
@@ -57,6 +62,53 @@ describe('plan_open', () => {
     expect(plan.action).toBe('pane')
     if (plan.action !== 'pane') throw new Error('expected pane')
     expect(plan.leafId).toBe(empty.id)
+  })
+
+  // Regression: a full-pane terminal tab (landing "Terminal" converts the
+  // structure tab's only leaf to a terminal) + Split/Overwrite silently showed
+  // nothing — the plan targeted the terminal leaf in place, which can't host a
+  // structure. Overwrite aimed at a terminal must escalate like `new`.
+  it('split + overwrite over a terminal leaf escalates to a split', () => {
+    const root = create_terminal_leaf()
+    const plan = plan_open(root, root.id, t('split', 'overwrite'))
+    expect(plan.action).toBe('pane')
+    if (plan.action !== 'pane') throw new Error('expected pane')
+    expect(plan.root.kind).toBe('split') // terminal kept, structure pane beside it
+    expect(plan.leafId).not.toBe(root.id)
+  })
+
+  it('split + overwrite over a terminal leaf reuses an existing empty pane', () => {
+    const root = buildPreset('splitH')
+    const b = leaves(root)[1]
+    const withTerm = { ...root, children: [create_terminal_leaf(), b] } as typeof root
+    const term = leaves(withTerm)[0]
+    const plan = plan_open(withTerm, term.id, t('split', 'overwrite'))
+    expect(plan.action).toBe('pane')
+    if (plan.action !== 'pane') throw new Error('expected pane')
+    expect(plan.leafId).toBe(b.id) // the empty structure leaf, tree unchanged
+    expect(plan.root).toBe(withTerm)
+  })
+
+  it('split + overwrite over a structure leaf still loads in place', () => {
+    const root = buildPreset('single')
+    const plan = plan_open(root, root.id, t('split', 'overwrite'))
+    expect(plan).toEqual({ action: 'pane', root, leafId: root.id })
+  })
+
+  it('split + overwrite over a terminal at the pane cap falls back to a new tab', () => {
+    // 4 terminal leaves = CAP reached, nothing empty, nothing splittable.
+    const col = (l1: ReturnType<typeof create_terminal_leaf>, l2: ReturnType<typeof create_terminal_leaf>) =>
+      ({ kind: 'split', id: `s-${l1.id}`, direction: 'v', ratio: 0.5, children: [l1, l2] }) as const
+    const t1 = create_terminal_leaf(), t2 = create_terminal_leaf()
+    const t3 = create_terminal_leaf(), t4 = create_terminal_leaf()
+    const root = {
+      kind: 'split',
+      id: `s-root`,
+      direction: 'h',
+      ratio: 0.5,
+      children: [col(t1, t2), col(t3, t4)],
+    } as unknown as ReturnType<typeof buildPreset>
+    expect(plan_open(root, t1.id, t('split', 'overwrite'))).toEqual({ action: 'new-tab' })
   })
 })
 


### PR DESCRIPTION
## Symptom

Full-pane terminal tab (landing page → Terminal) + open mode **Split + Overwrite**: opening a structure file (terminal Ctrl+click, sidebar, or examples) adds it to the tab's structure library but **no structure ever renders**.

## Root cause

The landing "Terminal" button converts the structure tab's only leaf into a terminal leaf — the tab keeps `type: 'structure'`. So the open pipeline finds "a structure tab", and `plan_open(split+overwrite)` returns the **active leaf in place** — which is the terminal leaf. `process_file_content` pushes the library entry (visible in the library column), but `apply_entry_to_pane` has no structure pane to render into. Silent no-op.

(#454 fixed the true `type: 'terminal'` tab case; this is the converted-structure-tab case.)

## Fix

`plan_open`: for `split + overwrite`, check the active leaf. Structure leaf → in-place load, unchanged. Terminal leaf → escalate like `new`: reuse the first empty structure pane, else split beside the terminal, else (pane cap) new tab.

## Verification

- +4 vitest in `tests/desktop/open-target.test.ts` (escalate-to-split, reuse-empty-pane, in-place regression, cap fallback); 25 pass across the three touched suites.
- **Live-verified** on the dev stack at :3100: full-pane terminal + Split/Overwrite + clicking `BaTiO3-tetragonal.poscar` → structure renders in a pane split beside the terminal, terminal preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)