### PR TITLE
chore(release): v1.4.2

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -258,6 +258,15 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
+            ### New in 1.4.2
+            - **Terminal file opening works end-to-end** — Ctrl+click a file in a local shell opens it again (empty-session reads were rejected by the backend), and Ctrl+click a **directory** now navigates the Files sidebar to it.
+            - **"Open files in" targets are honored everywhere** — with a full-pane terminal, Split/Tab place the structure beside the terminal instead of silently doing nothing; **Overwrite replaces** the existing pane instead of splitting a new one each time; **Window + Overwrite** reuses a single popout and live-updates it on every open.
+            - **PDFs render in the doc viewer on every platform** — pages are drawn with pdf.js (fit-to-width, high-DPI), so Linux no longer shows a blank frame; local PDFs/images load correctly too. Markdown preview upgraded to GitHub-grade GFM + safe raw HTML, and the Edit toggle sits in the header next to PDF/Download.
+            - **`catgo view` is reliable** — repeat pushes update the External tab's label, and multi-file trajectory pushes (`catgo view a.xyz b.poscar …`) display instead of being dropped (SSE fan-out now reaches tab-alias subscribers).
+            - **Desktop popout windows fixed** — structure popouts had no Tauri ACL capability, so every call from them failed (the "Update failed: … not allowed by ACL" toast). Update checks now run only in the main window.
+            - **iOS: Chinese dictation into the terminal** — the transcript no longer re-appends on every recognizer refinement; Chinese takes the same reconcile path as English.
+            - **MCP `catgo_analyze` repaired** — symmetry / dft_input / optimize / rdf / coordination hit real endpoints (new standalone symmetry, single-structure RDF, CrystalNN coordination).
+
             ### New in 1.4.1
             - **In-app auto-update** — Windows & macOS notice new releases and update with one click (download the signed bundle → relaunch); Linux gets a "new version" banner linking to the download page. The banner only shows when a newer release exists.
             - **Developer-ID signed macOS** — the `.dmg`/`.app` are code-signed (first launch: right-click → Open; notarization lands in a follow-up).
@@ -265,14 +274,6 @@ jobs:
             - **Search Database fixed** — OPTIMADE providers retry on cold start, so it's no longer PubChem-only.
             - **VS Code extension** — trajectory playback no longer janks (off-thread bond recompute); **plots** — axis titles no longer overlap tick labels at large fonts.
             - **iOS** — CatGo is now on the App Store (static viewer build); the web "Get the App" button is embedded in the landing page.
-
-            See the [CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md) for the full list.
-
-            ### New in 1.4.0
-            - **`catgo view` / `catgo gui` CLI** — open structures & trajectories like `ase gui`: `catgo view */POSCAR` stacks files into one trajectory, per-file `@SLICE` frame selection, `--interpolate` (IDPP), and headless `-g/-t` convergence plots. On a packaged install, running `catgo view` with no app open **launches CatGo** and shows the structure.
-            - **Nanoparticle / cluster builder** — Wulff, octahedron, icosahedron, decahedron (via `ase.cluster`), in the Build panel, the CLI (`catgo nanoparticle`), and the `catgo_nanoparticle` MCP tool.
-            - **Random concentration doping** — substitute N of a host element with a dopant mix at random sites, with seed & dedup.
-            - **Web "Get the App"** — the browser build now surfaces a one-click download (Windows/macOS/Linux/Android + iOS TestFlight) instead of a bare GitHub link.
 
             See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for the full list.
           releaseDraft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2026-07-02
+
+### Added
+- **Terminal Ctrl+click a directory** navigates the Files sidebar to it (local shells and HPC sessions).
+- **Doc viewer renders PDFs everywhere** — pages are drawn with pdf.js (fit-to-width, high-DPI), so PDFs display on Linux too, where the system webview has no native PDF renderer. Local PDFs/images now load through the backend's local-file binary route.
+- **GitHub-grade markdown preview** — README-style files render with full GFM + safe raw HTML (badges, centered headers, tables) instead of the chat renderer.
+
+### Fixed
+- **Terminal Ctrl+click a file opens it again** — a local shell sent an empty session id the backend rejected (404) and the dir-check misclassified every path as a directory; both ends fixed.
+- **"Open files in" targets are honored from a full-pane terminal** — Split/Tab create or reuse a structure pane beside the terminal instead of silently doing nothing; Overwrite replaces the tab's existing structure pane instead of splitting a new one on every open.
+- **Window + Overwrite reuses one popout and actually updates it** — the reuse popout now receives every subsequent structure (storage-event + Tauri-event delivery, restored-terminal-tab fallback, no more payload theft by other popouts).
+- **Popout structure windows work again on desktop** — they had no Tauri ACL capability, so every IPC from them was denied (the "Update failed: Command plugin:app|version not allowed by ACL" toast, dead reuse reloads). Update checks now run only in the main window.
+- **`catgo view` pushes reach the External tab reliably** — SSE events were delivered to a registry key nobody subscribed to once a pane had been touched: the tab label froze on the first structure and multi-file trajectory pushes were dropped outright. Both fixed by alias-aware fan-out.
+- **Doc viewer polish** — the markdown Edit toggle sits in the header row (it used to float over Download); the docs window follows the app theme (the active tab no longer looks dimmer than inactive ones in light theme); Monaco's benign "Canceled" rejection no longer whites out the window.
+- **iOS: Chinese dictation into the terminal** no longer re-appends the whole transcript on every recognizer refinement — Chinese now takes the same reconcile path as English.
+- **MCP `catgo_analyze` routes** — symmetry / dft_input / optimize / rdf / coordination now hit real endpoints (new standalone symmetry, single-structure RDF and CrystalNN coordination); the adsorption router is mounted.
+
+### Changed
+- Linux `.rpm` packages use zstd compression (smaller, faster CI).
+
 ## [1.4.1] - 2026-06-26
 
 ### Added

--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.4.1";
+  const VERSION = "1.4.2";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.1"
+version = "1.4.2"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump + release notes for **v1.4.2** — the fix batch from the 2026-07-01/02 testing round (#448–#463).

Surfaces bumped (mirrors #444): `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` + `Cargo.lock`, `deploy/download/index.html` VERSION, `CHANGELOG.md` (new 1.4.2 section), `tauri-build.yml` releaseBody (New in 1.4.2; 1.4.0 section rotated out).

After merge: tag `v1.4.2` → tauri-build (Win/macOS/Linux + updater `latest.json`) + vscode sidecars run on the tag; draft release gets published once builds are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)