### PR TITLE
fix(docs): Render toggle joins the Monaco header (was floating over Save)

### DIFF
--- a/src/lib/structure/MonacoEditorPanel.svelte
+++ b/src/lib/structure/MonacoEditorPanel.svelte
@@ -13,6 +13,7 @@
     onsave,
     onchange,
     onvisualize,
+    edit_action = null,
   }: {
     content?: string
     filename?: string
@@ -29,6 +30,9 @@
     onchange?: (content: string) => void
     /** Callback to visualize the file content as structure/trajectory. */
     onvisualize?: (content: string, filename: string) => void
+    /** Optional extra header button (e.g. the doc viewer's Render toggle),
+     *  rendered with the same styling as Visualize/Save. */
+    edit_action?: { label: string; onclick: () => void } | null
   } = $props()
 
   let container_el: HTMLDivElement | undefined = $state()
@@ -304,6 +308,11 @@
       {/if}
     </div>
     <div class="editor-controls">
+      {#if edit_action}
+        <button class="editor-btn" onclick={edit_action.onclick}>
+          {edit_action.label}
+        </button>
+      {/if}
       {#if can_visualize}
         <button
           class="editor-btn visualize-btn"

--- a/src/lib/viewer/DocViewer.svelte
+++ b/src/lib/viewer/DocViewer.svelte
@@ -82,11 +82,11 @@
     {:else if !loaded[active.id]}
       <div class="doc-empty">{t('viewer.loading')}</div>
     {:else}
-      <!-- The floating toggle stays only for renderers WITHOUT their own header
-           row (Monaco / HtmlView). Markdown preview renders FilePreviewPanel,
-           which has a header — there the toggle is passed in as a header action
-           so it doesn't float over the PDF/Download buttons. -->
-      {#if (active.kind === 'markdown' || active.kind === 'html') && kind_for(active) !== 'mdpreview'}
+      <!-- The floating toggle stays only for HtmlView, which has no header row.
+           Markdown preview (FilePreviewPanel) and edit view (MonacoEditorPanel)
+           both have headers — the toggle rides in them as edit_action so it
+           can't float over Download / the Save status. -->
+      {#if (active.kind === 'markdown' || active.kind === 'html') && kind_for(active) === 'htmlview'}
         <div class="doc-view-toggle">
           <button
             class="view-toggle-btn"
@@ -108,6 +108,9 @@
             readonly={!active.editable}
             onchange={() => set_dirty(active.id, true)}
             onsave={async (text) => { await save_doc_content(active, text); set_dirty(active.id, false) }}
+            edit_action={active.kind === 'markdown' || active.kind === 'html'
+              ? { label: t('viewer.render'), onclick: () => toggle_view(active) }
+              : null}
           />
         {/key}
       {:else if kind_for(active) === 'mdpreview'}


### PR DESCRIPTION
## Symptom

#462 fixed the **Edit** button (markdown preview header), but switching to edit view still showed the **Render (渲染)** toggle as a floating overlay — sitting on top of MonacoEditorPanel's Save status in the top-right corner.

## Fix

Same pattern as #462: `MonacoEditorPanel` gains an `edit_action` prop rendered in its own header controls (before Visualize/Save, same `.editor-btn` styling). DocViewer passes the Render toggle through it for markdown/html **edit** views. The absolute overlay remains only for `HtmlView` — the one renderer with no header row.

## Tests

Viewer suites: 42 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)