### PR TITLE
chore(pip): align catgo package version to 1.4.5

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catgo"
-version = "0.1.1"
+version = "1.4.5"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
 readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Bumps the pip package (`server/pyproject.toml`) from its legacy 0.1.x line to **1.4.5**, matching the desktop app / release version so `pip install catgo` and the GitHub release share one number.

After merge, dispatch `pypi-publish.yml` to publish catgo 1.4.5 to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)