### PR TITLE
feat(cli): pip-installable catgo — bare `catgo` launches the app, SPA bundled in the wheel

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,96 @@
+name: pypi-publish
+
+# Build the frontend, bundle it into the `catgo` wheel, and publish to PyPI.
+# Triggers on a published GitHub Release, or manually via workflow_dispatch.
+#
+# Auth: set the `PYPI_API_TOKEN` repo secret (a PyPI project/API token). Or drop
+# the `password:` line and configure Trusted Publishing (OIDC) on the PyPI
+# project — the `id-token: write` permission below already enables it.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build the wheel but do not publish'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write   # required for PyPI Trusted Publishing (OIDC)
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+
+      - name: Setup Rust (+ wasm target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install JS deps
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build WASM crates
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+          cd extensions/rust
+          wasm-pack build --target web --out-dir ../rust-wasm/pkg --features wasm
+          cd ../chgdiff-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/electronic/chgdiff-wasm-pkg
+          cd ../catrender-wasm
+          wasm-pack build --target web --out-dir ../../src/lib/structure/catrender/catrender-wasm-pkg
+
+      - name: Build doc chunks
+        run: pnpm run build:doc-chunks
+
+      - name: Build static SPA
+        run: pnpm desktop:build
+
+      - name: Bundle SPA into the Python package
+        run: node scripts/bundle-web.mjs
+
+      - name: Build wheel
+        # Wheel only — the bundled SPA (catgo/web) is a git-ignored artifact that
+        # an sdist would omit, and the wheel is universal (py3-none-any) anyway.
+        run: |
+          python -m pip install --upgrade build
+          cd server
+          python -m build --wheel
+
+      - name: Check artifacts
+        run: |
+          ls -lh server/dist/
+          python -m pip install --upgrade twine
+          twine check server/dist/*
+
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' || !inputs.dry_run }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: server/dist/
+          # Remove `password:` to use Trusted Publishing (OIDC) instead.
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ repro-*.jpeg
 repro-*.png
 server/catgo/data/
 .understand-anything/
+server/catgo/web/

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ repro-*.png
 server/catgo/data/
 .understand-anything/
 server/catgo/web/
+server/dist_test/

--- a/scripts/bundle-web.mjs
+++ b/scripts/bundle-web.mjs
@@ -1,0 +1,19 @@
+// Copy the built SPA (build-desktop/) into the Python package (server/catgo/web/)
+// so `python -m build` bundles a working UI into the `catgo` wheel. Run after
+// `pnpm desktop:build` and before building the wheel. See server/pyproject.toml
+// ([tool.hatch.build.targets.wheel].artifacts) for the whitelist that ships it.
+import { cpSync, existsSync, rmSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), `..`)
+const src = resolve(root, `build-desktop`)
+const dst = resolve(root, `server/catgo/web`)
+
+if (!existsSync(resolve(src, `index.html`))) {
+  console.error(`✗ build-desktop/index.html not found — run \`pnpm desktop:build\` first`)
+  process.exit(1)
+}
+rmSync(dst, { recursive: true, force: true })
+cpSync(src, dst, { recursive: true })
+console.log(`✓ bundled SPA → server/catgo/web`)

--- a/server/README-pypi.md
+++ b/server/README-pypi.md
@@ -1,0 +1,36 @@
+# CatGo
+
+**AI-driven workbench for computational materials science** — a 3D
+structure/trajectory viewer + workflow engine, installable straight from PyPI.
+
+```bash
+pip install catgo      # or:  uv pip install catgo
+catgo                  # launches the app and opens it in your browser
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `catgo` | Start the backend and open the CatGo UI in a browser |
+| `catgo app` / `catgo web` | Same as bare `catgo` (`--no-browser` to skip opening one) |
+| `catgo view POSCAR CONTCAR …` | Open structure/trajectory file(s) in the viewer (like `ase gui`) |
+| `catgo serve` | Run the API/backend only (no browser) |
+| `catgo shell` | Interactive REPL |
+| `catgo setup` | Register the CatGo MCP server for Claude Code |
+
+The web UI is bundled in the wheel and served same-origin by the local backend
+(default `http://localhost:8000`), so it works offline after install.
+
+## Optional extras
+
+```bash
+pip install "catgo[analyze]"   # DOS/band/COHP plotting (matplotlib, scienceplots)
+pip install "catgo[ml]"        # MACE ML potentials
+pip install "catgo[full]"      # mdtraj, h5py, scikit-learn, custodian
+```
+
+Prefer the native desktop app (Tauri) for the fastest 3D — see the project
+repository. This package is the Python/CLI + web-UI distribution.
+
+License: AGPL-3.0-or-later.

--- a/server/catgo/cli/__init__.py
+++ b/server/catgo/cli/__init__.py
@@ -7,8 +7,16 @@ from __future__ import annotations
 import sys
 
 from catgo.cli._legacy import (
-    cmd_serve, cmd_setup, cmd_status, cmd_stop,
+    cmd_app, cmd_serve, cmd_setup, cmd_status, cmd_stop,
 )
+
+
+def cmd_shell(args):
+    """Interactive CatGo REPL (was the bare-`catgo` behaviour before the app
+    launcher took that slot)."""
+    from catgo.cli.shell import InteractiveShell
+    InteractiveShell(no_autostart=getattr(args, "no_autostart", False)).run()
+    return 0
 
 
 def _build_legacy_parser():
@@ -29,6 +37,20 @@ def _build_legacy_parser():
     p_serve.add_argument("--daemon", action="store_true", help="Run as background daemon (Unix only)")
     p_serve.add_argument("--reload", action="store_true", help="Enable auto-reload (dev mode)")
     p_serve.set_defaults(func=cmd_serve)
+
+    p_app = sub.add_parser(
+        "app", aliases=["web"],
+        help="Launch the CatGo web UI (start the backend + open a browser)")
+    p_app.add_argument("--port", type=int, default=0, help="Port (default: 8000)")
+    p_app.add_argument("--host", default=None, help="Host (default: 127.0.0.1)")
+    p_app.add_argument(
+        "--no-browser", action="store_true", dest="no_browser",
+        help="Start the server but don't open a browser")
+    p_app.set_defaults(func=cmd_app)
+
+    p_shell = sub.add_parser(
+        "shell", help="Interactive CatGo REPL (the old bare-`catgo` shell)")
+    p_shell.set_defaults(func=cmd_shell)
 
     p_setup = sub.add_parser("setup", help="Configure MCP for Claude Code")
     p_setup.add_argument("--port", type=int, default=0, help="API port (default: 8000)")
@@ -230,9 +252,11 @@ def main(argv: list[str] | None = None) -> None:
     parser, sub = _build_legacy_parser()
     _add_op_subparsers(sub)
     if not effective:
-        from catgo.cli.shell import InteractiveShell
-        InteractiveShell(no_autostart=no_auto).run()
-        return
+        # Bare `catgo` launches the app (backend + browser). The interactive
+        # REPL moved to `catgo shell`.
+        import argparse as _argparse
+        raise SystemExit(
+            cmd_app(_argparse.Namespace(port=0, host=None, no_browser=False)))
     # Passthrough subcommands: their tail is forwarded verbatim to a launcher and may
     # LEAD with an option (e.g. `catgo freq-inputs --structure ...`), which argparse
     # REMAINDER mishandles. Dispatch them directly, before the top-level parser.

--- a/server/catgo/cli/_legacy.py
+++ b/server/catgo/cli/_legacy.py
@@ -26,6 +26,67 @@ def _get_port() -> int:
     return int(os.environ.get("SERVER_PORT", 0)) or 8000
 
 
+def _bundled_frontend() -> Path | None:
+    """Return the built SPA shipped inside the installed package (catgo/web),
+    if present. This is what makes `pip install catgo` show a UI."""
+    web = Path(__file__).resolve().parent.parent / "web"
+    return web if (web / "index.html").is_file() else None
+
+
+def _ensure_frontend_dir() -> Path | None:
+    """Point CATGO_FRONTEND_DIR at the bundled SPA (unless already set), so
+    main.py mounts it. Returns the resolved dir (or None if no UI is bundled)."""
+    existing = os.environ.get("CATGO_FRONTEND_DIR")
+    if existing:
+        return Path(existing) if Path(existing, "index.html").is_file() else None
+    web = _bundled_frontend()
+    if web:
+        os.environ["CATGO_FRONTEND_DIR"] = str(web)
+    return web
+
+
+# ──────────────────────────────────────────────
+# catgo (bare) / catgo app — launch the UI
+# ──────────────────────────────────────────────
+
+def cmd_app(args) -> int:
+    """Launch CatGo: start the backend and open the web UI in a browser.
+
+    This is what bare `catgo` runs. The SPA is served same-origin by the
+    FastAPI backend (default port 8000, matching the built bundle's API URL)."""
+    import threading
+    import time
+    import webbrowser
+
+    _ensure_sys_path()
+    web = _ensure_frontend_dir()
+    port = getattr(args, "port", 0) or _get_port()
+    host = getattr(args, "host", None) or "127.0.0.1"
+    url = f"http://localhost:{port}"
+
+    if web is None:
+        print("⚠  No bundled web UI found (catgo/web/index.html missing).")
+        print("   Serving the API only — run a dev frontend, or reinstall a")
+        print("   release wheel that bundles the UI. Continuing with API at")
+        print(f"   {url}/api")
+    else:
+        print(f"CatGo — starting at {url}")
+
+    if web is not None and not getattr(args, "no_browser", False):
+        def _open() -> None:
+            time.sleep(1.8)  # give uvicorn a moment to bind
+            try:
+                webbrowser.open(url)
+            except Exception:
+                pass
+        threading.Thread(target=_open, daemon=True).start()
+
+    import uvicorn
+    print(f"  (Ctrl-C to stop)")
+    uvicorn.run("main:app", host=host, port=port)
+    return 0
+
+
 # ──────────────────────────────────────────────
 # catgo serve
 # ──────────────────────────────────────────────
@@ -33,6 +94,7 @@ def _get_port() -> int:
 def cmd_serve(args):
     """Start the CatGo backend server."""
     _ensure_sys_path()
+    _ensure_frontend_dir()
     port = args.port or _get_port()
 
     if args.daemon:

--- a/server/main.py
+++ b/server/main.py
@@ -677,12 +677,28 @@ _frontend_dir = Path(
     os.environ.get("CATGO_FRONTEND_DIR") or (_repo_root / "build-desktop")
 )
 if _frontend_dir.is_dir():
-    from fastapi.responses import FileResponse
+    from fastapi.responses import FileResponse, HTMLResponse
     from fastapi.staticfiles import StaticFiles
     from starlette.responses import Response
 
     _index_html = _frontend_dir / "index.html"
     _frontend_base = _frontend_dir.resolve()
+
+    # Tell the SPA to talk to whatever origin served it, so `catgo`/`catgo app`
+    # works on ANY port (the bundle's compiled default is localhost:8000). The
+    # frontend reads `globalThis.__CATGO_RUNTIME_SERVER__` (see api/config.ts);
+    # inject it into <head> so it runs before the app bundle. Built once.
+    _RUNTIME_SERVER_TAG = (
+        "<script>globalThis.__CATGO_RUNTIME_SERVER__=location.origin</script>"
+    )
+
+    def _index_document() -> str:
+        html = _index_html.read_text(encoding="utf-8")
+        if "__CATGO_RUNTIME_SERVER__" in html:
+            return html
+        if "<head>" in html:
+            return html.replace("<head>", "<head>" + _RUNTIME_SERVER_TAG, 1)
+        return _RUNTIME_SERVER_TAG + html
     _assets_dir = _frontend_dir / "assets"
     if _assets_dir.is_dir():
         app.mount(
@@ -709,7 +725,7 @@ if _frontend_dir.is_dir():
                 candidate = None
             if candidate is not None and candidate.is_file():
                 return FileResponse(str(candidate))
-        return FileResponse(str(_index_html))
+        return HTMLResponse(_index_document())
 
     print(f"[Server] Serving prebuilt SPA from {_frontend_dir}")
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -3,9 +3,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "catgo-engine"
+name = "catgo"
 version = "0.1.0"
-description = "CatGo — Computational Chemistry Workflow Engine with MCP integration"
+description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
+readme = "README.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
 authors = [
@@ -63,3 +64,9 @@ catgo = "catgo.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["catgo"]
+# The built SPA (catgo/web/**) is a generated, git-ignored artifact copied in by
+# scripts/bundle-web.mjs before `python -m build`. Whitelist it so the wheel ships
+# a working UI — without this, `pip install catgo` would have no frontend.
+artifacts = [
+    "catgo/web/**/*",
+]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "catgo"
 version = "0.1.0"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
