### PR TITLE
fix(desktop): route file downloads through the Tauri-aware helper

### DIFF
--- a/desktop/sidebar/hpc-browser.svelte.ts
+++ b/desktop/sidebar/hpc-browser.svelte.ts
@@ -9,6 +9,7 @@ import { readRemoteFile, uploadFile, getDownloadUrl, mergeStructuresFromDir, hpc
 import { read_file } from '$lib/api/project'
 import { LOCAL_SESSION_ID } from '$lib/hpc-sessions.svelte'
 import { start_hpc_managed_download } from '$lib/downloads/hpc-download'
+import { download } from '$lib/io/fetch'
 import type { RemoteFile } from '$lib/api/hpc'
 
 export interface HpcBrowserCallbacks {
@@ -223,16 +224,11 @@ export function create_hpc_browser_state(callbacks: HpcBrowserCallbacks) {
         }
       } else if (!file.is_dir) {
         // Web/dev mode: Tauri shell is unavailable (the button was a silent
-        // no-op), so stream the file via /__files/raw and trigger a browser
-        // download.
-        const link = document.createElement(`a`)
-        link.href = `/__files/raw?path=${encodeURIComponent(file.path)}`
-        link.download = file.name
-        link.rel = `noopener`
-        link.style.display = `none`
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
+        // no-op), so fetch the file via /__files/raw and route through the
+        // shared download() helper (native save dialog on desktop).
+        const url = `/__files/raw?path=${encodeURIComponent(file.path)}`
+        const blob = await (await fetch(url)).blob()
+        download(blob, file.name, `application/octet-stream`)
       } else {
         navigator.clipboard.writeText(file.path).catch(() => {})
       }
@@ -254,14 +250,9 @@ export function create_hpc_browser_state(callbacks: HpcBrowserCallbacks) {
 
       const global_download = (globalThis as Record<string, unknown>).download
       if (typeof document !== `undefined` && typeof global_download !== `function`) {
-        const link = document.createElement(`a`)
-        link.href = getDownloadUrl(source, file.path, { is_dir: file.is_dir, skip_stat: true })
-        link.download = filename
-        link.rel = `noopener`
-        link.style.display = `none`
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
+        const url = getDownloadUrl(source, file.path, { is_dir: file.is_dir, skip_stat: true })
+        const blob = await (await fetch(url)).blob()
+        download(blob, filename, `application/octet-stream`)
         return
       }
     } catch (err) {

--- a/src/lib/api/heterostructure.ts
+++ b/src/lib/api/heterostructure.ts
@@ -1,4 +1,5 @@
 import type { AnyStructure, PymatgenStructure } from '$lib/structure'
+import { download } from '$lib/io/fetch'
 import {
   structure_to_cif_str,
   structure_to_extxyz_str,
@@ -374,16 +375,9 @@ function serialize_structure(structure: PymatgenStructure, fmt: string): string 
   }
 }
 
-/** Trigger a browser download of a Blob under the given filename. */
+/** Trigger a download of the registry-candidates Blob under the given filename. */
 function trigger_download(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement(`a`)
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
+  download(blob, filename, `application/zip`)
 }
 
 export async function downloadRegistryCandidates(
@@ -482,14 +476,7 @@ export async function downloadRegistryCandidates(
   // Download the zip blob
   const candidate_count = response.headers.get(`X-Candidate-Count`) ?? `?`
   const blob = await response.blob()
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement(`a`)
-  a.href = url
-  a.download = `registry_candidates_${candidate_count}.zip`
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
+  download(blob, `registry_candidates_${candidate_count}.zip`, `application/zip`)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/brillouin/BrillouinZoneExportPane.svelte
+++ b/src/lib/brillouin/BrillouinZoneExportPane.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { DraggablePane } from '$lib'
   import { export_canvas_as_png } from '$lib/io/export'
+  import { download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import { tooltip } from 'svelte-multiselect/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -44,15 +45,11 @@
     const json_data = get_json_data()
     if (!json_data || !bz_data) return
 
-    const blob = new Blob([JSON.stringify(json_data, null, 2)], {
-      type: `application/json`,
-    })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement(`a`)
-    link.href = url
-    link.download = `${filename}-bz-order-${bz_data.order}.json`
-    link.click()
-    URL.revokeObjectURL(url)
+    download(
+      JSON.stringify(json_data, null, 2),
+      `${filename}-bz-order-${bz_data.order}.json`,
+      `application/json`,
+    )
   }
 
   function get_json_data() {

--- a/src/lib/cube/CubeControls.svelte
+++ b/src/lib/cube/CubeControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CubeState, IsosurfaceResult, CubeAtom } from './api'
+  import { download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import {
     extractIsosurface,
@@ -193,12 +194,11 @@
         },
         format,
       )
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = `isosurface.${format}`
-      a.click()
-      URL.revokeObjectURL(url)
+      download(
+        blob,
+        `isosurface.${format}`,
+        format === `glb` ? `model/gltf-binary` : `model/obj`,
+      )
     } catch (err) {
       cube_state.error = t('structure.cube_export_failed', { error: (err as Error).message })
     } finally {

--- a/src/lib/cube/CubeViewer.svelte
+++ b/src/lib/cube/CubeViewer.svelte
@@ -4,6 +4,7 @@
   import CubeControls from './CubeControls.svelte'
   import type { CubeState, IsosurfaceResult, CubeMesh, CubeAtom } from './api'
   import { uploadCubeFile, extractIsosurface } from './api'
+  import { download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module('structure')
@@ -94,12 +95,7 @@
 
   function download_slice() {
     if (!slice_blob) return
-    const url = URL.createObjectURL(slice_blob)
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `slice.png`
-    a.click()
-    URL.revokeObjectURL(url)
+    download(slice_blob, `slice.png`, `image/png`)
   }
 
   function handle_atom_click(index: number) {

--- a/src/lib/cube/SlicePanel.svelte
+++ b/src/lib/cube/SlicePanel.svelte
@@ -9,6 +9,7 @@
     type ColormapName,
   } from './slice'
   import { colors } from '$lib/state.svelte'
+  import { download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module('structure')
@@ -109,12 +110,7 @@
     if (!canvas) return
     canvas.toBlob((blob) => {
       if (!blob) return
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = filename
-      a.click()
-      URL.revokeObjectURL(url)
+      download(blob, filename, `image/png`)
     }, `image/png`)
   }
 </script>

--- a/src/lib/electronic/DosPlotWindow.svelte
+++ b/src/lib/electronic/DosPlotWindow.svelte
@@ -4,6 +4,7 @@
   import DosPlot from './DosPlot.svelte'
   import ExportDpiControl from './ExportDpiControl.svelte'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import { download } from '$lib/io/fetch'
 
   load_i18n_module('structure')
 
@@ -48,13 +49,9 @@
   )
 
   function download_blob(content: string, filename: string, mime: string) {
-    const blob = new Blob([content], { type: mime })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = filename
-    a.click()
-    URL.revokeObjectURL(url)
+    // Route through the shared helper so the Tauri desktop native save dialog is
+    // used — a raw <a download> click is silently ignored by WebKitGTK.
+    download(content, filename, mime)
   }
 
   async function export_csv() {
@@ -74,10 +71,10 @@
     const opts = format === `png` ? { dpi: export_dpi, width_mm: export_width_mm } : undefined
     const url = await dos_plot.export_image(format, opts)
     if (!url) return
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `dos_plot.${format}`
-    a.click()
+    // `url` is a data:/blob: URL — fetch it back to bytes so the shared helper
+    // saves the image, not the URL text (raw <a download> is a no-op in WebKitGTK).
+    const blob = await (await fetch(url)).blob()
+    download(blob, `dos_plot.${format}`, format === `png` ? `image/png` : `image/svg+xml`)
   }
 </script>
 

--- a/src/lib/structure/CubePanel.svelte
+++ b/src/lib/structure/CubePanel.svelte
@@ -21,6 +21,7 @@
     type Vec3,
   } from '$lib/cube/slice'
   import { extract_isosurface_client, dispose_worker } from '$lib/cube/client'
+  import { download } from '$lib/io/fetch'
   import { atomic_radii } from '$lib/structure'
   import { element_data } from '$lib/element'
   import { onDestroy } from 'svelte'
@@ -399,12 +400,11 @@
         },
         format,
       )
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = `isosurface.${format}`
-      a.click()
-      URL.revokeObjectURL(url)
+      download(
+        blob,
+        `isosurface.${format}`,
+        format === `glb` ? `model/gltf-binary` : `model/obj`,
+      )
     } catch (err) {
       cube_state.error = `Export failed: ${(err as Error).message}`
     } finally {

--- a/src/lib/structure/ServerPane.svelte
+++ b/src/lib/structure/ServerPane.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { DraggablePane } from '$lib'
   import FileTree from './FileTree.svelte'
+  import { download } from '$lib/io/fetch'
   import type { Snippet } from 'svelte'
   import {
     hpc_session_store,
@@ -903,17 +904,17 @@
           navigator.clipboard.writeText(file.path).catch(() => {})
         }
       } else if (!file.is_dir) {
-        // Web/dev mode: stream the local file via /__files/raw and trigger a
-        // browser download (Tauri shell open is unavailable, so the button was
-        // a silent no-op before).
-        const link = document.createElement(`a`)
-        link.href = `/__files/raw?path=${encodeURIComponent(file.path)}`
-        link.download = file.name
-        link.rel = `noopener`
-        link.style.display = `none`
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
+        // Web/dev mode: stream the local file via /__files/raw and save it
+        // through the shared download helper (raw anchor downloads are ignored
+        // in the Tauri WKWebView; Tauri shell open is unavailable in web/dev, so
+        // the button was a silent no-op before).
+        try {
+          const resp = await fetch(`/__files/raw?path=${encodeURIComponent(file.path)}`)
+          const blob = await resp.blob()
+          download(blob, file.name, `application/octet-stream`)
+        } catch {
+          navigator.clipboard.writeText(file.path).catch(() => {})
+        }
       } else {
         // Local directory in web mode: no raw stream for dirs — copy the path.
         navigator.clipboard.writeText(file.path).catch(() => {})
@@ -936,14 +937,10 @@
 
       const global_download = (globalThis as Record<string, unknown>).download
       if (typeof document !== `undefined` && typeof global_download !== `function`) {
-        const link = document.createElement(`a`)
-        link.href = getDownloadUrl(session_id, file.path, { is_dir: file.is_dir, skip_stat: true })
-        link.download = filename
-        link.rel = `noopener`
-        link.style.display = `none`
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
+        const url = getDownloadUrl(session_id, file.path, { is_dir: file.is_dir, skip_stat: true })
+        const resp = await fetch(url)
+        const blob = await resp.blob()
+        download(blob, filename, `application/octet-stream`)
         return
       }
     } catch (e: any) {

--- a/src/lib/structure/SlowGrowthPane.svelte
+++ b/src/lib/structure/SlowGrowthPane.svelte
@@ -14,6 +14,7 @@
   import { extent } from 'd3-array'
   import { onMount, onDestroy } from 'svelte'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import { download } from '$lib/io/fetch'
 
   load_i18n_module(`structure`)
 
@@ -304,14 +305,8 @@
       }
 
       const csv_text = [header, ...rows].join(`\n`)
