### PR TITLE
chore(release): v1.4.3

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -258,6 +258,12 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
+            ### New in 1.4.3
+            - **LAMMPS `.data` files open correctly** — force-field data files (`Atoms # full` from `write_data`) no longer freeze the viewer for minutes or show absurd elements: the style annotation wins over column guessing (image flags were read as coordinates), atoms are shifted by the box origin, and `Pair Coeffs` no longer bleeds into the Masses table. An 11k-atom kerogen renders in seconds as C/H/O/N.
+            - **Large systems no longer freeze on PBC boundary images** — the image search dropped its reactive-proxy overhead (190 s → 0.1 s for 11k atoms) and a successful zero-image WASM result no longer re-runs the search in JS.
+            - **Terminal Chinese input no longer swallows characters** — committing a pinyin candidate could emit synthetic backspaces that erased the tail of the just-typed text (timing-dependent). Fixed on desktop and mobile.
+            - **Doc viewer polish** — the Render toggle sits in the editor header next to Visualize/Save with proper accent styling.
+
             ### New in 1.4.2
             - **Terminal file opening works end-to-end** — Ctrl+click a file in a local shell opens it again (empty-session reads were rejected by the backend), and Ctrl+click a **directory** now navigates the Files sidebar to it.
             - **"Open files in" targets are honored everywhere** — with a full-pane terminal, Split/Tab place the structure beside the terminal instead of silently doing nothing; **Overwrite replaces** the existing pane instead of splitting a new one each time; **Window + Overwrite** reuses a single popout and live-updates it on every open.
@@ -266,14 +272,6 @@ jobs:
             - **Desktop popout windows fixed** — structure popouts had no Tauri ACL capability, so every call from them failed (the "Update failed: … not allowed by ACL" toast). Update checks now run only in the main window.
             - **iOS: Chinese dictation into the terminal** — the transcript no longer re-appends on every recognizer refinement; Chinese takes the same reconcile path as English.
             - **MCP `catgo_analyze` repaired** — symmetry / dft_input / optimize / rdf / coordination hit real endpoints (new standalone symmetry, single-structure RDF, CrystalNN coordination).
-
-            ### New in 1.4.1
-            - **In-app auto-update** — Windows & macOS notice new releases and update with one click (download the signed bundle → relaunch); Linux gets a "new version" banner linking to the download page. The banner only shows when a newer release exists.
-            - **Developer-ID signed macOS** — the `.dmg`/`.app` are code-signed (first launch: right-click → Open; notarization lands in a follow-up).
-            - **Bonds preserved when adding a lattice** — adding a periodic box to a molecule (Build → Lattice) no longer drops the bonds (correct fractional coords, incl. non-orthogonal cells).
-            - **Search Database fixed** — OPTIMADE providers retry on cold start, so it's no longer PubChem-only.
-            - **VS Code extension** — trajectory playback no longer janks (off-thread bond recompute); **plots** — axis titles no longer overlap tick labels at large fonts.
-            - **iOS** — CatGo is now on the App Store (static viewer build); the web "Get the App" button is embedded in the landing page.
 
             See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for the full list.
           releaseDraft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.3] - 2026-07-06
+
+### Fixed
+- **LAMMPS `.data` files open correctly** — dragging a force-field data file (`Atoms # full`, as written by `write_data`) used to freeze the viewer for minutes and, once past that, showed absurd elements. Three fixes: the section-header style annotation now wins over column guessing (trailing per-atom image flags were being read as coordinates, collapsing every atom onto the origin); atoms are shifted by the box origin before computing fractional coordinates (LAMMPS boxes need not start at 0); and `Pair Coeffs`/other sections no longer bleed into the Masses parse (LJ sigma once overwrote every atom mass, mapping an 11k-atom kerogen to He/Te/Sb). An 11k-atom kerogen now renders in seconds with the right composition.
+- **PBC boundary images no longer freeze large systems** — the image search read every coordinate through Svelte's reactive proxy in its hot loops (profiled at 100+ seconds for 11k atoms); geometry is now extracted into typed arrays once (190 s → 0.1 s). A successful WASM run with zero images no longer falls through to the slow JS path.
+- **Terminal Chinese input no longer swallows characters** — after committing a pinyin candidate, the post-commit textarea clear made xterm emit synthetic backspaces that intermittently erased the tail of the just-committed text. Synthetic DELs are now eaten against an exact debt; real backspaces always pass through. Fixed in both the desktop and mobile terminals.
+- **Doc viewer Render toggle** sits in the Monaco editor header next to Visualize/Save (it used to float over the Save status) and uses the accent color instead of looking disabled.
+
 ## [1.4.2] - 2026-07-02
 
 ### Added

--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.4.2";
+  const VERSION = "1.4.3";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.2"
+version = "1.4.3"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump + release notes for **v1.4.3** — the #465–#469 fix batch (LAMMPS `.data` open chain, PBC image-search perf, terminal CJK synthetic-DEL swallowing, doc-viewer Render toggle), all user-verified in dev.

Surfaces bumped (mirrors #464): `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` + `Cargo.lock`, `deploy/download/index.html` VERSION, `CHANGELOG.md`, `tauri-build.yml` releaseBody (New in 1.4.3; 1.4.1 section rotated out).

Merging on green; after merge: tag `v1.4.3` → desktop/sidecar/vsix/hpc workflows → publish (with the release-body overwrite step — the asset-first workflow clobbers it, see v1.4.2 notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)