### PR TITLE
fix(lammps): any unknown section header ends the current section

### DIFF
--- a/src/lib/structure/parsers/lammps.ts
+++ b/src/lib/structure/parsers/lammps.ts
@@ -250,6 +250,14 @@ export function parse_lammps_data(content: string): ParsedStructure | null {
         break
       } else if (line === `Impropers` || line.startsWith(`Impropers`)) {
         break
+      } else if (/^[A-Z][A-Za-z]*( [A-Za-z]+)*( #.*)?$/.test(line)) {
+        // Any OTHER section header (Pair Coeffs, Bond Coeffs, Velocities, …)
+        // ends the current section. Without this, `Pair Coeffs` lines kept
+        // feeding the Masses parser: the LJ sigma column overwrote every
+        // atom mass (σ ≈ 3.5 → He), so an 11k-atom kerogen rendered as
+        // He₁₀₄₆₄Te₂₁₆Sb₂₁₆… instead of C/H/O/N.
+        current_section = ``
+        continue
       }
 
       // Parse atom count

--- a/tests/vitest/structure/lammps-data-parse.test.ts
+++ b/tests/vitest/structure/lammps-data-parse.test.ts
@@ -21,6 +21,11 @@ Masses
 1 15.9994
 2 12.0112
 
+Pair Coeffs # lj/cut/coul/long
+
+1 0.066 3.5
+2 0.07 3.55
+
 Atoms # full
 
 1 1 1 -0.2 -17.36 6.16 -13.12 0 0 0
@@ -55,7 +60,9 @@ describe(`parse_lammps_data atom_style handling`, () => {
     // xyz shifted by the box origin (xlo=-20, ylo=0, zlo=-16)
     expect(s.sites[0].xyz[0]).toBeCloseTo(-17.36 + 20, 6)
     expect(s.sites[0].xyz[2]).toBeCloseTo(-13.12 + 16, 6)
-    // element from mass table via type column (col 3, NOT col 2 = molecule id)
+    // element from mass table via type column (col 3, NOT col 2 = molecule id).
+    // The Pair Coeffs section above must NOT bleed into the Masses parse —
+    // its sigma column (3.5) once overwrote the masses and mapped types to He.
     expect(s.sites[0].species[0].element).toBe(`O`)
     expect(s.sites[1].species[0].element).toBe(`C`)
     // abc in [0,1] for in-box atoms — the old bug left every abc at 0


### PR DESCRIPTION
Follow-up to #467 — with coordinates fixed, the kerogen file rendered but with absurd elements (**He₁₀₄₆₄Te₂₁₆Sb₂₁₆Cd₂₁₆In₇₂H₄₈** instead of C/H/O/N).

## Root cause

The section scanner recognized only Masses/Atoms/Bonds/Angles/Dihedrals/Impropers. `Pair Coeffs` (present in every force-field `write_data` output) didn't reset `current_section`, so its rows kept feeding the Masses parser — the LJ **sigma column (~3.5) overwrote every atom mass**, and mass→element mapped everything to He/heavy junk (Bond/Angle Coeffs magnitudes → Te/Sb/Cd).

## Fix

Any other capitalized section header (`Pair Coeffs`, `Bond Coeffs`, `Velocities`, …) resets the section. Title lines can't match (they contain digits/punctuation).

## Verification

Regression test: Masses + Pair Coeffs interference keeps O/C. Full suite: 4,410 pass. Kerogen legend now C/H/O/N (browser-verified below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)