-      const blob = new Blob([csv_text], { type: `text/csv;charset=utf-8` })
-      const url = URL.createObjectURL(blob)
       const filename = `slow_growth_b${active_constraint}.csv`
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = filename
-      a.click()
-      URL.revokeObjectURL(url)
+      download(csv_text, filename, `text/csv`)
       export_status = t(`structure.export_started`, { filename })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -3994,11 +3994,7 @@
                             <button class="sym-analyze-btn" style="margin-top: 4px" onclick={() => {
                               if (!rac_result) return
                               const csv = [`name,value`, ...rac_result.descriptors.map(d => `${d.name},${d.value}`)].join(`\n`)
-                              const blob = new Blob([csv], { type: `text/csv` })
-                              const url = URL.createObjectURL(blob)
-                              const a = document.createElement(`a`)
-                              a.href = url; a.download = `rac_descriptors.csv`; a.click()
-                              URL.revokeObjectURL(url)
+                              download(csv, `rac_descriptors.csv`, `text/csv`)
                             }}>{t(`structure.export_csv`)}</button>
                           </div>
                         {/if}

--- a/src/lib/structure/catrender/CatRenderViewPane.svelte
+++ b/src/lib/structure/catrender/CatRenderViewPane.svelte
@@ -15,6 +15,7 @@
   import { prune_atom_overrides } from './atom-merge'
   import { catrender_state as S, AXIS_COLORS } from './catrender-state.svelte'
   import { drag_rotate, type DragRotateHandlers } from './drag-rotate-action'
