### PR TITLE
fix(desktop): reuse popout updates via the DOM storage event

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -586,21 +586,29 @@
           })
         } else if (hash.startsWith(`#structure`)) {
           load_popout_structure(hash, get_active_ts, tm.active_tab_id, update_tab_label)
-          // Window + Overwrite reuses this popout: the opener writes a fresh
-          // localStorage payload and emits this event (popout-manager). Without
-          // a listener the reused window only got focused and kept showing the
-          // FIRST structure. Listener lives for the popout window's lifetime.
+          // Window + Overwrite reuses this popout: the opener rewrites the
+          // reuse payload key. Two delivery channels, because each can fail
+          // alone: the DOM storage event (fires in every OTHER same-origin
+          // window; the browser named-window path can't rely on re-navigation —
+          // the reuse URL is identical so window.open skips it) and the Tauri
+          // event from popout-manager. Whichever fires first consumes the
+          // payload via removeItem; the other reads null and no-ops. Listeners
+          // live for the popout window's lifetime.
+          const reload_from_key = (k: string) =>
+            load_popout_structure(
+              `#structure?key=${encodeURIComponent(k)}`,
+              get_active_ts,
+              tm.active_tab_id,
+              update_tab_label,
+            )
+          window.addEventListener(`storage`, (e) => {
+            if (e.key === `catgo-popout-reuse` && e.newValue) reload_from_key(e.key)
+          })
           if (is_tauri) {
             void import(`@tauri-apps/api/event`).then(({ listen }) =>
               listen<{ key: string }>(`catgo-reload-structure`, (e) => {
                 const k = e.payload?.key
-                if (!k) return
-                load_popout_structure(
-                  `#structure?key=${encodeURIComponent(k)}`,
-                  get_active_ts,
-                  tm.active_tab_id,
-                  update_tab_label,
-                )
+                if (k) reload_from_key(k)
               })
             ).catch(() => {})
           }


### PR DESCRIPTION
## Symptom

Follow-up to #457/#458: Window + **Overwrite** — the first structure opens in the popout, but opening another file changes nothing.

## Root cause — both delivery paths broken independently

- **Browser named-window path**: the reuse URL is byte-identical every time (`#structure?key=catgo-popout-reuse`), so `window.open(url, name)` performs no navigation — the popout never re-reads the payload.
- **Tauri path**: depends on `getByLabel` + event delivery working end-to-end, with no fallback when it doesn't.

## Fix

Third channel that needs neither IPC nor navigation: the popout listens for the **DOM `storage` event** on the reuse key. localStorage writes fire it in every *other* same-origin window — exactly the semantics needed (the writer never notifies itself). The Tauri event stays as belt-and-braces; whichever channel fires first consumes the payload (`removeItem`), the loser reads null and no-ops.

## Verification

**Live-verified** at :3100: main window opens Fe-BCC with Window+Overwrite → the existing popout switches BaTiO₃→Fe with no navigation (URL unchanged). Payload-consumption logic covered by the #458 vitest suite (4 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)