### PR TITLE
fix(terminal): Ctrl+click opens remote files (session_id was dropped)

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -339,11 +339,12 @@
     return false
   }
   function handle_terminal_open_file(file_path: string, filename: string, session_id: string) { return _handle_terminal_open_file(sidebar_deps, file_path, filename, session_id) }
-  // Ctrl+click file-open from a terminal *leaf* — derive filename from the path and
-  // use the leaf's own session_id (reuses the same handler the side-panel terminal used).
-  function handle_terminal_leaf_open_file(file_path: string, term: TerminalLeafState) {
+  // Ctrl+click file-open from a terminal *leaf* — derive filename from the path and use
+  // the session the click resolved against (threaded through from open_terminal_click,
+  // the same session the directory-check used), falling back to the leaf's own session.
+  function handle_terminal_leaf_open_file(file_path: string, term: TerminalLeafState, session_id?: string) {
     const name = file_path.split(`/`).pop() || file_path
-    return handle_terminal_open_file(file_path, name, term.session_id || ``)
+    return handle_terminal_open_file(file_path, name, session_id || term.session_id || ``)
   }
   // Header label for a terminal leaf: remote host > shell > CWD basename > 'Terminal'.
   function terminalLabel(term: TerminalLeafState): string {
@@ -2793,7 +2794,7 @@
               initial_sync_cwd={term.sync_cwd}
               onpopout={() => popout_terminal_leaf(tab.id, leaf.id)}
               onclose={() => close_terminal_leaf(tab.id, leaf.id)}
-              on_open_file={(p) => handle_terminal_leaf_open_file(p, term)}
+              on_open_file={(p, sid) => handle_terminal_leaf_open_file(p, term, sid)}
               on_ask_catbot={() => open_chat_beside(leaf)}
             />
           {/if}

--- a/src/lib/structure/TerminalPanel.svelte
+++ b/src/lib/structure/TerminalPanel.svelte
@@ -50,7 +50,7 @@
     onpopout?: () => void
     on_cwd_change?: (path: string) => void
     /** Callback when user Ctrl+clicks a file path in the terminal output. */
-    on_open_file?: (file_path: string) => void
+    on_open_file?: (file_path: string, session_id?: string) => void
   } = $props()
 
   let container_el: HTMLDivElement | undefined = $state()
@@ -327,7 +327,7 @@
                     // explicit jump); file → open it. dir-detection is async so it
                     // can't run inside xterm's synchronous activate().
                     void open_terminal_click(resolved, session_id ?? ``, {
-                      open_file: (p) => on_open_file?.(p),
+                      open_file: (p, sid) => on_open_file?.(p, sid),
                       navigate_dir: (p, sid) => {
                         const seq = ++_cwd_seq
                         window.dispatchEvent(

--- a/src/lib/structure/TerminalWindow.svelte
+++ b/src/lib/structure/TerminalWindow.svelte
@@ -43,7 +43,7 @@
     onpopout?: () => void
     on_ask_catbot?: () => void
     /** Callback when user Ctrl+clicks a file path in the terminal output. */
-    on_open_file?: (file_path: string) => void
+    on_open_file?: (file_path: string, session_id?: string) => void
   } = $props()
 
   // ====== Server list ======

--- a/src/lib/structure/__tests__/terminal-path-nav.test.ts
+++ b/src/lib/structure/__tests__/terminal-path-nav.test.ts
@@ -24,7 +24,7 @@ describe('open_terminal_click', () => {
       { open_file, navigate_dir },
       async () => false, // is_directory
     )
-    expect(open_file).toHaveBeenCalledWith('/home/u/proj/ir20_bare_distinct.extxyz')
+    expect(open_file).toHaveBeenCalledWith('/home/u/proj/ir20_bare_distinct.extxyz', '')
     expect(navigate_dir).not.toHaveBeenCalled()
   })
 
@@ -40,6 +40,22 @@ describe('open_terminal_click', () => {
     expect(navigate_dir).toHaveBeenCalledWith('/scratch/run42', 'sess-abc')
   })
 
+  it('forwards the remote session_id to open_file for a remote file (regression)', async () => {
+    const open_file = vi.fn()
+    const navigate_dir = vi.fn()
+    await open_terminal_click(
+      '/home/jzhang89/build_prod500.py',
+      'sess-abc',
+      { open_file, navigate_dir },
+      async () => false, // it's a file
+    )
+    // Bug: open_file was called with only the path, dropping session_id — so the
+    // file-open handler read the LOCAL fs instead of the remote SSH session, and an
+    // existing remote file came back "Not found".
+    expect(open_file).toHaveBeenCalledWith('/home/jzhang89/build_prod500.py', 'sess-abc')
+    expect(navigate_dir).not.toHaveBeenCalled()
+  })
+
   it('treats a detection failure as a file (safe fallback)', async () => {
     const open_file = vi.fn()
     const navigate_dir = vi.fn()
@@ -49,7 +65,7 @@ describe('open_terminal_click', () => {
       { open_file, navigate_dir },
       async () => false, // path_is_directory swallows errors → false
     )
-    expect(open_file).toHaveBeenCalledWith('/maybe/gone')
+    expect(open_file).toHaveBeenCalledWith('/maybe/gone', '')
     expect(navigate_dir).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/structure/terminal-path-nav.ts
+++ b/src/lib/structure/terminal-path-nav.ts
@@ -39,7 +39,7 @@ export async function path_is_directory(path: string, session_id: string): Promi
 
 export interface TerminalClickHandlers {
   /** Open a file path (structure/editor/preview) — the pre-existing behaviour. */
-  open_file: (path: string) => void
+  open_file: (path: string, session_id: string) => void
   /** Navigate the Files panel for this session to `path` (a directory). */
   navigate_dir: (path: string, session_id: string) => void
 }
@@ -55,6 +55,6 @@ export async function open_terminal_click(
   if (await is_directory(path, session_id)) {
     handlers.navigate_dir(path, session_id)
   } else {
-    handlers.open_file(path)
+    handlers.open_file(path, session_id)
   }
 }


### PR DESCRIPTION
## Summary

**Ctrl+clicking a file path in a remote SSH terminal did not open the file**, even when the file exists — the backend returned `"Not found: <path>"` (e.g. `/home/jzhang89/build_prod500.py`, a real 2.8 KB file on Expanse).

## Root cause

An API asymmetry in the terminal click router (`terminal-path-nav.ts`). `open_terminal_click` routes a Ctrl+clicked path to either the Files panel (directory) or the file viewer (file):

- **directory** → `navigate_dir(path, session_id)` ✅ gets `session_id`
- **file** → `open_file(path)` ❌ **`session_id` was dropped**

Downstream, `handle_terminal_leaf_open_file` then fell back to the terminal leaf's own `term.session_id`, which is empty. So `/api/hpc/files/read-content` ran against the **local backend filesystem** instead of the remote SSH session. The directory check (`/api/hpc/files/list`) used the correct session and correctly reported "it's a file"; only the *read* used the wrong (local) session — the backend home differs from the remote home, so an existing remote file came back "Not found".

## Fix

Thread `session_id` through the file-open path, symmetric with `navigate_dir`:

- `open_terminal_click` → `handlers.open_file(path, session_id)`
- `session_id` param added to `TerminalClickHandlers.open_file`, `TerminalPanel.on_open_file`, `TerminalWindow.on_open_file` (optional, backward-compatible)
- `handle_terminal_leaf_open_file` prefers the passed `session_id` over `term.session_id`

Backward compatible: the new parameter is optional; existing callers are unaffected.

## Verification

- **Live-verified on SDSC Expanse**: Ctrl+click now opens remote files in the viewer.
- **Regression test** added to `terminal-path-nav.test.ts` (a remote file's `session_id` is forwarded to `open_file`); the two existing `open_file` assertions were updated for the new signature. **Suite 9/9 pass.**
- **svelte-check**: 0 new errors (the 4 changed files are clean; the pre-existing baseline is untouched).

## Scope

Frontend-only, `+29/−12` across 5 files. Independent of the terminal-disconnect fix in #474.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
