### PR TITLE
feat(viewer): full VASP trajectory support (vasprun.xml / OUTCAR / XDATCAR) — forces, energy, fixed-atom masking

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1387,32 +1387,47 @@
     // OUTCAR/XDATCAR carry no fixed-atom info — pull selective dynamics from a
     // sibling CONTCAR/POSCAR in the same dir and stamp it on the trajectory
     // (async, mutates the reactive trajectory in place).
-    if (e.is_trajectory && remote_origin) {
-      void attach_vasp_constraints(p, remote_origin, e.filename)
+    if (e.is_trajectory && (remote_origin || local_file_path)) {
+      void attach_vasp_constraints(p, e.filename, remote_origin, local_file_path)
     }
   }
 
-  /** For a remote OUTCAR/XDATCAR (no inline constraints), fetch the sibling
-   *  CONTCAR/POSCAR and stamp its selective dynamics onto the trajectory. */
+  /** For an OUTCAR/XDATCAR (no inline constraints), fetch a sibling
+   *  CONTCAR/POSCAR — remote via the SSH session, local via the filesystem —
+   *  and stamp its selective dynamics onto the trajectory. */
   async function attach_vasp_constraints(
     p: PaneState,
-    origin: { session_id: string; file_path: string },
     filename: string,
+    origin: { session_id: string; file_path: string } | null,
+    local_file_path: string | null,
   ) {
     const traj = p.trajectory as TrajectoryType | null
     if (!traj?.frames?.length) return
     if (!/outcar|xdatcar/i.test(filename)) return
+    const base = origin?.file_path ?? local_file_path
+    if (!base) return
     const { has_constraints, move_mask_from_poscar, apply_move_mask } = await import(
       `$lib/trajectory/vasp-constraints`
     )
     if (has_constraints(traj)) return // vasprun already carries them
-    const dir = origin.file_path.replace(/[/\\][^/\\]*$/, ``)
-    const { readRemoteFile } = await import(`$lib/api/hpc`)
+    const sep = base.includes(`\\`) ? `\\` : `/`
+    const dir = base.replace(/[/\\][^/\\]*$/, ``)
+    const read: (name: string) => Promise<string | null> = origin
+      ? async (name) => {
+        const { readRemoteFile } = await import(`$lib/api/hpc`)
+        const r = await readRemoteFile(origin.session_id, `${dir}${sep}${name}`, 0)
+        return r?.success ? r.content ?? null : null
+      }
+      : async (name) => {
+        const { read_file } = await import(`$lib/api/project`)
+        const r = await read_file(`${dir}${sep}${name}`)
+        return r?.content ?? null
+      }
     for (const name of [`CONTCAR`, `POSCAR`]) {
       try {
-        const r = await readRemoteFile(origin.session_id, `${dir}/${name}`, 0)
-        if (r?.success && r.content) {
-          const mask = move_mask_from_poscar(r.content)
+        const content = await read(name)
+        if (content) {
+          const mask = move_mask_from_poscar(content)
           if (mask && apply_move_mask(traj, mask)) return
         }
       } catch { /* try next sibling */ }

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -1384,6 +1384,39 @@
     p.bio_format = e.bio_format
     ts.active_leaf_id = leaf_id
     update_tab_label(tab_id)
+    // OUTCAR/XDATCAR carry no fixed-atom info — pull selective dynamics from a
+    // sibling CONTCAR/POSCAR in the same dir and stamp it on the trajectory
+    // (async, mutates the reactive trajectory in place).
+    if (e.is_trajectory && remote_origin) {
+      void attach_vasp_constraints(p, remote_origin, e.filename)
+    }
+  }
+
+  /** For a remote OUTCAR/XDATCAR (no inline constraints), fetch the sibling
+   *  CONTCAR/POSCAR and stamp its selective dynamics onto the trajectory. */
+  async function attach_vasp_constraints(
+    p: PaneState,
+    origin: { session_id: string; file_path: string },
+    filename: string,
+  ) {
+    const traj = p.trajectory as TrajectoryType | null
+    if (!traj?.frames?.length) return
+    if (!/outcar|xdatcar/i.test(filename)) return
+    const { has_constraints, move_mask_from_poscar, apply_move_mask } = await import(
+      `$lib/trajectory/vasp-constraints`
+    )
+    if (has_constraints(traj)) return // vasprun already carries them
+    const dir = origin.file_path.replace(/[/\\][^/\\]*$/, ``)
+    const { readRemoteFile } = await import(`$lib/api/hpc`)
+    for (const name of [`CONTCAR`, `POSCAR`]) {
+      try {
+        const r = await readRemoteFile(origin.session_id, `${dir}/${name}`, 0)
+        if (r?.success && r.content) {
+          const mask = move_mask_from_poscar(r.content)
+          if (mask && apply_move_mask(traj, mask)) return
+        }
+      } catch { /* try next sibling */ }
+    }
   }
 
   /**

--- a/desktop/sidebar/hpc-browser.svelte.ts
+++ b/desktop/sidebar/hpc-browser.svelte.ts
@@ -42,14 +42,19 @@ export function create_hpc_browser_state(callbacks: HpcBrowserCallbacks) {
     if (hpc_merge_timer) clearTimeout(hpc_merge_timer)
   }
 
-  /** Read file content — local filesystem (read_file) or remote (readRemoteFile) */
-  async function read_file_content(file: RemoteFile): Promise<string | null> {
+  /** Read file content — local filesystem (read_file) or remote (readRemoteFile).
+   *  `full` reads without the default byte cap (max_bytes=0) — required for
+   *  multi-frame files (vasprun.xml/OUTCAR): a truncated read yields malformed XML
+   *  or a partial trajectory, which fails to parse ("Unsupported text format").
+   *  Streamable huge files (XDATCAR/xyz) are intercepted earlier and never reach
+   *  here, so an unlimited read of what remains is safe. */
+  async function read_file_content(file: RemoteFile, full = false): Promise<string | null> {
     const source = callbacks.get_source()
     if (source === LOCAL_SESSION_ID) {
       const result = await read_file(file.path)
       return result.content || null
     }
-    const result = await readRemoteFile(source, file.path)
+    const result = await readRemoteFile(source, file.path, full ? 0 : undefined)
     if (!result.success) {
       set_hpc_merge_status(`error`, `Failed to read ${file.name}: ${result.message || `unknown error`}`)
       return null
@@ -105,7 +110,7 @@ export function create_hpc_browser_state(callbacks: HpcBrowserCallbacks) {
           return
         }
       }
-      const content = await read_file_content(file)
+      const content = await read_file_content(file, true) // full read — no byte cap
       if (!content) return
       const filename = file.path.split(/[/\\]/).pop() || file.name
       // Auto-detect trajectory files

--- a/src/lib/gesture/__tests__/backend-whisper.test.ts
+++ b/src/lib/gesture/__tests__/backend-whisper.test.ts
@@ -47,7 +47,7 @@ describe('BackendWhisperEngine', () => {
     await flush()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
     expect(url).toContain('/stt/transcribe')
     expect(url).toContain('language=en')
     expect(url).toContain('model=whisper-base')

--- a/src/lib/gesture/__tests__/local-whisper.test.ts
+++ b/src/lib/gesture/__tests__/local-whisper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const pipeline_spy = vi.fn(async () => async () => ({ text: `` }))
+const pipeline_spy = vi.fn(async (..._a: any[]) => async () => ({ text: `` }))
 
 vi.mock('@huggingface/transformers', () => ({
   pipeline: (...args: any[]) => pipeline_spy(...args),

--- a/src/lib/gesture/__tests__/stt-accel.test.ts
+++ b/src/lib/gesture/__tests__/stt-accel.test.ts
@@ -29,25 +29,25 @@ describe('stt-accel client', () => {
   })
 
   it('accel_install POSTs', async () => {
-    const f = vi.fn(async () => ({ ok: true, json: async () => ({ started: true }) }))
+    const f = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true, json: async () => ({ started: true }) }))
     vi.stubGlobal('fetch', f)
     expect(await accel_install()).toBe(true)
     expect(f.mock.calls[0][0]).toContain('/stt/accel/install')
-    expect(f.mock.calls[0][1].method).toBe('POST')
+    expect(f.mock.calls[0][1]!.method).toBe('POST')
   })
 
   it('accel_download_model passes the size', async () => {
-    const f = vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+    const f = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true, json: async () => ({}) }))
     vi.stubGlobal('fetch', f)
     await accel_download_model('small')
     expect(f.mock.calls[0][0]).toContain('size=small')
   })
 
   it('accel_set_engine sends the engine in the body', async () => {
-    const f = vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+    const f = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true, json: async () => ({}) }))
     vi.stubGlobal('fetch', f)
     await accel_set_engine('whispercpp')
-    expect(JSON.parse(f.mock.calls[0][1].body)).toEqual({ engine: 'whispercpp' })
+    expect(JSON.parse(f.mock.calls[0][1]!.body as string)).toEqual({ engine: 'whispercpp' })
   })
 
   it('poll_accel_progress loops until download inactive', async () => {

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -137,7 +137,7 @@ async function blob_with_png_dpi(blob: Blob, dpi?: number): Promise<Blob> {
   if (!dpi || blob.type !== `image/png`) return blob
   const bytes = new Uint8Array(await blob.arrayBuffer())
   const patched = add_png_dpi_metadata(bytes, dpi)
-  return new Blob([patched], { type: blob.type })
+  return new Blob([patched as unknown as BlobPart], { type: blob.type })
 }
 
 // Decide the actual off-screen render size. With a crop, render only that

--- a/src/lib/structure/FilePreviewPanel.svelte
+++ b/src/lib/structure/FilePreviewPanel.svelte
@@ -92,8 +92,11 @@
           if (!ctx) throw new Error(`canvas 2d context unavailable`)
           await page.render({
             canvasContext: ctx,
+            canvas,
             viewport,
-            transform: dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined,
+            // Omit (not set to undefined) when unscaled — RenderParameters uses
+            // exactOptionalPropertyTypes, so `transform: undefined` is a type error.
+            ...(dpr !== 1 ? { transform: [dpr, 0, 0, dpr, 0, 0] } : {}),
           }).promise
           if (cancelled) return
           container.appendChild(canvas)

--- a/src/lib/structure/parsers/vasp.ts
+++ b/src/lib/structure/parsers/vasp.ts
@@ -393,8 +393,13 @@ function direct_child(el: Element, tag: string, name?: string): Element | null {
 // the one file that carries positions + forces + constraints + energy together.
 export function parse_vasprun_trajectory(content: string): string | null {
   try {
+    // Strip the `<?xml … encoding="ISO-8859-1"?>` prolog + any BOM before parsing.
+    // The JS string is already Unicode, so WebKitGTK's DOMParser can reject the
+    // (now-false) byte-encoding declaration with a parsererror — jsdom ignores it.
+    // We only need the element tree, so the prolog is safe to drop.
+    const xml = content.replace(/^﻿?\s*<\?xml[^>]*\?>\s*/i, ``)
     const parser = new DOMParser()
-    const doc = parser.parseFromString(content, `text/xml`)
+    const doc = parser.parseFromString(xml, `text/xml`)
     if (doc.querySelector(`parsererror`)) return null
     if (doc.documentElement.tagName !== `modeling`) return null
 

--- a/src/lib/structure/parsers/vasp.ts
+++ b/src/lib/structure/parsers/vasp.ts
@@ -371,7 +371,26 @@ export function count_vasprun_ionic_steps(content: string): number {
   return count
 }
 
-// Parse all frames from vasprun.xml as multi-frame XYZ string (for trajectory player)
+/** Direct children of `el` with the given lowercase tag name (XML is case-sensitive). */
+function direct_children(el: Element, tag: string): Element[] {
+  return Array.from(el.children).filter((c) => c.tagName === tag)
+}
+
+/** First direct child matching tag (+ optional name="…"), or null. */
+function direct_child(el: Element, tag: string, name?: string): Element | null {
+  for (const c of direct_children(el, tag)) {
+    if (name === undefined || c.getAttribute(`name`) === name) return c
+  }
+  return null
+}
+
+// Parse all frames from vasprun.xml as a multi-frame extended-XYZ string for the
+// trajectory player. Unlike a bare position dump, each frame carries the ionic
+// energy (`energy=` in the comment → energy curve), per-atom forces
+// (`forces:R:3` columns → force curve + arrows), and — when the run used
+// selective dynamics — a `move_mask:L:1` column (T=free, F=fully fixed) so the
+// viewer can exclude constrained atoms from the max-force display. vasprun.xml is
+// the one file that carries positions + forces + constraints + energy together.
 export function parse_vasprun_trajectory(content: string): string | null {
   try {
     const parser = new DOMParser()
@@ -389,41 +408,86 @@ export function parse_vasprun_trajectory(content: string): string | null {
       }
     }
     if (elements.length === 0) return null
+    const n = elements.length
 
-    // Collect all structures from <calculation> blocks
-    const structures = doc.querySelectorAll(`calculation > structure`)
-    if (structures.length < 2) return null
+    // Selective dynamics (constant across frames) lives on the initial structure.
+    // move_mask token: T when the atom can move in ANY direction (not fully fixed),
+    // F when constrained in all three — matching the "exclude only F F F" rule.
+    let move_mask: string[] | null = null
+    const init_struct = doc.querySelector(`structure[name="initialpos"]`)
+      ?? doc.querySelector(`structure[name="initial_positions"]`)
+    const sel_varray = init_struct
+      ? direct_child(init_struct, `varray`, `selective`)
+      : null
+    if (sel_varray) {
+      const flags = direct_children(sel_varray, `v`)
+      if (flags.length === n) {
+        move_mask = flags.map((v) => {
+          const toks = (v.textContent ?? ``).trim().split(/\s+/)
+          return toks.some((tkn) => tkn.toUpperCase().startsWith(`T`)) ? `T` : `F`
+        })
+      }
+    }
 
+    const calcs = Array.from(doc.querySelectorAll(`calculation`))
+    if (calcs.length < 2) return null
+
+    const props = `species:S:1:pos:R:3:forces:R:3` + (move_mask ? `:move_mask:L:1` : ``)
     const frames: string[] = []
-    for (const struct_el of structures) {
-      const crystal = struct_el.querySelector(`crystal`)
-      if (!crystal) continue
-      const basis_varray = crystal.querySelector(`varray[name="basis"]`)
+
+    for (const calc of calcs) {
+      const struct_el = direct_child(calc, `structure`)
+      if (!struct_el) continue
+      const crystal = direct_child(struct_el, `crystal`)
+      const basis_varray = crystal ? direct_child(crystal, `varray`, `basis`) : null
       if (!basis_varray) continue
-      const basis_vs = basis_varray.querySelectorAll(`v`)
+      const basis_vs = direct_children(basis_varray, `v`)
       if (basis_vs.length < 3) continue
-      const matrix: number[][] = []
-      for (let i = 0; i < 3; i++) {
-        matrix.push(basis_vs[i].textContent!.trim().split(/\s+/).map(Number))
+      const matrix = basis_vs.slice(0, 3).map((v) =>
+        (v.textContent ?? ``).trim().split(/\s+/).map(Number)
+      )
+
+      const pos_varray = direct_child(struct_el, `varray`, `positions`)
+      const pos_vs = pos_varray ? direct_children(pos_varray, `v`) : []
+      if (pos_vs.length !== n) continue
+
+      // Forces (Cartesian, eV/Å) for this ionic step.
+      const force_varray = direct_child(calc, `varray`, `forces`)
+      const force_vs = force_varray ? direct_children(force_varray, `v`) : []
+      const forces = force_vs.length === n
+        ? force_vs.map((v) => (v.textContent ?? ``).trim().split(/\s+/).map(Number))
+        : null
+
+      // Ionic energy: prefer free energy (matches OSZICAR F / TOTEN), then E(sigma→0).
+      const energy_el = direct_child(calc, `energy`)
+      let energy: number | null = null
+      if (energy_el) {
+        for (const key of [`e_fr_energy`, `e_0_energy`, `e_wo_entrp`]) {
+          const i_el = direct_child(energy_el, `i`, key)
+          const val = i_el ? Number((i_el.textContent ?? ``).trim()) : NaN
+          if (Number.isFinite(val)) { energy = val; break }
+        }
       }
 
-      const pos_varray = struct_el.querySelector(`varray[name="positions"]`)
-      if (!pos_varray) continue
-      const pos_vs = pos_varray.querySelectorAll(`v`)
-      if (pos_vs.length !== elements.length) continue
-
-      // Build extended XYZ frame
-      const frame_lines: string[] = []
-      frame_lines.push(String(elements.length))
-      // Lattice line for extxyz
       const lat = matrix.flat().map((v) => v.toFixed(8)).join(` `)
-      frame_lines.push(`Lattice="${lat}" Properties=species:S:1:pos:R:3 pbc="T T T"`)
-      for (let i = 0; i < elements.length; i++) {
-        const abc = pos_vs[i].textContent!.trim().split(/\s+/).map(Number)
+      const energy_tag = energy !== null ? ` energy=${energy}` : ``
+      const frame_lines: string[] = [
+        String(n),
+        `Lattice="${lat}" Properties=${props}${energy_tag} pbc="T T T"`,
+      ]
+      for (let i = 0; i < n; i++) {
+        const abc = (pos_vs[i].textContent ?? ``).trim().split(/\s+/).map(Number)
         const x = abc[0] * matrix[0][0] + abc[1] * matrix[1][0] + abc[2] * matrix[2][0]
         const y = abc[0] * matrix[0][1] + abc[1] * matrix[1][1] + abc[2] * matrix[2][1]
         const z = abc[0] * matrix[0][2] + abc[1] * matrix[1][2] + abc[2] * matrix[2][2]
-        frame_lines.push(`${elements[i]}  ${x.toFixed(8)}  ${y.toFixed(8)}  ${z.toFixed(8)}`)
+        const f = forces?.[i] ?? [0, 0, 0]
+        const cols = [
+          elements[i],
+          x.toFixed(8), y.toFixed(8), z.toFixed(8),
+          f[0].toFixed(8), f[1].toFixed(8), f[2].toFixed(8),
+        ]
+        if (move_mask) cols.push(move_mask[i])
+        frame_lines.push(cols.join(`  `))
       }
       frames.push(frame_lines.join(`\n`))
     }

--- a/src/lib/structure/pbc.ts
+++ b/src/lib/structure/pbc.ts
@@ -329,7 +329,7 @@ export function get_pbc_image_sites(
   const radii = new Float64Array(n)
   let max_radius = 0
   for (let i = 0; i < n; i++) {
-    const r = covalent_radii.get(geom.elem[i]) ?? 1.5 // already in Å
+    const r = covalent_radii.get(geom.elem[i]!) ?? 1.5 // already in Å
     radii[i] = r
     if (r > max_radius) max_radius = r
   }

--- a/src/lib/structure/scene/render-data.ts
+++ b/src/lib/structure/scene/render-data.ts
@@ -121,6 +121,14 @@ export function compute_force_data(
   const all_forces = structure_sites
     .map((site) => {
       if (!site.properties?.force || !Array.isArray(site.properties.force)) return null
+      // Skip fully-constrained atoms. VASP still prints a (often large) force on
+      // fixed atoms, but it's a constraint reaction, not a relaxation force — it
+      // must not dominate the max/range/arrow display. Fixed atoms arrive either as
+      // selective_dynamics [F,F,F] (POSCAR/CONTCAR) or move_mask=false (trajectory
+      // frames from extxyz / vasprun.xml).
+      const sd = site.properties?.selective_dynamics as [boolean, boolean, boolean] | undefined
+      if (sd && sd[0] === false && sd[1] === false && sd[2] === false) return null
+      if (site.properties?.move_mask === false) return null
       const force = site.properties.force as Vec3
       const magnitude = Math.sqrt(force[0] ** 2 + force[1] ** 2 + force[2] ** 2)
       const majority_element = site.species.reduce((max, spec) =>

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -709,14 +709,16 @@
   })
   // Generate axis labels based on first visible series on each axis
   let y_axis_labels = $derived(generate_axis_labels(plot_series))
+  // Plain decimal (not SI-prefix `~s`): scientific quantities read as "0.8" /
+  // "-213.5", not "800m" / "-210". `~` trims trailing zeros.
   let y_axis = $derived({
     label: y_axis_labels.y1,
-    format: `.2~s`,
+    format: `.3~f`,
     label_shift: { y: 20 },
   })
   let y2_axis = $derived({
     label: y_axis_labels.y2,
-    format: `.2~s`,
+    format: `.3~f`,
     label_shift: { y: 80 },
   })
 

--- a/src/lib/trajectory/extract.ts
+++ b/src/lib/trajectory/extract.ts
@@ -49,12 +49,20 @@ export const force_stress_data_extractor: TrajectoryDataExtractor = (
     if (frame.metadata.forces && Array.isArray(frame.metadata.forces)) {
       const forces = frame.metadata.forces as number[][]
       if (forces.length > 0) {
-        const force_magnitudes = forces.map((force) => Math.hypot(...force))
-        data.force_max = Math.max(...force_magnitudes)
+        // Exclude fully-fixed atoms (move_mask=false) from the F_max / F_norm
+        // convergence curve — a frozen atom's large constraint reaction is not a
+        // relaxation force and must not mask the actual convergence of the free
+        // atoms. Falls back to all atoms when no constraint info is present.
+        const sites = frame.structure?.sites
+        const all_mags = forces.map((force) => Math.hypot(...force))
+        const free_mags = all_mags.filter(
+          (_, i) => sites?.[i]?.properties?.move_mask !== false,
+        )
+        const mags = free_mags.length > 0 ? free_mags : all_mags
+        data.force_max = Math.max(...mags)
         // Calculate RMS (root mean square) of force magnitudes
         data.force_norm = Math.sqrt(
-          force_magnitudes.reduce((sum, f) => sum + f ** 2, 0) /
-            force_magnitudes.length,
+          mags.reduce((sum, f) => sum + f ** 2, 0) / mags.length,
         )
       }
     } else {

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -228,6 +228,13 @@ export async function parse_trajectory_data(
       const { parse_vasprun_trajectory } = await import(`$lib/structure/parse`)
       const extxyz = parse_vasprun_trajectory(content)
       if (extxyz) return parse_xyz_trajectory(extxyz)
+      // Detected a vasprun but produced no frames — surface WHY (truncated read
+      // vs parse failure) instead of the generic "Unsupported text format".
+      const calcs = (content.match(/<calculation/g) || []).length
+      const tail = content.slice(-30).replace(/\s+/g, ` `)
+      throw new Error(
+        `vasprun parse produced no frames: bytes=${content.length}, calcs=${calcs}, tail="${tail}"`,
+      )
     }
 
     // Single XYZ fallback

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -220,8 +220,11 @@ export async function parse_trajectory_data(
       return parse_gaussian_output(content, filename)
     }
 
-    // vasprun.xml trajectory — convert to extxyz then parse
-    if (filename?.toLowerCase().endsWith(`.xml`) && content.includes(`<modeling`)) {
+    // vasprun.xml trajectory — detect by CONTENT, not extension. The filename here
+    // can be a temp/materialized path (large remote files are staged locally before
+    // loading) that no longer ends in `.xml`, so an extension check silently skips
+    // vasprun and the file falls through to the "Unsupported text format" throw.
+    if (content.includes(`<modeling`) && content.includes(`<calculation`)) {
       const { parse_vasprun_trajectory } = await import(`$lib/structure/parse`)
       const extxyz = parse_vasprun_trajectory(content)
       if (extxyz) return parse_xyz_trajectory(extxyz)

--- a/src/lib/trajectory/parsers/common.ts
+++ b/src/lib/trajectory/parsers/common.ts
@@ -128,7 +128,15 @@ export const create_structure = (
     const properties: Record<string, unknown> = force_data?.[idx]
       ? { force: force_data[idx] as Vec3 }
       : {}
-    if (move_mask) properties.move_mask = move_mask[idx]
+    if (move_mask) {
+      properties.move_mask = move_mask[idx]
+      // Also expose as selective dynamics so the frozen-atom indicators (rings),
+      // exporters, and every consumer that reads selective_dynamics (not just
+      // move_mask) see the constraint. move_mask=false → fully fixed [F,F,F].
+      properties.selective_dynamics = move_mask[idx]
+        ? [true, true, true]
+        : [false, false, false]
+    }
     return {
       species: [{ element: elements[idx], occu: 1, oxidation_state: 0 }],
       abc,

--- a/src/lib/trajectory/parsers/vasp.ts
+++ b/src/lib/trajectory/parsers/vasp.ts
@@ -241,13 +241,36 @@ export const parse_vasp_outcar = (content: string, filename?: string): Trajector
         if (nums.length >= 6) forces.push([nums[3], nums[4], nums[5]])
       }
       if (positions.length === n_atoms && lattice) {
+        // Ionic-step energy: the "FREE ENERGIE OF THE ION-ELECTRON SYSTEM"
+        // summary block follows the TOTAL-FORCE block. Prefer energy(sigma->0)
+        // (the extrapolated E0, matching ASE / OSZICAR); fall back to the
+        // free-energy TOTEN on the same block. Stop at the next step's forces.
+        let energy: number | undefined
+        let toten: number | undefined
+        for (let k = i + 1; k < lines.length; k++) {
+          if (lines[k].includes(`TOTAL-FORCE`)) break
+          const es = lines[k].match(/energy\(sigma->0\)\s*=\s*([-\d.eE+]+)/)
+          if (es) { energy = Number(es[1]); break }
+          if (toten === undefined) {
+            const ft = lines[k].match(/free\s+energy\s+TOTEN\s*=\s*([-\d.eE+]+)/)
+            if (ft) toten = Number(ft[1])
+          }
+        }
+        if (energy === undefined) energy = toten
+        const meta: Record<string, unknown> = {
+          volume: math.calc_lattice_params(lattice).volume,
+        }
+        if (energy !== undefined && Number.isFinite(energy)) meta.energy = energy
+        // Expose forces on metadata too (not just site.properties) so the
+        // F_max/F_norm convergence curve has data, matching the extxyz path.
+        if (forces.length === n_atoms) meta.forces = forces
         frames.push(create_trajectory_frame(
           positions,
           elements,
           lattice,
           pbc,
           step++,
-          { volume: math.calc_lattice_params(lattice).volume },
+          meta,
           forces.length === n_atoms ? forces : undefined,
         ))
       }

--- a/src/lib/trajectory/parsers/xyz.ts
+++ b/src/lib/trajectory/parsers/xyz.ts
@@ -127,10 +127,15 @@ export const parse_xyz_trajectory = (content: string): TrajectoryType => {
     if (forces.length > 0) {
       metadata.forces = forces
       const magnitudes = forces.map((force) => Math.hypot(...force))
-      metadata.force_max = Math.max(...magnitudes)
+      // Exclude fully-fixed atoms (move_mask=false) from the reported max/RMS so the
+      // force curve tracks the free atoms actually being relaxed, not a large
+      // constraint reaction on a frozen atom.
+      const free = magnitudes.filter((_, i) => move_mask.length === 0 || move_mask[i] !== false)
+      const mags = free.length > 0 ? free : magnitudes
+      metadata.force_max = Math.max(...mags)
       // Calculate RMS (root mean square) of force magnitudes
       metadata.force_norm = Math.sqrt(
-        magnitudes.reduce((sum, mag) => sum + mag ** 2, 0) / magnitudes.length,
+        mags.reduce((sum, mag) => sum + mag ** 2, 0) / mags.length,
       )
     }
     frames.push(

--- a/src/lib/trajectory/vasp-constraints.ts
+++ b/src/lib/trajectory/vasp-constraints.ts
@@ -1,0 +1,53 @@
+// OUTCAR and XDATCAR carry no selective-dynamics (fixed-atom) information — it
+// lives only in the POSCAR/CONTCAR. These helpers derive the fixed mask from a
+// sibling CONTCAR/POSCAR and stamp it onto an already-parsed trajectory so the
+// frozen-atom rings and the F_max/F_norm curve exclude the constrained atoms,
+// exactly as they do for vasprun.xml (which has the constraints inline).
+
+import { parse_poscar } from '$lib/structure/parse'
+import type { TrajectoryType } from './index'
+
+/** Per-atom "movable" mask from a POSCAR/CONTCAR's selective dynamics.
+ *  true = free (movable in ≥1 direction), false = fully fixed (F F F).
+ *  Returns null when the file declares no selective dynamics. */
+export function move_mask_from_poscar(content: string): boolean[] | null {
+  const parsed = parse_poscar(content)
+  if (!parsed?.sites?.length) return null
+  let any_sd = false
+  const mask = parsed.sites.map((s) => {
+    const sd = s.properties?.selective_dynamics as [boolean, boolean, boolean] | undefined
+    if (sd) any_sd = true
+    return sd ? sd[0] || sd[1] || sd[2] : true
+  })
+  return any_sd ? mask : null
+}
+
+/** Stamp a per-atom movable mask onto every frame of a trajectory (by index —
+ *  VASP preserves atom order across POSCAR/OUTCAR/XDATCAR). Sets both move_mask
+ *  and selective_dynamics so every consumer (frozen rings, F_max curve, force
+ *  arrows, exporters) sees it. No-op + false if the atom counts don't match. */
+export function apply_move_mask(trajectory: TrajectoryType, mask: boolean[]): boolean {
+  const n = trajectory.frames?.[0]?.structure?.sites?.length
+  if (!n || n !== mask.length) return false
+  for (const frame of trajectory.frames) {
+    const sites = frame.structure?.sites
+    if (!sites || sites.length !== mask.length) continue
+    sites.forEach((site, i) => {
+      site.properties = {
+        ...site.properties,
+        move_mask: mask[i],
+        selective_dynamics: mask[i]
+          ? [true, true, true]
+          : [false, false, false],
+      }
+    })
+  }
+  return true
+}
+
+/** True when a trajectory already carries per-atom constraint info (vasprun) and
+ *  therefore needs no sibling-CONTCAR lookup. */
+export function has_constraints(trajectory: TrajectoryType): boolean {
+  const p = trajectory.frames?.[0]?.structure?.sites?.[0]?.properties
+  return !!(p && (p.selective_dynamics || p.move_mask !== undefined))
+}

--- a/tests/vitest/vasp-constraints.test.ts
+++ b/tests/vitest/vasp-constraints.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { apply_move_mask, has_constraints, move_mask_from_poscar } from '$lib/trajectory/vasp-constraints'
+import type { TrajectoryType } from '$lib/trajectory'
+
+// POSCAR with selective dynamics: atom 0 free (T T T), atom 1 fully fixed (F F F).
+const POSCAR = `Pt O test
+1.0
+5.0 0.0 0.0
+0.0 5.0 0.0
+0.0 0.0 5.0
+Pt O
+1 1
+Selective dynamics
+Direct
+0.0 0.0 0.0  T T T
+0.5 0.5 0.5  F F F
+`
+
+function fake_traj(): TrajectoryType {
+  const mk = (force: number[][]) => ({
+    step: 0,
+    metadata: { forces: force },
+    structure: {
+      sites: [
+        { species: [{ element: 'Pt', occu: 1, oxidation_state: 0 }], abc: [0, 0, 0], xyz: [0, 0, 0], label: 'Pt1', properties: {} },
+        { species: [{ element: 'O', occu: 1, oxidation_state: 0 }], abc: [0.5, 0.5, 0.5], xyz: [2.5, 2.5, 2.5], label: 'O2', properties: {} },
+      ],
+    },
+  })
+  return { frames: [mk([[0.1, 0, 0], [3.0, 0, 0]])], metadata: {} } as unknown as TrajectoryType
+}
+
+describe('vasp-constraints (OUTCAR/XDATCAR sibling CONTCAR)', () => {
+  it('move_mask_from_poscar: free atom true, fully-fixed atom false', () => {
+    expect(move_mask_from_poscar(POSCAR)).toEqual([true, false])
+  })
+
+  it('returns null when the POSCAR has no selective dynamics', () => {
+    const no_sd = POSCAR.replace('Selective dynamics\n', '')
+    expect(move_mask_from_poscar(no_sd)).toBeNull()
+  })
+
+  it('apply_move_mask stamps selective_dynamics + move_mask on every frame', () => {
+    const traj = fake_traj()
+    expect(has_constraints(traj)).toBe(false)
+    expect(apply_move_mask(traj, [true, false])).toBe(true)
+    expect(has_constraints(traj)).toBe(true)
+    const sites = traj.frames[0].structure.sites
+    expect(sites[1].properties?.selective_dynamics).toEqual([false, false, false])
+    expect(sites[1].properties?.move_mask).toBe(false)
+    expect(sites[0].properties?.move_mask).toBe(true)
+  })
+
+  it('apply_move_mask no-ops on atom-count mismatch', () => {
+    const traj = fake_traj()
+    expect(apply_move_mask(traj, [true])).toBe(false)
+  })
+})

--- a/tests/vitest/vasprun-trajectory.test.ts
+++ b/tests/vitest/vasprun-trajectory.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { parse_vasprun_trajectory } from '$lib/structure/parsers/vasp'
+import { parse_xyz_trajectory } from '$lib/trajectory/parsers/xyz'
+import { compute_force_data } from '$lib/structure/scene/render-data'
+import type { Site } from '$lib'
+
+// vasprun.xml with a fixed atom (O, selective F F F) that carries the LARGEST
+// force. The energy/force curves and the force arrows must ignore it — the max
+// force belongs to the free atom (Cu).
+const VASPRUN = `<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <atominfo>
+  <array name="atoms">
+   <set>
+    <rc><c>Cu</c><c>1</c></rc>
+    <rc><c>O </c><c>2</c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos">
+  <varray name="selective">
+   <v> T  T  T </v>
+   <v> F  F  F </v>
+  </varray>
+ </structure>
+ <calculation>
+  <structure>
+   <crystal>
+    <varray name="basis">
+     <v> 5 0 0 </v><v> 0 5 0 </v><v> 0 0 5 </v>
+    </varray>
+   </crystal>
+   <varray name="positions">
+    <v> 0.0 0.0 0.0 </v><v> 0.5 0.5 0.5 </v>
+   </varray>
+  </structure>
+  <varray name="forces">
+   <v> 0.10 0 0 </v><v> 3.00 0 0 </v>
+  </varray>
+  <energy><i name="e_fr_energy"> -10.5 </i><i name="e_0_energy"> -10.4 </i></energy>
+ </calculation>
+ <calculation>
+  <structure>
+   <crystal>
+    <varray name="basis">
+     <v> 5 0 0 </v><v> 0 5 0 </v><v> 0 0 5 </v>
+    </varray>
+   </crystal>
+   <varray name="positions">
+    <v> 0.0 0.0 0.0 </v><v> 0.5 0.5 0.5 </v>
+   </varray>
+  </structure>
+  <varray name="forces">
+   <v> 0.05 0 0 </v><v> 2.50 0 0 </v>
+  </varray>
+  <energy><i name="e_fr_energy"> -11.0 </i></energy>
+ </calculation>
+</modeling>`
+
+describe('vasprun.xml trajectory (energy + forces + selective dynamics)', () => {
+  it('emits extxyz with energy, forces, and a move_mask column', () => {
+    const extxyz = parse_vasprun_trajectory(VASPRUN)
+    expect(extxyz).not.toBeNull()
+    expect(extxyz!).toContain('energy=-10.5')
+    expect(extxyz!).toContain('energy=-11')
+    expect(extxyz!).toContain('forces:R:3')
+    expect(extxyz!).toContain('move_mask:L:1')
+  })
+
+  it('parses two frames with per-step energy; force_max excludes the fixed atom', () => {
+    const extxyz = parse_vasprun_trajectory(VASPRUN)!
+    const traj = parse_xyz_trajectory(extxyz)
+    expect(traj.frames.length).toBe(2)
+    expect(traj.frames[0].metadata.energy).toBeCloseTo(-10.5, 6)
+    expect(traj.frames[1].metadata.energy).toBeCloseTo(-11.0, 6)
+    // Fixed O atom has |F|=3.0 but is F F F → force curve must report the free
+    // Cu atom's 0.1, NOT 3.0.
+    expect(traj.frames[0].metadata.force_max).toBeCloseTo(0.1, 6)
+    expect(traj.frames[1].metadata.force_max).toBeCloseTo(0.05, 6)
+    // The fixed atom is flagged movable=false on the site.
+    expect(traj.frames[0].structure.sites[1].properties?.move_mask).toBe(false)
+    expect(traj.frames[0].structure.sites[0].properties?.move_mask).toBe(true)
+  })
+
+  it('compute_force_data max_only picks the free atom, not the larger fixed force', () => {
+    const sites = [
+      { species: [{ element: 'Cu', occu: 1, oxidation_state: 0 }], abc: [0, 0, 0], xyz: [0, 0, 0], label: 'Cu1', properties: { force: [0.1, 0, 0], move_mask: true } },
+      { species: [{ element: 'O', occu: 1, oxidation_state: 0 }], abc: [0.5, 0.5, 0.5], xyz: [2.5, 2.5, 2.5], label: 'O2', properties: { force: [3.0, 0, 0], move_mask: false } },
+    ] as unknown as Site[]
+    const arrows = compute_force_data(sites, 1, '#fff', 'element', 'max_only', {}, 0, Infinity)
+    expect(arrows.length).toBe(1)
+    expect(arrows[0].magnitude).toBeCloseTo(0.1, 6) // Cu, not the fixed O's 3.0
+    expect(arrows[0].position).toEqual([0, 0, 0])
+  })
+})


### PR DESCRIPTION
Opening a VASP relaxation in the viewer should show its energy + force-convergence curves and mark the fixed (selective-dynamics) atoms, with the **max force reported on the free atoms** — not on a frozen atom's large constraint reaction. This PR makes that work across all three VASP trajectory formats.

## What was broken

- **vasprun.xml wouldn't load at all** ("Unsupported text format") — extension-based routing missed it, and WebKitGTK's DOMParser rejected the `<?xml encoding="ISO-8859-1"?>` prolog; large files were truncated → malformed XML.
- The **F_max/F_norm curve and force arrows included fixed atoms** (~0.6 eV/Å) so the curve never showed the real ~0.03 convergence.
- **OUTCAR/XDATCAR** had no energy curve and no fixed-atom info (that data isn't in those files).
- Force axis rendered as `800m` (SI prefix) instead of `0.8`.

## Fixes

**vasprun.xml**
- Detect by **content** (`<modeling>`+`<calculation>`), not extension.
- Strip the XML prolog before `DOMParser` (WebKitGTK encoding gotcha).
- Read multi-frame remote files **in full** (no byte cap) so the XML is well-formed.
- Parse per-step **energy** (`e_fr_energy`), **forces**, and **selective dynamics** → `move_mask`.

**Fixed-atom masking (all formats)**
- `compute_force_data` (arrows) + the `extract`/xyz `force_max`/`force_norm` (curve) exclude fully-fixed atoms.
- Trajectory frames expose the mask as both `move_mask` **and** `selective_dynamics`, so the frozen-atom rings, exporters, and force display all see it.

**OUTCAR / XDATCAR**
- `parse_vasp_outcar` extracts per-step energy + exposes forces on metadata (energy + force curves).
- On open, fetch a **sibling CONTCAR/POSCAR** (remote via SSH session, local via filesystem) and stamp its selective dynamics onto every frame — so OUTCAR/XDATCAR match vasprun.

**Misc**
- Trajectory plot axes use plain decimals (`0.8` / `-213.5`), not SI prefixes.
- Cleared all **12 pre-existing svelte-check errors** (pbc index, Blob part cast, pdf.js RenderParameters, gesture-test fetch mocks) → `svelte-check` reports **0 errors**.

## Verification

Validated against a real Expanse relaxation (Pt111_OH, 44 steps): last-frame F_max **0.63 (all atoms) → 0.026 (free only)**; 18 fixed / 20 free; OUTCAR + sibling CONTCAR reproduces the same. New pure-function vitest for the vasprun parser, force masking, and sibling-constraint helpers; `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)