### PR TITLE
fix(desktop): Overwrite from a terminal reuses the existing structure pane

### DIFF
--- a/desktop/lib/open-dispatch.ts
+++ b/desktop/lib/open-dispatch.ts
@@ -26,8 +26,10 @@ export type OpenPlan =
  *                       else (at CAP) fall back to a new tab.
  * - split + overwrite → load into the active leaf in place — unless that leaf
  *                       is a terminal (it can't host a structure, so an
- *                       in-place overwrite silently shows nothing); escalate
- *                       like `new` instead.
+ *                       in-place overwrite silently shows nothing). Overwrite
+ *                       means "replace what's showing": reuse the tab's first
+ *                       structure pane (empty or not); only a tab with no
+ *                       structure pane at all escalates like `new`.
  */
 export function plan_open(root: PaneNode, activeLeafId: string, target: OpenTarget): OpenPlan {
   if (target.kind === 'window') return { action: 'window' }
@@ -42,7 +44,12 @@ export function plan_open(root: PaneNode, activeLeafId: string, target: OpenTarg
   if (target.mode === 'overwrite') {
     const active = leaves(root).find((l) => l.id === activeLeafId)
     if (!active || !isTerminalLeaf(active)) return { action: 'pane', root, leafId: activeLeafId }
-    // fall through: overwrite aimed at a terminal leaf escalates like `new`
+    // Overwrite aimed at a terminal leaf (clicking a terminal link focuses the
+    // terminal, so this is the common case): overwrite the tab's first
+    // structure pane instead of splitting a fresh one on every open.
+    const structLeaf = leaves(root).find((l) => !isTerminalLeaf(l))
+    if (structLeaf) return { action: 'pane', root, leafId: structLeaf.id }
+    // fall through: no structure pane in the tab — escalate like `new`
   }
 
   const esc = escalateForImport(root, activeLeafId)

--- a/tests/desktop/open-target.test.ts
+++ b/tests/desktop/open-target.test.ts
@@ -3,6 +3,7 @@ import { resolve_open_target, type OpenTarget } from '../../src/lib/state.svelte
 import { plan_open } from '../../desktop/lib/open-dispatch'
 import {
   buildPreset,
+  create_empty_leaf,
   create_terminal_leaf,
   findFirstEmptyLeaf,
   leaves,
@@ -93,6 +94,25 @@ describe('plan_open', () => {
     const root = buildPreset('single')
     const plan = plan_open(root, root.id, t('split', 'overwrite'))
     expect(plan).toEqual({ action: 'pane', root, leafId: root.id })
+  })
+
+  // Regression: after the first escalate created a structure pane beside the
+  // terminal, every later Ctrl+click (which re-focuses the terminal) split yet
+  // ANOTHER pane. Overwrite means "replace what's showing" — reuse the
+  // existing structure pane even when it already has content.
+  it('split + overwrite over a terminal overwrites an existing full structure pane', () => {
+    const full = create_empty_leaf()
+    ;(full.content as { pane: { structure?: unknown } }).pane.structure = { sites: [] }
+    const term = create_terminal_leaf()
+    const root = {
+      kind: 'split',
+      id: 's-mixed',
+      direction: 'h',
+      ratio: 0.5,
+      children: [term, full],
+    } as unknown as ReturnType<typeof buildPreset>
+    const plan = plan_open(root, term.id, t('split', 'overwrite'))
+    expect(plan).toEqual({ action: 'pane', root, leafId: full.id })
   })
 
   it('split + overwrite over a terminal at the pane cap falls back to a new tab', () => {


### PR DESCRIPTION
## Symptom

Follow-up to #455. With Split + **Overwrite** and a terminal focused: the first open correctly splits a structure pane beside the terminal, but every subsequent Ctrl+click splits **another** pane instead of overwriting — Overwrite behaved like New.

## Root cause

Ctrl+clicking a terminal link re-focuses the terminal, so at plan time the active leaf is the terminal again. #455's escalation treated every overwrite-on-terminal like `new` (reuse empty / split), and with no empty pane left it split a fresh one per open.

## Fix

Overwrite aimed at a terminal leaf now targets the tab's **first structure pane** (empty or full) — replace what's showing. Only a tab with no structure pane at all still escalates (split beside the terminal / new tab at cap).

## Verification

- +1 vitest: terminal-active + full structure pane → plan overwrites that pane in place (13 pass in the suite).
- **Live-verified** at :3100: terminal + BaTiO₃ pane → focus terminal → open Fe-BCC.json with Split+Overwrite → Fe replaces BaTiO₃ in the same pane, still two panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)