### PR TITLE
feat(viewer): visualize per-atom magnetic moment vectors (+ OUTCAR magmom parsing)

### DIFF
--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -9,6 +9,7 @@ const structure: Record<string, string> = {
   site_indices: `Site Indices`,
   label_offset: `Label offset`,
   force_vectors: `Force Vectors`,
+  magmom_vectors: `Magnetic Moments`,
   unit_cell: `Unit Cell`,
   lattice_vectors: `Lattice Vectors`,
   bonds: `Bonds`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -9,6 +9,7 @@ const structure: Record<string, string> = {
   site_indices: `位点序号`,
   label_offset: `标签偏移`,
   force_vectors: `受力向量`,
+  magmom_vectors: `磁矩`,
   unit_cell: `晶胞`,
   lattice_vectors: `晶格向量`,
   bonds: `成键`,

--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -548,6 +548,28 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       description:
         `Force color mode: element (match atom color) or custom (use force_color setting)`,
     },
+    // Magnetic moments
+    show_magmom_vectors: {
+      value: false,
+      description:
+        `Display per-atom magnetic moment vectors as arrows (from site magmom — ` +
+        `scalar collinear moments point along z, non-collinear use their 3-vector; ` +
+        `red = spin up, blue = spin down)`,
+    },
+    magmom_scale: {
+      value: 1.0,
+      description: `Scale factor for magnetic moment arrows (Å per µB)`,
+      minimum: 0.05,
+      maximum: 10,
+    },
+    magmom_up_color: {
+      value: `#e0524a`,
+      description: `Colour for spin-up magnetic moment arrows`,
+    },
+    magmom_down_color: {
+      value: `#4a6fe0`,
+      description: `Colour for spin-down magnetic moment arrows`,
+    },
     show_cell: {
       value: true,
       description: `Display system cell`,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -231,6 +231,10 @@ export interface SettingsConfig {
     force_range_min: SettingType<number>
     force_range_max: SettingType<number>
     force_color_mode: SettingType<`element` | `custom`>
+    show_magmom_vectors: SettingType<boolean>
+    magmom_scale: SettingType<number>
+    magmom_up_color: SettingType<string>
+    magmom_down_color: SettingType<string>
     show_cell: SettingType<boolean>
     show_cell_vectors: SettingType<boolean>
     show_scale_bar: SettingType<boolean>

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -151,6 +151,15 @@
     ) ?? false,
   )
 
+  // Detect per-atom magnetic moments (scalar collinear or 3-vector non-collinear).
+  let has_magmom = $derived(
+    structure?.sites?.some((site) => {
+      const m = site.properties?.magmom
+      return typeof m === `number` ? Math.abs(m) > 1e-3
+        : Array.isArray(m) && m.length === 3
+    }) ?? false,
+  )
+
   // Detect if structure has lattice (can create supercells)
   let has_lattice = $derived(
     structure && `lattice` in structure && structure.lattice !== undefined,
@@ -398,6 +407,16 @@
         >
           <input type="checkbox" bind:checked={scene_props.show_force_vectors} />
           {t('structure.force_vectors')}
+        </label>
+      {/if}
+      {#if has_magmom}
+        <label
+          {@attach tooltip({
+            content: SETTINGS_CONFIG.structure.show_magmom_vectors.description,
+          })}
+        >
+          <input type="checkbox" bind:checked={scene_props.show_magmom_vectors} />
+          {t('structure.magmom_vectors')}
         </label>
       {/if}
       <label

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -34,6 +34,7 @@
     get_frozen_info,
     desaturate_color,
     compute_force_data,
+    compute_magmom_data,
     get_majority_color,
     toggle_site_selection,
     clean_measured_sites,
@@ -443,6 +444,10 @@
     site_label_padding = 3,
     show_force_vectors = DEFAULTS.structure.show_force_vectors,
     force_scale = DEFAULTS.structure.force_scale,
+    show_magmom_vectors = DEFAULTS.structure.show_magmom_vectors,
+    magmom_scale = DEFAULTS.structure.magmom_scale,
+    magmom_up_color = DEFAULTS.structure.magmom_up_color,
+    magmom_down_color = DEFAULTS.structure.magmom_down_color,
     force_color = DEFAULTS.structure.force_color,
     force_display_mode = DEFAULTS.structure.force_display_mode,
     force_color_mode = DEFAULTS.structure.force_color_mode,
@@ -707,6 +712,10 @@
     show_site_indices?: boolean
     show_force_vectors?: boolean
     force_scale?: number
+    show_magmom_vectors?: boolean
+    magmom_scale?: number
+    magmom_up_color?: string
+    magmom_down_color?: string
     force_color?: string
     force_display_mode?: `all` | `max_only` | `range`
     force_color_mode?: `element` | `custom`
@@ -4699,6 +4708,16 @@
     )
   })
 
