### PR TITLE
viewer polish: atom_radii bond default, glossy/metallic lighting, brighter seam-free bonds

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -200,12 +200,12 @@
         },
         "catgo.structure.bonding_strategy": {
           "type": "string",
-          "default": "electroneg_ratio",
+          "default": "atom_radii",
           "description": "Method for determining bonds between atoms",
           "enum": [
+            "atom_radii",
             "electroneg_ratio",
-            "solid_angle",
-            "atom_radii"
+            "solid_angle"
           ]
         },
         "catgo.structure.show_gizmo": {

--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -26,13 +26,18 @@ export const LIGHTING_PROFILE_DEFAULTS: Readonly<Record<RenderStyle, LightingPro
     ambient_light: 0.6,
     highlight_strength: 1.0,
   },
-  // Metallic reuses the glossy (specular) shader branch but with a stronger,
-  // lower-angle key light for a harder, compact highlight — reads as shinier.
+  // Metallic reuses the glossy (specular) shader branch but at higher roughness
+  // + metalness, for a bigger, softer, element-tinted highlight (not a compact
+  // hot spot). The shader reads roughness/metalness per style; these are lights.
   metallic: {
-    light_azimuth: 35,
-    light_elevation: 30,
-    directional_light: 0.55,
-    ambient_light: 0.5,
+    // pretty-lattice "metallic": shader roughness 0.4 / metalness 0.4 gives a
+    // bigger, softer, element-tinted highlight than glossy; pair it with a bright
+    // near-head-on key (2.5) and a high ambient fill (1.0) so the metal-dimmed
+    // diffuse stays legible.
+    light_azimuth: 0,
+    light_elevation: 5,
+    directional_light: 2.5,
+    ambient_light: 1.0,
     highlight_strength: 1.0,
   },
   // MatCap samples a baked studio-sphere texture instead of the scene lights, so

