### PR TITLE
Add molfile open support

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -93,6 +93,7 @@
   import { create_tab_manager } from './lib/tab-manager.svelte'
   // Extracted close-all helpers (pure functions)
   import { build_close_all_entries, execute_close_all_saves, close_all_structure_tabs } from './lib/close-all-helper'
+  import { parse_molfile } from './lib/molfile'
   // Extracted keyboard shortcuts (pure function factory)
   import { create_handle_keydown } from './lib/keyboard-shortcuts'
   // Extracted popout manager
@@ -652,6 +653,18 @@
     { name: `Water`, description: `H₂O molecule`, formula: `H₂O`, data: water as unknown as AnyStructure },
   ]
 
+  function parse_structure_text(text: string, filename: string): AnyStructure | null {
+    let parsed: AnyStructure | null | undefined = null
+    try {
+      parsed = parse_structure_file(text, filename) as AnyStructure | null | undefined
+    } catch (err) {
+      if (!/\.(mol|sdf)$/i.test(filename)) throw err
+    }
+    if (parsed?.sites?.length) return parsed as AnyStructure
+    if (/\.(mol|sdf)$/i.test(filename)) return parse_molfile(text) as AnyStructure | null
+    return null
+  }
+
   $effect(() => {
     sidebar.persist()
   })
@@ -712,7 +725,7 @@
     sidebar.editor_on_save = (new_content: string) => {
       // Parse text back into structure and update the pane
       try {
-        const parsed = parse_structure_file(new_content, filename)
+        const parsed = parse_structure_text(new_content, filename)
         if (parsed?.sites?.length) {
           const target_ts = tab_states[target_tab_id]
           const leaf = target_ts ? findLeafById(target_ts.root, target_leaf_id) : null
@@ -1319,7 +1332,7 @@
       }
     }
 
-    const parsed = parse_structure_file(text, filename)
+    const parsed = parse_structure_text(text, filename)
     if (parsed?.sites?.length) {
       return { kind: `entry`, entry: { filename, source_path: null, format: ext, structure: parsed, trajectory: undefined, is_trajectory: false, cube_file: null } }
     }
@@ -1445,7 +1458,7 @@
     if (p.viewer_kind === `molstar`) {
       // → native: parse the raw text on demand (lazy; only when overridden).
       if (p.bio_raw_content) {
-        const parsed = parse_structure_file(p.bio_raw_content, p.source_filename || `bio`)
+        const parsed = parse_structure_text(p.bio_raw_content, p.source_filename || `bio`)
         if (parsed?.sites?.length) {
           p.structure = parsed
           p.initial_site_count = parsed.sites.length
@@ -2111,7 +2124,7 @@
   bind:this={file_input_ref}
   type="file"
   multiple
-  accept=".cif,.poscar,.vasp,.xyz,.json,.extxyz,.traj,.h5,.hdf5,.gz,.bz2,.xz,.zst,.cube,.cub,.xml,.data,.lammps,*"
+  accept=".cif,.poscar,.vasp,.xyz,.json,.extxyz,.mol,.sdf,.mol2,.traj,.h5,.hdf5,.gz,.bz2,.xz,.zst,.cube,.cub,.xml,.data,.lammps,*"
   onchange={handle_file_input}
   hidden
 />

--- a/desktop/lib/molfile.ts
+++ b/desktop/lib/molfile.ts
@@ -1,0 +1,36 @@
+type MolfileStructure = {
+  sites: Array<{
+    species: Array<{ element: string; occu: number }>
+    abc: number[]
+    xyz: number[]
+    label: string
+    properties: Record<string, never>
+  }>
+  charge: number
+  spin_multiplicity: number
+}
+
+export function parse_molfile(text: string): MolfileStructure | null {
+  const lines = text.replace(/\r\n/g, `\n`).split(`\n`)
+  if (lines.length < 4) return null
+  const counts = lines[3] ?? ``
+  const atom_count = Number.parseInt(counts.slice(0, 3).trim(), 10)
+  if (!Number.isFinite(atom_count) || atom_count <= 0) return null
+  const sites = []
+  for (let i = 0; i < atom_count; i++) {
+    const line = lines[4 + i] ?? ``
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 4) return null
+    const xyz = parts.slice(0, 3).map(Number)
+    const element = parts[3]
+    if (xyz.some(n => !Number.isFinite(n)) || !/^[A-Z][a-z]?$/.test(element)) return null
+    sites.push({
+      species: [{ element, occu: 1 }],
+      abc: [0, 0, 0],
+      xyz,
+      label: element,
+      properties: {},
+    })
+  }
+  return { sites, charge: 0, spin_multiplicity: 1 }
+}

--- a/desktop/lib/popout-manager.ts
+++ b/desktop/lib/popout-manager.ts
@@ -9,6 +9,7 @@ import type { AnyStructure } from '$lib'
 import type { StructureTabState } from '../pane-utils'
 import { findLeafById, leaves, isTerminalLeaf, structurePane } from '../pane-tree'
 import { pending_open_structure } from '$lib/workflow/workflow-state.svelte'
+import { parse_molfile } from './molfile'
 
 /**
  * Open a FILE PATH in a new app window that loads/streams it there. Used for
@@ -106,7 +107,13 @@ export async function parse_and_open_structure_window(content: string, filename:
       }
     }
     const { parse_structure_file } = await import(`$lib/structure/parse`)
-    const parsed = parse_structure_file(content, filename)
+    let parsed: AnyStructure | null | undefined = null
+    try {
+      parsed = parse_structure_file(content, filename) as AnyStructure | null | undefined
+    } catch (err) {
+      if (!/\.(mol|sdf)$/i.test(filename)) throw err
+    }
+    parsed ??= /\.(mol|sdf)$/i.test(filename) ? parse_molfile(content) as AnyStructure | null : null
     if (parsed) {
       await open_structure_in_new_window(parsed as AnyStructure, filename, is_tauri, reuse)
     }


### PR DESCRIPTION
  ## Summary
  - add a lightweight MDL V2000 molfile parser for .mol/.sdf fallback imports
  - include .mol/.sdf/.mol2 in the desktop file picker
  - use the molfile fallback for pane imports, text edit reparsing, and popout windows

  ## Verification
  - node --experimental-strip-types parser check with a V2000 water sample
  - npx -p typescript@5 tsc --noEmit --strict --target esnext --module esnext --moduleResolution bundler --skipLibCheck
  desktop\lib\molfile.ts