+  let magmom_data = $derived.by(() => {
+    if (webgl_suspended) return []
+    if (!show_magmom_vectors || !structure?.sites) return []
+    // Magnetic moments come from the per-site `magmom` property (scalar collinear
+    // or 3-vector non-collinear) — see compute_magmom_data.
+    return compute_magmom_data(
+      structure.sites, magmom_scale, magmom_up_color, magmom_down_color,
+    )
+  })
+
   // Build a set for fast selected_sites lookup
   let selected_sites_set = $derived.by(() => new Set(selected_sites))
 
@@ -5498,6 +5517,12 @@
       {#if force_data.length > 0}
         {#each force_data as force (force.position.join(`,`) + force.vector.join(`,`))}
           <Arrow {...force} />
+        {/each}
+      {/if}
+
+      {#if magmom_data.length > 0}
+        {#each magmom_data as magmom (magmom.position.join(`,`) + magmom.vector.join(`,`))}
+          <Arrow {...magmom} />
         {/each}
       {/if}
 

--- a/src/lib/structure/parsers/outcar.ts
+++ b/src/lib/structure/parsers/outcar.ts
@@ -81,6 +81,56 @@ function last_positions(lines: string[], n_atoms: number): Vec3[] | null {
   return out.length > 0 ? out : null
 }
 
+// Per-atom magnetic moments from the LAST "magnetization (axis)" table.
+// Layout:  magnetization (x) \n \n # of ion  s  p  d  tot \n ---- \n
+//          <ion> <s> <p> <d> <tot> ... \n ---- \n tot  ...
+// The per-ion `tot` column (last number) is that atom's moment along `axis`.
+function magnetization_block(
+  lines: string[],
+  axis: `x` | `y` | `z`,
+  n_atoms: number,
+): number[] | null {
+  const marker = `magnetization (${axis})`
+  let found = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(marker)) found = i
+  }
+  if (found < 0) return null
+  const vals: number[] = []
+  let in_rows = false
+  for (let i = found + 1; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line.startsWith(`# of ion`)) continue
+    if (line.startsWith(`---`)) {
+      if (!in_rows) { in_rows = true; continue } // header separator → rows begin
+      break // trailing separator → block ends
+    }
+    if (!in_rows || line === ``) continue
+    const nums = line.split(/\s+/).map(Number)
+    // Stop at the trailing "tot" summary row (non-numeric first column).
+    if (nums.length < 2 || Number.isNaN(nums[0])) break
+    vals.push(nums[nums.length - 1])
+    if (n_atoms > 0 && vals.length === n_atoms) break
+  }
+  return vals.length > 0 ? vals : null
+}
+
+/** Per-atom magmom: scalar (collinear, only the x table) or [mx,my,mz]
+ *  (non-collinear, all three tables present). */
+function last_magnetization(
+  lines: string[],
+  n_atoms: number,
+): (number | Vec3)[] | null {
+  const mx = magnetization_block(lines, `x`, n_atoms)
+  if (!mx) return null
+  const my = magnetization_block(lines, `y`, n_atoms)
+  const mz = magnetization_block(lines, `z`, n_atoms)
+  if (my && mz && my.length === mx.length && mz.length === mx.length) {
+    return mx.map((x, i) => [x, my[i], mz[i]] as Vec3)
+  }
+  return mx
+}
+
 export function parse_outcar(content: string): ParsedStructure | null {
   try {
     const lines = content.split(/\r?\n/)
@@ -102,6 +152,16 @@ export function parse_outcar(content: string): ParsedStructure | null {
     }
 
     if (sites.length === 0) return null
+
+    // Attach per-atom magnetic moments (spin-polarised runs only) so the viewer
+    // can draw magmom arrows without any extra setup.
+    const magmoms = last_magnetization(lines, sites.length)
+    if (magmoms && magmoms.length === sites.length) {
+      for (let i = 0; i < sites.length; i++) {
+        sites[i].properties = { ...(sites[i].properties ?? {}), magmom: magmoms[i] }
+      }
+    }
+
     return { sites, lattice: periodic_lattice(matrix) }
   } catch (error) {
     console.error(`Error parsing OUTCAR file:`, error)

--- a/src/lib/structure/scene/index.ts
+++ b/src/lib/structure/scene/index.ts
@@ -15,6 +15,7 @@ export {
   get_position_hash,
   get_structure_fingerprint,
   compute_force_data,
+  compute_magmom_data,
   get_majority_element,
   get_majority_color,
 } from './render-data'

--- a/src/lib/structure/scene/render-data.ts
+++ b/src/lib/structure/scene/render-data.ts
@@ -162,6 +162,51 @@ export function compute_force_data(
   return all_forces
 }
 
+/** Compute magnetic-moment arrow data from structure sites.
+ *
+ * Reads `site.properties.magmom`, which pymatgen carries either as a scalar
+ * (collinear / ISPIN=2 — the moment is along the spin quantization axis, drawn
+ * along +z, sign = up/down) or as a 3-vector [mx,my,mz] (non-collinear — a true
+ * direction). Arrows are coloured by the sign of the z-component so spin-up and
+ * spin-down read at a glance (red up / blue down). */
+export function compute_magmom_data(
+  structure_sites: Site[],
+  magmom_scale: number,
+  up_color: string,
+  down_color: string,
+): {
+  position: Vec3
+  vector: Vec3
+  scale: number
+  color: string
+  magnitude: number
+}[] {
+  return structure_sites
+    .map((site) => {
+      const raw = site.properties?.magmom as number | number[] | undefined
+      if (raw === undefined || raw === null) return null
+      let vector: Vec3
+      if (typeof raw === `number`) {
+        vector = [0, 0, raw]
+      } else if (Array.isArray(raw) && raw.length === 3) {
+        vector = [raw[0], raw[1], raw[2]] as Vec3
+      } else {
+        return null
+      }
+      const magnitude = Math.sqrt(vector[0] ** 2 + vector[1] ** 2 + vector[2] ** 2)
+      // Skip effectively-zero moments (non-magnetic atoms) — no arrow clutter.
+      if (magnitude < 1e-3) return null
+      return {
+        position: site.xyz,
+        vector,
+        scale: magmom_scale,
+        color: vector[2] >= 0 ? up_color : down_color,
+        magnitude,
+      }
+    })
+    .filter((item): item is NonNullable<typeof item> => item !== null)
+}
+
 /**
  * Get the majority element of a site (the species with highest occupancy).
  */

--- a/tests/vitest/structure/outcar-magmom.test.ts
+++ b/tests/vitest/structure/outcar-magmom.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest'
+import { parse_outcar } from '$lib/structure/parsers/outcar'
+
+// Minimal OUTCAR: 2 Fe atoms + a collinear "magnetization (x)" table (AFM: +3/-3).
+const OUTCAR_COLLINEAR = ` VRHFIN =Fe: s2p2
+ ions per type =               2
+
+      direct lattice vectors
+     2.870000000  0.000000000  0.000000000
+     0.000000000  2.870000000  0.000000000
+     0.000000000  0.000000000  2.870000000
+
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------
+     0.00000      0.00000      0.00000         0.000000  0.000000  0.000000
+     1.43500      1.43500      1.43500         0.000000  0.000000  0.000000
+ -----------------------------------------------------------------------------
+
+ magnetization (x)
+
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.010   0.020   2.970   3.000
+    2       -0.010  -0.020  -2.970  -3.000
+--------------------------------------------------
+tot          0.000   0.000   0.000   0.000
+`
+
+// Same but non-collinear: (x)/(y)/(z) tables → a 3-vector moment per atom.
+const OUTCAR_NONCOLLINEAR = OUTCAR_COLLINEAR
+  + `
+ magnetization (y)
+
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.000   0.000   1.000   1.000
+    2        0.000   0.000  -1.000  -1.000
+--------------------------------------------------
+tot          0.000   0.000   0.000   0.000
+
+ magnetization (z)
+
+# of ion       s       p       d       tot
+------------------------------------------
+    1        0.000   0.000   0.500   0.500
+    2        0.000   0.000  -0.500  -0.500
+--------------------------------------------------
+tot          0.000   0.000   0.000   0.000
+`
+
+describe(`parse_outcar magmom`, () => {
+  test(`collinear: scalar magmom per atom (tot column)`, () => {
+    const s = parse_outcar(OUTCAR_COLLINEAR)
+    expect(s).not.toBeNull()
+    expect(s!.sites).toHaveLength(2)
+    expect(s!.sites[0].properties?.magmom).toBe(3)
+    expect(s!.sites[1].properties?.magmom).toBe(-3)
+  })
+
+  test(`non-collinear: [mx,my,mz] vector per atom`, () => {
+    const s = parse_outcar(OUTCAR_NONCOLLINEAR)
+    expect(s).not.toBeNull()
+    expect(s!.sites[0].properties?.magmom).toEqual([3, 1, 0.5])
+    expect(s!.sites[1].properties?.magmom).toEqual([-3, -1, -0.5])
+  })
+})

--- a/tests/vitest/structure/scene.test.ts
+++ b/tests/vitest/structure/scene.test.ts
@@ -31,6 +31,7 @@ import {
   get_position_hash,
   get_structure_fingerprint,
   compute_force_data,
+  compute_magmom_data,
   get_majority_element,
   get_majority_color,
 } from '$lib/structure/scene/render-data'
@@ -627,5 +628,45 @@ describe(`get_majority_color`, () => {
 
   test(`returns fallback for undefined site`, () => {
     expect(get_majority_color(undefined, { Si: `#aabb00` }, `#123456`)).toBe(`#123456`)
+  })
+})
+
+describe(`compute_magmom_data`, () => {
+  const UP = `#e0524a`, DOWN = `#4a6fe0`
+
+  test(`returns empty for sites without magmom`, () => {
+    expect(compute_magmom_data([make_site([0, 0, 0])], 1, UP, DOWN)).toHaveLength(0)
+  })
+
+  test(`scalar collinear magmom → z arrow, coloured by sign`, () => {
+    const sites = [
+      make_site([0, 0, 0], `Fe`, { magmom: 2.5 }),
+      make_site([1, 0, 0], `Fe`, { magmom: -2.5 }),
+    ]
+    const r = compute_magmom_data(sites, 1.5, UP, DOWN)
+    expect(r).toHaveLength(2)
+    expect(r[0].vector).toEqual([0, 0, 2.5])
+    expect(r[0].color).toBe(UP)
+    expect(r[0].scale).toBe(1.5)
+    expect(r[1].vector).toEqual([0, 0, -2.5])
+    expect(r[1].color).toBe(DOWN)
+  })
+
+  test(`non-collinear 3-vector magmom passes through with magnitude`, () => {
+    const sites = [make_site([0, 0, 0], `Ni`, { magmom: [0, 3, 4] })]
+    const r = compute_magmom_data(sites, 1, UP, DOWN)
+    expect(r).toHaveLength(1)
+    expect(r[0].vector).toEqual([0, 3, 4])
+    expect(r[0].magnitude).toBeCloseTo(5)
+    expect(r[0].color).toBe(UP) // z-component >= 0
+  })
+
+  test(`skips effectively-zero moments`, () => {
+    const sites = [
+      make_site([0, 0, 0], `O`, { magmom: 0 }),
+      make_site([1, 0, 0], `O`, { magmom: 0.0001 }),
+      make_site([2, 0, 0], `Fe`, { magmom: 1.2 }),
+    ]
+    expect(compute_magmom_data(sites, 1, UP, DOWN)).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Summary

Visualize per-atom **magnetic moment vectors** in the 3D viewer, mirroring the existing force-vector path.

- `compute_magmom_data` reads `site.properties.magmom`: a **scalar** (collinear / ISPIN=2 → drawn along z, sign = spin up/down) or a **3-vector** `[mx,my,mz]` (non-collinear → true direction). Arrows are coloured **red = up / blue = down**.
- Rendered with the same `Arrow` component as forces; a **"Magnetic Moments"** controls toggle appears only when the structure carries magmom (`has_magmom` gate).
- New settings: `show_magmom_vectors` / `magmom_scale` / `magmom_up_color` / `magmom_down_color`. en/zh i18n in parity.
- **OUTCAR parsing**: `parse_outcar` now extracts per-atom moments from the last `magnetization (x)` (+ `(y)/(z)` for non-collinear) tables into `site.properties.magmom`, so opening a magnetic VASP OUTCAR surfaces the toggle + arrows with no extra setup.

## Verification
- Unit tests: `compute_magmom_data` (scalar / vector / zero-skip / colour-by-sign) + `parse_outcar` magmom (collinear + non-collinear).
- Live: loaded an Fe antiferromagnet (magmom ±3) — red spin-up + blue spin-down arrows render (confirmed the exact `#e0524a`/`#4a6fe0` cones in the scene).
- `pnpm check`: 0 errors.

## Notes
- Data source: OUTCAR (added) + pymatgen structures that already carry `site.properties.magmom`. vasprun.xml does not reliably carry per-atom moments, so it is intentionally not parsed for magmom.
