### PR TITLE
fix(desktop): popout structure load survives a restored terminal tab

### DIFF
--- a/desktop/lib/popout-manager.ts
+++ b/desktop/lib/popout-manager.ts
@@ -8,6 +8,7 @@
 import type { AnyStructure } from '$lib'
 import type { StructureTabState } from '../pane-utils'
 import { findLeafById, leaves, isTerminalLeaf, structurePane } from '../pane-tree'
+import { pending_open_structure } from '$lib/workflow/workflow-state.svelte'
 
 /**
  * Open a FILE PATH in a new app window that loads/streams it there. Used for
@@ -132,17 +133,24 @@ export function load_popout_structure(
     if (!raw) return
     const { structure, filename } = JSON.parse(raw) as { structure: AnyStructure; filename: string }
     if (!structure) return
-    // Ensure a structure tab exists and load the data
+    // Popouts share localStorage with the main window, so the restored active
+    // tab may be a terminal clone whose leaves have no structure pane. Load
+    // into the active leaf if it can host a structure, else into the tab's
+    // first structure pane, else signal the app to create a structure tab
+    // (pending_open_structure) — the payload must never be dropped silently.
     const ts = get_active_ts()
-    if (ts) {
-      const leaf = findLeafById(ts.root, ts.active_leaf_id) ?? leaves(ts.root)[0]
-      if (!leaf) return
-      const pane = structurePane(leaf)
-      if (!pane) return
+    const active_leaf = ts ? findLeafById(ts.root, ts.active_leaf_id) ?? leaves(ts.root)[0] : null
+    const pane = (active_leaf && structurePane(active_leaf)) ??
+      (ts ? leaves(ts.root).map(structurePane).find(Boolean) ?? null : null)
+    if (pane) {
       pane.structure = structure
       pane.source_filename = filename
       pane.modified = false
       update_tab_label(active_tab_id)
+    } else {
+      pending_open_structure.structure = structure
+      pending_open_structure.label = filename
+      pending_open_structure.seq++
     }
   } catch (e) {
     console.error(`Failed to load popout structure:`, e)

--- a/tests/vitest/desktop/popout-load.test.ts
+++ b/tests/vitest/desktop/popout-load.test.ts
@@ -1,0 +1,77 @@
+// load_popout_structure must never drop the payload: popouts share
+// localStorage with the main window, so the restored active tab can be a
+// terminal clone with no structure pane — the old code silently returned and
+// the popout showed a terminal instead of the structure (Window + Overwrite
+// "nothing opens").
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock(`$lib/workflow/workflow-state.svelte`, () => ({
+  pending_open_structure: { structure: null, label: ``, seq: 0 },
+}))
+
+import { pending_open_structure } from '$lib/workflow/workflow-state.svelte'
+import { load_popout_structure } from '../../../desktop/lib/popout-manager'
+import {
+  create_empty_leaf,
+  create_terminal_leaf,
+  structurePane,
+} from '../../../desktop/pane-tree'
+import type { StructureTabState } from '../../../desktop/pane-utils'
+
+const PAYLOAD = { structure: { sites: [{}] }, filename: `a.poscar` }
+
+function stash(key: string) {
+  localStorage.setItem(key, JSON.stringify(PAYLOAD))
+  return `#structure?key=${key}`
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  pending_open_structure.structure = null
+  pending_open_structure.label = ``
+  pending_open_structure.seq = 0
+})
+
+describe(`load_popout_structure`, () => {
+  test(`loads into the active structure leaf`, () => {
+    const root = create_empty_leaf()
+    const ts = { root, active_leaf_id: root.id } as unknown as StructureTabState
+    const update = vi.fn()
+    load_popout_structure(stash(`k1`), () => ts, `tab-1`, update)
+    expect(structurePane(root)?.structure).toEqual(PAYLOAD.structure)
+    expect(structurePane(root)?.source_filename).toBe(`a.poscar`)
+    expect(update).toHaveBeenCalledWith(`tab-1`)
+    expect(pending_open_structure.seq).toBe(0)
+  })
+
+  test(`falls back to the tab's first structure pane when the active leaf is a terminal`, () => {
+    const term = create_terminal_leaf()
+    const struct = create_empty_leaf()
+    const root = {
+      kind: `split`,
+      id: `s1`,
+      direction: `h`,
+      ratio: 0.5,
+      children: [term, struct],
+    } as unknown as StructureTabState[`root`]
+    const ts = { root, active_leaf_id: term.id } as unknown as StructureTabState
+    load_popout_structure(stash(`k2`), () => ts, `tab-1`, vi.fn())
+    expect(structurePane(struct)?.structure).toEqual(PAYLOAD.structure)
+    expect(pending_open_structure.seq).toBe(0)
+  })
+
+  test(`signals pending_open_structure when the tab has no structure pane at all`, () => {
+    const root = create_terminal_leaf()
+    const ts = { root, active_leaf_id: root.id } as unknown as StructureTabState
+    load_popout_structure(stash(`k3`), () => ts, `tab-1`, vi.fn())
+    expect(pending_open_structure.seq).toBe(1)
+    expect(pending_open_structure.structure).toEqual(PAYLOAD.structure)
+    expect(pending_open_structure.label).toBe(`a.poscar`)
+  })
+
+  test(`signals pending_open_structure when there is no active tab state`, () => {
+    load_popout_structure(stash(`k4`), () => null, `tab-1`, vi.fn())
+    expect(pending_open_structure.seq).toBe(1)
+    expect(pending_open_structure.structure).toEqual(PAYLOAD.structure)
+  })
+})


### PR DESCRIPTION
## Symptom

**Window + Overwrite** (and Window + New): the popout opens but shows a clone of the main window's terminal tab instead of the structure — "nothing opens". State-dependent: it only reproduces once the persisted active tab is a terminal, which is why it looked like #457 caused it.

## Root cause

`load_popout_structure` wrote into the **active leaf's** structure pane and silently returned if there wasn't one. Popout windows share localStorage with the main window, so the popout restores the main window's persisted tab set — a restored full-pane terminal tab has no structure pane on its active leaf, and the payload was dropped on the floor.

## Fix

Fallback chain, payload never dropped:
1. active leaf's structure pane (unchanged fast path)
2. the tab's first structure pane
3. `pending_open_structure` signal — the app's existing "open in a new structure tab" effect creates a proper tab

## Verification

- +4 vitest (`tests/vitest/desktop/popout-load.test.ts`): active-structure-leaf, terminal-active-with-sibling-pane, terminal-only → pending, no-ts → pending.
- **Live-verified** at :3100 with a persisted terminal tab: Window+Overwrite popout now renders BaTiO₃.

🤖 Generated with [Claude Code](https://claude.com/claude-code)