### PR TITLE
fix(view): SSE events reach tab-alias subscribers after a pane is touched

### DIFF
--- a/server/catgo/routers/view_state.py
+++ b/server/catgo/routers/view_state.py
@@ -73,21 +73,39 @@ def unsubscribe(panel_id: str, q: asyncio.Queue) -> None:
         subs.remove(q)
 
 
+def _subscriber_keys(panel_id: str) -> set[str]:
+    """The registry keys whose subscribers should see events for `panel_id`.
+
+    Subscribers register under the RAW id they asked for (e.g. `default`),
+    but writers notify with the RESOLVED id (resolve_panel_id maps a tab id
+    to its active viewer once the user touches a pane). Without the reverse
+    mapping, a `catgo view` push to `default` lands in a key nobody
+    subscribed to and the event silently vanishes — the External tab's label
+    froze and trajectory pushes (SSE-only, no poll fallback) were dropped.
+    """
+    keys = {panel_id}
+    for tab_id, viewer_id in active_viewer_by_tab.items():
+        if viewer_id == panel_id:
+            keys.add(tab_id)
+    return keys
+
+
 def has_subscribers(panel_id: str) -> bool:
-    """Whether any SSE subscriber is currently listening on this panel."""
-    return bool(panel_subscribers.get(panel_id))
+    """Whether any SSE subscriber is listening on this panel (tab aliases included)."""
+    return any(panel_subscribers.get(k) for k in _subscriber_keys(panel_id))
 
 
 def _notify(panel_id: str, event: str, data: dict) -> None:
     msg = {"event": event, "data": data}
-    for q in list(panel_subscribers.get(panel_id, [])):
-        try:
-            q.put_nowait(msg)
-        except asyncio.QueueFull:
-            logger.warning(
-                "SSE subscriber queue full for panel '%s' (event=%s) — dropping",
-                panel_id, event,
-            )
+    for key in _subscriber_keys(panel_id):
+        for q in list(panel_subscribers.get(key, [])):
+            try:
+                q.put_nowait(msg)
+            except asyncio.QueueFull:
+                logger.warning(
+                    "SSE subscriber queue full for panel '%s' (event=%s) — dropping",
+                    key, event,
+                )
 
 
 def notify_structure(


### PR DESCRIPTION
## Symptoms (all one root cause)

1. `catgo view <file>` repeatedly: the External tab's **label stays frozen** on the first structure (e.g. 🤖 Fe) while the content does change.
2. `catgo view a.xyz b.poscar c.cif` (multi-file → trajectory): CLI reports "opened trajectory (N frames)" but the viewer **keeps showing the previous structure** — the trajectory never arrives.

## Root cause

SSE subscribers register under the **raw** panel id they request (frontend subscribes to `default`), but writers notify with the **resolved** id: `resolve_panel_id` maps a tab id to its active viewer once `mark_active` has run — i.e. after the user touches any pane. From then on every push to `default` was delivered to a registry key with zero subscribers and vanished.

Why the two symptoms differ: structure pushes have a legacy **poll fallback** in the component (content updated; the App-level SSE injector that refreshes the tab label never fired). Trajectory pushes are **SSE-only** — dropped outright.

## Fix

`_subscriber_keys(panel_id)`: deliver to the resolved key **and** every tab id that currently resolves to it. `_notify` fans out over that set; `has_subscribers` gains the same alias awareness.

## Verification

Direct module test: `subscribe('default')` → `mark_active('default:structure-abc')` → `push_structure` / `push_trajectory` to `default` → subscriber receives both `structure` and `trajectory` events (both dropped before the fix). Live SSE curl previously showed only the connect `snapshot` and no `structure` event for a push — the exact vanishing.

Note: needs a backend restart to take effect (server-side only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)