### PR TITLE
fix(viewer): depth cueing no longer washes out molecules

### DIFF
--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -31,6 +31,7 @@
     compute_show_bulk_atoms,
     get_lattice as get_lattice_pure,
     compute_structure_size,
+    compute_atom_span_radius,
     get_frozen_info,
     desaturate_color,
     compute_force_data,
@@ -2143,7 +2144,14 @@
       if (cam) {
         const center = new Vector3(...(rotation_target ?? [0, 0, 0]))
         const cam_dist = cam.position.distanceTo(center)
-        const half_range = Math.max(structure_size, 2) * 0.5
+        // Fog range must track the ACTUAL drawn atoms, not the lattice: a molecule
+        // sits in a large vacuum box, so a lattice-based range (compute_structure_size)
+        // puts the whole molecule inside the fog interval and washes it uniformly
+        // toward the background. Use the atom bounding-box radius; fall back to the
+        // lattice size only when there are no atoms. Floor at 0.1 Å so the fog
+        // interval never collapses to zero width.
+        const atom_span = compute_atom_span_radius(structure)
+        const half_range = Math.max(atom_span ?? structure_size * 0.5, 0.1)
         const front = cam_dist - half_range
         const back = cam_dist + half_range
         const full_depth = back - front

--- a/src/lib/structure/scene/index.ts
+++ b/src/lib/structure/scene/index.ts
@@ -6,6 +6,7 @@ export {
   compute_show_bulk_atoms,
   get_lattice,
   compute_structure_size,
+  compute_atom_span_radius,
   get_frozen_info,
 } from './visibility'
 

--- a/src/lib/structure/scene/visibility.ts
+++ b/src/lib/structure/scene/visibility.ts
@@ -159,6 +159,34 @@ export function compute_structure_size(lattice: PymatgenLattice | null): number 
 }
 
 /**
+ * Half of the largest atom bounding-box axis (world Å) — the REAL extent of the
+ * drawn atoms, independent of any vacuum padding in the lattice. `compute_
+ * structure_size` measures the cell, so a molecule dropped in a big vacuum box
+ * reports a large size even though the atoms occupy a tiny region; using that
+ * for depth-cue fog puts the whole molecule inside the fog interval and washes
+ * it uniformly toward the background. Fog range should use THIS instead.
+ * Returns null when there are no atoms.
+ */
+export function compute_atom_span_radius(
+  structure: AnyStructure | undefined,
+): number | null {
+  if (!structure?.sites?.length) return null
+  let min_x = Infinity, max_x = -Infinity
+  let min_y = Infinity, max_y = -Infinity
+  let min_z = Infinity, max_z = -Infinity
+  for (const site of structure.sites) {
+    const [x, y, z] = site.xyz
+    if (x < min_x) min_x = x
+    if (x > max_x) max_x = x
+    if (y < min_y) min_y = y
+    if (y > max_y) max_y = y
+    if (z < min_z) min_z = z
+    if (z > max_z) max_z = z
+  }
+  return Math.max(max_x - min_x, max_y - min_y, max_z - min_z) / 2
+}
+
+/**
  * Get frozen atom info from a site's selective_dynamics property.
  * Returns null if no selective_dynamics, or an object describing the frozen state.
  */

--- a/tests/vitest/structure/scene.test.ts
+++ b/tests/vitest/structure/scene.test.ts
@@ -10,6 +10,7 @@ import {
   filter_bonds_during_drag,
   filter_bond_pairs,
   build_cutting_visibility_map,
+  compute_atom_span_radius,
   compute_show_bulk_atoms,
   get_lattice,
   compute_structure_size,
@@ -304,6 +305,33 @@ describe(`compute_structure_size`, () => {
   test(`returns 10 when lattice has no params or matrix`, () => {
     const lattice = { pbc: [true, true, true] } as unknown as PymatgenLattice
     expect(compute_structure_size(lattice)).toBe(10)
+  })
+})
+
+describe(`compute_atom_span_radius`, () => {
+  test(`returns null for undefined / empty structure`, () => {
+    expect(compute_atom_span_radius(undefined)).toBeNull()
+    expect(compute_atom_span_radius({ sites: [] } as unknown as PymatgenStructure))
+      .toBeNull()
+  })
+
+  test(`half of the largest atom bbox axis, ignoring the lattice/vacuum box`, () => {
+    // Molecule-like: atoms span 2 Å in x, 1 Å in y, 0 in z. Even if dropped in a
+    // huge vacuum lattice, the span radius reflects the ATOMS, not the box.
+    const sites = [
+      make_site([0, 0, 0], `O`),
+      make_site([2, 1, 0], `H`),
+      make_site([1, 0, 0], `H`),
+    ]
+    const structure = { sites, lattice: make_lattice(20, 20, 20) } as
+      unknown as PymatgenStructure
+    // max axis span = x: 2 → radius 1
+    expect(compute_atom_span_radius(structure)).toBeCloseTo(1)
+  })
+
+  test(`single atom → 0 span`, () => {
+    const structure = { sites: [make_site([5, 5, 5])] } as unknown as PymatgenStructure
+    expect(compute_atom_span_radius(structure)).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Bug
H₂O / small molecules render **washed out / greyed** — the whole molecule looks faded.

## Root cause
Depth-cue fog range was computed from `compute_structure_size(lattice)` = the **cell** size. A molecule sits in a large vacuum box, so the fog interval spanned the entire box while the atoms occupied only its centre. The whole molecule therefore fell *inside* the fog interval (after `depth_cue_start`) and got mixed uniformly toward the background colour.

Confirmed live on the Water demo: fog `near = 9.9`, nearest atom at `10.9` → every atom past the fog start, uniform ~7-10% grey wash. Turning depth cueing off removed it entirely (pixel mean\|Δ\| 3.3).

## Fix
New pure helper `compute_atom_span_radius(structure)` — half the largest atom bounding-box axis, i.e. the **actual drawn extent**, independent of vacuum padding. Fog `half_range` uses it instead of the lattice size (falls back to the lattice only when there are no atoms; floored at 0.1 Å so the interval never collapses).

- **Crystals** (atoms ≈ cell): unchanged — TiO₂ still fades back rows (fog on/off differ ~40%).
- **Molecules**: only genuine front-to-back depth cueing remains, no flat wash. Water now matches depth-cueing-off (pixel mean\|Δ\| **0.24** vs 3.3 before).

## Tests
- New `compute_atom_span_radius` unit tests (empty → null, molecule-in-vacuum ignores box, single atom → 0).
- `pnpm check` 0 errors; full vitest 4439 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)