### PR TITLE
revert(structure): drop the align_to_principal_axes flip guard from #484

### DIFF
--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -614,17 +614,6 @@ export function align_to_principal_axes(structure: AnyStructure): AnyStructure {
     [axes[0][2], axes[1][2], axes[2][2]],
   ]
 
-  // Principal axes are sign-ambiguous — the eigenvector signs can turn the
-  // molecule upside-down. If the original +z direction ends up pointing down,
-  // rotate 180° about the new x-axis (still principal-axes aligned) so the
-  // molecule keeps its input vertical orientation.
-  if (R[2][2] < 0) {
-    for (let j = 0; j < 3; j++) {
-      R[1][j] = -R[1][j]
-      R[2][j] = -R[2][j]
-    }
-  }
-
   // Transform each site (molecules only - no lattice)
   const new_sites = structure.sites.map((site) => {
     // Translate to center of mass


### PR DESCRIPTION
Removes the eigenvector-sign flip guard added to `align_to_principal_axes` in #484.

- It did not achieve its goal (the launcher water sample still renders flipped).
- It is the only code from #484 that executes on the launcher page, where main's e2e `launcher renders the sample structure preview` check began failing immediately after that merge (runs 28984181378, 28990573049 — canvas never appears in the CI container; not reproducible locally).

The heterostructure orientation/build fixes in #484 are untouched. Supersedes #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)