### PR TITLE
fix(docs): PDF renders via pdf.js; themed shell; Edit in header; swallow Monaco Canceled

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -24,8 +24,14 @@ function render_status(html: string, color = `#888`) {
 
 function is_ignorable_runtime_error(err: unknown) {
   const message = err instanceof Error ? err.message : String(err)
+  const name = err instanceof Error ? err.name : ``
   return message === `ResizeObserver loop completed with undelivered notifications.` ||
     message === `ResizeObserver loop limit exceeded` ||
+    // Monaco cancels in-flight delayers/worker requests when an editor or
+    // model is disposed (doc tab closed, HMR remount) — the rejection reaches
+    // this listener BEFORE MonacoEditorPanel's own guard can preventDefault
+    // (listeners fire in registration order), so filter it here too. Benign.
+    name === `Canceled` || message === `Canceled` ||
     // On mobile there is no Python/Node sidecar, so any code path that tries to
     // spawn one fails with the shell plugin's "Scoped shell IO error: No such
     // file or directory". That feature is simply unavailable on mobile — log it,

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "molstar": "^5.9.0",
     "monaco-editor": "^0.55.1",
     "opencc-js": "^1.3.1",
+    "pdfjs-dist": "^6.1.200",
     "plotly.js-dist-min": "^3.3.1",
     "quickhull3d": "^3.1.2",
     "sql.js": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       opencc-js:
         specifier: ^1.3.1
         version: 1.3.1
+      pdfjs-dist:
+        specifier: ^6.1.200
+        version: 6.1.200
       plotly.js-dist-min:
         specifier: ^3.3.1
         version: 3.3.1
@@ -1054,6 +1057,81 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
+    engines: {node: '>= 10'}
 
   '@openai/codex-sdk@0.132.0-alpha.1':
     resolution: {integrity: sha512-HkWVAb5S6n7jQTSJiO/9xwk1biIlVvhDCn9O66TLyZVanvzUgkji+1q84v+N8vkneuMQ7pNh+tbAtcJFhWy5uQ==}
@@ -3511,6 +3589,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfjs-dist@6.1.200:
+    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -5031,6 +5113,54 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas@1.0.2':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
+    optional: true
 
   '@openai/codex-sdk@0.132.0-alpha.1(patch_hash=9a82114b2cce8ca4a05e4ef971eab411712e1f9e273f5557f3f7b79e981af1c6)':
     dependencies:
@@ -7796,6 +7926,10 @@ snapshots:
   path-to-regexp@8.4.0: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@6.1.200:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.2
 
   perfect-debounce@1.0.0: {}
 

--- a/src/lib/structure/FilePreviewPanel.svelte
+++ b/src/lib/structure/FilePreviewPanel.svelte
@@ -18,6 +18,7 @@
     session_id = ``,
     readonly = true,
     onclose,
+    edit_action = null,
   }: {
     mode: 'image' | 'pdf' | 'markdown' | 'csv' | 'excel' | 'text'
     content?: string
@@ -28,6 +29,9 @@
     session_id?: string
     readonly?: boolean
     onclose?: () => void
+    /** Optional extra header button (e.g. the doc viewer's Edit toggle),
+     *  rendered with the same styling as PDF/Download. */
+    edit_action?: { label: string; onclick: () => void } | null
   } = $props()
 
   // --- Image zoom state ---
@@ -47,18 +51,61 @@
     img_natural_height = img.naturalHeight
   }
 
