### PR TITLE
fix(desktop): Window+Overwrite reuse popout now reloads its structure

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -586,6 +586,24 @@
           })
         } else if (hash.startsWith(`#structure`)) {
           load_popout_structure(hash, get_active_ts, tm.active_tab_id, update_tab_label)
+          // Window + Overwrite reuses this popout: the opener writes a fresh
+          // localStorage payload and emits this event (popout-manager). Without
+          // a listener the reused window only got focused and kept showing the
+          // FIRST structure. Listener lives for the popout window's lifetime.
+          if (is_tauri) {
+            void import(`@tauri-apps/api/event`).then(({ listen }) =>
+              listen<{ key: string }>(`catgo-reload-structure`, (e) => {
+                const k = e.payload?.key
+                if (!k) return
+                load_popout_structure(
+                  `#structure?key=${encodeURIComponent(k)}`,
+                  get_active_ts,
+                  tm.active_tab_id,
+                  update_tab_label,
+                )
+              })
+            ).catch(() => {})
+          }
         } else if (hash.startsWith(`#openpath`)) {
           // A "New window" file open: stream the path into THIS new window's tree.
           // force_local=true so it loads here instead of opening yet another window.


### PR DESCRIPTION
## Symptom

Open mode **Window + Overwrite**: the first file opens a popout, but every later open only focuses that popout — it keeps showing the first structure. Only one structure can ever be opened.

## Root cause

The reuse path (`open_structure_in_new_window`, `reuse=true`) writes a fresh localStorage payload and emits `catgo-reload-structure` at the existing `structure-reuse` window. **No listener for that event exists anywhere in the codebase** — the emit has been dead code since the reuse feature landed. (The browser fallback works because `window.open` with a fixed name re-navigates the named window.)

## Fix

The popout's `#structure` hash route now registers a Tauri event listener: on `catgo-reload-structure`, re-run `load_popout_structure` with the pushed key. Listener lifetime = popout window lifetime. Depends on #453 (structure-* windows now have event permissions).

## Verification

- Existing open-target suites pass (19).
- Tauri event plumbing isn't reachable from jsdom/browser; needs a native check: Window+Overwrite → open file A (popout shows A) → open file B → same popout switches to B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)