-readme = "README.md"
+readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
 authors = [

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -6,9 +6,21 @@ declare const __CATGO_SERVER_URL__: string
 declare const __CATGO_DESKTOP__: boolean
 declare const __CATGO_STATIC_ONLY__: boolean
 
-export let SERVER_URL: string = typeof __CATGO_SERVER_URL__ !== `undefined`
-  ? __CATGO_SERVER_URL__
-  : `http://localhost:8000`
+function _default_server_url(): string {
+  // Runtime override the backend injects into the served index.html
+  // (`globalThis.__CATGO_RUNTIME_SERVER__ = location.origin`), so a
+  // backend-served SPA is same-origin and `catgo` / `catgo app` works on ANY
+  // port. Read as a DYNAMIC global-property access so the bundler can't fold it
+  // away — a `typeof window` guard tree-shakes to the fallback in the SSR build.
+  const runtime = (globalThis as Record<string, unknown>).__CATGO_RUNTIME_SERVER__
+  if (typeof runtime === `string` && runtime.length > 0) return runtime
+  if (typeof __CATGO_SERVER_URL__ !== `undefined` && __CATGO_SERVER_URL__) {
+    return __CATGO_SERVER_URL__
+  }
+  return `http://localhost:8000`
+}
+
+export let SERVER_URL: string = _default_server_url()
 
 export let API_BASE = `${SERVER_URL}/api`
 export let WS_BASE = SERVER_URL.replace(/^http/, `ws`) + `/api`


### PR DESCRIPTION
## Summary

Make CatGo installable from PyPI — `pip install catgo` → `catgo` launches the full app.

- **Bare `catgo`** launches the app: starts the backend and opens the web UI in a browser. The old REPL moved to **`catgo shell`**; new **`catgo app`/`catgo web`** aliases (`--no-browser` to skip).
- **The web UI ships in the wheel.** `scripts/bundle-web.mjs` copies the built SPA (`build-desktop/`) into the package (`server/catgo/web/`, git-ignored); `pyproject` whitelists it as a wheel artifact. `catgo app`/`serve` resolve the bundled SPA and the backend serves it same-origin.
- **Works on any port.** The bundle's compiled API URL is `localhost:8000`, but the backend injects `globalThis.__CATGO_RUNTIME_SERVER__ = location.origin` into the served `index.html` and `api/config.ts` reads it (a dynamic global the bundler can't fold), so the app talks to whatever origin served it — `catgo app --port N` just works even if 8000 is taken.
- **Package renamed** `catgo-engine` → `catgo` (free on PyPI); entry point unchanged. `README-pypi.md` as the long_description. **`pypi-publish.yml`** builds WASM + SPA, bundles it, builds the wheel, twine-checks, and publishes on Release / manual dispatch.

## Verified (locally)
- Wheel `catgo-0.1.0-py3-none-any.whl` (46 MB) bundles `catgo/web` (371 files).
- `catgo app --port 8010` serves the SPA and every `/api` call hits `:8010` (200) — verified in-browser, including a live HPC (SSH) connect and the user's workflows/DB.

## To publish
Add a `PYPI_API_TOKEN` repo secret (or configure PyPI Trusted Publishing — `id-token: write` is set), then cut a Release or run the workflow.

## Notes
- Wheel is ~46 MB (raw SPA 83 MB) — gesture ONNX (~28 MB) + Monaco dominate; a slimming pass can come later.