-  // --- PDF blob URL ---
-  let pdf_blob_url = $state(``)
+  // --- PDF rendering (pdf.js) ---
+  // An <iframe src=blob> relies on the webview's NATIVE PDF renderer.
+  // WebKitGTK (the Tauri webview on Linux) has none — the frame stays blank —
+  // so render pages to canvases with pdf.js instead (consistent everywhere).
+  let pdf_container = $state<HTMLDivElement | null>(null)
+  let pdf_error = $state(``)
+  let pdf_loading = $state(false)
 
   $effect(() => {
-    if (mode !== `pdf` || !binary_data) return
-    const bytes = Uint8Array.from(atob(binary_data), (c) => c.charCodeAt(0))
-    const blob = new Blob([bytes], { type: mime_type || `application/pdf` })
-    const url = URL.createObjectURL(blob)
-    pdf_blob_url = url
+    if (mode !== `pdf` || !binary_data || !pdf_container) return
+    const container = pdf_container
+    let cancelled = false
+    pdf_error = ``
+    pdf_loading = true
+    ;(async () => {
+      try {
+        const pdfjs = await import(`pdfjs-dist`)
+        const worker_url = (await import(`pdfjs-dist/build/pdf.worker.min.mjs?url`)).default
+        pdfjs.GlobalWorkerOptions.workerSrc = worker_url
+        const bytes = Uint8Array.from(atob(binary_data), (c) => c.charCodeAt(0))
+        const doc = await pdfjs.getDocument({ data: bytes }).promise
+        if (cancelled) return
+        container.replaceChildren()
+        // Fit page width to the container once, at open time.
+        const avail = (container.clientWidth || 800) - 24
+        const dpr = window.devicePixelRatio || 1
+        for (let i = 1; i <= doc.numPages; i++) {
+          const page = await doc.getPage(i)
+          if (cancelled) return
+          const base = page.getViewport({ scale: 1 })
+          const scale = Math.min(Math.max(avail / base.width, 0.5), 2.5)
+          const viewport = page.getViewport({ scale })
+          const canvas = document.createElement(`canvas`)
+          canvas.width = Math.floor(viewport.width * dpr)
+          canvas.height = Math.floor(viewport.height * dpr)
+          canvas.style.width = `${Math.floor(viewport.width)}px`
+          canvas.className = `pdf-page`
+          const ctx = canvas.getContext(`2d`)
+          if (!ctx) throw new Error(`canvas 2d context unavailable`)
+          await page.render({
+            canvasContext: ctx,
+            viewport,
+            transform: dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined,
+          }).promise
+          if (cancelled) return
+          container.appendChild(canvas)
+        }
+      } catch (e) {
+        if (!cancelled) pdf_error = e instanceof Error ? e.message : String(e)
+      } finally {
+        if (!cancelled) pdf_loading = false
+      }
+    })()
     return () => {
-      URL.revokeObjectURL(url)
-      pdf_blob_url = ``
+      cancelled = true
     }
   })
 
@@ -375,6 +422,11 @@
       {mode_info}
     </div>
     <div class="preview-controls">
