### PR TITLE
fix(hetero): interface orientation normalization, bulk rebuild crash, bulk grid scan + OTP input width

### DIFF
--- a/extensions/rust/src/heterostructure.rs
+++ b/extensions/rust/src/heterostructure.rs
@@ -344,7 +344,57 @@ fn stack_slabs(
         keep_species.push(species[i].clone());
     }
 
-    Structure::new(new_lattice, keep_species, keep_frac)
+    normalize_interface_orientation(&Structure::new(new_lattice, keep_species, keep_frac))
+}
+
+/// Normalize a stacked interface to the conventional orientation. Faithful
+/// port of Python `_normalize_interface_orientation`:
+///
+/// - **c pointing down** (negative z), inherited from a c-down substrate
+///   slab: rigid 180° rotation of the whole assembly about the a-axis — a
+///   proper rotation, so chirality and stacking order are preserved.
+/// - **Left-handed cell** (negative determinant), from a/b-swapped
+///   sl_vectors: relabel b -> -b (same Bravais lattice; Cartesian positions
+///   unchanged, in-plane fracs re-wrap).
+///
+/// Site order is preserved, so substrate/film index ranges stay valid.
+fn normalize_interface_orientation(structure: &Structure) -> Structure {
+    let mut matrix = *structure.lattice.matrix();
+    let mut frac = structure.frac_coords.clone();
+    let mut changed = false;
+
+    if matrix[(2, 2)] < 0.0 {
+        let a = Vector3::new(matrix[(0, 0)], matrix[(0, 1)], matrix[(0, 2)]);
+        let a_hat = a / a.norm();
+        let rot = 2.0 * a_hat * a_hat.transpose() - Matrix3::identity();
+        let rotated = matrix * rot.transpose();
+        // Only helps when a lies (near) the xy-plane — true for slabs; skip
+        // rather than worsen an already-odd cell.
+        if rotated[(2, 2)] > matrix[(2, 2)] + 1e-9 {
+            matrix = rotated;
+            changed = true;
+        }
+    }
+
+    if matrix.determinant() < 0.0 {
+        for j in 0..3 {
+            matrix[(1, j)] = -matrix[(1, j)];
+        }
+        for f in frac.iter_mut() {
+            f.y = wrap01(-f.y);
+        }
+        changed = true;
+    }
+
+    if !changed {
+        return structure.clone();
+    }
+    let mut lattice = Lattice::new(matrix);
+    lattice.pbc = structure.lattice.pbc;
+    let mut normalized =
+        Structure::new_from_occupancies(lattice, structure.site_occupancies.clone(), frac);
+    normalized.properties = structure.properties.clone();
+    normalized
 }
 
 /// Rotate the in-plane (x, y) components of `cart` by `twist_angle` degrees
@@ -1430,7 +1480,7 @@ fn stack_slabs_target_z(
         keep_species.push(species[i].clone());
     }
 
-    Structure::new(new_lattice, keep_species, keep_frac)
+    normalize_interface_orientation(&Structure::new(new_lattice, keep_species, keep_frac))
 }
 
 /// A single grid-scan entry: an in-plane shift applied to the film atoms of an
