### PR TITLE
fix(docs): local PDFs/images load via the blank-session read-binary route

### DIFF
--- a/src/lib/viewer/doc-content.ts
+++ b/src/lib/viewer/doc-content.ts
@@ -29,11 +29,12 @@ export async function load_doc_content(tab: DocTab): Promise<DocContent> {
 
   if (tab.local_path) {
     if (want_binary) {
-      // Local binary base64 endpoint is a deferred backend follow-up (v1 has no
-      // local binary read API — read_file returns text, not base64). Degrade
-      // gracefully so the renderer shows an empty/no-content state instead of
-      // trying to decode text as base64.
-      return { text: null, binary: null, mime: null }
+      // A blank session_id maps to the backend's local-filesystem connection
+      // (_get_hpc, PR #451), so the same read-binary route serves local
+      // PDFs/images — the old "no local binary API" limitation is gone.
+      const { readRemoteBinaryFile } = await import(`$lib/api/hpc`)
+      const r = await readRemoteBinaryFile(``, tab.local_path)
+      return { text: null, binary: r.success ? r.data : null, mime: r.mime_type ?? null }
     }
     const { read_file } = await import(`$lib/api/project`)
     const r = await read_file(tab.local_path)

--- a/tests/vitest/viewer/doc-content.test.ts
+++ b/tests/vitest/viewer/doc-content.test.ts
@@ -38,8 +38,13 @@ describe('load_doc_content', () => {
     const r = await load_doc_content(tab({ local_path: null, inline: { text: null, binary: 'B64', mime: 'image/png' } }))
     expect(r).toEqual({ text: null, binary: 'B64', mime: 'image/png' })
   })
-  it('degrades gracefully for local-path binary (no base64 endpoint in v1)', async () => {
+  it('reads local-path binary via the blank-session read-binary route', async () => {
+    // Regression: this used to return {binary: null} ("no local binary API"),
+    // so a local PDF rendered as an empty pane. A blank session_id maps to the
+    // backend's local-filesystem connection since #451.
+    const { readRemoteBinaryFile } = await import('$lib/api/hpc')
     const r = await load_doc_content(tab({ kind: 'pdf', filename: 'd.pdf', local_path: '/tmp/d.pdf', origin: null, inline: null }))
-    expect(r).toEqual({ text: null, binary: null, mime: null })
+    expect(readRemoteBinaryFile).toHaveBeenCalledWith('', '/tmp/d.pdf')
+    expect(r).toEqual({ text: null, binary: 'BASE64', mime: 'application/pdf' })
   })
 })


### PR DESCRIPTION
## Symptom

Opening a **local** PDF in the doc viewer shows an empty pane — even after #462's pdf.js renderer. No error, no loading state.

## Root cause

`load_doc_content` hard-returned `{binary: null}` for local-path binary docs, with a comment: "v1 has no local binary read API". The pdf effect then early-returns on empty `binary_data` — silent blank. Remote (HPC-origin) and inline PDFs worked.

## Fix

The limitation is stale since #451: a blank `session_id` maps to the backend's local-filesystem connection in `_get_hpc`, and `/hpc/files/read-binary` uses the same resolver — **verified live** (`{"session_id":"","file_path":<local pdf>}` → base64 + mime). Local binaries now load via `readRemoteBinaryFile('', local_path)`, failure degrades to the previous empty state.

## Tests

`doc-content.test.ts`: the old "degrades gracefully (no endpoint)" case is flipped into a regression test asserting the blank-session call and the returned base64; 6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)