### PR TITLE
fix(docs): Render header button uses the accent color (looked disabled)

### DIFF
--- a/src/lib/structure/MonacoEditorPanel.svelte
+++ b/src/lib/structure/MonacoEditorPanel.svelte
@@ -309,7 +309,7 @@
     </div>
     <div class="editor-controls">
       {#if edit_action}
-        <button class="editor-btn" onclick={edit_action.onclick}>
+        <button class="editor-btn action-btn" onclick={edit_action.onclick}>
           {edit_action.label}
         </button>
       {/if}
@@ -409,7 +409,8 @@
     opacity: 0.5;
     cursor: default;
   }
-  .visualize-btn {
+  .visualize-btn,
+  .action-btn {
     color: var(--accent-color, #4dabf7);
     border-color: color-mix(in srgb, var(--accent-color, #4dabf7) 30%, transparent);
   }


### PR DESCRIPTION
Follow-up to #465: the Render toggle inherited bare `.editor-btn` styling — muted gray that reads as disabled next to blue Visualize / green Save. New `.action-btn` class shares the Visualize accent styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)