@@ -1612,12 +1662,15 @@ pub fn grid_scan(
     n_grid_y: usize,
     symprec: f64,
 ) -> GridScanResult {
+    // Fix orientation of heterostructures built before normalization existed
+    // (c-down / left-handed cells) — atom order is preserved, so
+    // n_atoms_substrate stays valid. Mirrors the Python /grid-scan route.
+    let hetero = normalize_interface_orientation(heterostructure);
     let film_stripped = strip_vacuum(film_slab, 0.5);
     let sym_ops_2d = get_2d_symmetry_operations(&film_stripped, symprec);
     let (irr_points, zone_extent) =
         get_irreducible_grid_points(&sym_ops_2d, n_grid_x, n_grid_y);
-    let entries =
-        generate_grid_scan_structures(heterostructure, n_atoms_substrate, &irr_points);
+    let entries = generate_grid_scan_structures(&hetero, n_atoms_substrate, &irr_points);
 
     GridScanResult {
         entries,

--- a/extensions/rust/tests/heterostructure_compat.rs
+++ b/extensions/rust/tests/heterostructure_compat.rs
@@ -84,7 +84,7 @@ fn slab_build_match1_matches_backend() {
     let film = square_slab(3.15, 25.0, "Au", &[10.0, 12.0]);
 
     // match_id 1 = generation-order index of the clean ~9.18% strain match.
-    let res = build_interface_slab(&sub, &film, 1, 2.0, 20.0, 200.0, 0.09, 0.06, 0.02).unwrap();
+    let res = build_interface_slab(&sub, &film, 1, 2.0, 20.0, 0.0, 200.0, 0.09, 0.06, 0.02).unwrap();
 
     // Backend: n_atoms=38 (20 sub + 18 film), area=90.0, strain=9.1796,
     // lattice a=3.0 b=30.0 c=26.5, angles 90/90/90.
@@ -184,7 +184,9 @@ fn slab_pair2_hex_matches_backend() {
     // Pair 2: graphene-like substrate (a=2.46, hex) + BN-like film (a=2.50, hex),
     // ~1.6% mismatch. Search params: max_area=120, ratio_tol=0.09,
     // length_tol=0.04, angle_tol=0.02.
-    let sub = hex_slab(2.46, 20.0, &[("C", 8.0), ("C", 8.0)]);
+    // Distinct z per C atom — coincident atoms would be dropped by the
+    // build's duplicate-atom filter.
+    let sub = hex_slab(2.46, 20.0, &[("C", 8.0), ("C", 9.0)]);
     let film = hex_slab(2.50, 20.0, &[("B", 8.0), ("N", 8.0)]);
 
     let matches = search_matches_slab(&sub, &film, 120.0, 0.09, 0.04, 0.02, 50);
@@ -199,9 +201,10 @@ fn slab_pair2_hex_matches_backend() {
     assert_eq!(m0.film_transformation, [[1, 0], [0, 1]]);
 
     // Build the 1x1 match (generation-order id 0).
-    let res = build_interface_slab(&sub, &film, 0, 2.0, 20.0, 120.0, 0.09, 0.04, 0.02).unwrap();
+    let res = build_interface_slab(&sub, &film, 0, 2.0, 20.0, 0.0, 120.0, 0.09, 0.04, 0.02).unwrap();
     // Backend: n=4 (2 sub + 2 film), area 5.24, strain 1.6,
-    // lattice a=b=2.46, c=22.5, gamma=60 (reduced hex).
+    // lattice a=b=2.46, c=23.5, gamma=120 (the ZSL-reduced hex cell is
+    // left-handed; orientation normalization flips b, so gamma 60 -> 120).
     assert_eq!(res.n_atoms, 4);
     assert_eq!(res.n_atoms_substrate, 2);
     assert_eq!(res.n_atoms_film, 2);
@@ -211,12 +214,12 @@ fn slab_pair2_hex_matches_backend() {
     let lengths = res.structure.lattice.lengths();
     assert!((lengths[0] - 2.46).abs() < 1e-3, "a {}", lengths[0]);
     assert!((lengths[1] - 2.46).abs() < 1e-3, "b {}", lengths[1]);
-    assert!((lengths[2] - 22.5).abs() < 1e-3, "c {}", lengths[2]);
+    assert!((lengths[2] - 23.5).abs() < 1e-3, "c {}", lengths[2]);
     let gamma = res.structure.lattice.angles()[2];
-    assert!((gamma - 60.0).abs() < 1e-2, "gamma {}", gamma);
+    assert!((gamma - 120.0).abs() < 1e-2, "gamma {}", gamma);
 
-    // All four atoms sit on the c-axis at origin; substrate C at z=0.5,
-    // film B/N at z=2.5 (gap=2.0 above the 0.5 substrate top -> 2.5).
+    // All four atoms sit on the c-axis at origin; substrate C at z=0.5 and
+    // 1.5, film B/N at z=3.5 (gap=2.0 above the 1.5 substrate top -> 3.5).
     let zs: Vec<(String, f64)> = res
         .structure
         .cart_coords()
@@ -224,11 +227,14 @@ fn slab_pair2_hex_matches_backend() {
         .zip(res.structure.species())
         .map(|(p, sp)| (sp.element.symbol().to_string(), (p.z * 1e4).round() / 1e4))
         .collect();
-    let n_sub_z05 = zs.iter().filter(|(s, z)| s == "C" && (z - 0.5).abs() < 1e-2).count();
-    assert_eq!(n_sub_z05, 2, "two C at z=0.5");
-    let n_film_z25 = zs
+    let n_sub_c = zs
         .iter()
-        .filter(|(s, z)| (s == "B" || s == "N") && (z - 2.5).abs() < 1e-2)
+        .filter(|(s, z)| s == "C" && ((z - 0.5).abs() < 1e-2 || (z - 1.5).abs() < 1e-2))
         .count();
-    assert_eq!(n_film_z25, 2, "B and N at z=2.5");
+    assert_eq!(n_sub_c, 2, "two C at z=0.5 and 1.5");
+    let n_film_z35 = zs
+        .iter()
+        .filter(|(s, z)| (s == "B" || s == "N") && (z - 3.5).abs() < 1e-2)
+        .count();
+    assert_eq!(n_film_z35, 2, "B and N at z=3.5");
 }

--- a/server/catgo/routers/heterostructure.py
+++ b/server/catgo/routers/heterostructure.py
@@ -52,6 +52,7 @@ from catgo.utils.heterostructure_algorithm import (
     search_lateral_matches,
     search_matches,
     search_matches_slab,
+    _normalize_interface_orientation,
     _strip_vacuum,
 )
 
@@ -551,7 +552,12 @@ def grid_scan_heterostructure(request: GridScanRequest) -> GridScanResult:
     try:
         params = request.params or GridScanParams()
 
-        hetero = _model_to_native(request.heterostructure)
+        # Fix orientation of heterostructures built before normalization
+        # existed (c-down / left-handed cells) — atom order is preserved,
+        # so n_atoms_substrate stays valid.
+        hetero = _normalize_interface_orientation(
+            _model_to_native(request.heterostructure)
+        )
         film = _model_to_native(request.film)
 
         # Strip vacuum from film for correct symmetry analysis

--- a/server/catgo/utils/heterostructure_algorithm.py
+++ b/server/catgo/utils/heterostructure_algorithm.py
@@ -210,6 +210,51 @@ def _wrap_inplane_fracs(structure: Structure) -> Structure:
     return Structure(structure.lattice, structure.species, fracs)
 
 
+def _normalize_interface_orientation(structure: Structure) -> Structure:
+    """Normalize a stacked interface to the conventional orientation.
+
+    Two defects can reach the final interface cell:
+
+    - **c pointing down** (negative z): inherited from a substrate slab whose
+      c-axis points down (e.g. pasted from an external tool); the interface
+      then renders upside-down against the world axes. Fixed by a rigid 180°
+      rotation of the whole assembly about the a-axis — a proper rotation, so
+      chirality and the substrate/film stacking order are preserved.
+
+    - **Left-handed cell** (negative determinant): `_align_sl_vectors` may
+      swap the matched superlattice vectors to align a with the input
+      substrate, flipping the in-plane determinant. VASP rejects a negative
+      triple product. Fixed by relabelling b -> -b (the same Bravais lattice;
+      Cartesian positions are unchanged, in-plane fracs re-wrap).
+
+    Site order is preserved, so substrate/film index ranges stay valid.
+    Site properties are dropped (callers count film/substrate atoms before
+    this, matching `_wrap_inplane_fracs`).
+    """
+    matrix = np.array(structure.lattice.matrix, dtype=float)
+    frac = structure.frac_coords.copy()
+    changed = False
+
+    if matrix[2][2] < 0:
+        a_hat = matrix[0] / np.linalg.norm(matrix[0])
+        rot = 2.0 * np.outer(a_hat, a_hat) - np.eye(3)
+        rotated = matrix @ rot.T
+        # Only helps when a lies (near) the xy-plane — true for slabs; skip
+        # rather than worsen an already-odd cell.
+        if rotated[2][2] > matrix[2][2] + 1e-9:
+            matrix = rotated
+            changed = True
+
+    if np.linalg.det(matrix) < 0:
+        matrix[1] = -matrix[1]
+        frac[:, 1] = (-frac[:, 1]) % 1.0
+        changed = True
+
+    if not changed:
+        return structure
+    return Structure(PmgLattice(matrix), structure.species, frac)
+
+
 def _stack_slabs(
     substrate: Structure,
     film: Structure,
@@ -326,7 +371,9 @@ def _stack_slabs(
         new_lattice, all_species, all_cart, coords_are_cartesian=True
     )
     frac_wrapped = interface.frac_coords % 1.0
-    return Structure(new_lattice, all_species, frac_wrapped)
+    return _normalize_interface_orientation(
+        Structure(new_lattice, all_species, frac_wrapped)
+    )
 
 
 def search_matches_slab(
@@ -1134,6 +1181,14 @@ def build_interface_intermat(
     if n_film == 0 and n_substrate == 0:
         n_substrate = len(interface) // 2
         n_film = len(interface) - n_substrate
+
+    # Downstream tools (grid scan) treat indices >= n_atoms_substrate as film
+    # atoms, so reorder substrate ("bottom") atoms first when props map them.
+    if props and len(props) == len(interface) and n_film > 0 and n_substrate > 0:
+        order = [i for i, p in enumerate(props) if p == "bottom"]
+        order += [i for i, p in enumerate(props) if p != "bottom"]
+        if order != list(range(len(interface))):
+            interface = Structure.from_sites([interface[i] for i in order])
 
     # Mismatch info
     mismatch_u = float(res.get("mismatch_u", 0.0))

--- a/src/lib/structure/HeterostructurePane.svelte
+++ b/src/lib/structure/HeterostructurePane.svelte
@@ -139,9 +139,27 @@
   // Saved from build result: original film + how many substrate atoms
   let gs_film_snapshot = $state<PymatgenStructure | null>(null)
   let gs_n_atoms_substrate = $state(0)
+  // The built heterostructure the scan shifts — scans stay relative to the
+  // build even after an entry is applied or the viewer structure changes
+  let gs_hetero_snapshot = $state<PymatgenStructure | null>(null)
 
   // -- Shared state --
   let original_substrate = $state<PymatgenStructure | undefined>(undefined)
+
+  // Structures produced by builds / grid-scan shifts. Rebuilding must not feed
+  // one of these back in as the substrate (interface-on-interface garbage).
+  const built_outputs = new WeakSet<object>()
+
+  function substrate_for_build(): PymatgenStructure | undefined {
+    if (structure && built_outputs.has(structure) && original_substrate) return original_substrate
+    return structure
+  }
+
+  function mark_built(raw: PymatgenStructure) {
+    built_outputs.add(raw)
+    // $state reads may hand back a proxy of the assigned object — track both
+    if (structure) built_outputs.add(structure)
+  }
   let search_status = $state<`idle` | `searching` | `done` | `error`>(`idle`)
   let build_status = $state<`idle` | `building` | `done` | `error`>(`idle`)
   let error_message = $state<string | null>(null)
@@ -206,14 +224,15 @@
 
   // -- Slab mode: ZSL search --
   async function do_search() {
-    if (!structure || !film_structure) return
+    const substrate = substrate_for_build()
+    if (!substrate || !film_structure) return
 
     error_message = null
     result_message = null
     matches = []
     terminations = []
     selected_match_idx = null
-    original_substrate = structure
+    original_substrate = substrate
     search_status = `searching`
     build_status = `idle`
 
@@ -227,7 +246,7 @@
       }
 
       const result = await searchHeterostructureMatches(
-        structure,
+        substrate,
         film_structure,
         params,
         server_url,
@@ -245,7 +264,10 @@
 
   // -- Slab mode: build from selected ZSL match --
   async function do_build_slab() {
-    if (!structure || !film_structure || !selected_match) return
+    // Build from the same substrate the search ran on, not the current viewer
+    // structure (which is the built interface after the first build)
+    const substrate = original_substrate ?? substrate_for_build()
+    if (!substrate || !film_structure || !selected_match) return
 
     on_push_undo?.()
     error_message = null
@@ -270,7 +292,7 @@
       gs_film_snapshot = film_structure
 
       const result = await buildHeterostructure(
-        structure,
+        substrate,
         film_structure,
         selected_match,
         0,
@@ -280,7 +302,11 @@
       )
 
       gs_n_atoms_substrate = result.n_atoms_substrate
+      gs_hetero_snapshot = result.structure
+      gs_result = null
+      gs_selected_idx = null
       structure = result.structure
+      mark_built(result.structure)
       on_structure_change?.(result.structure)
       build_status = `done`
       result_message = result.message
@@ -333,18 +359,20 @@
 
   // -- Slab mode: manual transform build --
   async function do_build_manual() {
-    if (!structure || !film_structure) return
+    const substrate = substrate_for_build()
+    if (!substrate || !film_structure) return
 
     on_push_undo?.()
     error_message = null
     build_status = `building`
+    original_substrate = substrate
 
     try {
       // Save film snapshot for grid scan symmetry analysis
       gs_film_snapshot = film_structure
 
       const result = await buildHeterostructureManual(
-        structure,
+        substrate,
         film_structure,
         [[sub_t00, sub_t01], [sub_t10, sub_t11]],
         [[film_t00, film_t01], [film_t10, film_t11]],
@@ -356,7 +384,11 @@
       )
 
       gs_n_atoms_substrate = result.n_atoms_substrate
+      gs_hetero_snapshot = result.structure
+      gs_result = null
+      gs_selected_idx = null
       structure = result.structure
+      mark_built(result.structure)
       on_structure_change?.(result.structure)
       build_status = `done`
       result_message = result.message
@@ -368,12 +400,14 @@
 
   // -- Bulk mode: intermat one-step generate --
   async function do_build_bulk() {
-    if (!structure || !film_structure) return
+    const substrate = substrate_for_build()
+    if (!substrate || !film_structure) return
 
     on_push_undo?.()
     error_message = null
     im_result = null
     build_status = `building`
+    original_substrate = substrate
 
     try {
       const params: IntermatBuildParams = {
@@ -392,14 +426,25 @@
       }
 
       const result = await buildHeterostructureIntermat(
-        structure,
+        substrate,
         film_structure,
         params,
         server_url,
       )
 
       im_result = result
+      // Grid scan setup: the film slab as placed in the interface (film input
+      // here is a bulk crystal, so slice the film atoms out of the result)
+      gs_n_atoms_substrate = result.n_atoms_substrate
+      gs_film_snapshot = {
+        ...result.structure,
+        sites: result.structure.sites.slice(result.n_atoms_substrate),
+      }
+      gs_hetero_snapshot = result.structure
+      gs_result = null
+      gs_selected_idx = null
       structure = result.structure
+      mark_built(result.structure)
       on_structure_change?.(result.structure)
       build_status = `done`
       result_message = result.message
@@ -411,7 +456,8 @@
 
   // -- Lateral mode handlers --
   async function do_search_lateral() {
-    if (!structure || !film_structure) return
+    const slab_A = substrate_for_build()
+    if (!slab_A || !film_structure) return
 
     search_status = `searching`
     error_message = null
@@ -419,6 +465,7 @@
     lat_matches = []
     lat_selected_idx = null
     lat_result = null
+    original_substrate = slab_A
 
     try {
       const params: LateralSearchParams = {
@@ -426,7 +473,7 @@
         max_length: lat_max_length,
         max_strain: lat_max_strain,
       }
-      const result = await searchLateralMatches(structure, film_structure, params, server_url)
+      const result = await searchLateralMatches(slab_A, film_structure, params, server_url)
       lat_matches = result.matches
       result_message = result.message
       search_status = `done`
@@ -437,7 +484,8 @@
   }
 
   async function do_build_lateral() {
-    if (!structure || !film_structure || !lat_selected) return
+    const slab_A = original_substrate ?? substrate_for_build()
+    if (!slab_A || !film_structure || !lat_selected) return
 
     on_push_undo?.()
     build_status = `building`
@@ -457,10 +505,11 @@
         max_strain: lat_max_strain,
       }
       const result = await buildLateralInterface(
-        structure, film_structure, lat_selected, params, search_params, server_url,
+        slab_A, film_structure, lat_selected, params, search_params, server_url,
       )
       lat_result = result
       structure = result.structure
+      mark_built(result.structure)
       on_structure_change?.(result.structure)
       result_message = result.message
       build_status = `done`
@@ -471,7 +520,10 @@
   }
 
   async function do_grid_scan() {
-    if (!structure || !gs_film_snapshot || !gs_n_atoms_substrate) return
+    // Scan the built heterostructure, not the viewer structure — applying a
+    // shift entry and re-scanning must not compound shifts
+    const hetero = gs_hetero_snapshot ?? structure
+    if (!hetero || !gs_film_snapshot || !gs_n_atoms_substrate) return
 
     error_message = null
     result_message = null
@@ -486,7 +538,7 @@
         symprec: gs_symprec,
       }
       const result = await gridScanHeterostructure(
-        structure, gs_film_snapshot, gs_n_atoms_substrate, params, server_url,
+        hetero, gs_film_snapshot, gs_n_atoms_substrate, params, server_url,
       )
       gs_result = result
       result_message = result.message
@@ -501,6 +553,7 @@
     if (!gs_result || idx >= gs_result.entries.length) return
     on_push_undo?.()
     structure = gs_result.entries[idx].structure
+    mark_built(gs_result.entries[idx].structure)
     on_structure_change?.(gs_result.entries[idx].structure)
     gs_selected_idx = idx
   }
@@ -904,89 +957,6 @@
       </fieldset>
     {/if}
 
-    <!-- Grid Scan: available after build (shifts film atoms in the built heterostructure) -->
-    {#if build_status === 'done' && structure && gs_film_snapshot && gs_n_atoms_substrate > 0}
-      <details class="grid-scan-section">
-        <summary>Stacking Grid Scan</summary>
-        <div class="build-params">
-          <label>
-            <span>Grid N<sub>x</sub></span>
-            <input type="number" bind:value={gs_n_grid_x} min={2} max={30} step={1} />
-          </label>
-          <label>
-            <span>Grid N<sub>y</sub></span>
-            <input type="number" bind:value={gs_n_grid_y} min={2} max={30} step={1} />
-          </label>
-          <label>
-            <span>Sym. tol. (Å)</span>
-            <input type="number" bind:value={gs_symprec} min={0.001} max={1} step={0.01} />
-          </label>
-        </div>
-        <div class="controls" style="margin-top: 6pt">
-          <button
-            type="button"
-            onclick={do_grid_scan}
-            disabled={gs_scanning}
-            class="primary"
-          >
-            {gs_scanning ? `Scanning...` : `Run Grid Scan`}
-          </button>
-          <span class="hint" style="margin-left: 6pt">
-            {gs_n_grid_x * gs_n_grid_y} points
-          </span>
-        </div>
-
-        {#if gs_result}
-          <div class="im-results" style="margin-top: 6pt">
-            <div class="im-results-grid">
-              <span class="im-label">Sym. ops:</span>
-              <span class="im-value">{gs_result.n_symmetry_ops} ({gs_result.reduction_ratio.toFixed(0)}× zone reduction)</span>
-              <span class="im-label">Structures:</span>
-              <span class="im-value">{gs_result.n_irreducible}</span>
-            </div>
-            <div class="hint" style="margin-top: 2pt">{gs_result.message}</div>
-          </div>
-
-          <div class="results-table-wrapper" style="margin-top: 4pt">
-            <table class="results-table">
-              <thead>
-                <tr><th></th><th>f<sub>x</sub></th><th>f<sub>y</sub></th><th>Atoms</th></tr>
-              </thead>
-              <tbody>
-                {#each gs_result.entries as entry, idx}
-                  <tr
-                    class:selected={gs_selected_idx === idx}
-                    onclick={() => apply_grid_scan_entry(idx)}
-                  >
-                    <td><input type="radio" checked={gs_selected_idx === idx} /></td>
-                    <td>{entry.shift_frac[0].toFixed(3)}</td>
-                    <td>{entry.shift_frac[1].toFixed(3)}</td>
-                    <td>{entry.n_atoms}</td>
-                  </tr>
-                {/each}
-              </tbody>
-            </table>
-          </div>
-
-          <div class="controls" style="margin-top: 6pt; flex-wrap: wrap; gap: 4pt">
-            <button type="button" onclick={gs_export_file}>
-              Export .extxyz
-            </button>
-            {#if on_save_to_database}
-              <button type="button" onclick={gs_save_to_database}>
-                Save to Database
-              </button>
-            {/if}
-            {#if on_export_to_hpc}
-              <button type="button" onclick={gs_export_to_hpc}>
-                Export to HPC
-              </button>
-            {/if}
-          </div>
-        {/if}
-      </details>
-    {/if}
-
   {:else if mode === 'bulk'}
     <!-- ==================== BULK MODE (intermat) ==================== -->
     <fieldset class="search-fieldset">
@@ -1198,6 +1168,89 @@
         </div>
       </div>
     {/if}
+  {/if}
+
+  <!-- Grid Scan: shifts film atoms of the built heterostructure (slab + bulk modes) -->
+  {#if (mode === 'slab' || mode === 'bulk') && build_status === 'done' && gs_hetero_snapshot && gs_film_snapshot && gs_n_atoms_substrate > 0}
+    <details class="grid-scan-section">
+      <summary>Stacking Grid Scan</summary>
+      <div class="build-params">
+        <label>
+          <span>Grid N<sub>x</sub></span>
+          <input type="number" bind:value={gs_n_grid_x} min={2} max={30} step={1} />
+        </label>
+        <label>
+          <span>Grid N<sub>y</sub></span>
+          <input type="number" bind:value={gs_n_grid_y} min={2} max={30} step={1} />
+        </label>
+        <label>
+          <span>Sym. tol. (Å)</span>
+          <input type="number" bind:value={gs_symprec} min={0.001} max={1} step={0.01} />
+        </label>
+      </div>
+      <div class="controls" style="margin-top: 6pt">
+        <button
+          type="button"
+          onclick={do_grid_scan}
+          disabled={gs_scanning}
+          class="primary"
+        >
+          {gs_scanning ? `Scanning...` : `Run Grid Scan`}
+        </button>
+        <span class="hint" style="margin-left: 6pt">
+          {gs_n_grid_x * gs_n_grid_y} points
+        </span>
+      </div>
+
+      {#if gs_result}
+        <div class="im-results" style="margin-top: 6pt">
+          <div class="im-results-grid">
+            <span class="im-label">Sym. ops:</span>
+            <span class="im-value">{gs_result.n_symmetry_ops} ({gs_result.reduction_ratio.toFixed(0)}× zone reduction)</span>
+            <span class="im-label">Structures:</span>
+            <span class="im-value">{gs_result.n_irreducible}</span>
+          </div>
+          <div class="hint" style="margin-top: 2pt">{gs_result.message}</div>
+        </div>
+
+        <div class="results-table-wrapper" style="margin-top: 4pt">
+          <table class="results-table">
+            <thead>
+              <tr><th></th><th>f<sub>x</sub></th><th>f<sub>y</sub></th><th>Atoms</th></tr>
+            </thead>
+            <tbody>
+              {#each gs_result.entries as entry, idx}
+                <tr
+                  class:selected={gs_selected_idx === idx}
+                  onclick={() => apply_grid_scan_entry(idx)}
+                >
+                  <td><input type="radio" checked={gs_selected_idx === idx} /></td>
+                  <td>{entry.shift_frac[0].toFixed(3)}</td>
+                  <td>{entry.shift_frac[1].toFixed(3)}</td>
+                  <td>{entry.n_atoms}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+
+        <div class="controls" style="margin-top: 6pt; flex-wrap: wrap; gap: 4pt">
+          <button type="button" onclick={gs_export_file}>
+            Export .extxyz
+          </button>
+          {#if on_save_to_database}
+            <button type="button" onclick={gs_save_to_database}>
+              Save to Database
+            </button>
+          {/if}
+          {#if on_export_to_hpc}
+            <button type="button" onclick={gs_export_to_hpc}>
+              Export to HPC
+            </button>
+          {/if}
+        </div>
+      {/if}
+    </details>
   {/if}
 
   {#if error_message}

--- a/src/lib/structure/ServerPane.svelte
+++ b/src/lib/structure/ServerPane.svelte
@@ -1232,7 +1232,7 @@
           <section class="action-section">
             <h5>{t('structure.two_factor_auth')}</h5>
             <p class="description">{active_session?.otp_prompt}</p>
-            <div class="form-row">
+            <div class="form-row otp-row">
               <input
                 type="text"
                 bind:value={active_session.otp_code}
@@ -2079,6 +2079,13 @@
     letter-spacing: 4px;
     font-family: monospace;
     flex: 1;
+    min-width: 8ch;
+  }
+  /* pane-shared.css stretches .apply-btn to width:100%; in this flex row that
+     full-width flex-basis squeezes the flex:1 (basis 0) input to nothing */
+  .otp-row .apply-btn {
+    width: auto;
+    flex: 0 0 auto;
   }
   .checkbox-row {
     display: flex;

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -614,6 +614,17 @@ export function align_to_principal_axes(structure: AnyStructure): AnyStructure {
     [axes[0][2], axes[1][2], axes[2][2]],
   ]
 
+  // Principal axes are sign-ambiguous — the eigenvector signs can turn the
+  // molecule upside-down. If the original +z direction ends up pointing down,
+  // rotate 180° about the new x-axis (still principal-axes aligned) so the
+  // molecule keeps its input vertical orientation.
+  if (R[2][2] < 0) {
+    for (let j = 0; j < 3; j++) {
+      R[1][j] = -R[1][j]
+      R[2][j] = -R[2][j]
+    }
+  }
+
   // Transform each site (molecules only - no lattice)
   const new_sites = structure.sites.map((site) => {
     // Translate to center of mass


### PR DESCRIPTION
## Problems

1. **Exported/built slab heterostructures could render upside-down**: the interface cell inherits the substrate slab's c direction, so a c-down substrate produced a c-down interface (cell drawn downward against the world axes, grid-scan extxyz exports flipped).
2. **~Half of all ZSL slab matches produced left-handed cells** (negative determinant): `_align_sl_vectors` swaps the matched a/b superlattice vectors to align a with the input substrate, flipping the in-plane determinant. VASP rejects a negative triple product.
3. **Bulk mode: clicking Generate Interface twice exploded the structure** — the built interface replaced the pane structure and was fed back in as the "bulk substrate" for the next build.
4. **Bulk mode had no Stacking Grid Scan** section (slab-only), and the intermat result did not guarantee substrate-first atom ordering, which the scan's film-atom slice relies on.
5. **HPC 2FA verification-code input collapsed to ~1 character wide** (unusable): the shared `.draggable-pane .apply-btn { width: 100% }` rule squeezed the `flex: 1` input in the OTP row.

## Fixes

- `_normalize_interface_orientation` (Python + faithful Rust/WASM port): c-down interfaces get a rigid 180° rotation about the a-axis (proper rotation — chirality, stacking order, and interatomic distances preserved); left-handed cells are relabelled `b -> -b` (same Bravais lattice, Cartesian positions unchanged). Applied at the end of slab stacking and on structures entering `/grid-scan`, so previously-built flipped interfaces are corrected on re-scan.
- All heterostructure build paths track built outputs and rebuild from the original substrate (slab / manual / bulk / lateral).
- Bulk mode gets the grid-scan section; intermat results are reordered substrate-first ("bottom" props) before returning.
- Grid scan runs on a snapshot of the built interface (no shift compounding after applying an entry); stale scan results are cleared on rebuild.
- Molecule principal-axes alignment keeps the input vertical sense (eigenvector sign ambiguity could display molecules upside-down).
- OTP row scopes the submit button back to auto width.
- Repaired the `heterostructure_compat` Rust test (missing `twist_angle` arg — it did not compile on main — plus coincident test atoms silently dropped by the build's dedup filter, and the hex gamma expectation for the now right-handed cell).

## Verification

- Python: end-to-end slab search -> build over 10 matches, all now right-handed with c up; a c-down substrate yields a c-up interface; internal distances unchanged; normalization is idempotent; grid-scan entries inherit the corrected cell.
- Rust: full `cargo test` suite passes (1056 tests incl. the repaired compat tests); WASM rebuilt.
- `vitest` suite passes; `svelte-check` reports no new errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)