### PR TITLE
fix(pty): remote terminal no longer disconnects on vi/full-screen apps

### DIFF
--- a/server/catgo/routers/pty.py
+++ b/server/catgo/routers/pty.py
@@ -166,37 +166,90 @@ async def _run_remote_pty(
         await _run_remote_asyncssh_pty(ws, pty_id, cols, rows, hpc)
 
 
+# --- asyncssh PTY ops, each awaited on the connection's OWNER loop ---
+# asyncssh's SSHClientProcess and its stdin/stdout streams are bound to the loop
+# that created the connection (see hpc_connection.py rule #4). These tiny
+# coroutines let the WebSocket handler — which may run on a different loop —
+# drive the process via ``hpc.run_on_owner(...)`` instead of mutating
+# loop-private channel state directly (the cross-loop misuse that corrupts the
+# session under the heavy, interleaved I/O a full-screen program produces).
+
+async def _pty_write(process, data: bytes) -> None:
+    process.stdin.write(data)
+
+
+async def _pty_resize(process, cols: int, rows: int) -> None:
+    process.change_terminal_size(cols, rows)
+
+
+async def _pty_close(process) -> None:
+    try:
+        process.stdin.write_eof()
+    except Exception:
+        pass
+    try:
+        process.close()
+    except Exception:
+        pass
+
+
 async def _run_remote_asyncssh_pty(
     ws: WebSocket, pty_id: int, cols: int, rows: int, hpc
 ) -> None:
-    """Remote PTY via asyncssh interactive session."""
+    """Remote PTY via asyncssh interactive session.
+
+    Two invariants make full-screen programs (vi/vim/less/top/tmux) survive:
+
+    1. BINARY transport (``encoding=None``). A PTY carries arbitrary terminal
+       bytes — escape sequences, box-drawing, non-UTF-8 payloads. In asyncssh's
+       default UTF-8 text mode ``stdout.read()`` raises ``UnicodeDecodeError`` on
+       the first non-UTF-8 byte; the read loop treats that as channel death and
+       tears down the WebSocket — which is exactly why ``cat`` of a UTF-8 file
+       worked while ``vi`` dropped the connection. Binary mode base64-forwards
+       raw bytes untouched (matching the local/subprocess ``os.read`` paths).
+
+    2. OWNER-LOOP affinity. The asyncssh process and its streams belong to the
+       connection's owner loop (hpc_connection.py rule #4). create / read /
+       write / resize / close are dispatched through ``hpc.run_on_owner`` /
+       ``hpc.stream_on_owner`` so loop-private channel state is never mutated
+       from a foreign loop. Both are a zero-cost passthrough when the handler is
+       already on the owner loop, so the common single-loop path is unchanged.
+    """
     read_task: Optional[asyncio.Task] = None
     monitor_task: Optional[asyncio.Task] = None
     process = None
     channel_closed = asyncio.Event()
 
     try:
-        # Create an interactive process with PTY allocation
-        process = await hpc.conn.create_process(
-            term_type="xterm-256color",
-            term_size=(cols, rows),
+        # Create the interactive PTY process on the owner loop, in binary mode.
+        process = await hpc.run_on_owner(
+            lambda: hpc.conn.create_process(
+                term_type="xterm-256color",
+                term_size=(cols, rows),
+                encoding=None,
+            )
         )
 
         await ws.send_json({"type": "opened", "id": pty_id})
         logger.info(
             f"[PTY {pty_id}] Remote asyncssh session opened "
-            f"({hpc.username}@{hpc.host}, {cols}x{rows})"
+            f"({hpc.username}@{hpc.host}, {cols}x{rows}, binary)"
         )
 
-        # Background task: read remote process stdout → WebSocket
+        # Read remote stdout on the owner loop; stream_on_owner bridges the raw
+        # bytes back to this (FastAPI) loop, then base64 → WebSocket.
+        async def stdout_chunks():
+            while True:
+                data = await process.stdout.read(8192)
+                if not data:
+                    break
+                if isinstance(data, str):  # defensive: only if a text stream slips through
+                    data = data.encode("utf-8", "surrogatepass")
+                yield data
+
         async def read_loop() -> None:
             try:
-                while True:
-                    data = await process.stdout.read(8192)
-                    if not data:
-                        break
-                    if isinstance(data, str):
-                        data = data.encode("utf-8")
+                async for data in hpc.stream_on_owner(stdout_chunks):
                     encoded = base64.b64encode(data).decode("ascii")
                     await ws.send_json({"type": "output", "data": encoded})
             except asyncio.CancelledError:
@@ -229,8 +282,9 @@ async def _run_remote_asyncssh_pty(
 
             if action == "input":
                 raw = msg.get("data", "")
+                data = raw.encode("utf-8", "surrogatepass") if isinstance(raw, str) else bytes(raw)
                 try:
-                    process.stdin.write(raw)
+                    await hpc.run_on_owner(lambda: _pty_write(process, data))
                 except Exception as exc:
                     logger.debug(f"[PTY {pty_id}] Write error (channel closed?): {exc}")
                     break
@@ -238,7 +292,7 @@ async def _run_remote_asyncssh_pty(
                 new_cols = msg.get("cols", cols)
                 new_rows = msg.get("rows", rows)
                 try:
-                    process.change_terminal_size(new_cols, new_rows)
+                    await hpc.run_on_owner(lambda: _pty_resize(process, new_cols, new_rows))
                 except Exception:
                     pass
             elif action == "close":
@@ -257,13 +311,9 @@ async def _run_remote_asyncssh_pty(
                     await task
                 except (asyncio.CancelledError, Exception):
                     pass
-        if process:
+        if process is not None:
             try:
-                process.stdin.write_eof()
-            except Exception:
-                pass
-            try:
-                process.close()
+                await hpc.run_on_owner(lambda: _pty_close(process))
             except Exception:
                 pass
 

--- a/server/tests/test_remote_pty_binary.py
+++ b/server/tests/test_remote_pty_binary.py
@@ -1,0 +1,170 @@
+"""Remote asyncssh PTY must be binary-safe and owner-loop-bound.
+
+Regression: full-screen programs (vi/vim/less/top/tmux) dropped the SSH
+connection *immediately*, while `cat` of a UTF-8 file worked. Root cause: the
+asyncssh session was opened in asyncssh's default UTF-8 **text** mode, so the
+first non-UTF-8 byte in a terminal redraw/escape stream raised
+``UnicodeDecodeError`` inside ``process.stdout.read()``; the read loop treats any
+read exception as channel death and closes the WebSocket. The fix opens the PTY
+in **binary** mode (``encoding=None``) and drives every process op through the
+connection's owner loop (``run_on_owner`` / ``stream_on_owner``).
+
+pytest-asyncio is not installed here; coroutines are driven via ``asyncio.run``.
+The fake stdout yields its chunks and then *blocks* (never EOFs), so the handler
+is torn down deterministically by the client's ``close`` — no reliance on
+background-task/event timing (which ``nest_asyncio`` in this env perturbs).
+"""
+
+import asyncio
+import base64
+
+from catgo.routers.pty import _run_remote_asyncssh_pty
+
+# A terminal redraw burst that is NOT valid UTF-8: 0xff/0xfe/0x80/0xc0/0xc1 are
+# illegal UTF-8 lead/continuation bytes. asyncssh text mode raises on these.
+NON_UTF8 = b"\x1b[2J\x1b[H\xff\xfe\x80\x81 box \xc0\xc1 \xe2\x94\x80"
+
+
+class FakeStream:
+    """Yields the given chunks, then blocks until cancelled (a live PTY never
+    spontaneously EOFs mid-session; the session ends via the client `close`)."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self._blocked = asyncio.Event()  # never set
+
+    async def read(self, _n):
+        if self._chunks:
+            return self._chunks.pop(0)
+        await self._blocked.wait()  # block until the read task is cancelled
+        return b""
+
+
+class FakeStdin:
+    def __init__(self):
+        self.writes = []
+        self.eof = False
+
+    def write(self, data):
+        self.writes.append(data)
+
+    def write_eof(self):
+        self.eof = True
+
+
+class FakeProcess:
+    def __init__(self, out_chunks):
+        self.stdout = FakeStream(out_chunks)
+        self.stdin = FakeStdin()
+        self.resizes = []
+        self.closed = False
+
+    def change_terminal_size(self, cols, rows):
+        self.resizes.append((cols, rows))
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(self, process):
+        self._process = process
+        self.create_kwargs = None
+
+    async def create_process(self, **kwargs):
+        self.create_kwargs = kwargs
+        return self._process
+
+
+class FakeHPC:
+    """Minimal HPCConnection stand-in with owner-loop passthroughs."""
+
+    username = "user"
+    host = "login.example.edu"
+
+    def __init__(self, process):
+        self.conn = FakeConn(process)
+        self.run_on_owner_calls = 0
+
+    async def run_on_owner(self, coro_factory):
+        self.run_on_owner_calls += 1
+        return await coro_factory()
+
+    async def stream_on_owner(self, stream_factory):
+        async for chunk in stream_factory():
+            yield chunk
+
+
+class FakeWS:
+    def __init__(self, script):
+        self._script = list(script)
+        self.sent = []
+        self.closed = False
+
+    async def send_json(self, obj):
+        self.sent.append(obj)
+
+    async def receive_json(self):
+        # A real yield so the background read task gets to forward any pending
+        # output before the client advances the script.
+        await asyncio.sleep(0.05)
+        if self._script:
+            return self._script.pop(0)
+        return {"action": "close"}  # always terminate the main loop
+
+    async def close(self):
+        self.closed = True
+
+
+def _run(out_chunks, script):
+    async def driver():
+        proc = FakeProcess(out_chunks)
+        hpc = FakeHPC(proc)
+        ws = FakeWS(script)
+        await asyncio.wait_for(
+            _run_remote_asyncssh_pty(ws, pty_id=1, cols=80, rows=24, hpc=hpc),
+            timeout=10,
+        )
+        return proc, hpc, ws
+
+    return asyncio.run(driver())
+
+
+def test_non_utf8_output_survives_and_forwards_verbatim():
+    proc, hpc, ws = _run([NON_UTF8], script=[{"action": "close"}])
+    outputs = [m for m in ws.sent if m.get("type") == "output"]
+    assert outputs, "no output forwarded — the read loop died (text-mode regression)"
+    decoded = b"".join(base64.b64decode(m["data"]) for m in outputs)
+    assert decoded == NON_UTF8, "binary terminal bytes were mangled or dropped"
+
+
+def test_process_opened_in_binary_mode():
+    proc, hpc, ws = _run([], script=[{"action": "close"}])
+    assert hpc.conn.create_kwargs is not None, "create_process was never called"
+    assert hpc.conn.create_kwargs.get("encoding", "MISSING") is None, (
+        "PTY must be opened with encoding=None (binary); text mode breaks "
+        "vi/top/tmux on the first non-UTF-8 byte"
+    )
+
+
+def test_input_is_written_as_bytes_on_owner_loop():
+    proc, hpc, ws = _run(
+        [], script=[{"action": "input", "data": "iHello"}, {"action": "close"}]
+    )
+    assert proc.stdin.writes == [b"iHello"], (
+        f"terminal input must reach stdin as bytes, got {proc.stdin.writes!r}"
+    )
+    # create_process + the write both go through run_on_owner.
+    assert hpc.run_on_owner_calls >= 2
+
+
+def test_resize_is_routed_to_the_process():
+    proc, hpc, ws = _run(
+        [], script=[{"action": "resize", "cols": 120, "rows": 40}, {"action": "close"}]
+    )
+    assert (120, 40) in proc.resizes, f"resize not applied, got {proc.resizes!r}"
+
+
+def test_process_closed_via_owner_loop_on_exit():
+    proc, hpc, ws = _run([], script=[{"action": "close"}])
+    assert proc.stdin.eof is True and proc.closed is True, "PTY not cleaned up on exit"


### PR DESCRIPTION
## Summary

The **remote SSH terminal dropped the connection the instant a full-screen program started** (`vi`/`vim`/`less`/`top`/`tmux`), while `cat` of a UTF-8 file worked. This fixes it in the backend so users don't have to avoid full-screen editors.

## Root cause

The asyncssh PTY session (`server/catgo/routers/pty.py`, `_run_remote_asyncssh_pty`) was opened in asyncssh's **default UTF-8 text mode**. A terminal carries arbitrary bytes — escape sequences, box-drawing, non-UTF-8 payloads — and the first non-UTF-8 byte raised `UnicodeDecodeError` inside `process.stdout.read()`. The read loop treats any read exception as channel death and tears the WebSocket down.

The **local** and **subprocess** PTY paths were already binary-safe (`os.read` → bytes), which is exactly why only the **remote (asyncssh)** terminal broke.

Secondary (real but latent on a single event loop): the handler drove the asyncssh process (`create_process`, `stdout.read`, `stdin.write`, `change_terminal_size`, `close`) **directly on the WebSocket loop**, violating the loop-ownership contract documented in `hpc_connection.py` (rule 4) — asyncssh channel state is loop-private and must not be mutated from a foreign loop (e.g. when a connection is owned by the workflow-engine thread).

## Fix

In `_run_remote_asyncssh_pty`:
- **Binary transport** (`encoding=None`); base64-forward raw bytes, matching the `os.read` paths. This is the immediate fix for the disconnect.
- **Owner-loop affinity**: create / read / write / resize / close now go through `hpc.run_on_owner` / `hpc.stream_on_owner` (the connection's own cross-loop bridges). Zero-cost passthrough on the common single-loop path; correct dispatch when the connection is owned by another loop.
- Encode client input (str) → bytes for the binary stdin.

`pty.py` had not changed since v1.0.1 (2026-05-12); the bug shipped in the initial release.

## Verification

- **Unit tests** — new `server/tests/test_remote_pty_binary.py`, **5/5 pass**: non-UTF-8 output forwards verbatim (the regression), binary-mode open, input-as-bytes, resize routing, clean teardown. Existing terminal/HPC tests unaffected.
- **Live-verified**: ran the fixed backend against **SDSC Expanse** and confirmed **`vi` no longer disconnects** the remote terminal (full-screen render + edit + `:q` with the session intact).

## Scope

Backend-only, confined to `_run_remote_asyncssh_pty` + the new test (`+241/−21`). No change to the local/subprocess PTY paths or the connection pool.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