--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -18,10 +18,10 @@ import type { LightingProfile, RenderStyle, SettingsConfig, ShowBonds } from './
 export const LIGHTING_PROFILE_DEFAULTS: Readonly<Record<RenderStyle, LightingProfile>> = {
   glossy: {
     // Physically-based key: ambient fill + a near-head-on camera-relative key at
-    // HDR intensity 2.2 (offset ≈ az17/el11), fed through the GGX shader + ACES.
+    // HDR intensity 2.2 (offset ≈ az0/el5), fed through the GGX shader + ACES.
     // Muted colours, a small centred specular hot spot.
-    light_azimuth: 17,
-    light_elevation: 11,
+    light_azimuth: 0,
+    light_elevation: 5,
     directional_light: 2.2,
     ambient_light: 0.6,
     highlight_strength: 1.0,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1976,7 +1976,7 @@
     get_positions_invalidate_all: () => trajectory_positions_version.all,
     get_trajectory_active: () => trajectory_active,
     get_positions: () => get_trajectory_frame_positions,
-    get_strategy: () => (scene_props?.bonding_strategy ?? `electroneg_ratio`) as BondingStrategy,
+    get_strategy: () => (scene_props?.bonding_strategy ?? `atom_radii`) as BondingStrategy,
     get_show_bonds: () => (scene_props?.show_bonds ?? `always`) as string,
     get_options: () => (scene_props?.bonding_options ?? {}) as Record<string, number>,
     set_connectivity: (v) => { trajectory_bond_connectivity_for_frame = v },

--- a/src/lib/structure/atoms/AtomManagerInstances.svelte
+++ b/src/lib/structure/atoms/AtomManagerInstances.svelte
@@ -135,6 +135,17 @@
     return 0
   }
 
+  // Per-render-style PBR (roughness, metalness) for the GGX specular branch,
+  // ported from pretty-lattice's material presets: glossy = crisp dielectric
+  // hot spot, metallic = a bigger/softer, element-colour-tinted highlight.
+  function style_pbr(
+    style: `glossy` | `metallic` | `matte` | `soft` | `flat` | `toon` | `matcap`,
+  ): { roughness: number; metalness: number } {
+    return style === `metallic`
+      ? { roughness: 0.4, metalness: 0.4 }
+      : { roughness: 0.2, metalness: 0.0 }
+  }
+
   const threlte = useThrelte()
 
   // Render-loop refactor (R4c): all canvas-paint requests in this component
@@ -202,6 +213,8 @@
     uniform float uHighlightThreshold;
     uniform float uShadowBrightness;
     uniform float uSpecStrength;  // glossy specular highlight multiplier (1.0 = default)
+    uniform float uRoughness;     // GGX roughness (glossy 0.2, metallic 0.4 → bigger hot spot)
+    uniform float uMetalness;     // 0 dielectric (glossy), 0.4 metallic (colour-tinted spec)
     uniform sampler2D uMatcap;    // baked studio-sphere lighting (render style 3)
     // projectionMatrix is only auto-injected into vertex shader, must re-declare for fragment
     uniform mat4 projectionMatrix;
@@ -333,7 +346,11 @@
         //    at roughness 0.2, metalness 0) lit by ambient + a near-head-on key.
         //    GGX(rough=0.2) is what gives the SMALL, bright, centred hot spot;
         //    ACES rolls the HDR key light back to display range. ──
-        float rough = 0.2;
+        //    uRoughness/uMetalness are per-render-style (glossy 0.2/0.0,
+        //    metallic 0.4/0.4) — a bigger roughness widens/softens the hot spot,
+        //    metalness tints the highlight by the element colour and dims the
+        //    diffuse (MeshStandardMaterial metal workflow), matching pretty-lattice.
+        float rough = uRoughness;
         float a = rough * rough;
         float a2 = a * a;
         float NdotL = max(dot(normal, lightDirView), 0.0);
@@ -347,14 +364,18 @@
         // Smith-Schlick geometry.
         float k = a * 0.5;
         float G = (NdotV / (NdotV * (1.0 - k) + k)) * (NdotL / (NdotL * (1.0 - k) + k));
-        // Schlick Fresnel, dielectric F0 = 0.04.
-        float F = 0.04 + 0.96 * pow(1.0 - VdotH, 5.0);
-        float specular = (D * G * F) / (4.0 * NdotV * NdotL + 1e-4);
+        // Schlick Fresnel with a metalness-tinted F0: dielectric 0.04, metals
+        // reflect their own (element) colour. glossy (metalness 0) stays 0.04.
+        vec3 F0 = mix(vec3(0.04), baseColor, uMetalness);
+        vec3 F = F0 + (vec3(1.0) - F0) * pow(1.0 - VdotH, 5.0);
+        vec3 specular = (D * G) * F / (4.0 * NdotV * NdotL + 1e-4);
+        // Metals have little/no diffuse — attenuate it by (1 - metalness).
+        vec3 diffuseColor = baseColor * (1.0 - uMetalness);
         // Energy-conserving Lambert (÷π) on the key, like MeshStandardMaterial —
         // without it the base*key diffuse blew out (too bright, over-saturated).
         // uDirectionalIntensity = HDR key strength, uAmbientIntensity = fill.
-        vec3 color2 = baseColor * (uAmbientIntensity + uDirectionalIntensity * NdotL * 0.31831)
-                 + vec3(1.0) * specular * uDirectionalIntensity * NdotL * uSpecStrength;
+        vec3 color2 = diffuseColor * (uAmbientIntensity + uDirectionalIntensity * NdotL * 0.31831)
+                 + specular * uDirectionalIntensity * NdotL * uSpecStrength;
         // Soft rim shadow: darken the grazing silhouette a touch (NdotV→0 at the
         // edge) for a little volume / ambient-occlusion feel, like VESTA spheres.
         color2 *= mix(0.6, 1.0, smoothstep(0.0, 0.5, NdotV));
@@ -412,6 +433,9 @@
         uRenderStyle: { value: render_style_to_int(render_style) },
         // Glossy specular highlight multiplier (slider-driven); kept live by $effect below.
         uSpecStrength: { value: highlight_strength },
+        // Per-style PBR (glossy vs metallic); kept live by the render-style $effect.
+        uRoughness: { value: style_pbr(render_style).roughness },
+        uMetalness: { value: style_pbr(render_style).metalness },
         // Toon (cel) thresholds — AtomCanvas ToonHighlightMaterial defaults.
         uShadowThreshold: { value: 0.3 },
         uHighlightThreshold: { value: 0.97 },
@@ -598,6 +622,9 @@
   // no material swap, so glossy/matte/toon toggle live with zero GPU churn.
   $effect(() => {
     opaque_material.uniforms.uRenderStyle.value = render_style_to_int(render_style)
+    const pbr = style_pbr(render_style)
+    opaque_material.uniforms.uRoughness.value = pbr.roughness
+    opaque_material.uniforms.uMetalness.value = pbr.metalness
     // Generate/swap the baked matcap texture ONLY while MatCap is the active
     // style. Building it eagerly on the default (toon) path meant every scene —
     // including headless CI — paid a canvas-texture bake it never sampled; gate

--- a/src/lib/structure/bonding/BondManagerInstances.svelte
+++ b/src/lib/structure/bonding/BondManagerInstances.svelte
@@ -207,20 +207,21 @@
       );
     }
 
-    // 3-point procedural studio env (key + fill + sky/ground gradient).
-    // n is view-space normal. Returns linear-RGB env response for that normal.
+    // Procedural env for the bond cylinders. The old version summed a key lobe
+    // and a near-opposite fill lobe — for a cylinder that left a dark VALLEY
+    // along the axis (the strip whose normal is perpendicular to BOTH lights got
+    // neither), read as a dark line down the middle of every bond. Replace with
+    // a flat ambient floor + a single soft key so the shading is a gentle
+    // one-sided gradient with no dark seam. n is the view-space normal.
     vec3 studio_env(vec3 n, vec3 keyDir) {
-      vec3 col = vec3(0.0);
-      // Key: warm white from primary direction. Quadratic falloff (cheap, no pow).
+      // Flat ambient floor — the cylinder never goes dark on its shaded side.
+      vec3 col = vec3(0.72);
+      // Soft key highlight on the lit side (quadratic falloff, cheap).
       float k = max(dot(n, keyDir), 0.0);
-      col += vec3(1.00, 0.97, 0.92) * (k * k) * 0.55;
-      // Fill: cool white opposite-ish.
-      vec3 fillDir = normalize(vec3(-keyDir.x * 0.9, keyDir.y * 0.4, keyDir.z * 0.6));
-      float f = max(dot(n, fillDir), 0.0);
-      col += vec3(0.88, 0.93, 1.00) * (f * f) * 0.30;
-      // Sky-to-ground gradient driven by vertical view-space normal
+      col += vec3(1.00, 0.97, 0.92) * (k * k) * 0.35;
+      // Faint vertical sky lift for a touch of volume.
       float sky = n.y * 0.5 + 0.5;
-      col += mix(vec3(0.42, 0.43, 0.50), vec3(0.95, 0.97, 1.00), sky) * 0.22;
+      col += vec3(0.06, 0.06, 0.07) * sky;
       return col;
     }
 
@@ -295,7 +296,11 @@
     transparent: true,
     depthWrite: true,
     uniforms: {
-      ambientIntensity: { value: 0.7 },
+      // Bonds are lit by their own fixed studio env (not the atom render-style
+      // profile). With the flattened env (ambient floor ~0.72) exposure ~0.95
+      // lands the cylinders at roughly their base colour — matching the atoms
+      // they connect, no dark seam. ACES rolls off any over-bright key.
+      ambientIntensity: { value: 0.8 },
       directionalIntensity: { value: 0.3 },
       saturation: { value: saturation },
       brightness: { value: brightness },

--- a/src/lib/structure/catrender/CatRenderViewPane.svelte
+++ b/src/lib/structure/catrender/CatRenderViewPane.svelte
@@ -160,7 +160,7 @@
   // store the pane can subscribe to); the app default is the honest,
   // non-hardcoded source available to a prop-only pane.
   const BOND_STRATEGY =
-    (DEFAULTS.structure.bonding_strategy ?? `electroneg_ratio`) as BondingStrategy
+    (DEFAULTS.structure.bonding_strategy ?? `atom_radii`) as BondingStrategy
   const BOND_OPTIONS =
     (DEFAULTS.structure.bonding_options ?? {}) as Record<string, number>
 


### PR DESCRIPTION
Four viewer default/appearance tweaks (all live-verified on TiO₂ / Si).

### 1. `chore(bonds)` — default bonding strategy = atom_radii everywhere
The viewer setting default was already `atom_radii`; align the rest so nothing falls back to `electroneg_ratio`: VS Code ext default + enum order, and the viewer strategy fallbacks.

### 2. `chore(viewer)` — glossy key light → azimuth 0 / elevation 5
Head-on key (was az17/el11) for a more centred specular hot spot.

### 3. `feat(viewer)` — metallic gets a bigger, softer highlight (pretty-lattice port)
Metallic shared glossy's hardcoded GGX roughness 0.2. Add per-render-style `uRoughness`/`uMetalness` (metallic 0.4/0.4) — a wider, element-colour-tinted highlight — plus the matching bright near-head-on key (2.5) / high ambient (1.0). **Glossy is byte-identical** (metalness 0, roughness 0.2 → same math).

### 4. `fix(viewer)` — brighter bonds, no dark seam down the cylinder
`BondManagerInstances` (default instanced bonds) rendered cylinders ~0.4× their base colour (too dark) and had a **dark line down each bond** — its studio env summed a key + near-opposite fill lobe, leaving a dark valley on the strip perpendicular to both. Replaced with a flat ambient floor + single soft key so bonds match their end atoms with a gentle highlight and no seam. (DashedBond/Bond.svelte use a different, profile-driven path — unaffected.)

## Verification
- `pnpm check` 0 errors; targeted vitest green (bonding/coordination/settings/scene).
- Live screenshots: bonds no longer dark / seamed; metallic highlight visibly bigger than glossy; glossy pixel-identical before/after the shader refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)