### PR TITLE
chore(release): v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.4] - 2026-07-08
+
+### Added
+- **Full VASP trajectory support** — `vasprun.xml`, `OUTCAR`, and `XDATCAR` open with energy and force-convergence (F<sub>max</sub>/F<sub>norm</sub>) curves. The reported max force is on the **free** atoms, not a frozen atom's constraint reaction, and fixed atoms show their selective-dynamics rings. `OUTCAR`/`XDATCAR` carry no constraint info, so it's pulled from a sibling `CONTCAR`/`POSCAR` (remote via the SSH session, local via the filesystem). `vasprun.xml` now also parses reliably on Linux/WebKitGTK and is read in full instead of truncated.
+
+### Fixed
+- **Selected-atom rotation follows the screen** — rotating selected atoms turns about the on-screen axes, not the (possibly reoriented) cell axes.
+- **Remote terminal survives full-screen programs** — `vi`/`vim`/`less`/`top`/`tmux` no longer drop the SSH connection instantly; the asyncssh PTY is binary-safe and driven on its owner loop.
+- **Terminal Ctrl+click opens remote files** — the session id is threaded through the file-open path, so an existing remote file no longer comes back "Not found".
+- **Download buttons work in the desktop app** — every export / plot / structure download now routes through the native save dialog; WebKitGTK silently ignored the old `<a download>` clicks.
+- Trajectory plot axes read as plain decimals (`0.8`, not `800m`).
+
 ## [1.4.3] - 2026-07-06
 
 ### Fixed

--- a/deploy/download/index.html
+++ b/deploy/download/index.html
@@ -351,7 +351,7 @@
 
 <script>
   // Single source of truth for the current release — bump on each release.
-  const VERSION = "1.4.3";
+  const VERSION = "1.4.4";
   const REPO = "https://github.com/Hello-QM/catgo-LRG";
   const APK = `${REPO}/releases/download/v${VERSION}/CatGo-v${VERSION}-android-universal.apk`;
   const LATEST = `${REPO}/releases/latest`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.3"
+version = "1.4.4"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
Version bump to 1.4.4 across package.json / tauri.conf.json / Cargo.toml+lock / download page + CHANGELOG. Tag `v1.4.4` is already building the release; this lands the bump on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)