+  import { download } from '$lib/io/fetch'
 
   let {
     show = $bindable(false),
@@ -330,17 +331,8 @@
     }
   })
 
-  function download(name: string, blob: Blob) {
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = name
-    a.click()
-    URL.revokeObjectURL(url)
-  }
-
   function export_svg() {
-    download(`catrender.svg`, new Blob([svg], { type: `image/svg+xml` }))
+    download(svg, `catrender.svg`, `image/svg+xml`)
   }
 
   async function export_png() {
@@ -362,7 +354,7 @@
     c.height = h
     const ctx = c.getContext(`2d`)!
     ctx.drawImage(img, 0, 0, w, h)
-    c.toBlob((b) => b && download(`catrender.png`, b), `image/png`)
+    c.toBlob((b) => b && download(b, `catrender.png`, `image/png`), `image/png`)
   }
 
   // Visible base bonds (after current overrides) for the per-row delete list.

--- a/src/lib/structure/export/__tests__/download-file.test.ts
+++ b/src/lib/structure/export/__tests__/download-file.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { download_file } from '../common-export'
+
+// Regression: the export panels' download buttons (INCAR/POSCAR/KPOINTS, etc.)
+// did nothing in the Tauri desktop app because download_file used a raw
+// `<a download>.click()`, which WebKitGTK silently ignores. It must instead
+// route through the shared download() helper, which uses the native save
+// override installed by init_tauri (globalThis.download).
+describe('download_file', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).download
+    vi.restoreAllMocks()
+  })
+
+  it('routes through the global download override (Tauri native save)', () => {
+    const spy = vi.fn()
+    ;(globalThis as Record<string, unknown>).download = spy
+    download_file('Automatic kpoint scheme\n0\nGamma\n3 2 1\n', 'KPOINTS')
+    expect(spy).toHaveBeenCalledWith(
+      'Automatic kpoint scheme\n0\nGamma\n3 2 1\n',
+      'KPOINTS',
+      'text/plain',
+    )
+  })
+})

