### PR TITLE
fix(viewer): rotate selected atoms about screen axes, not cell axes

### DIFF
--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -44,6 +44,7 @@ import {
   pick_locked_axis,
   rotate_points,
   drag_delta_for_axis,
+  world_axis_to_local,
   type LockAxis,
 } from '$lib/structure/rotation-math'
 import type { ElementSymbol } from '$lib'
@@ -789,7 +790,10 @@ export function create_interaction_controller(deps: InteractionDeps) {
     else if (direction === 'Forward') { rotation_axis = frame.x; angle = KEYBOARD_ROTATION_STEP }
     else { rotation_axis = frame.x; angle = -KEYBOARD_ROTATION_STEP }
 
-    const rotation_quat = new Quaternion().setFromAxisAngle(rotation_axis, angle)
+    // Undo the scene group rotation so the pitch/yaw/roll axes track the screen,
+    // not the cell, when the structure has been reoriented.
+    const local_axis = world_axis_to_local(rotation_axis, deps.get_scene_props().rotation || [0, 0, 0])
+    const rotation_quat = new Quaternion().setFromAxisAngle(local_axis, angle)
     const new_overrides = new Map(realtime_position_overrides)
     const center_vec = new Vector3(keyboard_rotation_center[0], keyboard_rotation_center[1], keyboard_rotation_center[2])
 
@@ -1510,7 +1514,10 @@ export function create_interaction_controller(deps: InteractionDeps) {
       const cam_quat = atom_rotation_camera_quat
         || (deps.get_camera() ? deps.get_camera().quaternion : new Quaternion())
       const frame = screen_frame_from_camera(cam_quat)
-      const axis_vec = frame[axis]
+      // Map the world-space screen axis into the structure's local (cell) frame,
+      // undoing the scene group rotation — otherwise atoms rotate about the cell
+      // axes instead of the on-screen axes when the structure is reoriented.
+      const axis_vec = world_axis_to_local(frame[axis], deps.get_scene_props().rotation || [0, 0, 0])
 
       const angle = drag_delta_for_axis(axis, total_dx, total_dy) * sensitivity
 

--- a/src/lib/structure/rotation-math.ts
+++ b/src/lib/structure/rotation-math.ts
@@ -1,4 +1,4 @@
-import { Quaternion, Vector3 } from 'three'
+import { Euler, Quaternion, Vector3 } from 'three'
 import type { Vec3 } from '$lib/math'
 
 /** Screen-aligned orthonormal frame. Origin is the selection centroid
@@ -29,6 +29,24 @@ export function screen_frame_from_camera(cam_quat: Quaternion): ScreenFrame {
     new Vector3(0, 0, 1).applyQuaternion(cam_quat).normalize(),
   )
   return { x: toward_viewer, y: right, z: up }
+}
+
+/** Map a world-space axis into the structure's LOCAL (cell) frame, undoing the
+ *  scene group rotation that `<T.Group {rotation}>` applies to atom coordinates.
+ *
+ *  Atoms are stored/rotated in local coords, but rendered as
+ *  `world = R_group · local` where `R_group = Euler(group_rotation_rad, 'XYZ')`.
+ *  The screen frame comes from the camera in WORLD space, so to make atoms
+ *  rotate about the on-screen axis we must express that axis in the local frame:
+ *  `axis_local = R_group⁻¹ · axis_world` (rotation conjugation). Without this the
+ *  atoms rotate about the cell axes instead of the screen axes whenever the
+ *  structure has been reoriented via the group rotation (axis-lock drag, the
+ *  numeric rotation controls, or lattice alignment on load). */
+export function world_axis_to_local(axis: Vector3, group_rotation_rad: Vec3): Vector3 {
+  const [rx, ry, rz] = group_rotation_rad
+  if (rx === 0 && ry === 0 && rz === 0) return axis.clone()
+  const inv = new Quaternion().setFromEuler(new Euler(rx, ry, rz, 'XYZ')).invert()
+  return axis.clone().applyQuaternion(inv)
 }
 
 export type LockAxis = 'x' | 'y' | 'z'

--- a/tests/vitest/rotation-math.test.ts
+++ b/tests/vitest/rotation-math.test.ts
@@ -1,10 +1,12 @@
 import { Quaternion, Vector3 } from 'three'
 import { describe, expect, it } from 'vitest'
+import { Euler } from 'three'
 import {
   screen_frame_from_camera,
   pick_locked_axis,
   rotate_points,
   drag_delta_for_axis,
+  world_axis_to_local,
 } from '$lib/structure/rotation-math'
 
 describe('screen_frame_from_camera', () => {
@@ -62,6 +64,36 @@ describe('rotate_points', () => {
     expect(out[0][0]).toBeCloseTo(1, 6)
     expect(out[0][1]).toBeCloseTo(2, 6)
     expect(out[0][2]).toBeCloseTo(3, 6)
+  })
+})
+
+describe('world_axis_to_local', () => {
+  it('identity group rotation leaves the axis unchanged', () => {
+    const out = world_axis_to_local(new Vector3(0, 0, 1), [0, 0, 0])
+    expect(out.toArray()).toEqual([0, 0, 1])
+  })
+  it('undoes a +90° z group rotation (world +x → local -y)', () => {
+    // Group applies Rz(+90°) to local coords: local +x renders as world +y.
+    // So the inverse maps world +x back to local -y.
+    const out = world_axis_to_local(new Vector3(1, 0, 0), [0, 0, Math.PI / 2])
+    expect(out.x).toBeCloseTo(0, 6)
+    expect(out.y).toBeCloseTo(-1, 6)
+    expect(out.z).toBeCloseTo(0, 6)
+  })
+  it('round-trips: re-applying the group rotation recovers the world axis', () => {
+    const rot: [number, number, number] = [0.3, -0.7, 1.1]
+    const world = new Vector3(0.2, 0.9, -0.4).normalize()
+    const local = world_axis_to_local(world, rot)
+    const back = local
+      .clone()
+      .applyQuaternion(new Quaternion().setFromEuler(new Euler(rot[0], rot[1], rot[2], 'XYZ')))
+    expect(back.x).toBeCloseTo(world.x, 6)
+    expect(back.y).toBeCloseTo(world.y, 6)
+    expect(back.z).toBeCloseTo(world.z, 6)
+  })
+  it('preserves unit length', () => {
+    const out = world_axis_to_local(new Vector3(1, 0, 0), [0.5, 1.2, -0.3])
+    expect(out.length()).toBeCloseTo(1, 6)
   })
 })
 


### PR DESCRIPTION
## Problem

Rotating **selected atoms** in the structure viewer rotated them about the **cell** XYZ axes instead of the **screen** XYZ axes. Reported by user: 旋转选中原子时轴是晶胞XYZ而非屏幕XYZ。

## Root cause

The rotation screen frame is built from `camera.quaternion` (**world** space), but the rotation is applied to `structure.sites.xyz`, which are **local/cell** coordinates. Atoms render inside `<T.Group {rotation}>` (`StructureScene.svelte`) where `R_group = Euler(scene_props.rotation, 'XYZ')`. The code omitted `R_group⁻¹`, so the world screen axis was applied directly to local coordinates.

Pure camera-orbit keeps `scene_props.rotation = [0,0,0]` (fix is a no-op there, matching prior correct behaviour). But reorienting the structure via the **group** rotation makes `R_group ≠ I`, and then atoms rotate about the cell axes. Triggered by:

- pressing `r` (lattice align, `interaction.svelte.ts:1070`)
- axis-lock X/Y/Z + drag (`:1313`)
- the numeric rotation controls (`StructureControls.svelte`)

## Fix

New pure helper `world_axis_to_local(axis, group_rot)` in `rotation-math.ts` maps the world screen axis into the local frame via `R_group⁻¹` (conjugation `R⁻¹·Rot(a)·R = Rot(R⁻¹·a)`), matching the existing `local_to_world` convention. Applied on **both** the drag (`:1514`) and keyboard (`:790`) rotation paths. Also corrects the yellow axis indicator (rendered inside the rotated group).

## Tests

- +4 vitest in `rotation-math.test.ts`: identity no-op regression, +90° z inverse, round-trip, unit-length. Suite **15/15 green**.
- `svelte-check`: 12 pre-existing errors (all unrelated files), zero in touched files — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)