### PR TITLE
fix(viewer): trajectory OUTCAR magmom + magmom display controls + anti-aliased atom edges

### DIFF
--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -10,6 +10,8 @@ const structure: Record<string, string> = {
   label_offset: `Label offset`,
   force_vectors: `Force Vectors`,
   magmom_vectors: `Magnetic Moments`,
+  magmom_up: `Up`,
+  magmom_down: `Down`,
   unit_cell: `Unit Cell`,
   lattice_vectors: `Lattice Vectors`,
   bonds: `Bonds`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -10,6 +10,8 @@ const structure: Record<string, string> = {
   label_offset: `标签偏移`,
   force_vectors: `受力向量`,
   magmom_vectors: `磁矩`,
+  magmom_up: `自旋↑`,
+  magmom_down: `自旋↓`,
   unit_cell: `晶胞`,
   lattice_vectors: `晶格向量`,
   bonds: `成键`,

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -904,6 +904,50 @@
     </SettingsSection>
   {/if}
 
+  {#if has_magmom && scene_props.show_magmom_vectors}
+    <SettingsSection
+      title={t('structure.magmom_vectors')}
+      current_values={{
+        magmom_scale: scene_props.magmom_scale,
+        magmom_up_color: scene_props.magmom_up_color,
+        magmom_down_color: scene_props.magmom_down_color,
+      }}
+      on_reset={() => {
+        scene_props.magmom_scale = DEFAULTS.structure.magmom_scale
+        scene_props.magmom_up_color = DEFAULTS.structure.magmom_up_color
+        scene_props.magmom_down_color = DEFAULTS.structure.magmom_down_color
+      }}
+    >
+      <label>
+        {t('structure.scale')}
+        <input
+          type="number"
+          min={0.05}
+          max={10}
+          step={0.05}
+          bind:value={scene_props.magmom_scale}
+        />
+        <input
+          type="range"
+          min={0.05}
+          max={10}
+          step={0.05}
+          bind:value={scene_props.magmom_scale}
+        />
+      </label>
+      <div class="pane-row">
+        <label>
+          {t('structure.magmom_up')}
+          <input type="color" bind:value={scene_props.magmom_up_color} />
+        </label>
+        <label>
+          {t('structure.magmom_down')}
+          <input type="color" bind:value={scene_props.magmom_down_color} />
+        </label>
+      </div>
+    </SettingsSection>
+  {/if}
+
   {#if has_lattice}
     <SettingsSection
       title={t('structure.cell')}

--- a/src/lib/structure/atoms/AtomManagerInstances.svelte
+++ b/src/lib/structure/atoms/AtomManagerInstances.svelte
@@ -231,6 +231,13 @@
 
       vec3 hitPos;
       vec3 normal;
+      // Silhouette anti-aliasing: instead of a hard discard at the sphere edge
+      // (d2 > r2), fade a ~1px coverage band via screen-space derivatives and
+      // feed it to alpha-to-coverage (material.alphaToCoverage + MSAA). This
+      // smooths the jagged impostor outline that plain MSAA can't touch, since
+      // a hard discard gives no sub-pixel coverage. thc is clamped so grazing-
+      // edge fragments (d2 slightly > r2) still get a finite hit for shading.
+      float coverage = 1.0;
 
       if (uIsOrthographic) {
         // Orthographic: ray origin at fragment XY on near plane, direction -Z
@@ -238,8 +245,10 @@
         vec2 offset = vQuadCoord * vRadius * 1.05;
         float d2 = dot(offset, offset);
         float r2 = vRadius * vRadius;
-        if (d2 > r2) discard;
-        float thc = sqrt(r2 - d2);
+        float aa = fwidth(d2);
+        coverage = 1.0 - smoothstep(r2 - aa, r2 + aa, d2);
+        if (coverage <= 0.0) discard;
+        float thc = sqrt(max(r2 - min(d2, r2), 0.0));
         // Hit point: fragment XY, sphere front Z
         hitPos = vec3(vCenter.xy + offset, vCenter.z + thc);
         normal = vec3(offset, thc) / vRadius;
@@ -251,10 +260,12 @@
         vec3 cr = cross(vCenter, rayDir);
         float d2 = dot(cr, cr);
         float r2 = vRadius * vRadius;
-        if (d2 > r2) discard;
+        float aa = fwidth(d2);
+        coverage = 1.0 - smoothstep(r2 - aa, r2 + aa, d2);
+        if (coverage <= 0.0) discard;
 
         float tca = dot(vCenter, rayDir);
-        float thc = sqrt(r2 - d2);
+        float thc = sqrt(max(r2 - min(d2, r2), 0.0));
         float t = tca - thc;
         hitPos = t * rayDir;
 
@@ -307,7 +318,7 @@
                  + vec3(1.0) * specular * 0.6 * uSpecStrength;
       }
 
-      gl_FragColor = vec4(linearTosRGB(color), vOpacity);
+      gl_FragColor = vec4(linearTosRGB(color), vOpacity * coverage);
 
       // Depth cueing: VESTA-style fade toward background.
       // uDepthCueBgColor is in linear-RGB (Three.js color space), but
@@ -339,6 +350,11 @@
       transparent,
       depthWrite: !transparent,
       depthTest: !transparent,
+      // Alpha-to-coverage turns the fragment's edge-coverage alpha into MSAA
+      // sample coverage — anti-aliases the impostor silhouette on the opaque
+      // pass (needs the canvas MSAA, which is on). Harmless on the transparent
+      // pass (it blends anyway).
+      alphaToCoverage: !transparent,
       side: 0,
       uniforms: {
         uIsOrthographic: { value: false },

--- a/src/lib/structure/atoms/AtomManagerInstances.svelte
+++ b/src/lib/structure/atoms/AtomManagerInstances.svelte
@@ -245,8 +245,10 @@
         vec2 offset = vQuadCoord * vRadius * 1.05;
         float d2 = dot(offset, offset);
         float r2 = vRadius * vRadius;
-        float aa = fwidth(d2);
-        coverage = 1.0 - smoothstep(r2 - aa, r2 + aa, d2);
+        // Analytic 1px-wide edge coverage on the RADIAL distance (not d², whose
+        // fast edge derivative gave a ~4px band that read as a white halo).
+        float d = length(offset);
+        coverage = clamp((vRadius - d) / fwidth(d) + 0.5, 0.0, 1.0);
         if (coverage <= 0.0) discard;
         float thc = sqrt(max(r2 - min(d2, r2), 0.0));
         // Hit point: fragment XY, sphere front Z
@@ -260,8 +262,9 @@
         vec3 cr = cross(vCenter, rayDir);
         float d2 = dot(cr, cr);
         float r2 = vRadius * vRadius;
-        float aa = fwidth(d2);
-        coverage = 1.0 - smoothstep(r2 - aa, r2 + aa, d2);
+        // Analytic 1px-wide edge coverage on the RADIAL distance (see ortho).
+        float d = sqrt(d2);
+        coverage = clamp((vRadius - d) / fwidth(d) + 0.5, 0.0, 1.0);
         if (coverage <= 0.0) discard;
 
         float tca = dot(vCenter, rayDir);

--- a/src/lib/structure/parsers/outcar.ts
+++ b/src/lib/structure/parsers/outcar.ts
@@ -116,8 +116,9 @@ function magnetization_block(
 }
 
 /** Per-atom magmom: scalar (collinear, only the x table) or [mx,my,mz]
- *  (non-collinear, all three tables present). */
-function last_magnetization(
+ *  (non-collinear, all three tables present). Exported so the trajectory OUTCAR
+ *  parser can attach magmom to a relaxation's final frame too. */
+export function last_magnetization(
   lines: string[],
   n_atoms: number,
 ): (number | Vec3)[] | null {

--- a/src/lib/trajectory/parsers/vasp.ts
+++ b/src/lib/trajectory/parsers/vasp.ts
@@ -4,6 +4,7 @@ import type { Matrix3x3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { TrajectoryFrame, TrajectoryType } from '../index'
 import { create_trajectory_frame } from './common'
+import { last_magnetization } from '$lib/structure/parsers/outcar'
 
 // A parsed XDATCAR header block: scale, lattice (already scaled), element
 // names + counts. NPT runs repeat this block before every frame; constant-cell
@@ -278,6 +279,18 @@ export const parse_vasp_outcar = (content: string, filename?: string): Trajector
   }
 
   if (frames.length === 0) throw new Error(`OUTCAR: no ionic steps found`)
+
+  // Attach per-atom magnetic moments (final converged "magnetization (x)" block,
+  // + (y)/(z) for non-collinear) to the last frame so magmom arrows show on the
+  // relaxed structure — the single-structure OUTCAR path (#481) only fires for a
+  // 1-step OUTCAR; a relaxation loads here as a trajectory.
+  const magmoms = last_magnetization(lines, n_atoms)
+  if (magmoms) {
+    const sites = frames[frames.length - 1].structure.sites
+    for (let i = 0; i < sites.length && i < magmoms.length; i++) {
+      sites[i].properties = { ...sites[i].properties, magmom: magmoms[i] }
+    }
+  }
   return {
     frames,
     metadata: {


### PR DESCRIPTION
## Summary

Three viewer fixes, split out of the CLI-packaging branch (all verified live on a real magnetic OUTCAR).

- **Trajectory OUTCAR magmom** — #481 added per-atom magmom only to the single-structure OUTCAR parser, but a relaxation OUTCAR (2+ ionic steps) loads as a *trajectory* via `parse_vasp_outcar`, which dropped it. Export `last_magnetization` and attach the final converged magnetization block to the trajectory's last (relaxed) frame.
- **Magnetic-moment display controls** — a "Magnetic Moments" settings section (mirrors the force-vector one): `magmom_scale` slider + spin-up/down colour pickers, shown when magmom is on. en/zh i18n.
- **Anti-aliased atom silhouettes** — the impostor ray-sphere used a hard `discard` at the edge, so MSAA couldn't smooth the jagged outline (discard gives no sub-pixel coverage). Fade an analytic 1px edge-coverage band on the radial distance (`clamp((r - length(offset)) / fwidth(d) + 0.5)`) and enable `alphaToCoverage` on the opaque material, so the canvas's 4× MSAA anti-aliases the silhouette. (An earlier d²-based band read as a white halo — fixed to the radial 1px form.)

## Verification
- `pnpm check`: 0 errors.
- Live: loaded a NiOOH bulk OUTCAR (ISPIN=2, MAGMOM = 1 -1 1 -1…) — red-up / blue-down arrows render the AFM Ni ordering (±1.022 µB); atom edges smooth with no halo.