--- a/src/lib/structure/export/common-export.ts
+++ b/src/lib/structure/export/common-export.ts
@@ -2,6 +2,7 @@
  * Shared validation helpers and constants used across export targets.
  */
 import type { AnyStructure, PymatgenStructure } from '$lib'
+import { download } from '$lib/io/fetch'
 
 // ====== MAGMOM Database ======
 export const MAGMOM_DATABASE: Record<string, number> = {
@@ -118,12 +119,13 @@ export function generate_magmom_string(
   return magmom_parts.join(' ')
 }
 
-/** Download a text file */
+/** Download a text file. Delegates to the shared `download()` helper so the
+ *  Tauri desktop app's native save dialog (installed by `init_tauri`) is used.
+ *  A raw `<a download>` click is silently ignored by WebKitGTK, so the export
+ *  panels' download buttons did nothing in the desktop app. `download()` still
+ *  falls back to `showSaveFilePicker` / `<a>` in a plain browser. */
 export function download_file(content: string, filename: string): void {
-  const blob = new Blob([content], { type: 'text/plain' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a'); a.href = url; a.download = filename; a.click()
-  URL.revokeObjectURL(url)
+  download(content, filename, 'text/plain')
 }
 
 /** Common fix mode / selective dynamics parameters */

--- a/src/lib/workflow/BatchStatusSection.svelte
+++ b/src/lib/workflow/BatchStatusSection.svelte
@@ -9,6 +9,7 @@
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import { get_convergence, type ConvergencePoint } from '$lib/api/workflow'
   import { pending_open_structure } from './workflow-state.svelte'
+  import { download } from '$lib/io/fetch'
 
   interface SubStep {
     index: number
@@ -213,11 +214,7 @@
                   {t('workflow.batch_status_open_structure_in_tab')}
                 </button>
                 <button class="bs-files-btn" onclick={() => {
-                  const blob = new Blob([step.contcar!], { type: 'chemical/x-vasp' })
-                  const url = URL.createObjectURL(blob)
-                  const a = document.createElement('a')
-                  a.href = url; a.download = `${(step.label ?? `branch_${step.index}`).replace(/[^a-zA-Z0-9()-]/g, '_')}_CONTCAR`; a.click()
-                  URL.revokeObjectURL(url)
+                  download(step.contcar!, `${(step.label ?? `branch_${step.index}`).replace(/[^a-zA-Z0-9()-]/g, '_')}_CONTCAR`, 'text/plain')
                 }}>
                   {t('workflow.batch_status_download_contcar')}
                 </button>

--- a/src/lib/workflow/BenchmarkTable.svelte
+++ b/src/lib/workflow/BenchmarkTable.svelte
@@ -2,6 +2,7 @@
   import type { ProjectDetail } from '$lib/api/project'
   import type { StepInfo } from './workflow-types'
   import * as workflow_api from '$lib/api/workflow'
+  import { download } from '$lib/io/fetch'
 
   let {
     project,
@@ -284,13 +285,7 @@
         lines.push([csv_quote(`# ${k}`), csv_quote(typeof v === `string` ? v : JSON.stringify(v))].join(`,`))
       }
     }
-    const blob = new Blob([lines.join(`\n`)], { type: `text/csv` })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `mace-ni-benchmark.csv`
-    a.click()
-    URL.revokeObjectURL(url)
+    download(lines.join(`\n`), `mace-ni-benchmark.csv`, `text/csv`)
   }
 </script>
 

--- a/src/lib/workflow/CoverageDependencePlot.svelte
+++ b/src/lib/workflow/CoverageDependencePlot.svelte
@@ -7,6 +7,7 @@
    * in computational catalysis (E_ads = intercept + slope * theta).
    */
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   let {
     coverages = [],
@@ -98,10 +99,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 1200, height: 800, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `coverage_sweep.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `coverage_sweep.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/EnergyDiagramEditor.svelte
+++ b/src/lib/workflow/EnergyDiagramEditor.svelte
@@ -2,6 +2,7 @@
   import { API_BASE } from '$lib/api/config'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import { lazy_load_plotly, base_layout, base_config, make_target_writable } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   load_i18n_module('common')
   load_i18n_module('workflow')
@@ -163,14 +164,11 @@
     }
   }
 
-  function export_diagram(format: 'png' | 'svg') {
+  async function export_diagram(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
-    Plotly.toImage(plot_div, { format, width: 1200, height: 600, scale: 2 }).then((url: string) => {
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = `energy_diagram.${format}`
-      a.click()
-    })
+    const url = await Plotly.toImage(plot_div, { format, width: 1200, height: 600, scale: 2 })
+    const blob = await (await fetch(url)).blob()
+    download(blob, `energy_diagram.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/EnergyDiagramPlot.svelte
+++ b/src/lib/workflow/EnergyDiagramPlot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   let {
     plotly_data = null,
@@ -52,10 +53,8 @@
   export async function export_diagram(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 1200, height: height * 2, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `energy_diagram.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `energy_diagram.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/NEBPathPlot.svelte
+++ b/src/lib/workflow/NEBPathPlot.svelte
@@ -7,6 +7,7 @@
    * forward / reverse barriers, and initial / final reference lines.
    */
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   let {
     energies_ev = [],
@@ -149,10 +150,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 1200, height: 800, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `neb_pathway.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `neb_pathway.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/NodeStatusPanel.svelte
+++ b/src/lib/workflow/NodeStatusPanel.svelte
@@ -6,6 +6,7 @@
   import type { ConvergencePoint } from '$lib/api/workflow'
   import BatchStatusSection from './BatchStatusSection.svelte'
   import * as api from '$lib/api/workflow'
+  import { download } from '$lib/io/fetch'
   import { API_BASE } from '$lib/api/config'
   import UvVisPlot from './UvVisPlot.svelte'
   import ConvergencePlot from './ConvergencePlot.svelte'
@@ -2092,11 +2093,7 @@
             <div class="sp-file-list">
               {#if mlp_contcar}
                 <button class="sp-file-btn" onclick={() => {
-                  const blob = new Blob([mlp_contcar!], { type: 'text/plain' })
-                  const url = URL.createObjectURL(blob)
-                  const a = document.createElement('a')
-                  a.href = url; a.download = mlp_contcar_filename; a.click()
-                  URL.revokeObjectURL(url)
+                  download(mlp_contcar!, mlp_contcar_filename, 'text/plain')
                 }}>
                   <span class="sp-file-icon">📄</span>
                   <span class="sp-file-name">{mlp_contcar_filename}</span>
@@ -2105,11 +2102,7 @@
               {/if}
               {#if cached_summary.stdout}
                 <button class="sp-file-btn" onclick={() => {
-                  const blob = new Blob([cached_summary.stdout!], { type: 'text/plain' })
-                  const url = URL.createObjectURL(blob)
-                  const a = document.createElement('a')
-                  a.href = url; a.download = 'output.log'; a.click()
-                  URL.revokeObjectURL(url)
+                  download(cached_summary.stdout!, 'output.log', 'text/plain')
                 }}>
                   <span class="sp-file-icon">📋</span>
                   <span class="sp-file-name">output.log</span>

--- a/src/lib/workflow/ParityPlot.svelte
+++ b/src/lib/workflow/ParityPlot.svelte
@@ -8,6 +8,7 @@
    * stats annotation, and per-point coloring.
    */
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   let {
     points = [],
@@ -167,10 +168,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 800, height: 500, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `parity_plot.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `parity_plot.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/ResultsTable.svelte
+++ b/src/lib/workflow/ResultsTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import type { EnrichedResult } from '$lib/api/project'
+  import { download } from '$lib/io/fetch'
 
   load_i18n_module(`workflow`)
 
@@ -145,13 +146,7 @@
   }
 
   function download_file(content: string, filename: string, mime: string) {
-    const blob = new Blob([content], { type: mime })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = filename
-    a.click()
-    URL.revokeObjectURL(url)
+    download(content, filename, mime)
   }
 </script>
 

--- a/src/lib/workflow/ScalingRelationsPlot.svelte
+++ b/src/lib/workflow/ScalingRelationsPlot.svelte
@@ -7,6 +7,7 @@
    * binding energies in computational catalysis (e.g. E_ads(OH*) vs E_ads(O*)).
    */
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   let {
     points = [],
@@ -142,10 +143,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 800, height: 500, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `scaling_relations.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `scaling_relations.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/StatusPopout.svelte
+++ b/src/lib/workflow/StatusPopout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PymatgenStructure } from '$lib'
+  import { download } from '$lib/io/fetch'
   import NodeStatusPanel from './NodeStatusPanel.svelte'
   import NodeConfigPanel from './NodeConfigPanel.svelte'
   import StructureInputPanel from './StructureInputPanel.svelte'
@@ -108,13 +109,7 @@
   function handle_download(node_id: string, filename: string) {
     if (!ctx.workflow_id) return
     api.get_step_output(ctx.workflow_id, node_id, filename).then((data) => {
-      const blob = new Blob([data.content], { type: `application/octet-stream` })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = filename
-      a.click()
-      setTimeout(() => URL.revokeObjectURL(url), 10_000)
+      download(data.content, filename, `application/octet-stream`)
     }).catch((err) => console.error(`Failed to download file:`, err))
   }
 </script>

--- a/src/lib/workflow/SurfaceEnergyPlot.svelte
+++ b/src/lib/workflow/SurfaceEnergyPlot.svelte
@@ -7,6 +7,7 @@
    * Each panel titled with facet name and gamma value.
    */
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
 
   let {
     per_facet = {},
@@ -174,10 +175,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 1200, height: 900, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `surface_energy_fits.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `surface_energy_fits.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/WorkflowEditor.svelte
+++ b/src/lib/workflow/WorkflowEditor.svelte
@@ -5,6 +5,7 @@
   import { load_dynamic_engines, all_engine_specs } from './node-defs/dynamic'
   import { STATUS_COLORS } from './workflow-types'
   import type { WorkflowRunConfig } from './workflow-types'
+  import { download } from '$lib/io/fetch'
   import {
     sync_workflow_state,
     clear_workflow_state,
@@ -1579,14 +1580,8 @@
       nodes,
       edges,
     }
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: `application/json` })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement(`a`)
-    a.href = url
     const safe_name = (workflow_name || `workflow`).replace(/[^a-z0-9_-]+/gi, `_`)
-    a.download = `${safe_name}.json`
-    a.click()
-    URL.revokeObjectURL(url)
+    download(JSON.stringify(payload, null, 2), `${safe_name}.json`, `application/json`)
   }
 
   /** Download a file from step output via browser download. */
@@ -1594,13 +1589,7 @@
     try {
       const data = await api.get_step_output(workflow_id, node_id, filename)
       if (!data?.content) return
-      const blob = new Blob([data.content], { type: `text/plain` })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement(`a`)
-      a.href = url
-      a.download = filename
-      a.click()
-      URL.revokeObjectURL(url)
+      download(data.content, filename, `text/plain`)
     } catch (err: any) {
       cycle_warning = `Failed to download ${filename}: ${err?.message}`
       setTimeout(() => cycle_warning = null, 5000)

--- a/src/lib/workflow/WulffPlot.svelte
+++ b/src/lib/workflow/WulffPlot.svelte
@@ -7,6 +7,7 @@
    * computational catalysis papers (replaces pymatgen WulffShape.get_plot()).
   */
   import { lazy_load_plotly, make_target_writable, base_layout, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module('workflow')
@@ -114,10 +115,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!Plotly || !plot_div) return
     const url = await Plotly.toImage(plot_div, { format, width: 800, height: 500, scale: 2 })
-    const a = document.createElement(`a`)
-    a.href = url
-    a.download = `wulff_construction.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `wulff_construction.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/WulffShape3D.svelte
+++ b/src/lib/workflow/WulffShape3D.svelte
@@ -15,6 +15,7 @@
    *   Plotly 3D scene sizing issues with responsive mode.
    */
   import { lazy_load_plotly, make_target_writable, base_config, observe_resize } from './plotly-utils'
+  import { download } from '$lib/io/fetch'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import { untrack } from 'svelte'
 
@@ -255,10 +256,8 @@
   export async function export_plot(format: 'png' | 'svg') {
     if (!_Plotly || !plot_div) return
     const url = await _Plotly.toImage(plot_div, { format, width: 800, height: 800, scale: 2 })
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `wulff_3d.${format}`
-    a.click()
+    const blob = await (await fetch(url)).blob()
+    download(blob, `wulff_3d.${format}`, format === 'png' ? 'image/png' : 'image/svg+xml')
   }
 </script>
 

--- a/src/lib/workflow/components/BranchStatusPanel.svelte
+++ b/src/lib/workflow/components/BranchStatusPanel.svelte
@@ -21,6 +21,7 @@
 <script lang="ts">
   import '$lib/dialog-shared.css'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import { download } from '$lib/io/fetch'
 
   load_i18n_module('common')
   load_i18n_module('workflow')
@@ -203,13 +204,7 @@
       b.error ?? '',
     ])
     const csv = [header, ...rows].map(r => r.map(c => `"${String(c).replace(/"/g, '""')}"`).join(',')).join('\n')
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `branches_${workflow_id}_${map_node_id}.csv`
-    a.click()
-    URL.revokeObjectURL(url)
+    download(csv, `branches_${workflow_id}_${map_node_id}.csv`, 'text/csv')
   }
 
   /** Format a numeric result value for display */

--- a/src/lib/workflow/components/ResultTablePanel.svelte
+++ b/src/lib/workflow/components/ResultTablePanel.svelte
@@ -20,6 +20,7 @@
 <script lang="ts">
   import '$lib/dialog-shared.css'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
+  import { download } from '$lib/io/fetch'
 
   load_i18n_module('common')
   load_i18n_module('workflow')
@@ -273,13 +274,7 @@
 
   /** Helper to trigger a download from a string blob */
   function download_blob(content: string, mime: string, filename: string) {
-    const blob = new Blob([content], { type: mime })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = filename
-    a.click()
-    URL.revokeObjectURL(url)
+    download(content, filename, mime)
   }
 
   /** Open top N structures in the viewer */

--- a/tests/vitest/structure/export-modules.test.ts
+++ b/tests/vitest/structure/export-modules.test.ts
@@ -232,20 +232,15 @@ describe(`common-export`, () => {
   })
 
   describe(`download_file`, () => {
-    it(`creates blob and triggers download`, () => {
-      const createObjectURL = vi.fn(() => `blob:test`)
-      const revokeObjectURL = vi.fn()
-      const click = vi.fn()
-      const createElement = vi.spyOn(document, `createElement`).mockReturnValue({ click, set href(_: string) {}, set download(_: string) {} } as any)
-      globalThis.URL.createObjectURL = createObjectURL
-      globalThis.URL.revokeObjectURL = revokeObjectURL
-
+    it(`routes through the shared download() helper (Tauri-aware native save)`, () => {
+      // download_file delegates to io/fetch download(), which uses the native
+      // save override (globalThis.download) in the desktop app — a raw
+      // <a download> click is a no-op in WebKitGTK.
+      const dl = vi.fn()
+      ;(globalThis as Record<string, unknown>).download = dl
       download_file(`test content`, `test.txt`)
-
-      expect(createObjectURL).toHaveBeenCalledOnce()
-      expect(click).toHaveBeenCalledOnce()
-      expect(revokeObjectURL).toHaveBeenCalledOnce()
-      createElement.mockRestore()
+      expect(dl).toHaveBeenCalledWith(`test content`, `test.txt`, `text/plain`)
+      delete (globalThis as Record<string, unknown>).download
     })
   })
 })


### PR DESCRIPTION
## Problem

In the **Tauri desktop window (WebKitGTK)** a programmatic `<a download>.click()` on a blob/object URL is **silently ignored**, so every download button that built its own anchor did nothing. Reported for the VASP input panel (INCAR/POSCAR/KPOINTS 下载), but it affected ~30 export sites app-wide.

## Root cause

The app ships a Tauri-aware `download(data, filename, type)` (`src/lib/io/fetch.ts`) that uses the native save dialog installed by `init_tauri` (`desktop/App.svelte:927`) and falls back to `showSaveFilePicker` / `<a>` in a plain browser. The broken sites just never used it — they hand-rolled `document.createElement('a')` + `a.download` + `a.click()`, which WebKitGTK drops.

## Fix

Route every raw-anchor download through `download()`:

- **`common-export.download_file`** (VASP/QE/LAMMPS/CP2K/ORCA/… export panels) delegates to it — fixes the reported VASP case + all format panels.
- **Image exporters** (`Plotly.toImage` / `canvas` data-URLs): fetch the URL back to a `Blob` first (`await (await fetch(url)).blob()`) so the *bytes* are saved, not the URL text.
- **Blob-in-hand** sites (heterostructure zips, `canvas.toBlob`): pass the Blob directly.
- **Text** sites (CSV/JSON/log/CONTCAR): pass the string with the right MIME.
- Removed a shadowing local `download(name, blob)` in `CatRenderViewPane`.

**Left untouched (correct):** mobile save paths (dedicated handling); `createObjectURL` used for *rendering* (img/canvas/iframe previews, plugin module loading, DocxView embedded images) — not downloads; `io/export.ts` (already uses `download()`).

## Files

31 files: `common-export.ts` + DosPlotWindow + ~28 export/plot/table/cube/structure/brillouin/api/desktop sites + 1 new test. Net −85 lines (anchor plumbing removed).

## Verify

- **+1 vitest** — `download_file` routes through the global override with `text/plain`.
- **svelte-check: 12 errors** — identical to the pre-existing baseline; none in the touched files (zero regression).
- **grep** — no raw `<a download>` save sites remain outside the intentional browser fallback in `io/fetch.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)