### PR TITLE
fix(pip): make the pip-installed catgo wheel actually launch (1.4.5.post1)

### DIFF
--- a/server/catgo/cli/_legacy.py
+++ b/server/catgo/cli/_legacy.py
@@ -20,6 +20,18 @@ def _ensure_sys_path():
     sd = str(_server_dir())
     if sd not in sys.path:
         sys.path.insert(0, sd)
+    # In a pip wheel, the top-level server modules that the code imports by bare
+    # name (`main`, the full `workflow` engine, `plugin_loader`, `mcp_server`)
+    # live outside the `catgo` package, so `packages=["catgo"]` can't ship them.
+    # The wheel force-includes them under `catgo/_bundled/`; put that first on
+    # the path so those bare imports resolve (and `import workflow` picks the
+    # full engine here, not the smaller `catgo.workflow`). In a source/editable
+    # checkout this directory doesn't exist, so this is a no-op there.
+    bundled = _server_dir() / "_bundled"
+    if bundled.is_dir():
+        bs = str(bundled)
+        if bs not in sys.path:
+            sys.path.insert(0, bs)
 
 
 def _get_port() -> int:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catgo"
-version = "1.4.5"
+version = "1.4.5.post1"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
 readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"
@@ -70,3 +70,16 @@ packages = ["catgo"]
 artifacts = [
     "catgo/web/**/*",
 ]
+
+# The server imports a few top-level modules by BARE name (`main`, the full
+# `workflow` engine, `plugin_loader`, `mcp_server`). They sit outside the
+# `catgo` package, so `packages=["catgo"]` cannot ship them and `pip install`ed
+# `catgo app`/`serve` crashed with `ModuleNotFoundError`. Bundle them under
+# `catgo/_bundled/`; `_ensure_sys_path()` puts that dir on sys.path at runtime
+# so the bare imports resolve (and `workflow` here is the full engine, kept
+# distinct from the smaller `catgo.workflow`).
+[tool.hatch.build.targets.wheel.force-include]
+"main.py" = "catgo/_bundled/main.py"
+"workflow" = "catgo/_bundled/workflow"
+"plugin_loader.py" = "catgo/_bundled/plugin_loader.py"
+"mcp_server.py" = "catgo/_bundled/mcp_server.py"


### PR DESCRIPTION
## Bug
\`pip install catgo\` (1.4.5) installs and \`catgo --help\` works, but \`catgo app\` / \`serve\` / \`status\` crash with \`ModuleNotFoundError\`. The wheel installs but the app never launches.

## Root cause
The server imports several **top-level** modules by **bare name** — \`main\`, the full \`workflow\` engine (\`workflow.node_sets\`, \`workflow.engines\`, …), and \`plugin_loader\`. These live *outside* the \`catgo\` package, so \`packages=["catgo"]\` never shipped them in the wheel. They only resolve in a source/editable checkout (where \`server/\` is on \`sys.path\`). There's also a name clash: a *different*, smaller \`catgo.workflow\` exists, so they can't simply be merged.

## Fix
- **Force-include** \`main.py\`, \`workflow/\`, \`plugin_loader.py\`, \`mcp_server.py\` under \`catgo/_bundled/\` in the wheel.
- \`_ensure_sys_path()\` adds \`catgo/_bundled\` to \`sys.path\` (first, so bare \`import workflow\` picks the full engine). In a source checkout that dir doesn't exist → **no-op**, so the editable dev install is untouched.
- Version → **1.4.5.post1** (packaging-only rebuild; PyPI is immutable, so 1.4.5 can't be re-uploaded — a post-release keeps the 1.4.5 identity).

## Verification
Built the wheel and installed it into a **clean venv** (not the dev tree): \`catgo status\` runs cleanly and \`catgo serve\` returns **API 200 / SPA UI 200 / MCP endpoint live**.

Desktop app version is unaffected (stays 1.4.5); this is a pip-package-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)