+      {#if edit_action}
+        <button class="preview-btn download-btn" onclick={edit_action.onclick}>
+          {edit_action.label}
+        </button>
+      {/if}
       {#if mode === `markdown`}
         <button class="preview-btn download-btn" onclick={export_pdf} title={t('structure.export_as_pdf')}>
           PDF
@@ -403,13 +455,14 @@
       </div>
 
     {:else if mode === `pdf`}
-      {#if pdf_blob_url}
-        <iframe
-          src={pdf_blob_url}
-          title={filename || t('structure.pdf_preview')}
-          class="pdf-frame"
-        ></iframe>
+      {#if pdf_loading}
+        <div class="pdf-status">{t('common.loading')}</div>
+      {:else if pdf_error}
+        <div class="pdf-status pdf-error">{pdf_error}</div>
       {/if}
+      <!-- pdf.js owns this element's children (canvases) — keep it free of
+           Svelte-managed content so replaceChildren can't clobber anything. -->
+      <div class="pdf-container" bind:this={pdf_container}></div>
 
     {:else if mode === `markdown`}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -597,11 +650,28 @@
   }
 
   /* --- PDF mode --- */
-  .pdf-frame {
+  .pdf-container {
     flex: 1;
-    width: 100%;
-    border: none;
-    background: light-dark(#fff, #1e1e2e);
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    background: light-dark(#e8eaed, #1e1e2e);
+  }
+  .pdf-container :global(canvas.pdf-page) {
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+    background: #fff;
+  }
+  .pdf-status {
+    padding: 16px;
+    text-align: center;
+    color: var(--text-muted, #94a3b8);
+  }
+  .pdf-error {
+    color: #e44;
+    white-space: pre-wrap;
   }
 
   /* --- Markdown mode --- */

--- a/src/lib/viewer/DocViewer.svelte
+++ b/src/lib/viewer/DocViewer.svelte
@@ -82,7 +82,11 @@
     {:else if !loaded[active.id]}
       <div class="doc-empty">{t('viewer.loading')}</div>
     {:else}
-      {#if active.kind === 'markdown' || active.kind === 'html'}
+      <!-- The floating toggle stays only for renderers WITHOUT their own header
+           row (Monaco / HtmlView). Markdown preview renders FilePreviewPanel,
+           which has a header — there the toggle is passed in as a header action
+           so it doesn't float over the PDF/Download buttons. -->
+      {#if (active.kind === 'markdown' || active.kind === 'html') && kind_for(active) !== 'mdpreview'}
         <div class="doc-view-toggle">
           <button
             class="view-toggle-btn"
@@ -114,6 +118,7 @@
             filename={active.filename}
             file_path={active.origin?.file_path ?? active.local_path ?? ''}
             session_id={active.origin?.session_id ?? ''}
+            edit_action={{ label: t('viewer.edit'), onclick: () => toggle_view(active) }}
           />
         {/key}
       {:else if kind_for(active) === 'htmlview'}
@@ -142,7 +147,11 @@
 </div>
 
 <style>
-  .doc-viewer { display: flex; flex-direction: column; height: 100vh; background: var(--bg-color, #1c1d21); }
+  /* --page-bg is the app's THEMED background var (--bg-color exists nowhere):
+     with the old var this shell was always dark, so in light theme the strip
+     showed light-theme text colors on a dark surface — the ACTIVE tab (themed
+     --text-color #374151) looked dimmer than inactive ones. */
+  .doc-viewer { display: flex; flex-direction: column; height: 100vh; background: var(--page-bg, #1c1d21); }
   .doc-tabstrip { display: flex; flex-wrap: wrap; gap: 2px; padding: 4px; border-bottom: 1px solid var(--border-color, rgba(128,128,128,0.2)); }
   .doc-tab { display: flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 5px 5px 0 0; font-size: 12px; cursor: pointer; border: none; background: transparent; color: var(--text-muted, #94a3b8); }
   .doc-tab.active { background: var(--btn-bg, rgba(128,128,128,0.18)); color: var(--text-color, #e2e8f0); }


### PR DESCRIPTION
Four doc-viewer issues from today's testing round:

## 1. PDF preview blank (desktop Linux)

`<iframe src=blob>` depends on the webview's **native** PDF renderer — WebKitGTK (Tauri's Linux webview) has none, so the frame was always empty. Replaced with **pdfjs-dist** canvas rendering: fit-to-width, devicePixelRatio-aware, one canvas per page, loading/error states. Consistent across Linux/macOS/Windows/browser.

## 2. Doc tab strip "active looks dim"

`.doc-viewer` referenced `--bg-color`, which is defined **nowhere** in the project — the shell always fell back to dark. With the app in light theme, the strip drew light-theme text (`--text-color: #374151`) on that dark surface: the active tab looked dimmer than inactive ones. Now uses the themed `--page-bg` (verified: light shell `#f1f3f5` in light theme).

## 3. markdown Edit button floating over Download

The Edit/Render toggle was an absolutely-positioned overlay on top of FilePreviewPanel's header. For markdown preview it now renders **inside the header row** (new `edit_action` prop, same `.preview-btn` styling as PDF/Download). The overlay remains only for renderers without a header (Monaco, HtmlView).

## 4. "Unhandled rejection: Canceled" error screen

Monaco cancels in-flight delayers when an editor/model is disposed (tab close, HMR). `desktop/main.ts`'s global rejection reporter runs **before** MonacoEditorPanel's `preventDefault` guard (listener registration order), so the benign `Canceled` is now filtered in `is_ignorable_runtime_error` as well.

## Verification

- Live at :3100 `#docs`: shell background follows theme; pdf.js 6.1 renders a generated test PDF to canvas with non-blank pixels through the same Vite pipeline the component uses.
- `vitest run`: 4406 pass.
- New dep: `pdfjs-dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)