### PR TITLE
feat: close/save guard for unsaved structure edits (VS Code ext + desktop)

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -176,6 +176,9 @@
   // `modified.is_modified(tab_id)` at the tab-/pane-close sites (reachable via
   // `pane_deps.modified`) and `modified.clear(tab_id)` after a successful save.
   const modified = create_modified_registry()
+  // Task B3 close-guard: wire the tab manager's per-tab close prompt to the
+  // modified registry so a clean tab closes with no confirmation dialog.
+  tm.is_tab_modified = (id) => modified.is_modified(id)
   // Destructure stable function references from the tab manager
   const { tab_states, get_active_ts, create_tab: open_tab, close_tab, request_close_tab, activate_tab, update_tab_label, switch_to_structure } = tm
 

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -80,6 +80,7 @@
   // Deep-clone structures on assignment into a pane so panes/tabs never alias
   // the same object (module-level samples, library entries, reused DB imports).
   import { clone_structure } from '$lib/structure/clone'
+  import { create_modified_registry } from '$lib/structure/close-guard.svelte'
   import { clone_trajectory_for_pane } from '$lib/trajectory/clone'
   import { set_terminal_opener, get_active_terminal, type TerminalHandle } from '$lib/structure/terminal-registry.svelte'
   // SDK-agent visible-terminal bridge: global poller + approval card
@@ -167,6 +168,14 @@
 
   // ========== Tab Management (extracted to ./lib/tab-manager.svelte.ts) ==========
   const tm = create_tab_manager()
+
+  // Per-tab unsaved-edit tracking for the close/save guard. Keyed by tab id:
+  // each viewer's `on_structure_change` marks its tab modified, and every fresh
+  // load/replace (file open, DB import, MCP push, sample/build card, editor
+  // save-back, chat split/overwrite) clears it. Task B3 reads
+  // `modified.is_modified(tab_id)` at the tab-/pane-close sites (reachable via
+  // `pane_deps.modified`) and `modified.clear(tab_id)` after a successful save.
+  const modified = create_modified_registry()
   // Destructure stable function references from the tab manager
   const { tab_states, get_active_ts, create_tab: open_tab, close_tab, request_close_tab, activate_tab, update_tab_label, switch_to_structure } = tm
 
@@ -212,6 +221,7 @@
   const pane_deps: PaneManagerDeps = {
     tab_states,
     update_tab_label,
+    modified,
     export_fs_browse: (dir) => export_fs_browse(dir),
     reset_viewer: (tab_id, leaf_id) => {
       if (!STATIC_ONLY) {
@@ -735,6 +745,7 @@
             p.initial_structure_ref = parsed
             p.initial_site_count = parsed.sites.length
             p.modified = false
+            modified.clear(target_tab_id)
             update_tab_label(target_tab_id)
           }
         }
@@ -824,6 +835,7 @@
     pane.initial_structure_ref = struct
     pane.initial_site_count = struct.sites?.length ?? 0
     pane.modified = false
+    modified.clear(tab_id)
     // Set tab label — use tm.tabs (raw $state), not tabs_with_badges ($derived copy)
     const tab = tm.tabs.find(t => t.id === tab_id)
     if (tab && label) tab.label = label
@@ -1099,6 +1111,7 @@
     pane.initial_site_count = imported.sites.length
     pane.initial_structure_ref = imported as AnyStructure
     pane.modified = false
+    modified.clear(modal.import_target_tab)
     pane.is_trajectory_mode = false
     pane.trajectory = null
 
@@ -1388,6 +1401,7 @@
     p.selected_sites = []
     p.current_step_idx = 0
     p.modified = false
+    modified.clear(tab_id)
     p.remote_origin = remote_origin
     p.local_file_path = local_file_path
     p.source_filename = e.filename
@@ -1676,6 +1690,7 @@
           p.initial_site_count = data.structure.sites?.length ?? 0
           p.initial_structure_ref = data.structure
           p.modified = false
+          modified.clear(tm.active_tab_id)
           new_ts.active_leaf_id = new_leaf.id
           update_tab_label(tm.active_tab_id)
         }
@@ -1694,6 +1709,7 @@
         p.initial_site_count = data.structure.sites?.length ?? 0
         p.initial_structure_ref = data.structure
         p.modified = false
+        modified.clear(tab_id)
       }
       if (data.trajectory) {
         const traj = data.trajectory as { frames?: unknown[]; metadata?: { source_format?: string } }
@@ -1706,6 +1722,7 @@
             p.initial_site_count = frame.structure.sites?.length ?? 0
             p.initial_structure_ref = frame.structure
             p.modified = false
+            modified.clear(tab_id)
             p.selected_sites = []
             p.current_step_idx = 0
             ts.active_leaf_id = target_id
@@ -1718,6 +1735,7 @@
         p.structure = undefined
         p.initial_site_count = 0
         p.modified = false
+        modified.clear(tab_id)
       }
       p.selected_sites = []
       p.current_step_idx = 0
@@ -1894,6 +1912,7 @@
       const pane = first ? structurePane(first) : null
       if (!ts || !pane) return false
       pane.structure = clone_structure(struct)
+      modified.clear(`default`)
       update_tab_label(`default`)
       return true
     }
@@ -1973,6 +1992,7 @@
       pane.source_filename = filename || null
       pane.raw_traj_b64 = btoa(unescape(encodeURIComponent(raw)))
       pane.raw_traj_format = (filename.toLowerCase().split(`.`).pop() || ``)
+      modified.clear(`default`)
       update_tab_label(`default`)
       return true
     }
@@ -2441,6 +2461,7 @@
               initial_panel={pane.initial_panel}
               on_file_load={create_on_file_load(tab.id, leaf.id)}
               on_file_drop={create_on_file_drop(tab.id, leaf.id)}
+              on_structure_change={() => modified.mark(tab.id)}
               on_structure_imported={() => update_tab_label(tab.id)}
               on_save_to_project={open_save_dialog}
               on_save_to_database={open_save_dialog}
@@ -2487,6 +2508,7 @@
                 np.initial_site_count = struct.sites.length
                 np.initial_structure_ref = struct
                 np.modified = false
+                modified.clear(new_tab_id)
                 const ntab = tm.tabs.find(t => t.id === new_tab_id)
                 if (ntab) ntab.label = `CatBot structure`
                 tm.update_tab_label(new_tab_id)
@@ -2543,6 +2565,7 @@
                       lp.initial_site_count = struct.sites.length
                       lp.initial_structure_ref = struct
                       lp.modified = false
+                      modified.clear(tab.id)
                     }
                   }
                   const right = findLeafById(ts.root, res.newLeafId)
@@ -2568,7 +2591,7 @@
                   if (!struct?.sites?.length) return
                   const target = leaves(ts.root).find(l => { if (l.id === leaf.id) return false; const p = structurePane(l); return !!p && pane_has_content(p) })
                   const tp = target ? structurePane(target) : null
-                  if (tp) { tp.structure = clone_structure(struct); tp.modified = false }
+                  if (tp) { tp.structure = clone_structure(struct); tp.modified = false; modified.clear(tab.id) }
                 }}
               />
             </div>
@@ -2630,6 +2653,7 @@
                         pane.initial_site_count = sample.data.sites?.length ?? 0
                         pane.initial_structure_ref = sample.data
                         pane.modified = false
+                        modified.clear(tab.id)
                         ts.active_leaf_id = leaf.id
                         update_tab_label(tab.id)
                       }}
@@ -2735,6 +2759,7 @@
                   pane.initial_site_count = 2
                   pane.initial_structure_ref = pane.structure
                   pane.modified = false
+                  modified.clear(tab.id)
                   ts.active_leaf_id = leaf.id
                 }}>
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -81,7 +81,8 @@
   // the same object (module-level samples, library entries, reused DB imports).
   import { clone_structure } from '$lib/structure/clone'
   import { create_modified_registry } from '$lib/structure/close-guard.svelte'
-  import { apply_beforeunload_guard } from '$lib/structure/save-on-close'
+  import { apply_beforeunload_guard, guard_close } from '$lib/structure/save-on-close'
+  import { save_format_from_path } from '$lib/structure/save-format'
   import { clone_trajectory_for_pane } from '$lib/trajectory/clone'
   import { set_terminal_opener, get_active_terminal, type TerminalHandle } from '$lib/structure/terminal-registry.svelte'
   // SDK-agent visible-terminal bridge: global poller + approval card
@@ -594,17 +595,28 @@
   async function save_and_close_tab(tab_id: string) {
     tab_close_saving = true
     tab_close_save_error = ``
-    try {
-      const entries = build_close_all_entries(tm.tabs.filter((tb) => tb.id === tab_id), tab_states)
-      await execute_close_all_saves(entries, tab_states)
-      sidebar.refresh_counter++
-      modified.clear(tab_id)
-      close_tab(tab_id)
-    } catch (e) {
-      tab_close_save_error = e instanceof Error ? e.message : t(`app.save_failed`)
-    } finally {
-      tab_close_saving = false
-    }
+    // The modal has already collected the user's choice (Save), so route the
+    // decision through the tested `guard_close` helper: confirm() resolves to
+    // 'save' and we close only if on_save() reports success — a failed save
+    // keeps the tab open with the error shown.
+    const may_close = await guard_close({
+      modified: true,
+      confirm: async () => `save`,
+      on_save: async () => {
+        try {
+          const entries = build_close_all_entries(tm.tabs.filter((tb) => tb.id === tab_id), tab_states)
+          await execute_close_all_saves(entries, tab_states)
+          sidebar.refresh_counter++
+          modified.clear(tab_id)
+          return true
+        } catch (e) {
+          tab_close_save_error = e instanceof Error ? e.message : t(`app.save_failed`)
+          return false
+        }
+      },
+    })
+    tab_close_saving = false
+    if (may_close) close_tab(tab_id)
   }
 
   function cancel_tab_close() {
@@ -612,6 +624,13 @@
     tm.tab_close_confirm_id = null
     tab_close_save_error = ``
   }
+
+  // A tab-close save error is modal-scoped: once the modal closes by ANY path
+  // (Cancel, Escape, the danger Close Tab button, overlay click) drop the error
+  // so the next tab-close modal never opens showing a stale error from before.
+  $effect(() => {
+    if (!tm.tab_close_confirm_id) tab_close_save_error = ``
+  })
 
   // Build project tree for save dialogs
   let save_project_children = $derived.by(() => {
@@ -761,13 +780,12 @@
     if (!pane) return
     const filename = pane.source_filename || `structure.cif`
 
-    // Determine format from filename
-    const ext = filename.split(`.`).pop()?.toLowerCase() || ``
-    let format = `cif`
-    if ([`poscar`, `vasp`, `contcar`].includes(ext) || /^(POSCAR|CONTCAR)$/i.test(filename)) format = `poscar`
-    else if (ext === `xyz`) format = `xyz`
-    else if (ext === `extxyz`) format = `extxyz`
-    else if (ext === `json`) format = `json`
+    // Fill the text-editor buffer in the source file's format. `cif` is the
+    // deliberate fallback when the path maps to no faithful serializer: this
+    // only seeds an editable buffer and NEVER writes back to the source file
+    // (the on-save handler re-parses and updates the pane in memory), so an
+    // unknown source can safely default to CIF here.
+    const format = save_format_from_path(filename) ?? `cif`
 
     // Serialize: try Python backend first, fallback to frontend serializers
     let content = ``
@@ -1998,6 +2016,7 @@
     request_close_tab,
     get_tab_close_confirm_id: () => tm.tab_close_confirm_id,
     set_tab_close_confirm_id: (v) => { tm.tab_close_confirm_id = v },
+    get_tab_close_saving: () => tab_close_saving,
     get_pending_layout_change: () => tm.pending_layout_change,
     set_pending_layout_change: (_v) => { tm.pending_layout_change = null },
   })

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -81,6 +81,7 @@
   // the same object (module-level samples, library entries, reused DB imports).
   import { clone_structure } from '$lib/structure/clone'
   import { create_modified_registry } from '$lib/structure/close-guard.svelte'
+  import { apply_beforeunload_guard } from '$lib/structure/save-on-close'
   import { clone_trajectory_for_pane } from '$lib/trajectory/clone'
   import { set_terminal_opener, get_active_terminal, type TerminalHandle } from '$lib/structure/terminal-registry.svelte'
   // SDK-agent visible-terminal bridge: global poller + approval card
@@ -184,6 +185,14 @@
 
   // ========== Popout / Sidebar / Pane / Layout / Export / DragDrop / Resize deps ==========
   let is_tauri = $state(false)
+  // Task B4 window-close guard. When the OS/user closes the whole window while
+  // any tab has unsaved edits, we intercept it — web via `beforeunload` (native
+  // browser prompt), desktop via Tauri `onCloseRequested`. On desktop we reuse
+  // the Close-All dialog; `window_close_pending` remembers that finishing that
+  // dialog (save all / close without saving) should then destroy the window.
+  // Plain `let` (not $state) — it gates async callbacks, never drives the UI.
+  let window_close_pending = false
+  let close_guard_registered = false
   let popout_chat_mode = $state(false)
   // Mobile (iOS/Android Tauri) gate. On mobile we render the purpose-built
   // MobileWorkspace (terminal-first; structure editor + russh SSH terminal +
@@ -532,6 +541,10 @@
   // ========== Close All Tabs (extracted to ./lib/close-all-helper.ts) ==========
 
   function open_close_all_dialog() {
+    // Opening via the normal menu is never a window-close request. Reset the
+    // flag so a cancel left over from an earlier window-close attempt can't make
+    // a later Close-All destroy the window (see setup_close_guard).
+    window_close_pending = false
     modal.close_all_entries = build_close_all_entries(tm.tabs, tab_states)
     modal.close_all_error = ``
     modal.close_all_visible = true
@@ -545,6 +558,9 @@
       sidebar.refresh_counter++
       close_all_structure_tabs(tm.tabs, tab_states, close_tab)
       modal.close_all_visible = false
+      // If this dialog came from a window-close request, everything is now saved
+      // → proceed to actually close the window.
+      destroy_main_window_after_close_guard()
     } catch (e) {
       modal.close_all_error = e instanceof Error ? e.message : t(`app.save_failed`)
     } finally {
@@ -555,6 +571,8 @@
   function close_all_without_saving() {
     close_all_structure_tabs(tm.tabs, tab_states, close_tab)
     modal.close_all_visible = false
+    // Window-close path: user chose to discard → close the window.
+    destroy_main_window_after_close_guard()
   }
 
   // ===== Per-tab close prompt: Save option (Task B3 close-guard) =====
@@ -981,6 +999,51 @@
     }
   }
 
+  // Web build: block the browser's unload (native "Leave site?" prompt) when any
+  // tab has unsaved edits. Named fn so re-adding on effect re-run is a no-op.
+  function handle_beforeunload(event: BeforeUnloadEvent) {
+    apply_beforeunload_guard(event, modified.any_modified())
+  }
+
+  // Desktop (Tauri): WebKitGTK does not reliably fire `beforeunload` on window
+  // close, so guard the main window via `onCloseRequested`. When tabs are dirty
+  // we cancel the close and surface the existing Close-All dialog; finishing it
+  // (save all / close without saving) then destroys the window (see
+  // execute_close_all / close_all_without_saving). Clean state closes silently.
+  // Popout windows (chat/structure/docs/workflow) are ephemeral mirrors with
+  // their own registry and are intentionally NOT guarded here.
+  async function setup_close_guard() {
+    if (close_guard_registered) return
+    try {
+      const { getCurrentWindow } = await import(`@tauri-apps/api/window`)
+      const win = getCurrentWindow()
+      if (win.label !== `main`) return
+      close_guard_registered = true
+      await win.onCloseRequested((event) => {
+        if (!modified.any_modified()) return // clean → allow the window to close
+        event.preventDefault()
+        open_close_all_dialog()
+        window_close_pending = true
+      })
+    } catch (err) {
+      console.error(`[Tauri] Failed to register window-close guard:`, err)
+    }
+  }
+
+  // Force-close the window after the user resolves the Close-All dialog from the
+  // window-close path. `destroy()` (not `close()`) bypasses onCloseRequested so
+  // we don't re-enter the guard.
+  async function destroy_main_window_after_close_guard() {
+    if (!window_close_pending) return
+    window_close_pending = false
+    try {
+      const { getCurrentWindow } = await import(`@tauri-apps/api/window`)
+      await getCurrentWindow().destroy()
+    } catch (err) {
+      console.error(`[Tauri] Failed to close window after save guard:`, err)
+    }
+  }
+
   $effect(() => {
     if (typeof window !== `undefined`) {
       apply_theme_to_dom(get_theme_preference())
@@ -990,6 +1053,11 @@
         setup_file_open_listener()
         drain_opened_files()
         setup_tauri_file_drop()
+        setup_close_guard()
+      } else {
+        // Web build: native beforeunload guard. Same fn ref → addEventListener
+        // dedupes if the effect re-runs.
+        window.addEventListener(`beforeunload`, handle_beforeunload)
       }
     }
   })

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -543,7 +543,7 @@
   function open_close_all_dialog() {
     // Opening via the normal menu is never a window-close request. Reset the
     // flag so a cancel left over from an earlier window-close attempt can't make
-    // a later Close-All destroy the window (see setup_close_guard).
+    // a later Close-All close the window (see setup_close_guard).
     window_close_pending = false
     modal.close_all_entries = build_close_all_entries(tm.tabs, tab_states)
     modal.close_all_error = ``
@@ -557,10 +557,15 @@
       await execute_close_all_saves(modal.close_all_entries, tab_states)
       sidebar.refresh_counter++
       close_all_structure_tabs(tm.tabs, tab_states, close_tab)
+      // Every structure tab is now closed (or reset to empty), so all modified
+      // flags are stale — clear them regardless of how the dialog was opened.
+      // On the window-close path this is also what lets the re-issued close()
+      // pass the onCloseRequested guard.
+      modified.clear_all()
       modal.close_all_visible = false
       // If this dialog came from a window-close request, everything is now saved
       // → proceed to actually close the window.
-      destroy_main_window_after_close_guard()
+      close_main_window_after_close_guard()
     } catch (e) {
       modal.close_all_error = e instanceof Error ? e.message : t(`app.save_failed`)
     } finally {
@@ -570,9 +575,11 @@
 
   function close_all_without_saving() {
     close_all_structure_tabs(tm.tabs, tab_states, close_tab)
+    // All tabs closed/reset → flags are stale (see execute_close_all).
+    modified.clear_all()
     modal.close_all_visible = false
     // Window-close path: user chose to discard → close the window.
-    destroy_main_window_after_close_guard()
+    close_main_window_after_close_guard()
   }
 
   // ===== Per-tab close prompt: Save option (Task B3 close-guard) =====
@@ -1008,8 +1015,12 @@
   // Desktop (Tauri): WebKitGTK does not reliably fire `beforeunload` on window
   // close, so guard the main window via `onCloseRequested`. When tabs are dirty
   // we cancel the close and surface the existing Close-All dialog; finishing it
-  // (save all / close without saving) then destroys the window (see
-  // execute_close_all / close_all_without_saving). Clean state closes silently.
+  // (save all / close without saving) clears the modified registry and re-issues
+  // close() so the guard passes and the window is destroyed → Rust Destroyed
+  // teardown runs (see execute_close_all / close_all_without_saving). Clean
+  // state closes silently. NOTE: registering this listener makes tauri route
+  // EVERY close request through JS, which is why the Rust teardown lives on
+  // WindowEvent::Destroyed, not CloseRequested (src-tauri/src/lib.rs).
   // Popout windows (chat/structure/docs/workflow) are ephemeral mirrors with
   // their own registry and are intentionally NOT guarded here.
   async function setup_close_guard() {
@@ -1030,15 +1041,19 @@
     }
   }
 
-  // Force-close the window after the user resolves the Close-All dialog from the
-  // window-close path. `destroy()` (not `close()`) bypasses onCloseRequested so
-  // we don't re-enter the guard.
-  async function destroy_main_window_after_close_guard() {
+  // Close the window after the user resolves the Close-All dialog from the
+  // window-close path. `close()` re-fires the close-requested guard; callers
+  // clear the modified registry first, so it reads any_modified() === false,
+  // does not preventDefault, and the Tauri JS api then destroys the window —
+  // which fires the Rust WindowEvent::Destroyed handler (src-tauri/src/lib.rs),
+  // the ONLY place the Python backend sidecar / agent bridge / PTY sessions are
+  // torn down and exit(0) runs. Never bypass that teardown.
+  async function close_main_window_after_close_guard() {
     if (!window_close_pending) return
     window_close_pending = false
     try {
       const { getCurrentWindow } = await import(`@tauri-apps/api/window`)
-      await getCurrentWindow().destroy()
+      await getCurrentWindow().close()
     } catch (err) {
       console.error(`[Tauri] Failed to close window after save guard:`, err)
     }

--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -66,7 +66,7 @@
     get_pane_label, create_empty_pane, pane_has_content,
     content_to_base64, create_tab_state, auto_name as _auto_name,
     is_chgcar_file, NON_STRUCTURE_EXTS, update_export_format, format_from_ext,
-    serialize_structure_content,
+    serialize_structure_content, clear_modified_if_sole_pane,
   } from './pane-utils'
   // Recursive pane tree (replaces the fixed single/splitH/splitV/quad grid)
   import PaneTree from './PaneTree.svelte'
@@ -243,6 +243,9 @@
   const export_deps: ExportHandlerDeps = {
     close_panel: (tab_id, leaf_id) => close_panel(tab_id, leaf_id),
     load_close_save_projects,
+    // Deferred Save-As-and-close completed: pane-scoped clear (sole-pane rule).
+    on_pane_saved: (tab_id, leaf_id) =>
+      clear_modified_if_sole_pane(modified, tab_states[tab_id]?.root, tab_id, leaf_id),
   }
   const drag_deps: DragDropDeps = {
     get_active_ts,
@@ -554,6 +557,37 @@
     modal.close_all_visible = false
   }
 
+  // ===== Per-tab close prompt: Save option (Task B3 close-guard) =====
+  // The tab-close confirm modal (tab ×, Ctrl+W on a single-pane tab) must offer
+  // Save / Don't Save / Cancel like every other close entry point. Save routes
+  // through the same seams as Close-All: local source file → silent overwrite
+  // in its original format (write_file), HPC origin → writeRemoteFile,
+  // otherwise → project DB. Any failure keeps the tab open and shows the error.
+  let tab_close_saving = $state(false)
+  let tab_close_save_error = $state(``)
+
+  async function save_and_close_tab(tab_id: string) {
+    tab_close_saving = true
+    tab_close_save_error = ``
+    try {
+      const entries = build_close_all_entries(tm.tabs.filter((tb) => tb.id === tab_id), tab_states)
+      await execute_close_all_saves(entries, tab_states)
+      sidebar.refresh_counter++
+      modified.clear(tab_id)
+      close_tab(tab_id)
+    } catch (e) {
+      tab_close_save_error = e instanceof Error ? e.message : t(`app.save_failed`)
+    } finally {
+      tab_close_saving = false
+    }
+  }
+
+  function cancel_tab_close() {
+    if (tab_close_saving) return
+    tm.tab_close_confirm_id = null
+    tab_close_save_error = ``
+  }
+
   // Build project tree for save dialogs
   let save_project_children = $derived.by(() => {
     const map: Record<string, ProjectSummary[]> = { __root__: [] }
@@ -748,7 +782,7 @@
             p.initial_structure_ref = parsed
             p.initial_site_count = parsed.sites.length
             p.modified = false
-            modified.clear(target_tab_id)
+            clear_modified_if_sole_pane(modified, target_ts.root, target_tab_id, target_leaf_id)
             update_tab_label(target_tab_id)
           }
         }
@@ -1114,7 +1148,7 @@
     pane.initial_site_count = imported.sites.length
     pane.initial_structure_ref = imported as AnyStructure
     pane.modified = false
-    modified.clear(modal.import_target_tab)
+    clear_modified_if_sole_pane(modified, ts.root, modal.import_target_tab, modal.import_target_leaf)
     pane.is_trajectory_mode = false
     pane.trajectory = null
 
@@ -1404,7 +1438,7 @@
     p.selected_sites = []
     p.current_step_idx = 0
     p.modified = false
-    modified.clear(tab_id)
+    clear_modified_if_sole_pane(modified, ts.root, tab_id, leaf_id)
     p.remote_origin = remote_origin
     p.local_file_path = local_file_path
     p.source_filename = e.filename
@@ -1712,7 +1746,7 @@
         p.initial_site_count = data.structure.sites?.length ?? 0
         p.initial_structure_ref = data.structure
         p.modified = false
-        modified.clear(tab_id)
+        clear_modified_if_sole_pane(modified, ts.root, tab_id, target_id)
       }
       if (data.trajectory) {
         const traj = data.trajectory as { frames?: unknown[]; metadata?: { source_format?: string } }
@@ -1725,7 +1759,7 @@
             p.initial_site_count = frame.structure.sites?.length ?? 0
             p.initial_structure_ref = frame.structure
             p.modified = false
-            modified.clear(tab_id)
+            clear_modified_if_sole_pane(modified, ts.root, tab_id, target_id)
             p.selected_sites = []
             p.current_step_idx = 0
             ts.active_leaf_id = target_id
@@ -1738,7 +1772,7 @@
         p.structure = undefined
         p.initial_site_count = 0
         p.modified = false
-        modified.clear(tab_id)
+        clear_modified_if_sole_pane(modified, ts.root, tab_id, target_id)
       }
       p.selected_sites = []
       p.current_step_idx = 0
@@ -1913,9 +1947,9 @@
       const ts = tab_states[`default`]
       const first = ts ? leaves(ts.root)[0] : null
       const pane = first ? structurePane(first) : null
-      if (!ts || !pane) return false
+      if (!ts || !first || !pane) return false
       pane.structure = clone_structure(struct)
-      modified.clear(`default`)
+      clear_modified_if_sole_pane(modified, ts.root, `default`, first.id)
       update_tab_label(`default`)
       return true
     }
@@ -1988,14 +2022,14 @@
       const ts = tab_states[`default`]
       const first = ts ? leaves(ts.root)[0] : null
       const pane = first ? structurePane(first) : null
-      if (!ts || !pane) return false
+      if (!ts || !first || !pane) return false
       pane.trajectory = clone_trajectory_for_pane(traj)
       pane.structure = undefined  // mutually exclusive
       pane.is_trajectory_mode = true
       pane.source_filename = filename || null
       pane.raw_traj_b64 = btoa(unescape(encodeURIComponent(raw)))
       pane.raw_traj_format = (filename.toLowerCase().split(`.`).pop() || ``)
-      modified.clear(`default`)
+      clear_modified_if_sole_pane(modified, ts.root, `default`, first.id)
       update_tab_label(`default`)
       return true
     }
@@ -2568,7 +2602,7 @@
                       lp.initial_site_count = struct.sites.length
                       lp.initial_structure_ref = struct
                       lp.modified = false
-                      modified.clear(tab.id)
+                      clear_modified_if_sole_pane(modified, ts.root, tab.id, leaf.id)
                     }
                   }
                   const right = findLeafById(ts.root, res.newLeafId)
@@ -2594,7 +2628,11 @@
                   if (!struct?.sites?.length) return
                   const target = leaves(ts.root).find(l => { if (l.id === leaf.id) return false; const p = structurePane(l); return !!p && pane_has_content(p) })
                   const tp = target ? structurePane(target) : null
-                  if (tp) { tp.structure = clone_structure(struct); tp.modified = false; modified.clear(tab.id) }
+                  if (target && tp) {
+                    tp.structure = clone_structure(struct)
+                    tp.modified = false
+                    clear_modified_if_sole_pane(modified, ts.root, tab.id, target.id)
+                  }
                 }}
               />
             </div>
@@ -2656,7 +2694,7 @@
                         pane.initial_site_count = sample.data.sites?.length ?? 0
                         pane.initial_structure_ref = sample.data
                         pane.modified = false
-                        modified.clear(tab.id)
+                        clear_modified_if_sole_pane(modified, ts.root, tab.id, leaf.id)
                         ts.active_leaf_id = leaf.id
                         update_tab_label(tab.id)
                       }}
@@ -2762,7 +2800,7 @@
                   pane.initial_site_count = 2
                   pane.initial_structure_ref = pane.structure
                   pane.modified = false
-                  modified.clear(tab.id)
+                  clear_modified_if_sole_pane(modified, ts.root, tab.id, leaf.id)
                   ts.active_leaf_id = leaf.id
                 }}>
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -2984,14 +3022,20 @@
   {#if confirm_tab && confirm_ts}
     {@const structure_count = leaves(confirm_ts.root).filter(l => { const p = structurePane(l); return !!p && pane_has_content(p) }).length}
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-    <div class="modal-overlay" onclick={() => tm.tab_close_confirm_id = null}>
+    <div class="modal-overlay" onclick={cancel_tab_close}>
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
       <div class="modal-dialog" onclick={(e) => e.stopPropagation()}>
         <h3>{t(`app.confirm_close_tab`, { label: confirm_tab.label })}</h3>
         <p>{t(`app.structures_will_be_removed`, { count: structure_count })}</p>
+        {#if tab_close_save_error}
+          <p class="tab-close-error">{tab_close_save_error}</p>
+        {/if}
         <div class="modal-actions">
-          <button class="modal-btn cancel" onclick={() => tm.tab_close_confirm_id = null}>{t(`common.cancel`)}</button>
-          <button class="modal-btn danger" onclick={() => close_tab(tm.tab_close_confirm_id!)}>{t(`app.close_tab`)}</button>
+          <button class="modal-btn cancel" disabled={tab_close_saving} onclick={cancel_tab_close}>{t(`common.cancel`)}</button>
+          <button class="modal-btn save" disabled={tab_close_saving} onclick={() => save_and_close_tab(tm.tab_close_confirm_id!)}>
+            {tab_close_saving ? t(`common.saving`) : t(`common.save_and_close`)}
+          </button>
+          <button class="modal-btn danger" disabled={tab_close_saving} onclick={() => close_tab(tm.tab_close_confirm_id!)}>{t(`app.close_tab`)}</button>
         </div>
       </div>
     </div>
@@ -3586,6 +3630,11 @@
   .modal-btn.save:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .tab-close-error {
+    color: #ef4444;
+    font-size: 0.85em;
   }
 
   /* Close-all and export dialog styles are now in their sub-components */

--- a/desktop/lib/close-all-helper.ts
+++ b/desktop/lib/close-all-helper.ts
@@ -16,6 +16,13 @@ import {
 import { leaves, structurePane } from '../pane-tree'
 import { save_structure_to_db, write_file } from '$lib/api/project'
 import { writeRemoteFile } from '$lib/api/hpc'
+import { save_format_from_path } from '$lib/structure/save-format'
+
+/** Error shown when a checked entry's source format has no faithful serializer. */
+function unserializable_message(path: string): string {
+  const base = path.split(/[/\\]/).pop() || path
+  return `Cannot save "${base}": its format has no serializer. Uncheck it or use Save As to export it in a supported format.`
+}
 
 /**
  * Build the list of entries for the close-all dialog.
@@ -77,19 +84,16 @@ export async function execute_close_all_saves(
     if (!structure) continue
 
     if (entry.save_target === `local` && entry.save_path) {
-      const ext = entry.save_path.split(`.`).pop()?.toLowerCase() || `cif`
-      let format = `cif`
-      if ([`poscar`, `vasp`, `contcar`].includes(ext) || /^(POSCAR|CONTCAR)$/i.test(entry.save_path.split(/[/\\]/).pop() || ``)) format = `poscar`
-      else if (ext === `xyz`) format = `xyz`
-      else if (ext === `extxyz`) format = `extxyz`
+      // Preserve the source's on-disk format. No faithful serializer → refuse:
+      // throw so the caller surfaces the error and keeps every tab open (this
+      // batch has no per-entry Save-As dialog), never CIF-ify the source.
+      const format = save_format_from_path(entry.save_path)
+      if (!format) throw new Error(unserializable_message(entry.save_path))
       const content = await serialize_structure_content(structure, format)
       await write_file(entry.save_path, content)
     } else if (entry.save_target === `hpc` && pane.remote_origin) {
-      const ext = pane.remote_origin.file_path.split(`.`).pop()?.toLowerCase() || `cif`
-      let format = `cif`
-      if ([`poscar`, `vasp`, `contcar`].includes(ext)) format = `poscar`
-      else if (ext === `xyz`) format = `xyz`
-      else if (ext === `extxyz`) format = `extxyz`
+      const format = save_format_from_path(pane.remote_origin.file_path)
+      if (!format) throw new Error(unserializable_message(pane.remote_origin.file_path))
       const content = await serialize_structure_content(structure, format)
       await writeRemoteFile(pane.remote_origin.session_id, pane.remote_origin.file_path, content)
     } else if (entry.save_target === `database`) {

--- a/desktop/lib/export-handlers.ts
+++ b/desktop/lib/export-handlers.ts
@@ -14,6 +14,10 @@ import { writeRemoteFile } from '$lib/api/hpc'
 export interface ExportHandlerDeps {
   close_panel: (tab_id: string, leaf_id: string) => void
   load_close_save_projects: () => void
+  /** Close-guard hook: a deferred save-and-close (Save As dialog) completed for
+   *  this pane — clear the tab's modified flag if the pane-scoped rule allows
+   *  (see clear_modified_if_sole_pane in pane-utils). */
+  on_pane_saved?: (tab_id: string, leaf_id: string) => void
 }
 
 export async function export_fs_browse(dir: string) {
@@ -84,6 +88,9 @@ export async function do_export(deps: ExportHandlerDeps) {
     }
     exp.dialog = null
     if (exp.close_after) {
+      // Must run before close_panel — the close empties the pane, which would
+      // make the sole-content-pane check in the hook see stale/empty state.
+      deps.on_pane_saved?.(exp.close_after.tab_id, exp.close_after.leaf_id)
       deps.close_panel(exp.close_after.tab_id, exp.close_after.leaf_id)
       exp.close_after = null
     }

--- a/desktop/lib/keyboard-shortcuts.ts
+++ b/desktop/lib/keyboard-shortcuts.ts
@@ -21,6 +21,7 @@ export interface KeyboardShortcutDeps {
   request_close_tab: (id: string) => void
   get_tab_close_confirm_id: () => string | null
   set_tab_close_confirm_id: (id: string | null) => void
+  get_tab_close_saving: () => boolean
   get_pending_layout_change: () => { tab_id: string; new_layout: PresetId; lost_count: number } | null
   set_pending_layout_change: (v: null) => void
 }
@@ -88,7 +89,9 @@ export function create_handle_keydown(deps: KeyboardShortcutDeps) {
         return
       }
       if (deps.get_tab_close_confirm_id()) {
-        deps.set_tab_close_confirm_id(null)
+        // While a save-and-close is in flight, Escape is inert — don't tear the
+        // modal down mid-save (it would hide the spinner / pending error state).
+        if (!deps.get_tab_close_saving()) deps.set_tab_close_confirm_id(null)
         return
       }
       if (deps.get_pending_layout_change()) {

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -7,7 +7,12 @@
 
 import type { PaneState, StructureTabState } from '../pane-utils'
 import type { create_modified_registry } from '$lib/structure/close-guard.svelte'
-import { create_empty_pane, auto_name as _auto_name, serialize_structure_content } from '../pane-utils'
+import {
+  create_empty_pane,
+  auto_name as _auto_name,
+  serialize_structure_content,
+  clear_modified_if_sole_pane,
+} from '../pane-utils'
 import { findLeafById, leafCount, leaves, removeLeaf, isTerminalLeaf, structurePane } from '../pane-tree'
 import { exp } from '../state/export-state.svelte'
 import { sidebar } from '../state/sidebar-state.svelte'
@@ -160,7 +165,9 @@ export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string
     } else {
       await save_structure_to_db(structure, _auto_name(structure), exp.close_save_project_id || undefined)
     }
-    deps.modified.clear(tab_id)
+    // Pane-scoped save success: only clear the tab flag when this pane is the
+    // tab's sole content-bearing pane — a dirty sibling must keep it set.
+    clear_modified_if_sole_pane(deps.modified, ts.root, tab_id, leaf_id)
     sidebar.refresh_counter++
     close_panel(deps, tab_id, leaf_id)
   } catch (e) {

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -115,7 +115,14 @@ export async function load_close_save_projects() {
 export function init_close_save_target(pane: PaneState) {
   if (pane.local_file_path) exp.close_save_target = `local`
   else if (pane.remote_origin?.session_id) exp.close_save_target = `hpc`
-  else exp.close_save_target = `project`
+  // Path-less panes (e.g. a structure imported from the project DB — no
+  // local_file_path, no remote_origin) default to a Save-As FILE dialog so
+  // "Save & Close" ASKS where to save instead of silently writing back to the
+  // DB. The `local` target with no local_file_path routes through the export
+  // dialog (see save_and_close_panel's `local` branch). Saving to the CatGO DB
+  // stays available as an explicit, conscious choice via the banner's target
+  // select — it is just no longer the silent default.
+  else exp.close_save_target = `local`
 }
 
 export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string, leaf_id: string) {
@@ -169,6 +176,12 @@ export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string
       const content = await serialize_structure_content(structure, remote_fmt)
       await writeRemoteFile(pane.remote_origin.session_id, pane.remote_origin.file_path, content)
     } else {
+      // Reached only when the user CONSCIOUSLY picks "CatGO DB" in the close
+      // banner's target select. Path-less panes no longer land here by default
+      // (init_close_save_target defaults them to `local` → the Save-As dialog
+      // above), so there is no silent DB write on close. The silent-DB batch
+      // save lives on in the Close-All flow (execute_close_all_saves), whose
+      // per-entry checklist makes the DB target an explicit opt-in.
       await save_structure_to_db(structure, _auto_name(structure), exp.close_save_project_id || undefined)
     }
     // Pane-scoped save success: only clear the tab flag when this pane is the

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -13,6 +13,7 @@ import {
   serialize_structure_content,
   clear_modified_if_sole_pane,
 } from '../pane-utils'
+import { save_format_from_path } from '$lib/structure/save-format'
 import { findLeafById, leafCount, leaves, removeLeaf, isTerminalLeaf, structurePane } from '../pane-tree'
 import { exp } from '../state/export-state.svelte'
 import { sidebar } from '../state/sidebar-state.svelte'
@@ -33,17 +34,6 @@ export interface PaneManagerDeps {
   modified: ReturnType<typeof create_modified_registry>
   export_fs_browse: (dir: string) => void
   reset_viewer?: (tab_id: string, leaf_id: string) => void
-}
-
-/** Pick the export serializer format that matches a source file's extension so
- *  a save preserves the original on-disk format (POSCAR/CONTCAR by name too). */
-function format_from_path(path: string): string {
-  const base = path.split(/[/\\]/).pop() || ``
-  const ext = base.split(`.`).pop()?.toLowerCase() || `cif`
-  if ([`poscar`, `vasp`, `contcar`].includes(ext) || /^(POSCAR|CONTCAR)$/i.test(base)) return `poscar`
-  if (ext === `xyz`) return `xyz`
-  if (ext === `extxyz`) return `extxyz`
-  return `cif`
 }
 
 export function handle_unload(deps: PaneManagerDeps, tab_id: string, leaf_id: string) {
@@ -139,17 +129,24 @@ export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string
     close_panel(deps, tab_id, leaf_id)
     return
   }
+  // Only silently overwrite a local source when we can serialize it back in its
+  // ORIGINAL format (plan constraint: "never change format on save"). A source
+  // with no faithful serializer (unknown ext, extension-less non-POSCAR, .gz)
+  // maps to null and must fall through to Save-As instead of being CIF-ified.
+  const local_fmt = pane.local_file_path ? save_format_from_path(pane.local_file_path) : null
   exp.close_saving = true
   try {
-    if (exp.close_save_target === `local` && pane.local_file_path) {
-      // Known source file → silently overwrite it in its original format.
-      // Plan constraint: the close-prompt "Save" never opens a dialog (that's
-      // "Save As", a separate explicit action) and never changes the format.
-      // Uses the same write seam as the close-all flow.
-      await write_file(pane.local_file_path, await serialize_structure_content(structure, format_from_path(pane.local_file_path)))
+    if (exp.close_save_target === `local` && pane.local_file_path && local_fmt) {
+      // Known source file with a faithful serializer → silently overwrite it in
+      // its original format. Plan constraint: the close-prompt "Save" never
+      // opens a dialog (that's "Save As", a separate explicit action) and never
+      // changes the format. Uses the same write seam as the close-all flow.
+      await write_file(pane.local_file_path, await serialize_structure_content(structure, local_fmt))
     } else if (exp.close_save_target === `local`) {
-      // No known source path → fall back to the export dialog (Save As); the
-      // close is deferred until the dialog completes (exp.close_after).
+      // No known source path, OR a source format with no faithful serializer →
+      // fall back to the export dialog (Save As), where the user explicitly
+      // picks a supported format; the close is deferred until the dialog
+      // completes (exp.close_after). Never silently rewrite as CIF.
       exp.close_after = { tab_id, leaf_id }
       ts.close_confirm_leaf_id = null
       const name = _auto_name(structure)
@@ -160,7 +157,16 @@ export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string
       exp.close_saving = false
       return
     } else if (exp.close_save_target === `hpc` && pane.remote_origin) {
-      const content = await serialize_structure_content(structure, format_from_path(pane.remote_origin.file_path))
+      // Remote overwrite is a headless seam — no Save-As dialog to fall back to.
+      // If the source format has no faithful serializer, refuse: throw so the
+      // catch surfaces the error and keeps the tab open (mirrors the VS Code
+      // extension's refuse-and-stay-dirty), never CIF-ify the remote file.
+      const remote_fmt = save_format_from_path(pane.remote_origin.file_path)
+      if (!remote_fmt) {
+        const base = pane.remote_origin.file_path.split(/[/\\]/).pop() || pane.remote_origin.file_path
+        throw new Error(`Cannot save "${base}" in place: its format has no serializer. Use Save As to export it in a supported format.`)
+      }
+      const content = await serialize_structure_content(structure, remote_fmt)
       await writeRemoteFile(pane.remote_origin.session_id, pane.remote_origin.file_path, content)
     } else {
       await save_structure_to_db(structure, _auto_name(structure), exp.close_save_project_id || undefined)

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PaneState, StructureTabState } from '../pane-utils'
+import type { create_modified_registry } from '$lib/structure/close-guard.svelte'
 import { create_empty_pane, auto_name as _auto_name, serialize_structure_content } from '../pane-utils'
 import { findLeafById, leafCount, leaves, removeLeaf, isTerminalLeaf, structurePane } from '../pane-tree'
 import { exp } from '../state/export-state.svelte'
@@ -21,6 +22,10 @@ import {
 export interface PaneManagerDeps {
   tab_states: Record<string, StructureTabState>
   update_tab_label: (tab_id: string) => void
+  // Per-tab unsaved-edit registry (close/save guard). Exposed here so Task B3
+  // can gate pane close on `modified.is_modified(tab_id)` and call
+  // `modified.clear(tab_id)` after a successful save-and-close.
+  modified: ReturnType<typeof create_modified_registry>
   export_fs_browse: (dir: string) => void
   reset_viewer?: (tab_id: string, leaf_id: string) => void
 }

--- a/desktop/lib/pane-manager.ts
+++ b/desktop/lib/pane-manager.ts
@@ -11,7 +11,7 @@ import { create_empty_pane, auto_name as _auto_name, serialize_structure_content
 import { findLeafById, leafCount, leaves, removeLeaf, isTerminalLeaf, structurePane } from '../pane-tree'
 import { exp } from '../state/export-state.svelte'
 import { sidebar } from '../state/sidebar-state.svelte'
-import { list_projects, save_structure_to_db } from '$lib/api/project'
+import { list_projects, save_structure_to_db, write_file } from '$lib/api/project'
 import { writeRemoteFile } from '$lib/api/hpc'
 import {
   cancel_pending_library_removal,
@@ -28,6 +28,17 @@ export interface PaneManagerDeps {
   modified: ReturnType<typeof create_modified_registry>
   export_fs_browse: (dir: string) => void
   reset_viewer?: (tab_id: string, leaf_id: string) => void
+}
+
+/** Pick the export serializer format that matches a source file's extension so
+ *  a save preserves the original on-disk format (POSCAR/CONTCAR by name too). */
+function format_from_path(path: string): string {
+  const base = path.split(/[/\\]/).pop() || ``
+  const ext = base.split(`.`).pop()?.toLowerCase() || `cif`
+  if ([`poscar`, `vasp`, `contcar`].includes(ext) || /^(POSCAR|CONTCAR)$/i.test(base)) return `poscar`
+  if (ext === `xyz`) return `xyz`
+  if (ext === `extxyz`) return `extxyz`
+  return `cif`
 }
 
 export function handle_unload(deps: PaneManagerDeps, tab_id: string, leaf_id: string) {
@@ -57,9 +68,14 @@ export function handle_unload(deps: PaneManagerDeps, tab_id: string, leaf_id: st
     close_panel(deps, tab_id, leaf_id)
     return
   }
-  // Structure panes: prompt if has content
+  // Structure panes: prompt only when the tab has unsaved edits (Task B3
+  // close-guard). A clean tab — content loaded/built but never edited — closes
+  // with no prompt, per the plan's "close while clean → no prompt" rule. This
+  // is the same decision `guard_close` ($lib/structure/save-on-close) encodes;
+  // the modified branch is realised by the app's inline save/discard/cancel
+  // banner (App.svelte), which saves to the source in its original format.
   const has_content = !!(pane.structure || pane.trajectory || pane.cube_file)
-  if (has_content) {
+  if (has_content && deps.modified.is_modified(tab_id)) {
     ts.close_confirm_leaf_id = leaf_id
     init_close_save_target(pane)
     if (pane.structure) load_close_save_projects()
@@ -120,39 +136,31 @@ export async function save_and_close_panel(deps: PaneManagerDeps, tab_id: string
   }
   exp.close_saving = true
   try {
-    if (exp.close_save_target === `local`) {
-      // Open export dialog with folder browser, close panel after save
+    if (exp.close_save_target === `local` && pane.local_file_path) {
+      // Known source file → silently overwrite it in its original format.
+      // Plan constraint: the close-prompt "Save" never opens a dialog (that's
+      // "Save As", a separate explicit action) and never changes the format.
+      // Uses the same write seam as the close-all flow.
+      await write_file(pane.local_file_path, await serialize_structure_content(structure, format_from_path(pane.local_file_path)))
+    } else if (exp.close_save_target === `local`) {
+      // No known source path → fall back to the export dialog (Save As); the
+      // close is deferred until the dialog completes (exp.close_after).
       exp.close_after = { tab_id, leaf_id }
       ts.close_confirm_leaf_id = null
       const name = _auto_name(structure)
       exp.pending_structure = structure
       exp.error = ``
-      if (pane.local_file_path) {
-        // Pre-populate with original file's directory and name
-        const parts = pane.local_file_path.replace(/\\/g, `/`).split(`/`)
-        const fname = parts.pop() || `${name}.cif`
-        const dir = parts.join(`/`) || `~`
-        const ext = fname.split(`.`).pop()?.toLowerCase() || `cif`
-        const format = [`poscar`, `vasp`, `contcar`].includes(ext) ? `poscar` : ext === `extxyz` ? `extxyz` : ext === `xyz` ? `xyz` : `cif`
-        exp.dialog = { mode: `file`, filename: fname, format }
-        deps.export_fs_browse(dir)
-      } else {
-        exp.dialog = { mode: `file`, filename: `${name}.cif`, format: `cif` }
-        deps.export_fs_browse(sidebar.fs_path || `~`)
-      }
+      exp.dialog = { mode: `file`, filename: `${name}.cif`, format: `cif` }
+      deps.export_fs_browse(sidebar.fs_path || `~`)
       exp.close_saving = false
       return
     } else if (exp.close_save_target === `hpc` && pane.remote_origin) {
-      const ext = pane.remote_origin.file_path.split(`.`).pop()?.toLowerCase() || `cif`
-      let format = `cif`
-      if ([`poscar`, `vasp`, `contcar`].includes(ext)) format = `poscar`
-      else if (ext === `xyz`) format = `xyz`
-      else if (ext === `extxyz`) format = `extxyz`
-      const content = await serialize_structure_content(structure, format)
+      const content = await serialize_structure_content(structure, format_from_path(pane.remote_origin.file_path))
       await writeRemoteFile(pane.remote_origin.session_id, pane.remote_origin.file_path, content)
     } else {
       await save_structure_to_db(structure, _auto_name(structure), exp.close_save_project_id || undefined)
     }
+    deps.modified.clear(tab_id)
     sidebar.refresh_counter++
     close_panel(deps, tab_id, leaf_id)
   } catch (e) {

--- a/desktop/lib/tab-manager.svelte.ts
+++ b/desktop/lib/tab-manager.svelte.ts
@@ -69,6 +69,12 @@ export function create_tab_manager() {
   let tab_close_confirm_id = $state<string | null>(null)
   let pending_layout_change = $state<{ tab_id: string, new_layout: PresetId, lost_count: number } | null>(null)
 
+  // Task B3 close-guard: predicate telling whether a tab has unsaved edits.
+  // App.svelte injects the per-tab `modified` registry here so a clean tab
+  // closes with no confirm prompt. Defaults to always-modified so, if left
+  // uninjected, the pre-B3 "confirm when the tab has content" behaviour holds.
+  let is_tab_modified: (id: string) => boolean = () => true
+
   function create_tab(type: `structure` | `workflow` | `terminal`) {
     if (type === `workflow`) {
       const existing = tabs.find(t => t.type === `workflow`)
@@ -173,7 +179,7 @@ export function create_tab_manager() {
           const pane = structurePane(l)
           return !!pane && pane_has_content(pane)
         }).length
-        if (loaded > 0) {
+        if (loaded > 0 && is_tab_modified(id)) {
           tab_close_confirm_id = id
           return
         }
@@ -294,6 +300,8 @@ export function create_tab_manager() {
     set tab_close_confirm_id(v: string | null) { tab_close_confirm_id = v },
     get pending_layout_change() { return pending_layout_change },
     set pending_layout_change(v: { tab_id: string, new_layout: PresetId, lost_count: number } | null) { pending_layout_change = v },
+    // Task B3: inject the unsaved-edit predicate (see is_tab_modified above).
+    set is_tab_modified(fn: (id: string) => boolean) { is_tab_modified = fn },
     create_tab,
     create_terminal_popout_tab,
     create_remote_tab,

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -238,12 +238,14 @@ import { serialize_structure } from '$lib/api/project'
  *  backend fallback for unsupported formats. */
 export async function serialize_structure_content(structure: Record<string, unknown>, format: string): Promise<string> {
   try {
-    const { structure_to_cif_str, structure_to_poscar_str, structure_to_xyz_str, structure_to_extxyz_str, structure_to_json_str } = await import(`$lib/structure/export`)
+    const { structure_to_cif_str, structure_to_poscar_str, structure_to_xyz_str, structure_to_extxyz_str, structure_to_json_str, structure_to_mol2_str, structure_to_pdb_str } = await import(`$lib/structure/export`)
     const s = structure as AnyStructureType
     if (format === `poscar`) return structure_to_poscar_str(s)
     if (format === `xyz`) return structure_to_xyz_str(s)
     if (format === `extxyz`) return structure_to_extxyz_str(s)
     if (format === `json`) return structure_to_json_str(s)
+    if (format === `mol2`) return structure_to_mol2_str(s)
+    if (format === `pdb`) return structure_to_pdb_str(s)
     return structure_to_cif_str(s)
   } catch {
     const result = await serialize_structure(structure, format)

--- a/desktop/pane-utils.ts
+++ b/desktop/pane-utils.ts
@@ -6,7 +6,7 @@
 
 import type { AnyStructure } from '$lib'
 import type { PaneNode, TerminalLeafState } from './pane-tree'
-import { create_empty_leaf, create_terminal_leaf } from './pane-tree'
+import { create_empty_leaf, create_terminal_leaf, leaves, structurePane } from './pane-tree'
 
 // ========== Types ==========
 
@@ -106,6 +106,32 @@ export function create_empty_pane(): PaneState {
 
 export function pane_has_content(p: PaneState): boolean {
   return p.mode === 'workflow' || !!(p.structure || p.trajectory || p.cube_file)
+}
+
+/** Close-guard clear rule for PANE-scoped successes (a pane save, a pane
+ *  overwrite, a pane-targeted load): the tab-keyed modified flag may be cleared
+ *  ONLY when the pane is the tab's sole content-bearing pane — otherwise a
+ *  dirty sibling pane would silently lose its edits at the next close. When a
+ *  sibling with content exists the flag stays set (worst case a spurious
+ *  prompt — the safe direction). TAB-scoped operations (fresh tab load, tab
+ *  reset-to-empty) should keep calling `modified.clear` unconditionally.
+ *  Call AFTER the pane's new content has been assigned. Returns whether the
+ *  flag was cleared. */
+export function clear_modified_if_sole_pane(
+  modified: { clear: (tab_id: string) => void },
+  root: PaneNode | null | undefined,
+  tab_id: string,
+  leaf_id: string,
+): boolean {
+  if (!root) return false
+  const content_leaves = leaves(root).filter((l) => {
+    const p = structurePane(l)
+    return !!p && pane_has_content(p)
+  })
+  if (content_leaves.length > 1) return false
+  if (content_leaves.length === 1 && content_leaves[0].id !== leaf_id) return false
+  modified.clear(tab_id)
+  return true
 }
 
 export function content_to_base64(content: string | ArrayBuffer): string {

--- a/docs/superpowers/plans/2026-07-09-close-save-guard.md
+++ b/docs/superpowers/plans/2026-07-09-close-save-guard.md
@@ -1,0 +1,494 @@
+# Close/Save Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prompt to save (or Save As) when closing a structure with unsaved edits — in both the VS Code extension and the desktop app.
+
+**Architecture:** Two independent subsystems, each shippable on its own. **Part A** flips the VS Code custom editor from readonly to editable so VS Code's native dirty/close-prompt/Ctrl+S/Save-As machinery applies, driven by a `dirty` message the webview emits on edit. **Part B** adds a per-tab `is_modified` flag in the desktop app and a close-guard confirm dialog that saves via the existing `save_with_dialog` + `export` serializers.
+
+**Tech Stack:** VS Code Extension API (CustomEditorProvider), Svelte 5 runes, Tauri, vitest.
+
+## Global Constraints
+
+- Save in the SOURCE file's format (xyz→xyz, POSCAR→POSCAR, …) — never change format on save.
+- Ctrl+S / close-prompt "Save" → silently overwrite the source file (no dialog). Save As → dialog pre-filled with the original path. Close while clean → no prompt.
+- Save failure → surface an error and keep the tab open (do not close / lose edits).
+- Ext formatting: no local `deno fmt` on `.ts` under extensions/vscode (that dir has its own build); match surrounding style (single quotes, no semicolons where the file already omits them).
+- App formatting enforced by pre-commit `deno fmt` (single quotes, no semicolons, 2-space, 90-col); `.svelte` excluded. Let the hook format, re-stage.
+- vitest lives under `tests/vitest/**` or `src/**/__tests__/**` only (CI ignores co-located `*.test.ts`). Run via `rtk proxy pnpm exec vitest run …`.
+
+---
+
+# Part A — VS Code extension
+
+Current: `extensions/vscode/src/extension.ts` registers a
+`CustomReadonlyEditorProvider` (class `Provider`, line ~885) whose
+`openCustomDocument` returns a bare `{ uri, dispose }`. The webview
+(`src/webview/main.ts`) already intercepts the frontend's `download()` and posts
+`{ command: 'saveAs', content, is_binary, filename }` (see `setup_vscode_download`,
+~line 276). There is NO dirty tracking or save method, so VS Code never prompts.
+
+### Task A1: Webview emits `dirty` on edit + answers `requestContent`
+
+**Files:**
+- Modify: `extensions/vscode/src/webview/main.ts` (Structure mount props ~line 693; message-in handler)
+
+**Interfaces:**
+- Produces: webview → ext message `{ command: 'dirty' }` (fired on each structure edit); webview handles ext → webview message `{ command: 'requestContent', request_id }` by replying `{ command: 'content', request_id, content, is_binary, filename }` using the same serializer the existing `saveAs` path uses.
+
+- [ ] **Step 1: Pass `on_structure_change` into the Structure mount so edits notify the host**
+
+In `create_display`/the `mount(Component, { target, props })` call (~line 693), add to `props` (only for the non-trajectory Structure component):
+
+```ts
+on_structure_change: () => {
+  vscode_api?.postMessage({ command: `dirty` })
+},
+```
+
+(`vscode_api` is already acquired at ~line 261. `Structure.svelte` already invokes `on_structure_change` on every edit — verified.)
+
+- [ ] **Step 2: Reuse the export serializer to answer content requests**
+
+Find where `setup_vscode_download` builds the `saveAs` payload (~line 276-289). Extract the "serialize current structure to text/base64 for the current filename" into a reusable function in this file:
+
+```ts
+// Serialize whatever the frontend's export/download would produce for the
+// active structure. Mirrors the intercepted-download path used by `saveAs`.
+async function serialize_current(): Promise<
+  { content: string; is_binary: boolean; filename: string } | null
+> {
+  // Trigger the same in-app export the download override captures. If the app
+  // exposes a direct export API on the mounted component, call it; otherwise
+  // reuse the captured `saveAs` payload cached by setup_vscode_download.
+  return _last_export_payload ?? null
+}
+```
+
+Add a module-level `let _last_export_payload: {content,is_binary,filename} | null = null` and, inside `setup_vscode_download`'s intercept, set `_last_export_payload = { content, is_binary, filename }` right before it posts `saveAs`. Also expose an explicit "export now" trigger: call the same code path the download button uses (the frontend `download()` for the current structure) so content is fresh on request.
+
+- [ ] **Step 3: Handle `requestContent` from the extension**
+
+In the webview's `window.addEventListener('message', …)` handler (where FileChangeMessage etc. are handled), add:
+
+```ts
+if (msg.command === `requestContent`) {
+  const payload = await serialize_current()
+  vscode_api?.postMessage({
+    command: `content`,
+    request_id: msg.request_id,
+    content: payload?.content ?? ``,
+    is_binary: payload?.is_binary ?? false,
+    filename: payload?.filename ?? ``,
+  })
+  return
+}
+```
+
+- [ ] **Step 4: Build + smoke check the webview bundle**
+
+Run: `cd extensions/vscode && pnpm run build` (or the ext's bundle script).
+Expected: builds with no type error; `dist/` updated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/vscode/src/webview/main.ts
+git commit -m "feat(vscode): webview emits dirty on edit + answers requestContent"
+```
+
+### Task A2: Provider becomes editable — dirty tracking + save methods
+
+**Files:**
+- Modify: `extensions/vscode/src/extension.ts` (class `Provider` ~885; message handler ~925; registration ~998)
+- Test: `extensions/vscode/src/__tests__/provider-save.test.ts` (new)
+
+**Interfaces:**
+- Consumes: webview `dirty` and `content` messages from Task A1.
+- Produces: `Provider implements vscode.CustomEditorProvider<CatgoDocument>` with `onDidChangeCustomDocument`, `saveCustomDocument`, `saveCustomDocumentAs`, `revertCustomDocument`, `backupCustomDocument`; a `CatgoDocument` class exposing `uri`, `requestContent(): Promise<{content,is_binary}>` (round-trips `requestContent`/`content` with the panel's webview).
+
+- [ ] **Step 1: Write the failing test for the document dirty/save wiring**
+
+Create `extensions/vscode/src/__tests__/provider-save.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { CatgoDocument } from '../extension'
+
+describe('CatgoDocument', () => {
+  it('marks dirty on a dirty signal and clears after save', async () => {
+    const uri = { fsPath: '/tmp/IS_raw.xyz' } as any
+    const writes: Array<[string, Uint8Array]> = []
+    const doc = new CatgoDocument(uri, {
+      requestContent: async () => ({ content: 'XYZ...', is_binary: false }),
+      writeFile: async (u: any, data: Uint8Array) => { writes.push([u.fsPath, data]) },
+    })
+    const changed = vi.fn()
+    doc.onDidChange(changed)
+    doc.signalEdit()
+    expect(changed).toHaveBeenCalledTimes(1)
+    await doc.save()
+    expect(writes[0][0]).toBe('/tmp/IS_raw.xyz')
+    expect(new TextDecoder().decode(writes[0][1])).toBe('XYZ...')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run extensions/vscode/src/__tests__/provider-save.test.ts`
+Expected: FAIL — `CatgoDocument` not exported.
+
+- [ ] **Step 3: Add the `CatgoDocument` class (testable, VS-Code-free core)**
+
+In `extension.ts`, add and export:
+
+```ts
+export interface DocDeps {
+  requestContent: () => Promise<{ content: string; is_binary: boolean }>
+  writeFile: (uri: vscode.Uri, data: Uint8Array) => Promise<void>
+}
+
+export class CatgoDocument implements vscode.CustomDocument {
+  private readonly _onDidChange = new vscode.EventEmitter<void>()
+  readonly onDidChange = this._onDidChange.event
+  constructor(public readonly uri: vscode.Uri, private deps: DocDeps) {}
+  signalEdit(): void { this._onDidChange.fire() }
+  async save(target: vscode.Uri = this.uri): Promise<void> {
+    const { content, is_binary } = await this.deps.requestContent()
+    const data = is_binary
+      ? Uint8Array.from(Buffer.from(content.replace(/^data:[^;]+;base64,/, ``), `base64`))
+      : new TextEncoder().encode(content)
+    await this.deps.writeFile(target, data)
+  }
+  dispose(): void { this._onDidChange.dispose() }
+}
+```
+
+(`vscode.EventEmitter` is imported already via `import * as vscode`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy pnpm exec vitest run extensions/vscode/src/__tests__/provider-save.test.ts`
+Expected: PASS. (In the test, `vscode` is the mocked module under `src/mocks/` — add a minimal `EventEmitter` if the mock lacks one.)
+
+- [ ] **Step 5: Convert `Provider` to `CustomEditorProvider` and wire the panel**
+
+Change the class header:
+
+```ts
+class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
+  private readonly _onDidChangeCustomDocument =
+    new vscode.EventEmitter<vscode.CustomDocumentEditEvent<CatgoDocument>>()
+  readonly onDidChangeCustomDocument = this._onDidChangeCustomDocument.event
+  private panels = new Map<string, vscode.WebviewPanel>()  // by uri.toString()
+```
+
+`openCustomDocument` returns a `CatgoDocument` whose `DocDeps.requestContent`
+round-trips the webview and whose `writeFile` is `vscode.workspace.fs.writeFile`:
+
+```ts
+openCustomDocument(uri: vscode.Uri): CatgoDocument {
+  const doc = new CatgoDocument(uri, {
+    requestContent: () => this.requestContentFor(uri),
+    writeFile: (u, data) => Promise.resolve(vscode.workspace.fs.writeFile(u, data)),
+  })
+  doc.onDidChange(() =>
+    this._onDidChangeCustomDocument.fire({
+      document: doc,
+      undo: async () => {}, redo: async () => {},   // structural undo lives in-webview
+      label: `Edit`,
+    }))
+  return doc
+}
+```
+
+In `resolveCustomEditor`, store the panel (`this.panels.set(document.uri.toString(), webview_panel)`; clear on `onDidDispose`). In the existing `onDidReceiveMessage` handler (~line 925) add:
+
+```ts
+if (msg.command === `dirty`) { document.signalEdit(); return }
+```
+
+Add `requestContentFor(uri)` that posts `{command:'requestContent', request_id}` to that uri's panel and resolves on the matching `{command:'content', request_id}` message (Promise keyed by request_id).
+
+Implement the provider save methods:
+
+```ts
+saveCustomDocument(document: CatgoDocument): Thenable<void> { return document.save() }
+saveCustomDocumentAs(document: CatgoDocument, dest: vscode.Uri): Thenable<void> {
+  return document.save(dest)
+}
+revertCustomDocument(document: CatgoDocument): Thenable<void> {
+  this.panels.get(document.uri.toString())?.webview.postMessage({ command: `revert` })
+  return Promise.resolve()
+}
+async backupCustomDocument(document: CatgoDocument, ctx: vscode.CustomDocumentBackupContext) {
+  await document.save(ctx.destination)
+  return { id: ctx.destination.toString(), delete: () =>
+    vscode.workspace.fs.delete(ctx.destination).then(() => {}, () => {}) }
+}
+```
+
+- [ ] **Step 6: Update the registration for editable + type-check**
+
+Registration (~line 998) stays `registerCustomEditorProvider(catgo.viewer, new Provider(context), { webviewOptions: { retainContextWhenHidden: true }, supportsMultipleEditorsPerDocument: false })`. Ensure package.json `contributes.customEditors[0]` (viewType `catgo.viewer`) is unchanged (editable uses the same contribution).
+
+Run: `cd extensions/vscode && pnpm run build`
+Expected: no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add extensions/vscode/src/extension.ts extensions/vscode/src/__tests__/provider-save.test.ts
+git commit -m "feat(vscode): editable custom editor — dirty tracking + save/saveAs/backup"
+```
+
+### Task A3: Live-verify the extension in VS Code
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Rebuild + launch the Extension Development Host**
+
+Run: `cd extensions/vscode && pnpm run build`, then F5 (or `code --extensionDevelopmentPath=.`).
+
+- [ ] **Step 2: Exercise the flow**
+
+Open a `*.xyz`/`CONTCAR` in the CatGo editor; edit atoms → the tab shows the dirty dot. `Ctrl+S` → file overwritten, dot clears. Edit again → close the tab → native "Do you want to save?" appears; Save writes the file. `Ctrl+Shift+S` → Save As dialog pre-filled with the original path; renaming writes a new file. Closing a clean (saved) tab shows no prompt.
+
+- [ ] **Step 3: Report** — confirm each behavior to the user.
+
+---
+
+# Part B — Desktop app
+
+Pieces present: the loaded structure carries `filename`/`file_path`
+(Structure.svelte ~4107-5453); `src/lib/io/fetch.ts` exports `save_with_dialog`;
+`src/lib/io/export.ts` serializes every format via `download(...)`;
+`DraggablePane.close_pane()` (~line 142) + the tab-bar close the panes/tabs.
+
+### Task B1: Per-tab `is_modified` state + helper
+
+**Files:**
+- Create: `src/lib/structure/close-guard.svelte.ts`
+- Test: `tests/vitest/structure/close-guard.test.ts` (new)
+
+**Interfaces:**
+- Produces: `create_modified_registry()` → `{ mark(tab_id: string): void; clear(tab_id: string): void; is_modified(tab_id: string): boolean; any_modified(): boolean }` backed by a `SvelteSet`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/vitest/structure/close-guard.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { create_modified_registry } from '$lib/structure/close-guard.svelte'
+
+describe('modified registry', () => {
+  it('tracks dirty tabs and clears on save', () => {
+    const r = create_modified_registry()
+    expect(r.is_modified('t1')).toBe(false)
+    r.mark('t1')
+    expect(r.is_modified('t1')).toBe(true)
+    expect(r.any_modified()).toBe(true)
+    r.clear('t1')
+    expect(r.is_modified('t1')).toBe(false)
+    expect(r.any_modified()).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/close-guard.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the registry**
+
+Create `src/lib/structure/close-guard.svelte.ts`:
+
+```ts
+import { SvelteSet } from 'svelte/reactivity'
+
+export function create_modified_registry() {
+  const dirty = new SvelteSet<string>()
+  return {
+    mark: (tab_id: string) => dirty.add(tab_id),
+    clear: (tab_id: string) => dirty.delete(tab_id),
+    is_modified: (tab_id: string) => dirty.has(tab_id),
+    any_modified: () => dirty.size > 0,
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/close-guard.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/structure/close-guard.svelte.ts tests/vitest/structure/close-guard.test.ts
+git commit -m "feat(viewer): per-tab modified registry for the close guard"
+```
+
+### Task B2: Mark modified on edit; wire the registry into the tab owner
+
+**Files:**
+- Modify: the component that owns the tab list + renders `Structure` per tab (find via `rtk proxy grep -rln "close_pane\|Structure.svelte\|active_tab" src` — likely `src/App.svelte` / `src/lib/DraggablePane.svelte` / the workspace component)
+- Modify: `src/lib/structure/Structure.svelte` (ensure an `on_structure_change` prop is forwarded to the owner; it already exists internally)
+
+**Interfaces:**
+- Consumes: `create_modified_registry()` from Task B1.
+- Produces: each mounted `Structure` calls `registry.mark(tab_id)` on `on_structure_change`; a successful save or fresh load calls `registry.clear(tab_id)`.
+
+- [ ] **Step 1: Instantiate the registry once in the tab owner**
+
+In the workspace/tab-owner component, `const modified = create_modified_registry()` and pass `on_structure_change={() => modified.mark(tab_id)}` to each `<Structure>` (Structure.svelte already fires it on edits).
+
+- [ ] **Step 2: Clear on load**
+
+Where a structure is loaded/replaced for a tab (file open, push, revert), call `modified.clear(tab_id)`.
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm check`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(viewer): mark tab modified on edit, clear on load"
+```
+
+### Task B3: Close-guard confirm + save on tab/pane close
+
+**Files:**
+- Create: `src/lib/structure/save-on-close.ts`
+- Modify: the tab-close + `DraggablePane.close_pane()` (~line 142) call sites
+- Test: `tests/vitest/structure/save-on-close.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `modified.is_modified(tab_id)`, `save_with_dialog` (io/fetch), the structure's `file_path`, `export`-format serializer.
+- Produces: `async function guard_close(opts: { modified: boolean; on_save: () => Promise<boolean>; confirm: () => Promise<'save'|'discard'|'cancel'> }): Promise<boolean>` — returns `true` if the caller should proceed to close, `false` to abort.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/vitest/structure/save-on-close.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { guard_close } from '$lib/structure/save-on-close'
+
+describe('guard_close', () => {
+  it('clean tab closes without prompting', async () => {
+    const confirm = vi.fn()
+    expect(await guard_close({ modified: false, on_save: vi.fn(), confirm })).toBe(true)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+  it('save → runs save, closes when save succeeds', async () => {
+    const on_save = vi.fn().mockResolvedValue(true)
+    expect(await guard_close({ modified: true, on_save,
+      confirm: async () => 'save' })).toBe(true)
+    expect(on_save).toHaveBeenCalled()
+  })
+  it('save failure keeps the tab open', async () => {
+    expect(await guard_close({ modified: true, on_save: async () => false,
+      confirm: async () => 'save' })).toBe(false)
+  })
+  it('discard closes, cancel aborts', async () => {
+    expect(await guard_close({ modified: true, on_save: vi.fn(),
+      confirm: async () => 'discard' })).toBe(true)
+    expect(await guard_close({ modified: true, on_save: vi.fn(),
+      confirm: async () => 'cancel' })).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/save-on-close.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `guard_close`**
+
+Create `src/lib/structure/save-on-close.ts`:
+
+```ts
+export async function guard_close(opts: {
+  modified: boolean
+  on_save: () => Promise<boolean>
+  confirm: () => Promise<`save` | `discard` | `cancel`>
+}): Promise<boolean> {
+  if (!opts.modified) return true
+  const choice = await opts.confirm()
+  if (choice === `cancel`) return false
+  if (choice === `discard`) return true
+  return opts.on_save() // true = saved → close; false = save failed → keep open
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/save-on-close.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Wire `guard_close` into the close call sites**
+
+At each tab-close and `DraggablePane.close_pane()`, make the handler `async` and gate the actual close:
+
+```ts
+const proceed = await guard_close({
+  modified: modified.is_modified(tab_id),
+  confirm: async () => {
+    const r = await confirm_dialog({
+      message: `Save changes to ${filename}?`,
+      buttons: [`Save`, `Don't Save`, `Cancel`],
+    })
+    return r === `Save` ? `save` : r === `Don't Save` ? `discard` : `cancel`
+  },
+  on_save: async () => {
+    try {
+      await save_with_dialog(serialize_structure(structure, file_path), {
+        defaultPath: file_path, filename,
+      })
+      modified.clear(tab_id)
+      return true
+    } catch (e) {
+      show_error(`Save failed: ${e}`)
+      return false
+    }
+  },
+})
+if (!proceed) return
+// … existing close logic …
+```
+
+Use the app's existing confirm-dialog helper (find it near CloseAllModal / the existing "Continue" prompts) and `serialize_structure` = the `export.ts` serializer for the structure's source format. `save_with_dialog` from `$lib/io/fetch`.
+
+- [ ] **Step 6: Type-check + full unit suite**
+
+Run: `pnpm check` (0 errors), then `rtk proxy pnpm exec vitest run` (all green incl. the two new tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(viewer): confirm + save on closing a modified structure tab"
+```
+
+### Task B4: Window-close warning + live verify
+
+**Files:**
+- Modify: the app root (`src/App.svelte` or the Tauri window setup) for `beforeunload`
+
+- [ ] **Step 1: Warn on window close when any tab is modified**
+
+In the app root, add a `beforeunload` handler (web) / Tauri `onCloseRequested` (desktop) that, if `modified.any_modified()`, prompts before exit (reuse the confirm helper; on desktop, `event.preventDefault()` then run the same guard).
+
+- [ ] **Step 2: Live-verify (desktop:dev)**
+
+Load a structure from a file, edit it, close the tab → confirm dialog; Save → `save_with_dialog` defaults to the original path; overwrite works, rename works; Don't Save closes; Cancel aborts. Clean tab closes silently. Screenshot each for the user.
+
+- [ ] **Step 3: Report** — show the user the results.

--- a/docs/superpowers/plans/2026-07-09-close-save-guard.md
+++ b/docs/superpowers/plans/2026-07-09-close-save-guard.md
@@ -370,7 +370,14 @@ git commit -m "feat(viewer): mark tab modified on edit, clear on load"
 - Test: `tests/vitest/structure/save-on-close.test.ts` (new)
 
 **Interfaces:**
-- Consumes: `modified.is_modified(tab_id)`, `save_with_dialog` (io/fetch), the structure's `file_path`, `export`-format serializer.
+- Consumes: `modified.is_modified(tab_id)`, `save_with_dialog` (io/fetch),
+  `writeRemoteFile` (`$lib/api/hpc`), the structure's `file_path` and
+  `remote_origin` (`{ session_id, file_path }`, set when loaded from HPC —
+  Structure.svelte ~847/4107), `export`-format serializer.
+- **Local vs remote save:** if the structure has `remote_origin`, Save writes
+  back to the HPC via `writeRemoteFile(session_id, file_path, content)`
+  (SFTP / `POST /api/hpc/files/write-content`); otherwise it uses the local
+  `save_with_dialog`. Save As is local-only (download to a chosen local path).
 - Produces: `async function guard_close(opts: { modified: boolean; on_save: () => Promise<boolean>; confirm: () => Promise<'save'|'discard'|'cancel'> }): Promise<boolean>` — returns `true` if the caller should proceed to close, `false` to abort.
 
 - [ ] **Step 1: Write the failing test**
@@ -450,9 +457,14 @@ const proceed = await guard_close({
   },
   on_save: async () => {
     try {
-      await save_with_dialog(serialize_structure(structure, file_path), {
-        defaultPath: file_path, filename,
-      })
+      const content = serialize_structure(structure, file_path)
+      if (remote_origin) {
+        // Opened from the HPC over SFTP → write back to the same remote path.
+        await writeRemoteFile(remote_origin.session_id, remote_origin.file_path, content)
+      } else {
+        // Local file → native save dialog defaulting to the original path.
+        await save_with_dialog(content, { defaultPath: file_path, filename })
+      }
       modified.clear(tab_id)
       return true
     } catch (e) {
@@ -492,3 +504,201 @@ In the app root, add a `beforeunload` handler (web) / Tauri `onCloseRequested` (
 Load a structure from a file, edit it, close the tab → confirm dialog; Save → `save_with_dialog` defaults to the original path; overwrite works, rename works; Don't Save closes; Cancel aborts. Clean tab closes silently. Screenshot each for the user.
 
 - [ ] **Step 3: Report** — show the user the results.
+
+---
+
+# Part C — VS Code extension fixes (batched)
+
+Two independent VS Code-only bugs, foldable into the same ext build as Part A.
+
+## Task C1: Cross-window atom copy/paste via the system clipboard
+
+**Problem:** `atom_clipboard` (`src/lib/state.svelte.ts:181`, a module-level
+`$state` singleton) is per-JS-context. Same window (desktop tabs/panes) shares
+it and works; two separate webviews (two VS Code editors, or popout windows)
+each get their own empty copy → paste finds nothing.
+
+**Fix:** keep the in-memory path for same-context (fast, exact); on copy ALSO
+write a serialized form to the system clipboard; on paste, when the in-memory
+clipboard is empty, fall back to reading + parsing the system clipboard.
+
+**Files:**
+- Create: `src/lib/structure/atom-clipboard-serial.ts`
+- Modify: `src/lib/structure/controllers/interaction.svelte.ts` (copy ~line 896-970; paste ~line 975-995)
+- Test: `tests/vitest/structure/atom-clipboard-serial.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `ClipboardSite` (`$lib/state.svelte`), `atom_clipboard` (same).
+- Produces: `serialize_atoms(sites: ClipboardSite[]): string` and
+  `parse_atoms(text: string): ClipboardSite[] | null` — round-trip via a marked
+  JSON envelope so foreign clipboard text is ignored.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/vitest/structure/atom-clipboard-serial.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { serialize_atoms, parse_atoms } from '$lib/structure/atom-clipboard-serial'
+
+describe('atom clipboard serial', () => {
+  const sites = [{ species: [{ element: 'O', occu: 1 }], xyz: [1, 2, 3], abc: [0, 0, 0] }] as any
+  it('round-trips sites through a marked envelope', () => {
+    const text = serialize_atoms(sites)
+    expect(text.startsWith('CATGO_ATOMS_V1')).toBe(true)
+    expect(parse_atoms(text)).toEqual(sites)
+  })
+  it('returns null for foreign / non-atom clipboard text', () => {
+    expect(parse_atoms('just some copied text')).toBeNull()
+    expect(parse_atoms('')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/atom-clipboard-serial.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the serializer**
+
+Create `src/lib/structure/atom-clipboard-serial.ts`:
+
+```ts
+import type { ClipboardSite } from '$lib/state.svelte'
+
+const MARKER = `CATGO_ATOMS_V1`
+
+export function serialize_atoms(sites: ClipboardSite[]): string {
+  return `${MARKER}\n${JSON.stringify(sites)}`
+}
+
+export function parse_atoms(text: string): ClipboardSite[] | null {
+  if (!text || !text.startsWith(MARKER)) return null
+  try {
+    const body = text.slice(text.indexOf(`\n`) + 1)
+    const parsed = JSON.parse(body)
+    return Array.isArray(parsed) ? (parsed as ClipboardSite[]) : null
+  } catch {
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy pnpm exec vitest run tests/vitest/structure/atom-clipboard-serial.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Copy also writes the system clipboard**
+
+In `interaction.svelte.ts`, import `serialize_atoms, parse_atoms` from
+`'../atom-clipboard-serial'`. In the Ctrl/Cmd+C branch, right after
+`atom_clipboard.sites = extract_clipboard_sites(structure, original_indices)`:
+
+```ts
+if (atom_clipboard.sites) {
+  void navigator.clipboard?.writeText?.(serialize_atoms(atom_clipboard.sites))
+    ?.catch(() => {})   // clipboard may be denied outside a gesture — best effort
+}
+```
+
+- [ ] **Step 6: Paste falls back to the system clipboard when in-memory is empty**
+
+In the Ctrl/Cmd+V branch, before the `if (atom_clipboard.sites) {` block, insert a
+fallback that fills `atom_clipboard.sites` from the system clipboard. Because the
+read is async, `preventDefault()` first, then read, then paste:
+
+```ts
+if (!atom_clipboard.sites) {
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  const text = await navigator.clipboard?.readText?.().catch(() => ``)
+  const foreign = parse_atoms(text ?? ``)
+  if (foreign && foreign.length) {
+    atom_clipboard.sites = foreign
+    atom_clipboard.paste_count = 0
+  } else {
+    return  // nothing to paste
+  }
+}
+```
+
+Make the `onkeydown` handler `async` (it already `return`s early in each branch;
+awaiting is safe). The existing `if (atom_clipboard.sites) { … insert … }` block
+then runs unchanged.
+
+- [ ] **Step 7: Type-check + tests**
+
+Run: `pnpm check` (0 errors), then `rtk proxy pnpm exec vitest run` (all green).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/structure/atom-clipboard-serial.ts tests/vitest/structure/atom-clipboard-serial.test.ts src/lib/structure/controllers/interaction.svelte.ts
+git commit -m "feat(viewer): cross-window atom copy/paste via system-clipboard fallback"
+```
+
+## Task C2: Hide the Full Screen button inside the VS Code extension
+
+**Problem:** the ⛶ Full Screen control calls `wrapper.requestFullscreen()`
+(`src/lib/structure/Structure.svelte:3209`). VS Code webviews are sandboxed
+iframes without `allow="fullscreen"`, so the call is blocked and the button
+silently does nothing.
+
+**Fix:** gate the button off in the VS Code ext build using the existing
+`__CATGO_VSCODE_EXTENSION__` define (declared in `src/app.d.ts:46`; the safe-read
+pattern is in `WaterLayerPane.svelte:12`).
+
+**Files:**
+- Modify: `src/lib/structure/Structure.svelte` (fullscreen button render, ~line 3395 `{fullscreen_toggle}`; also check the viewer overlay toolbar where the ⛶ actually lives — grep `fullscreen_toggle` / `toggle_fullscreen` to find the exact render site the screenshot shows)
+
+**Interfaces:**
+- Consumes: build define `__CATGO_VSCODE_EXTENSION__`.
+
+- [ ] **Step 1: Add a reactive `is_vscode_extension` flag**
+
+In `Structure.svelte`'s `<script>`, near the top (matching WaterLayerPane's
+pattern):
+
+```ts
+const is_vscode_extension =
+  typeof __CATGO_VSCODE_EXTENSION__ !== `undefined` && __CATGO_VSCODE_EXTENSION__
+```
+
+(`__CATGO_VSCODE_EXTENSION__` is already typed in `src/app.d.ts`; in the main app
+build the define is unset so `typeof` is `undefined` → flag is `false` → button
+shown as today.)
+
+- [ ] **Step 2: Gate the fullscreen button render**
+
+Wrap the fullscreen control (the `{fullscreen_toggle}` render at ~line 3395, and
+any other ⛶ button in the viewer toolbar found via grep) so it only renders when
+NOT in the extension:
+
+```svelte
+{#if !is_vscode_extension}
+  {fullscreen_toggle}
+{/if}
+```
+
+If the ⛶ button is a plain `<button onclick={() => toggle_fullscreen(wrapper)}>`
+in a toolbar snippet rather than the `fullscreen_toggle` prop, add the same
+`{#if !is_vscode_extension}` guard around that button.
+
+- [ ] **Step 3: Type-check + ext build**
+
+Run: `pnpm check` (0 errors). Then `cd extensions/vscode && pnpm run build` — the
+ext bundle sets `__CATGO_VSCODE_EXTENSION__: 'true'`, so the button is compiled
+out there; the desktop/web builds keep it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/structure/Structure.svelte
+git commit -m "fix(vscode): hide the non-functional Full Screen button in the extension"
+```
+
+- [ ] **Step 5: Live-verify** — rebuild the ext, open a structure/trajectory:
+the ⛶ button is gone in VS Code; confirm it still shows (and works) in
+`pnpm desktop:dev` and the web build.

--- a/docs/superpowers/specs/2026-07-09-close-save-guard-design.md
+++ b/docs/superpowers/specs/2026-07-09-close-save-guard-design.md
@@ -1,0 +1,82 @@
+# Unsaved-changes guard + save-on-close (VS Code ext + desktop app)
+
+**Date:** 2026-07-09
+**Status:** approved (design)
+
+## Problem
+
+Editing a structure and closing its editor/tab currently loses the changes
+silently — no "save changes?" prompt. Wanted in **both** surfaces:
+
+- **VS Code extension** — closing a CatGo custom-editor tab (e.g. `IS_raw.xyz`).
+- **Desktop app** — closing a structure tab/pane.
+
+## Behaviour (both surfaces)
+
+- Editing a structure marks it **modified** (dirty). The tab shows the standard
+  dirty indicator.
+- **Ctrl+S** → silently overwrite the source file, in the source file's format
+  (xyz→xyz, POSCAR→POSCAR, …). Clears dirty. No dialog.
+- **Save As** (Ctrl+Shift+S / a "Save As…" action) → native save dialog
+  **pre-filled with the original file path**; keeping it overwrites, changing it
+  renames/relocates. Becomes the new save target.
+- **Close while dirty** → prompt **Save / Don't Save / Cancel**. Save →
+  overwrite the source file. Cancel → abort the close.
+- **Close while clean** (already Ctrl+S'd) → close silently, no prompt.
+- **Save failure** → show an error, keep the tab open (do not close/lose edits).
+
+## A. VS Code extension — `CustomEditorProvider` (extensions/vscode/src/extension.ts)
+
+Currently `registerCustomEditorProvider` + `resolveCustomEditor` with a manual
+`saveAs` webview message, but **no dirty tracking / save methods** — so VS Code
+never prompts on close.
+
+- **Webview (`src/webview/main.ts`)**: wire the mounted CatGo component's
+  `on_structure_change` → `postMessage({ command: 'dirty' })`. On a
+  `requestContent` message from the extension, serialize the current structure in
+  the source format and reply `{ command: 'content', content, is_binary }`.
+- **Extension**:
+  - Per-document dirty flag + an `onDidChangeCustomDocument` emitter. On a
+    `dirty` webview message → fire the emitter → VS Code marks the tab dirty and
+    enables the native close prompt.
+  - `saveCustomDocument(document)` → request content from that document's
+    webview → `workspace.fs.writeFile(document.uri, content)` → clear dirty.
+  - `saveCustomDocumentAs(document, targetResource)` → write content to
+    `targetResource` (VS Code's Save As dialog supplies it, defaulting to the
+    original). The existing `saveAs` message handler is kept for an explicit
+    in-viewer "Save As…" button but routed through the same serialize path.
+  - `backupCustomDocument(...)` → write a backup copy for hot-exit safety.
+- Result: the native VS Code "save changes?" prompt, dirty dot, Ctrl+S overwrite,
+  and Save As all work with zero custom dialogs.
+
+## B. Desktop app — Tauri/Svelte (src/lib/structure/)
+
+Pieces already present: `file_path`/`filename` on the loaded structure,
+`io/fetch.ts` `save_with_dialog`, `io/export.ts` format serializers,
+`DraggablePane.close_pane()` + tab close.
+
+- Track `is_modified` per structure/tab: set `true` on `on_structure_change`,
+  `false` after a successful save or a fresh load.
+- Intercept tab/pane close (`close_pane` + the tab-bar close): if `is_modified`,
+  show a confirm dialog **Save / Don't Save / Cancel**.
+  - **Save** → `save_with_dialog` with `defaultPath = file_path`, content from
+    `io/export` in the source format. Overwrites if the path is unchanged, saves
+    a new file if changed. On success clear `is_modified` and close; on failure
+    keep the tab.
+  - **Don't Save** → close. **Cancel** → abort.
+- Window close (`beforeunload`) → if any tab is `is_modified`, warn before exit.
+
+## Testing
+
+- **Ext**: unit-test the `dirty` message → `onDidChangeCustomDocument` wiring and
+  the serialize-on-save path (mock the webview messaging). Manual: edit → dirty
+  dot → close → prompt → Save writes the file; Save As renames.
+- **App**: vitest for `is_modified` transitions and the close-guard decision
+  (dirty → prompt, clean → silent). Manual: edit → close tab → prompt → Save via
+  dialog defaulting to the original path.
+
+## Out of scope
+
+- Multi-select / bulk close prompts beyond the standard per-tab behavior.
+- Auto-save / periodic backup beyond hot-exit `backupCustomDocument`.
+- Changing the on-disk format on save (always save in the source format).

--- a/docs/superpowers/specs/2026-07-09-close-save-guard-design.md
+++ b/docs/superpowers/specs/2026-07-09-close-save-guard-design.md
@@ -59,10 +59,14 @@ Pieces already present: `file_path`/`filename` on the loaded structure,
   `false` after a successful save or a fresh load.
 - Intercept tab/pane close (`close_pane` + the tab-bar close): if `is_modified`,
   show a confirm dialog **Save / Don't Save / Cancel**.
-  - **Save** → `save_with_dialog` with `defaultPath = file_path`, content from
-    `io/export` in the source format. Overwrites if the path is unchanged, saves
-    a new file if changed. On success clear `is_modified` and close; on failure
-    keep the tab.
+  - **Save** → branch on origin:
+    - **Local** structure → `save_with_dialog` with `defaultPath = file_path`,
+      content from `io/export` in the source format (overwrite if unchanged,
+      new file if renamed).
+    - **Remote (HPC)** structure — one carrying `remote_origin
+      { session_id, file_path }` from an SFTP open → `writeRemoteFile(...)`
+      (`POST /api/hpc/files/write-content`) writes back to the same remote path.
+    On success clear `is_modified` and close; on failure keep the tab.
   - **Don't Save** → close. **Cancel** → abort.
 - Window close (`beforeunload`) → if any tab is `is_modified`, warn before exit.
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -81,9 +81,15 @@
           },
           {
             "filenamePattern": "*{trajectory,relax,npt,nvt,nve}*"
+          },
+          {
+            "filenamePattern": "*.{xyz,extxyz,cif,poscar,mol2,pdb}"
+          },
+          {
+            "filenamePattern": "*poscar*"
           }
         ],
-        "priority": "option"
+        "priority": "default"
       }
     ],
     "configuration": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -80,9 +80,6 @@
             "filenamePattern": "*{xdatcar,contcar,outcar}"
           },
           {
-            "filenamePattern": "*{trajectory,relax,npt,nvt,nve}*"
-          },
-          {
             "filenamePattern": "*.{xyz,extxyz,cif,poscar,mol2,pdb}"
           },
           {
@@ -90,6 +87,16 @@
           }
         ],
         "priority": "default"
+      },
+      {
+        "viewType": "catgo.viewerAuto",
+        "displayName": "CatGo Viewer (name match)",
+        "selector": [
+          {
+            "filenamePattern": "*{trajectory,relax,npt,nvt,nve}*"
+          }
+        ],
+        "priority": "option"
       }
     ],
     "configuration": {

--- a/extensions/vscode/src/__tests__/provider-save.test.ts
+++ b/extensions/vscode/src/__tests__/provider-save.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { gunzipSync } from 'node:zlib'
+// CatgoDocument lives in its own VS-Code-free module (re-exported by
+// extension.ts). Importing it directly here keeps this unit test off the
+// heavy extension.ts import chain (Svelte/@threlte/ferrox-wasm) — see
+// task-A2 report for the controller-sanctioned deviation rationale.
+import { CatgoDocument } from '../catgo-document'
+
+describe('CatgoDocument', () => {
+  it('marks dirty on a dirty signal and clears after save', async () => {
+    const uri = { fsPath: '/tmp/IS_raw.xyz' } as any
+    const writes: Array<[string, Uint8Array]> = []
+    const doc = new CatgoDocument(uri, {
+      requestContent: async () => ({ content: 'XYZ...', is_binary: false }),
+      writeFile: async (u: any, data: Uint8Array) => { writes.push([u.fsPath, data]) },
+    })
+    const changed = vi.fn()
+    doc.onDidChange(changed)
+    doc.signalEdit()
+    expect(changed).toHaveBeenCalledTimes(1)
+    await doc.save()
+    expect(writes[0][0]).toBe('/tmp/IS_raw.xyz')
+    expect(new TextDecoder().decode(writes[0][1])).toBe('XYZ...')
+  })
+
+  it('rejects (no write, error surfaced) when the webview returns empty content', async () => {
+    const uri = { fsPath: '/tmp/OUTCAR' } as any
+    const writes: Array<[string, Uint8Array]> = []
+    const showError = vi.fn()
+    const doc = new CatgoDocument(uri, {
+      requestContent: async () => ({ content: '', is_binary: false }),
+      writeFile: async (u: any, data: Uint8Array) => { writes.push([u.fsPath, data]) },
+      showError,
+    })
+    await expect(doc.save()).rejects.toThrow(/not editable/i)
+    expect(writes.length).toBe(0)
+    expect(showError).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-gzips content before writing a .gz target', async () => {
+    const uri = { fsPath: '/tmp/POSCAR.xyz.gz' } as any
+    const writes: Array<[string, Uint8Array]> = []
+    const doc = new CatgoDocument(uri, {
+      requestContent: async () => ({ content: 'XYZ...', is_binary: false }),
+      writeFile: async (u: any, data: Uint8Array) => { writes.push([u.fsPath, data]) },
+    })
+    await doc.save()
+    expect(writes[0][0]).toBe('/tmp/POSCAR.xyz.gz')
+    // Bytes on disk must be a valid gzip stream that decompresses to the text.
+    expect(new TextDecoder().decode(gunzipSync(writes[0][1]))).toBe('XYZ...')
+  })
+})

--- a/extensions/vscode/src/__tests__/provider-save.test.ts
+++ b/extensions/vscode/src/__tests__/provider-save.test.ts
@@ -49,4 +49,19 @@ describe('CatgoDocument', () => {
     // Bytes on disk must be a valid gzip stream that decompresses to the text.
     expect(new TextDecoder().decode(gunzipSync(writes[0][1]))).toBe('XYZ...')
   })
+
+  it('propagates a requestContent rejection (e.g. webview timeout) without writing', async () => {
+    // The Provider's requestContentFor rejects on timeout / panel dispose; a
+    // rejected save must reach VS Code (tab stays open & dirty) and not write.
+    const uri = { fsPath: '/tmp/IS_raw.xyz' } as any
+    const writes: Array<[string, Uint8Array]> = []
+    const doc = new CatgoDocument(uri, {
+      requestContent: async () => {
+        throw new Error('CatGo viewer did not return the file content (timeout)')
+      },
+      writeFile: async (u: any, data: Uint8Array) => { writes.push([u.fsPath, data]) },
+    })
+    await expect(doc.save()).rejects.toThrow(/timeout/)
+    expect(writes.length).toBe(0)
+  })
 })

--- a/extensions/vscode/src/catgo-document.ts
+++ b/extensions/vscode/src/catgo-document.ts
@@ -1,0 +1,52 @@
+import { Buffer } from 'node:buffer'
+import { basename } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import * as vscode from 'vscode'
+
+// Injected dependencies keep CatgoDocument a VS-Code-free, unit-testable core:
+// the round-trip to the webview and the actual disk write are supplied by the
+// Provider (see extension.ts), so tests can drive save() with plain fakes.
+export interface DocDeps {
+  requestContent: () => Promise<{ content: string; is_binary: boolean }>
+  writeFile: (uri: vscode.Uri, data: Uint8Array) => Promise<void>
+  showError?: (message: string) => void
+}
+
+// Editable custom-editor document. Structural edit state lives in the webview;
+// this only tracks dirtiness (via onDidChange) and performs saves by asking the
+// webview for the current content and writing it to `uri` (or a Save-As/backup
+// target). Format is never changed on save — whatever the webview returns is
+// written to the source path as-is (gzip re-applied for `.gz` sources).
+export class CatgoDocument implements vscode.CustomDocument {
+  private readonly _onDidChange = new vscode.EventEmitter<void>()
+  readonly onDidChange = this._onDidChange.event
+  constructor(public readonly uri: vscode.Uri, private deps: DocDeps) {}
+  signalEdit(): void {
+    this._onDidChange.fire()
+  }
+  async save(target: vscode.Uri = this.uri): Promise<void> {
+    const { content, is_binary } = await this.deps.requestContent()
+    // Empty content means the webview cannot serialize this source (OUTCAR,
+    // cube, CHGCAR, LAMMPS dump, trajectory formats). Treat as a failed save:
+    // surface an error and leave the file untouched — never write an empty
+    // file and never let VS Code mark the document clean.
+    if (!content) {
+      const message = `CatGo: cannot save ${basename(target.fsPath)} — ` +
+        `this file's format is not editable (the viewer produced no content).`
+      this.deps.showError?.(message)
+      throw new Error(message)
+    }
+    let data = is_binary
+      ? Uint8Array.from(Buffer.from(content.replace(/^data:[^;]+;base64,/, ``), `base64`))
+      : new TextEncoder().encode(content)
+    // A `.gz` source is delivered UNCOMPRESSED by the webview; re-gzip so the
+    // on-disk file stays a valid gzip archive rather than corrupt plain text.
+    if (target.fsPath.endsWith(`.gz`)) {
+      data = gzipSync(data)
+    }
+    await this.deps.writeFile(target, data)
+  }
+  dispose(): void {
+    this._onDidChange.dispose()
+  }
+}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -892,6 +892,10 @@ export const render = async (
   }
 }
 
+// How long a save waits for the webview's `content` reply before failing the
+// save (error surfaced, document stays dirty) instead of hanging forever.
+const CONTENT_REQUEST_TIMEOUT_MS = 15_000
+
 // Custom editor provider for CatGo files. Editable: structural edits happen in
 // the webview, which flags the document dirty and answers a content request on
 // save. Saves write back to the source file in its original format.
@@ -907,11 +911,13 @@ class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
   // current content back from the right webview.
   private panels = new Map<string, vscode.WebviewPanel>()
   // In-flight save content requests keyed by request_id; resolved by the
-  // webview's matching `content` reply.
-  private pending_content = new Map<
-    string,
-    (payload: { content: string; is_binary: boolean }) => void
-  >()
+  // webview's matching `content` reply, rejected on timeout or panel dispose.
+  private pending_content = new Map<string, {
+    uri_key: string
+    resolve: (payload: { content: string; is_binary: boolean }) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }>()
 
   openCustomDocument(
     uri: vscode.Uri,
@@ -972,10 +978,14 @@ class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
           }
           // Answer an in-flight save content request (keyed by request_id).
           if (msg.command === `content` && typeof msg.request_id === `string`) {
-            const resolve = this.pending_content.get(msg.request_id)
-            if (resolve) {
+            const pending = this.pending_content.get(msg.request_id)
+            if (pending) {
+              clearTimeout(pending.timer)
               this.pending_content.delete(msg.request_id)
-              resolve({ content: msg.content ?? ``, is_binary: !!msg.is_binary })
+              pending.resolve({
+                content: msg.content ?? ``,
+                is_binary: !!msg.is_binary,
+              })
             }
             return
           }
@@ -1021,6 +1031,16 @@ class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
 
         stop_watching_file(file_path) // Clean up file watcher
         this.panels.delete(document.uri.toString())
+        // Fail any in-flight content requests for this panel right away —
+        // don't leave a save/backup hanging until the timeout fires.
+        for (const [request_id, pending] of this.pending_content) {
+          if (pending.uri_key !== document.uri.toString()) continue
+          clearTimeout(pending.timer)
+          this.pending_content.delete(request_id)
+          pending.reject(
+            new Error(`CatGo editor was closed before returning the file content`),
+          )
+        }
       })
       // Note: webview_panel disposal is managed by VSCode for custom editors
     } catch (error: unknown) {
@@ -1031,16 +1051,23 @@ class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
 
   // Ask the webview bound to `uri` for its current content: post a content
   // request and resolve on the matching `content` reply (keyed by request_id).
+  // Rejects after CONTENT_REQUEST_TIMEOUT_MS so a broken/unresponsive webview
+  // fails the save (error surfaced, document stays dirty) instead of hanging it.
   private requestContentFor(
     uri: vscode.Uri,
   ): Promise<{ content: string; is_binary: boolean }> {
-    const panel = this.panels.get(uri.toString())
+    const uri_key = uri.toString()
+    const panel = this.panels.get(uri_key)
     if (!panel) {
       return Promise.reject(new Error(`No active CatGo editor for ${uri.fsPath}`))
     }
     const request_id = `save-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    return new Promise((resolve) => {
-      this.pending_content.set(request_id, resolve)
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending_content.delete(request_id)
+        reject(new Error(`CatGo viewer did not return the file content (timeout)`))
+      }, CONTENT_REQUEST_TIMEOUT_MS)
+      this.pending_content.set(request_id, { uri_key, resolve, reject, timer })
       panel.webview.postMessage({ command: `requestContent`, request_id })
     })
   }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1086,11 +1086,21 @@ class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
     return document.save(dest)
   }
 
-  revertCustomDocument(document: CatgoDocument): Thenable<void> {
-    this.panels
-      .get(document.uri.toString())
-      ?.webview.postMessage({ command: `revert` })
-    return Promise.resolve()
+  // File → Revert: reload the webview from the on-disk content so the viewer
+  // drops its edited state (VS Code marks the doc clean once this resolves).
+  // Reuse the file-watcher `fileUpdated` message shape — the webview remounts
+  // from it and re-seeds its save-content cache, so no stale edit survives.
+  async revertCustomDocument(document: CatgoDocument): Promise<void> {
+    const panel = this.panels.get(document.uri.toString())
+    if (!panel) return
+    const updated_file = await read_file(document.uri.fsPath)
+    panel.webview.postMessage({
+      command: `fileUpdated`,
+      file_path: document.uri.fsPath,
+      data: updated_file,
+      type: infer_view_type(updated_file),
+      theme: get_theme(),
+    })
   }
 
   async backupCustomDocument(

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1137,6 +1137,20 @@ export const activate = (context: vscode.ExtensionContext) => {
         supportsMultipleEditorsPerDocument: false,
       },
     ),
+    // Opt-in ("Reopen Editor With…") twin whose selector is ONLY the broad
+    // name-substring glob (*trajectory/relax/npt/nvt/nve*). Kept at priority
+    // `option` so it never claims arbitrary text files by default, while
+    // extension-less trajectory-ish names (XDATCAR_npt2, md_nvt_300K) stay
+    // reachable in the CatGo viewer. The Provider is uri-based and ignores the
+    // viewType, so behaviour is identical to `catgo.viewer`.
+    vscode.window.registerCustomEditorProvider(
+      `catgo.viewerAuto`,
+      new Provider(context),
+      {
+        webviewOptions: { retainContextWhenHidden: true },
+        supportsMultipleEditorsPerDocument: false,
+      },
+    ),
     vscode.workspace.onDidOpenTextDocument((document: vscode.TextDocument) => {
       // Update context on any document open
       update_supported_resource_context(document.uri)

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -17,6 +17,13 @@ import { start_server, stop_server, get_server_port } from './server'
 import { stream_file_to_buffer } from './node-io'
 import { search_optimade_structures_backend, type OptimadeSearchOptions } from './optimade-backend'
 import { search_pubchem_compounds_backend } from './pubchem-backend'
+import { CatgoDocument } from './catgo-document'
+
+// CatgoDocument is a VS-Code-free core (its own module so unit tests can import
+// it without pulling the full extension/webview graph); re-exported here so it
+// stays part of the extension's public surface.
+export { CatgoDocument } from './catgo-document'
+export type { DocDeps } from './catgo-document'
 
 interface FrameLoaderData {
   loader: FrameLoader
@@ -86,6 +93,10 @@ export type IncomingCommand =
   | `pubchem_search`
   | `api_request`
   | `api_ws`
+  // Editable custom-editor messages (see Provider): the webview marks the
+  // document dirty on each edit and answers a content request on save.
+  | `dirty`
+  | `content`
 
 export interface MessageData {
   command: IncomingCommand
@@ -881,28 +892,58 @@ export const render = async (
   }
 }
 
-// Custom editor provider for CatGo files
-class Provider implements vscode.CustomReadonlyEditorProvider<vscode.CustomDocument> {
+// Custom editor provider for CatGo files. Editable: structural edits happen in
+// the webview, which flags the document dirty and answers a content request on
+// save. Saves write back to the source file in its original format.
+class Provider implements vscode.CustomEditorProvider<CatgoDocument> {
   constructor(private context: vscode.ExtensionContext) {}
+
+  private readonly _onDidChangeCustomDocument = new vscode.EventEmitter<
+    vscode.CustomDocumentEditEvent<CatgoDocument>
+  >()
+  readonly onDidChangeCustomDocument = this._onDidChangeCustomDocument.event
+
+  // Live webview panels keyed by uri.toString(), so save() can round-trip the
+  // current content back from the right webview.
+  private panels = new Map<string, vscode.WebviewPanel>()
+  // In-flight save content requests keyed by request_id; resolved by the
+  // webview's matching `content` reply.
+  private pending_content = new Map<
+    string,
+    (payload: { content: string; is_binary: boolean }) => void
+  >()
 
   openCustomDocument(
     uri: vscode.Uri,
     _open_context: vscode.CustomDocumentOpenContext,
     _token: vscode.CancellationToken,
-  ): vscode.CustomDocument {
-    return {
-      uri,
-      dispose: () => {},
-    }
+  ): CatgoDocument {
+    const doc = new CatgoDocument(uri, {
+      requestContent: () => this.requestContentFor(uri),
+      writeFile: (u, data) => Promise.resolve(vscode.workspace.fs.writeFile(u, data)),
+      showError: (message) => {
+        vscode.window.showErrorMessage(message)
+      },
+    })
+    doc.onDidChange(() =>
+      this._onDidChangeCustomDocument.fire({
+        document: doc,
+        undo: async () => {},
+        redo: async () => {}, // structural undo/redo lives in the webview
+        label: `Edit`,
+      })
+    )
+    return doc
   }
 
   async resolveCustomEditor(
-    document: vscode.CustomDocument,
+    document: CatgoDocument,
     webview_panel: vscode.WebviewPanel,
     _token: vscode.CancellationToken,
   ): Promise<void> {
     try {
       const file_path = document.uri.fsPath
+      this.panels.set(document.uri.toString(), webview_panel)
 
       webview_panel.webview.options = {
         enableScripts: true,
@@ -923,7 +964,23 @@ class Provider implements vscode.CustomReadonlyEditorProvider<vscode.CustomDocum
         },
       )
       webview_panel.webview.onDidReceiveMessage(
-        (msg: MessageData) => handle_msg(msg, webview_panel.webview),
+        (msg: MessageData) => {
+          // The webview flags every structure edit; mark the document dirty.
+          if (msg.command === `dirty`) {
+            document.signalEdit()
+            return
+          }
+          // Answer an in-flight save content request (keyed by request_id).
+          if (msg.command === `content` && typeof msg.request_id === `string`) {
+            const resolve = this.pending_content.get(msg.request_id)
+            if (resolve) {
+              this.pending_content.delete(msg.request_id)
+              resolve({ content: msg.content ?? ``, is_binary: !!msg.is_binary })
+            }
+            return
+          }
+          handle_msg(msg, webview_panel.webview)
+        },
         undefined,
         this.context.subscriptions,
       )
@@ -963,11 +1020,61 @@ class Provider implements vscode.CustomReadonlyEditorProvider<vscode.CustomDocum
         config_change_listener.dispose()
 
         stop_watching_file(file_path) // Clean up file watcher
+        this.panels.delete(document.uri.toString())
       })
       // Note: webview_panel disposal is managed by VSCode for custom editors
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
       vscode.window.showErrorMessage(`Failed: ${message}`)
+    }
+  }
+
+  // Ask the webview bound to `uri` for its current content: post a content
+  // request and resolve on the matching `content` reply (keyed by request_id).
+  private requestContentFor(
+    uri: vscode.Uri,
+  ): Promise<{ content: string; is_binary: boolean }> {
+    const panel = this.panels.get(uri.toString())
+    if (!panel) {
+      return Promise.reject(new Error(`No active CatGo editor for ${uri.fsPath}`))
+    }
+    const request_id = `save-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    return new Promise((resolve) => {
+      this.pending_content.set(request_id, resolve)
+      panel.webview.postMessage({ command: `requestContent`, request_id })
+    })
+  }
+
+  // A rejection from save() keeps the tab open & dirty and surfaces the failure
+  // (the desired behaviour for empty/unserializable sources) — VS Code never
+  // marks the document clean on a rejected save.
+  saveCustomDocument(document: CatgoDocument): Thenable<void> {
+    return document.save()
+  }
+
+  saveCustomDocumentAs(
+    document: CatgoDocument,
+    dest: vscode.Uri,
+  ): Thenable<void> {
+    return document.save(dest)
+  }
+
+  revertCustomDocument(document: CatgoDocument): Thenable<void> {
+    this.panels
+      .get(document.uri.toString())
+      ?.webview.postMessage({ command: `revert` })
+    return Promise.resolve()
+  }
+
+  async backupCustomDocument(
+    document: CatgoDocument,
+    ctx: vscode.CustomDocumentBackupContext,
+  ): Promise<vscode.CustomDocumentBackup> {
+    await document.save(ctx.destination)
+    return {
+      id: ctx.destination.toString(),
+      delete: () =>
+        vscode.workspace.fs.delete(ctx.destination).then(() => {}, () => {}),
     }
   }
 }
@@ -998,7 +1105,10 @@ export const activate = (context: vscode.ExtensionContext) => {
     vscode.window.registerCustomEditorProvider(
       `catgo.viewer`,
       new Provider(context),
-      { webviewOptions: { retainContextWhenHidden: true } },
+      {
+        webviewOptions: { retainContextWhenHidden: true },
+        supportsMultipleEditorsPerDocument: false,
+      },
     ),
     vscode.workspace.onDidOpenTextDocument((document: vscode.TextDocument) => {
       // Update context on any document open

--- a/extensions/vscode/src/mocks/vscode.ts
+++ b/extensions/vscode/src/mocks/vscode.ts
@@ -1,0 +1,29 @@
+// Minimal `vscode` module mock for extension-host unit tests.
+//
+// The real `vscode` module is only provided by the VS Code host at runtime,
+// so it cannot be resolved under vitest. Extension-host tests either declare
+// an inline `vi.mock('vscode', ...)` (see tests/extension.test.ts) or rely on
+// this module via the `vscode` alias in vitest.config.ts.
+//
+// Only the surface exercised at runtime by the code under test is implemented.
+// `src/catgo-document.ts` (the VS-Code-free document core) uses a functional
+// `EventEmitter`; every other `vscode.*` reference in that file is type-only
+// and erased at compile time, so it needs no runtime shape here.
+
+export class EventEmitter<T> {
+  private listeners: Array<(e: T) => void> = []
+  readonly event = (listener: (e: T) => void): { dispose(): void } => {
+    this.listeners.push(listener)
+    return {
+      dispose: () => {
+        this.listeners = this.listeners.filter((l) => l !== listener)
+      },
+    }
+  }
+  fire(data: T): void {
+    for (const listener of [...this.listeners]) listener(data)
+  }
+  dispose(): void {
+    this.listeners = []
+  }
+}

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -344,6 +344,10 @@ export const setup_vscode_download = (): void => {
 // when there is no structure (trajectory view) or the source format has no
 // frontend serializer (OUTCAR, cube/CHGCAR, LAMMPS data, …) — the extension
 // must treat an empty `content` reply as "cannot save".
+// DRIFT NOTE: the desktop app shares this format→serializer dispatch as
+// `save_format_from_path` in `src/lib/structure/save-format.ts`. This webview
+// copy stays separate for bundle isolation — keep the two in lockstep (both
+// cover xyz/extxyz/cif/mol2/pdb/json/POSCAR-family and refuse everything else).
 export const serialize_current = (): {
   content: string
   is_binary: boolean

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -20,6 +20,16 @@ import { setMPApiBase } from '$lib/api/materials-project'
 // chain reported in issue #14.
 import { decompress_data, detect_compression_format } from '$lib/io/decompress'
 import { parse_structure_file } from '$lib/structure/parse'
+import type { AnyStructure } from '$lib'
+import {
+  structure_to_cif_str,
+  structure_to_extxyz_str,
+  structure_to_json_str,
+  structure_to_mol2_str,
+  structure_to_pdb_str,
+  structure_to_poscar_str,
+  structure_to_xyz_str,
+} from '$lib/structure/export'
 import { parse_cube_header, cube_atoms_to_molecule } from '$lib/cube/parse-cube'
 import { chgcar_to_cube } from '$lib/electronic/chgdiff-wasm'
 import Structure from '$lib/structure/Structure.svelte'
@@ -162,6 +172,14 @@ declare global {
 // Store VSCode API instance to avoid multiple acquisitions
 let vscode_api: VSCodeAPI | null = null
 let current_app: CatGoApp | null = null
+
+// Live structure for save round-trips: seeded with the parsed source file when
+// a (non-trajectory) Structure is mounted, refreshed by every
+// `on_structure_change` emission from the Structure component. `requestContent`
+// serializes this in the SOURCE file's format (xyz→xyz, POSCAR→POSCAR, …) —
+// never the last export format the user may have picked in the UI.
+let current_structure: AnyStructure | null = null
+let source_filename = ``
 
 // Global backend port — set once server is ready, read by fetch/WebSocket interceptors.
 // Backend-bound fetch/WebSocket calls made before the port is known are parked in
@@ -316,6 +334,59 @@ export const setup_vscode_download = (): void => {
       })
     }
   }
+}
+
+// Serialize the current (edited) structure in the SOURCE file's format —
+// xyz→xyz, POSCAR→POSCAR, … — using the same `$lib/structure/export`
+// serializers the in-app export/download path uses on the same base
+// `structure`. Reads the live structure kept fresh by `on_structure_change`,
+// so content reflects all edits at the moment of the request. Returns null
+// when there is no structure (trajectory view) or the source format has no
+// frontend serializer (OUTCAR, cube/CHGCAR, LAMMPS data, …) — the extension
+// must treat an empty `content` reply as "cannot save".
+export const serialize_current = (): {
+  content: string
+  is_binary: boolean
+  filename: string
+} | null => {
+  if (!current_structure || !source_filename) return null
+  // Mirror parse dispatch: strip compression extensions before reading the ext.
+  let base = source_filename.toLowerCase()
+  while (COMPRESSION_EXTENSIONS_REGEX.test(base)) {
+    base = base.replace(COMPRESSION_EXTENSIONS_REGEX, ``)
+  }
+  const ext = base.split(`.`).pop() ?? ``
+  try {
+    let content: string | null = null
+    if (ext === `xyz`) content = structure_to_xyz_str(current_structure)
+    else if (ext === `extxyz`) content = structure_to_extxyz_str(current_structure)
+    else if (ext === `cif`) content = structure_to_cif_str(current_structure)
+    else if (ext === `mol2`) content = structure_to_mol2_str(current_structure)
+    else if (ext === `pdb`) content = structure_to_pdb_str(current_structure)
+    else if (ext === `json`) content = structure_to_json_str(current_structure)
+    else if (
+      ext === `poscar` || ext === `vasp` || /poscar|contcar/.test(base)
+    ) content = structure_to_poscar_str(current_structure)
+    if (content === null) return null
+    return { content, is_binary: false, filename: source_filename }
+  } catch (error) {
+    // e.g. POSCAR serializer throws when the structure has no lattice
+    console.error(`[CatGO Webview] Failed to serialize ${source_filename}:`, error)
+    return null
+  }
+}
+
+// Answer an extension-host content request (save round-trip). Always replies —
+// an empty `content` signals "nothing serializable" to the extension.
+const handle_content_request = (request_id: string): void => {
+  const payload = serialize_current()
+  vscode_api?.postMessage({
+    command: `content`,
+    request_id,
+    content: payload?.content ?? ``,
+    is_binary: payload?.is_binary ?? false,
+    filename: payload?.filename ?? ``,
+  })
 }
 
 // Handle file change events from extension
@@ -611,6 +682,15 @@ const create_display = (
   const is_trajectory = result.type === `trajectory`
   const Component = is_trajectory ? Trajectory : Structure
 
+  // Seed the save-content cache from the freshly parsed source file; every
+  // subsequent user edit refreshes it via `on_structure_change` below. A
+  // remount from `fileUpdated` re-seeds here, so external reloads never
+  // resurrect stale edits.
+  if (!is_trajectory) {
+    current_structure = result.data as AnyStructure
+    source_filename = filename
+  }
+
   // Get defaults and create props
   const catgo_data = get_catgo_data()
   const defaults = merge(catgo_data?.defaults)
@@ -684,6 +764,13 @@ const create_display = (
         hidden_toolbar_items: ['terminal', 'chat', 'plugin_hub', 'gesture', 'workflow'],
         ...(result.cube_file ? { cube_file: result.cube_file } : {}),
         on_file_load,
+        // Fired by Structure.svelte after every user edit (never on mount or
+        // programmatic load): mark the VS Code document dirty and keep the
+        // save-content cache pointing at the live edited structure.
+        on_structure_change: (structure: AnyStructure) => {
+          current_structure = structure
+          vscode_api?.postMessage({ command: `dirty` })
+        },
       }),
     allow_file_drop: false,
     style: `height: 100%; border-radius: 0`,
@@ -888,10 +975,12 @@ async function initialize() {
 
   // Set up file change monitoring
   if (vscode_api) {
-    // Listen for file change messages from extension
+    // Listen for file change + content request messages from extension
     globalThis.addEventListener(`message`, (event) => {
       if ([`fileUpdated`, `fileDeleted`].includes(event.data.command)) {
         handle_file_change(event.data)
+      } else if (event.data.command === `requestContent`) {
+        handle_content_request(event.data.request_id)
       }
     })
   }

--- a/extensions/vscode/vitest.config.ts
+++ b/extensions/vscode/vitest.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       '$root': ROOT,
       'catgo': resolve(ROOT, 'src/lib'),
       '$app/environment': resolve(ROOT, 'src/lib/mocks/environment.ts'),
+      // The real `vscode` module is host-only and unresolvable under vitest.
+      // Tests that don't declare their own inline `vi.mock('vscode')` resolve
+      // it to this minimal mock instead. Inline `vi.mock('vscode')` still wins
+      // for the files that use it.
+      'vscode': resolve(__dirname, 'src/mocks/vscode.ts'),
     },
   },
   test: {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -671,7 +671,17 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { .. } = event {
+            // Teardown runs on Destroyed, NOT CloseRequested. The unsaved-changes
+            // guard (desktop/App.svelte setup_close_guard) registers a JS
+            // onCloseRequested listener; tauri then auto-prevents every close
+            // request and delegates the decision to JS — but user handlers here
+            // still receive CloseRequested on that same (possibly cancelled)
+            // request, so tearing down there would kill the backend + exit(0)
+            // underneath the confirm dialog. Destroyed fires exactly once when
+            // the window is really going away: after JS lets the close through
+            // (the api auto-calls destroy()), or directly when no JS listener
+            // exists — so backend/agent/PTY teardown is never skipped.
+            if let tauri::WindowEvent::Destroyed = event {
                 // Only exit the app when the main window is closed;
                 // secondary windows (chat popout, workflow, terminal) just close themselves.
                 if window.label() != "main" {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2850,7 +2850,9 @@
     get_hovered: () => hovered,
     get_fullscreen_toggle: () => fullscreen_toggle,
     get_enable_info_pane: () => enable_info_pane,
-    toggle_fullscreen_fn: () => toggle_fullscreen(wrapper),
+    // VS Code's sandboxed webview blocks requestFullscreen(); the `f` shortcut
+    // would otherwise flip internal state for nothing, so make it inert there.
+    toggle_fullscreen_fn: () => { if (!is_vscode_extension) toggle_fullscreen(wrapper) },
     get_lattice_alignment_rotation: () => lattice_alignment_rotation,
     get_pencil_mode_active: () => pencil.pencil_mode_active,
     set_pencil_mode_active: (v) => { pencil.pencil_mode_active = v },

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -467,6 +467,7 @@
             removed_atom_opacity_entries,
           })
           pencil.push_bond_undo()
+          notify_structure_change()
           if (removed_atom_opacity_entries.length > 0) {
             const next = new Map(prev_overrides)
             for (const idx of sorted_indices) next.delete(idx)
@@ -853,6 +854,7 @@
     on_camera_move,
     on_camera_reset,
     on_structure_imported,
+    on_structure_change,
     on_atoms_manipulated,
     on_atom_added,
     on_atoms_deleted,
@@ -984,6 +986,13 @@
       // multi-pane host can refresh the tab label). Notification only — the structure itself
       // is already applied via the bound `structure` prop.
       on_structure_imported?: () => void
+      // Fires after every user edit that changes the structure (atom add/delete/
+      // move/replace/rotate, build-pane apply, paste/import merge, undo/redo).
+      // NOT fired on initial mount or programmatic loads (data_url /
+      // structure_string / bridge pushes). Optional — strict no-op when absent.
+      // Used for dirty tracking by embedding hosts (VS Code webview custom
+      // editor; desktop tab owner).
+      on_structure_change?: (structure: AnyStructure) => void
       // Callback fired after atoms are committed from manipulation (drag, keyboard move, rotation).
       // Reports per-atom displacement vectors for cross-frame editing in trajectories.
       on_atoms_manipulated?: (event: import('./index').AtomManipulationEvent) => void
@@ -2659,6 +2668,7 @@
     // Capture the state we're undoing FROM (the forward state) so redo() can
     // restore it. Snapshot-based redo — see selection-state redo_history.
     sel_state.push_redo(structure)
+    notify_structure_change()
     if (entry.kind === `structure`) {
       structure = entry.structure
       pencil.pop_bond_undo()
@@ -2713,6 +2723,7 @@
     // undo entry, WITHOUT clearing the redo stack (so chained redo still works).
     sel_state.push_structure_entry($state.snapshot(structure) as AnyStructure, false)
     structure = snap as typeof structure
+    notify_structure_change()
   }
 
   // Populate the bindable editor_api handle so parents (e.g. mobile toolbar) can
@@ -2725,11 +2736,28 @@
     can_redo: () => sel_state.can_redo,
   }
 
+  // Notify the embedding host that the user edited the structure (dirty
+  // tracking, e.g. the VS Code custom editor / desktop tab owner). Deferred to
+  // a microtask so call-sites that snapshot undo state *before* applying their
+  // mutation (the standard pattern) deliver the post-edit structure; multiple
+  // pushes in one tick coalesce into a single emission. Strict no-op unless
+  // the parent passed on_structure_change — no cost for other builds.
+  let structure_change_queued = false
+  function notify_structure_change() {
+    if (!on_structure_change || structure_change_queued) return
+    structure_change_queued = true
+    queueMicrotask(() => {
+      structure_change_queued = false
+      if (structure) on_structure_change?.(structure)
+    })
+  }
+
   // Push current state to undo stack (used by slab cutter and other tools)
   function push_to_undo() {
     if (structure) {
       sel_state.push_structure_entry(structure)
       pencil.push_bond_undo()
+      notify_structure_change()
     }
   }
 
@@ -2780,7 +2808,11 @@
     set_scene_props_rotation: (r) => { settings.scene_props.rotation = r },
     get_rotation_target_ref: () => rotation_target_ref,
     push_to_undo,
-    push_atom_entry: (inv) => { sel_state.push_atom_entry(inv); pencil.push_bond_undo() },
+    push_atom_entry: (inv) => {
+      sel_state.push_atom_entry(inv)
+      pencil.push_bond_undo()
+      notify_structure_change()
+    },
     undo,
     redo,
     get_redo_length: () => (sel_state.can_redo ? 1 : 0),
@@ -2840,7 +2872,13 @@
     set_context_menu_3d_position: (pos) => { context_menu_3d_position = pos },
     set_context_menu_target_site: (idx) => { context_menu_target_site = idx },
     set_context_menu_visible: (v) => { context_menu_visible = v },
-    get_on_atoms_manipulated: () => on_atoms_manipulated,
+    // Wrapped so drag / keyboard-move / rotation COMMITS (which push their undo
+    // entry at gesture START, then set_structure at pointerup) re-emit
+    // on_structure_change with the post-commit structure.
+    get_on_atoms_manipulated: () => (event) => {
+      on_atoms_manipulated?.(event)
+      notify_structure_change()
+    },
     get_on_atoms_deleted: () => on_atoms_deleted,
     reindex_edits_after_delete: (deleted) => reindex_edits_on_delete(deleted),
     get_original_atoms_only,
@@ -2916,7 +2954,11 @@
     get_ghost_atom_indices: () => ghost_atom_indices,
     set_ghost_atom_indices: (s) => { ghost_atom_indices = s },
     push_to_undo,
-    push_atom_entry: (inv) => { sel_state.push_atom_entry(inv); pencil.push_bond_undo() },
+    push_atom_entry: (inv) => {
+      sel_state.push_atom_entry(inv)
+      pencil.push_bond_undo()
+      notify_structure_change()
+    },
     get_atom_opacity_overrides: () => sel_state.atom_opacity_overrides,
     set_atom_opacity_overrides: (m) => { sel_state.atom_opacity_overrides = m },
     push_selection_to_undo,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -186,6 +186,12 @@
   // Detect macOS for platform-specific keybindings
   const is_mac = typeof navigator !== `undefined` && /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent)
 
+  // __CATGO_VSCODE_EXTENSION__ is a vite `define` token (unset in the main app
+  // build → `typeof` is `undefined` → flag false); its type lives in src/app.d.ts.
+  // In VS Code's sandboxed webview iframe requestFullscreen() is blocked, so the
+  // Full Screen button silently does nothing — hide it there.
+  const is_vscode_extension = typeof __CATGO_VSCODE_EXTENSION__ !== `undefined` && __CATGO_VSCODE_EXTENSION__
+
   // Check if box selection modifier is pressed (Cmd on Mac, Ctrl on Windows/Linux)
   function is_box_select_modifier(event: MouseEvent | KeyboardEvent): boolean {
     return is_mac ? event.metaKey : event.ctrlKey
@@ -3434,7 +3440,7 @@
       {visible_buttons}
       {hide_extra_tools}
       {enable_measure_mode}
-      {fullscreen_toggle}
+      fullscreen_toggle={is_vscode_extension ? false : fullscreen_toggle}
       {hidden_toolbar_items}
       {remote_origin}
       {structure}

--- a/src/lib/structure/atom-clipboard-serial.ts
+++ b/src/lib/structure/atom-clipboard-serial.ts
@@ -1,0 +1,18 @@
+import type { ClipboardSite } from '$lib/state.svelte'
+
+const MARKER = `CATGO_ATOMS_V1`
+
+export function serialize_atoms(sites: ClipboardSite[]): string {
+  return `${MARKER}\n${JSON.stringify(sites)}`
+}
+
+export function parse_atoms(text: string): ClipboardSite[] | null {
+  if (!text || !text.startsWith(MARKER)) return null
+  try {
+    const body = text.slice(text.indexOf(`\n`) + 1)
+    const parsed = JSON.parse(body)
+    return Array.isArray(parsed) ? (parsed as ClipboardSite[]) : null
+  } catch {
+    return null
+  }
+}

--- a/src/lib/structure/close-guard.svelte.ts
+++ b/src/lib/structure/close-guard.svelte.ts
@@ -5,6 +5,7 @@ export function create_modified_registry() {
   return {
     mark: (tab_id: string) => dirty.add(tab_id),
     clear: (tab_id: string) => dirty.delete(tab_id),
+    clear_all: () => dirty.clear(),
     is_modified: (tab_id: string) => dirty.has(tab_id),
     any_modified: () => dirty.size > 0,
   }

--- a/src/lib/structure/close-guard.svelte.ts
+++ b/src/lib/structure/close-guard.svelte.ts
@@ -1,0 +1,11 @@
+import { SvelteSet } from 'svelte/reactivity'
+
+export function create_modified_registry() {
+  const dirty = new SvelteSet<string>()
+  return {
+    mark: (tab_id: string) => dirty.add(tab_id),
+    clear: (tab_id: string) => dirty.delete(tab_id),
+    is_modified: (tab_id: string) => dirty.has(tab_id),
+    any_modified: () => dirty.size > 0,
+  }
+}

--- a/src/lib/structure/controllers/interaction.svelte.ts
+++ b/src/lib/structure/controllers/interaction.svelte.ts
@@ -38,6 +38,7 @@ import { get_bond_key } from '../bonding'
 import { get_movement_step } from '../manipulation'
 import { get_center_of_mass, get_rotation_center } from '$lib/structure'
 import { atom_clipboard } from '$lib/state.svelte'
+import { serialize_atoms, parse_atoms } from '../atom-clipboard-serial'
 import { Euler, Plane, Quaternion, Raycaster, Vector2, Vector3 } from 'three'
 import {
   screen_frame_from_camera,
@@ -890,7 +891,7 @@ export function create_interaction_controller(deps: InteractionDeps) {
   // 事件处理器
   // ═══════════════════════════════════════════════════════════════════
 
-  function onkeydown(event: KeyboardEvent) {
+  async function onkeydown(event: KeyboardEvent) {
     if (!event.key) return
     const target = event.target as HTMLElement
     // Don't hijack edit/clipboard keys when typing inside an embedded editor.
@@ -967,6 +968,10 @@ export function create_interaction_controller(deps: InteractionDeps) {
         if (original_indices.length > 0) {
           atom_clipboard.sites = extract_clipboard_sites(structure, original_indices)
           atom_clipboard.paste_count = 0
+          if (atom_clipboard.sites) {
+            void navigator.clipboard?.writeText?.(serialize_atoms(atom_clipboard.sites))
+              ?.catch(() => {}) // clipboard may be denied outside a gesture — best effort
+          }
         }
       }
       return
@@ -978,6 +983,20 @@ export function create_interaction_controller(deps: InteractionDeps) {
       // 跳过隐藏/inert 或非活跃 pane — 只让用户最后点击的 pane 处理
       if (wrapper?.closest(`[inert]`)) return
       if (_active_interaction_wrapper && _active_interaction_wrapper !== wrapper && document.contains(_active_interaction_wrapper)) return
+      // Cross-window fallback: no in-memory sites (a different webview did the
+      // copy) — read + parse the marked envelope off the system clipboard.
+      if (!atom_clipboard.sites) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        const text = await navigator.clipboard?.readText?.().catch(() => ``)
+        const foreign = parse_atoms(text ?? ``)
+        if (foreign && foreign.length) {
+          atom_clipboard.sites = foreign
+          atom_clipboard.paste_count = 0
+        } else {
+          return // nothing to paste
+        }
+      }
       if (atom_clipboard.sites) {
         event.preventDefault()
         event.stopImmediatePropagation()

--- a/src/lib/structure/save-format.ts
+++ b/src/lib/structure/save-format.ts
@@ -1,0 +1,63 @@
+/**
+ * Source-format-preserving save mapper (close/save guard).
+ *
+ * The binding plan constraint is: "Save in the SOURCE file's format — never
+ * change format on save." This maps a source file path/name to the
+ * `$lib/structure/export` serializer format that round-trips it faithfully.
+ *
+ * When a source has NO faithful serializer — an unknown extension, an
+ * extension-less non-POSCAR file, or a compressed (.gz/.bz2/.xz/.zst/…) path —
+ * this returns `null`. Callers MUST treat `null` as "refuse the silent save":
+ * fall back to Save-As where a dialog is reachable, otherwise surface an error
+ * and keep the tab open. They must NEVER fall back to writing CIF (or any other
+ * format) into the source path, which would silently corrupt it.
+ *
+ * The set of faithful formats mirrors the serializers exported by
+ * `$lib/structure/export`: poscar, xyz, extxyz, cif, json, mol2, pdb.
+ *
+ * DRIFT NOTE: the VS Code webview keeps its own copy of this dispatch in
+ * `extensions/vscode/src/webview/main.ts` (`serialize_current`) for bundle
+ * isolation. Keep the two in lockstep — this module is the desktop source of
+ * truth. See that function's comment for the pointer back here.
+ */
+
+import { COMPRESSION_EXTENSIONS_REGEX } from '$lib/constants'
+
+/** On-disk formats `$lib/structure/export` can faithfully serialize back to. */
+export type SaveFormat = 'poscar' | 'xyz' | 'extxyz' | 'cif' | 'json' | 'mol2' | 'pdb'
+
+/**
+ * Map a source file path/name to the serializer format that PRESERVES its
+ * on-disk format, or `null` when no faithful serializer exists (caller must
+ * refuse the silent overwrite — see the module doc).
+ */
+export function save_format_from_path(path: string): SaveFormat | null {
+  const base = path.split(/[/\\]/).pop() || ``
+  // A compressed source (foo.cif.gz): the serializers emit plaintext, so
+  // writing their output back into the .gz path would corrupt it. Refuse
+  // rather than strip-and-mislabel.
+  if (COMPRESSION_EXTENSIONS_REGEX.test(base)) return null
+  const dot = base.lastIndexOf(`.`)
+  const ext = dot > 0 ? base.slice(dot + 1).toLowerCase() : ``
+  switch (ext) {
+    case `poscar`:
+    case `vasp`:
+    case `contcar`:
+      return `poscar`
+    case `xyz`:
+      return `xyz`
+    case `extxyz`:
+      return `extxyz`
+    case `cif`:
+      return `cif`
+    case `json`:
+      return `json`
+    case `mol2`:
+      return `mol2`
+    case `pdb`:
+      return `pdb`
+  }
+  // Extension-less VASP files (POSCAR, CONTCAR, POSCAR_relaxed, CONTCAR_1, …).
+  if (ext === `` && /^(poscar|contcar)/i.test(base)) return `poscar`
+  return null
+}

--- a/src/lib/structure/save-on-close.ts
+++ b/src/lib/structure/save-on-close.ts
@@ -16,3 +16,18 @@ export async function guard_close(opts: {
   // tab open so the user does not lose their edits.
   return opts.on_save()
 }
+
+// Window-close guard for the WEB build. Given a `beforeunload` event and whether
+// any tab is modified, block the unload (native browser "Leave site?" prompt)
+// when there are unsaved edits. Returns true if the unload was blocked. Browsers
+// ignore any custom UI here, so the native confirmation is all we can surface.
+export function apply_beforeunload_guard(
+  event: { preventDefault(): void; returnValue: unknown },
+  any_modified: boolean,
+): boolean {
+  if (!any_modified) return false
+  event.preventDefault()
+  // Chrome/legacy browsers only raise the confirmation when returnValue is set.
+  event.returnValue = ``
+  return true
+}

--- a/src/lib/structure/save-on-close.ts
+++ b/src/lib/structure/save-on-close.ts
@@ -1,0 +1,18 @@
+// Close-guard decision helper: given whether a tab is modified, a confirm
+// prompt, and a save action, decide whether the caller should proceed to close.
+//
+// Returns true  → caller may close the tab/pane.
+// Returns false → caller must abort the close (cancel, or a failed save).
+export async function guard_close(opts: {
+  modified: boolean
+  on_save: () => Promise<boolean>
+  confirm: () => Promise<'save' | 'discard' | 'cancel'>
+}): Promise<boolean> {
+  if (!opts.modified) return true
+  const choice = await opts.confirm()
+  if (choice === 'cancel') return false
+  if (choice === 'discard') return true
+  // 'save': close only if the save actually succeeded; a failed save keeps the
+  // tab open so the user does not lose their edits.
+  return opts.on_save()
+}

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -311,6 +311,13 @@
   let file_size = $state<number | undefined>(undefined)
   let file_object = $state<File | null>(null)
   let wrapper = $state<HTMLDivElement | undefined>(undefined)
+  // __CATGO_VSCODE_EXTENSION__ is a vite `define` token (unset in the main app
+  // build → `typeof` is `undefined` → flag false); its type lives in src/app.d.ts.
+  // VS Code's sandboxed webview blocks requestFullscreen(), so the Full Screen
+  // button + `f` shortcut are dead there — gate them off (matches Structure.svelte C2).
+  const is_vscode_extension = typeof __CATGO_VSCODE_EXTENSION__ !== `undefined` &&
+    __CATGO_VSCODE_EXTENSION__
+  const fullscreen_toggle_gated = $derived(is_vscode_extension ? false : fullscreen_toggle)
   let info_pane_open = $state(false)
   let parsing_progress = $state<ParseProgress | null>(null)
   let viewport = $state({ width: 0, height: 0 })
@@ -1210,7 +1217,7 @@
       total_frames,
       current_step_idx,
       is_playing,
-      has_fullscreen_toggle: !!fullscreen_toggle,
+      has_fullscreen_toggle: !!fullscreen_toggle_gated,
       view_mode_dropdown_open,
       fps_range,
       fps,
@@ -2109,17 +2116,17 @@
               </div>
             {/if}
             <!-- Fullscreen button - rightmost position -->
-            {#if fullscreen_toggle}
+            {#if fullscreen_toggle_gated}
               <button
                 type="button"
-                onclick={() => fullscreen_toggle && toggle_fullscreen(wrapper)}
+                onclick={() => fullscreen_toggle_gated && toggle_fullscreen(wrapper)}
                 title="{fullscreen ? `Exit` : `Enter`} fullscreen"
                 aria-label="{fullscreen ? `Exit` : `Enter`} fullscreen"
                 aria-pressed={fullscreen}
                 class="fullscreen-button"
               >
-                {#if typeof fullscreen_toggle === `function`}
-                  {@render fullscreen_toggle()}
+                {#if typeof fullscreen_toggle_gated === `function`}
+                  {@render fullscreen_toggle_gated()}
                 {:else}
                   <Icon icon="{fullscreen ? `Exit` : ``}Fullscreen" />
                 {/if}

--- a/tests/vitest/close-save-target.test.ts
+++ b/tests/vitest/close-save-target.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { create_empty_pane, type PaneState } from '../../desktop/pane-utils'
+import { init_close_save_target } from '../../desktop/lib/pane-manager'
+import { exp } from '../../desktop/state/export-state.svelte'
+
+/**
+ * Regression: closing a structure imported from the project DB (no
+ * local_file_path, no remote_origin) used to default the close-save target to
+ * `project`, so "Save & Close" silently wrote it back to the DB with no dialog.
+ * Path-less panes must instead default to `local`, which routes through the
+ * Save-As export dialog (asks WHERE to save). See init_close_save_target.
+ */
+function pane(overrides: Partial<PaneState>): PaneState {
+  return { ...create_empty_pane(), ...overrides }
+}
+
+describe(`init_close_save_target`, () => {
+  it(`defaults a path-less (DB-imported) pane to a Save-As dialog, not the DB`, () => {
+    exp.close_save_target = `project`
+    init_close_save_target(pane({ local_file_path: null, remote_origin: null }))
+    expect(exp.close_save_target).toBe(`local`)
+  })
+
+  it(`keeps a local-file pane on the local (source-path) target`, () => {
+    exp.close_save_target = `project`
+    init_close_save_target(pane({ local_file_path: `/tmp/foo.cif` }))
+    expect(exp.close_save_target).toBe(`local`)
+  })
+
+  it(`routes a remote (HPC) pane to the hpc target`, () => {
+    exp.close_save_target = `project`
+    init_close_save_target(
+      pane({ remote_origin: { session_id: `s1`, file_path: `/home/u/POSCAR` } }),
+    )
+    expect(exp.close_save_target).toBe(`hpc`)
+  })
+})

--- a/tests/vitest/structure/atom-clipboard-serial.test.ts
+++ b/tests/vitest/structure/atom-clipboard-serial.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { serialize_atoms, parse_atoms } from '$lib/structure/atom-clipboard-serial'
+
+describe('atom clipboard serial', () => {
+  const sites = [{ species: [{ element: 'O', occu: 1 }], xyz: [1, 2, 3], abc: [0, 0, 0] }] as any
+  it('round-trips sites through a marked envelope', () => {
+    const text = serialize_atoms(sites)
+    expect(text.startsWith('CATGO_ATOMS_V1')).toBe(true)
+    expect(parse_atoms(text)).toEqual(sites)
+  })
+  it('returns null for foreign / non-atom clipboard text', () => {
+    expect(parse_atoms('just some copied text')).toBeNull()
+    expect(parse_atoms('')).toBeNull()
+  })
+})

--- a/tests/vitest/structure/close-guard.test.ts
+++ b/tests/vitest/structure/close-guard.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { create_modified_registry } from '$lib/structure/close-guard.svelte'
+import { clear_modified_if_sole_pane, create_tab_state } from '../../../desktop/pane-utils'
+import { leaves, splitLeaf, structurePane } from '../../../desktop/pane-tree'
 
 describe('modified registry', () => {
   it('tracks dirty tabs and clears on save', () => {
@@ -11,5 +13,52 @@ describe('modified registry', () => {
     r.clear('t1')
     expect(r.is_modified('t1')).toBe(false)
     expect(r.any_modified()).toBe(false)
+  })
+})
+
+describe('clear_modified_if_sole_pane', () => {
+  const structure = { sites: [{}] } as never
+
+  it('clears when the pane is the sole content-bearing pane', () => {
+    const r = create_modified_registry()
+    const ts = create_tab_state()
+    const leaf = leaves(ts.root)[0]
+    structurePane(leaf)!.structure = structure
+    r.mark('t1')
+    expect(clear_modified_if_sole_pane(r, ts.root, 't1', leaf.id)).toBe(true)
+    expect(r.is_modified('t1')).toBe(false)
+  })
+
+  it('keeps the flag when a sibling pane also has content', () => {
+    const r = create_modified_registry()
+    const ts = create_tab_state()
+    const first = ts.active_leaf_id
+    const res = splitLeaf(ts.root, first, 'h')!
+    ts.root = res.root
+    for (const l of leaves(ts.root)) structurePane(l)!.structure = structure
+    r.mark('t1')
+    expect(clear_modified_if_sole_pane(r, ts.root, 't1', first)).toBe(false)
+    expect(r.is_modified('t1')).toBe(true)
+  })
+
+  it('keeps the flag when only a different pane has content', () => {
+    const r = create_modified_registry()
+    const ts = create_tab_state()
+    const first = ts.active_leaf_id
+    const res = splitLeaf(ts.root, first, 'h')!
+    ts.root = res.root
+    const sibling = leaves(ts.root).find((l) => l.id !== first)!
+    structurePane(sibling)!.structure = structure
+    r.mark('t1')
+    expect(clear_modified_if_sole_pane(r, ts.root, 't1', first)).toBe(false)
+    expect(r.is_modified('t1')).toBe(true)
+  })
+
+  it('clears when no pane has content', () => {
+    const r = create_modified_registry()
+    const ts = create_tab_state()
+    r.mark('t1')
+    expect(clear_modified_if_sole_pane(r, ts.root, 't1', ts.active_leaf_id)).toBe(true)
+    expect(r.is_modified('t1')).toBe(false)
   })
 })

--- a/tests/vitest/structure/close-guard.test.ts
+++ b/tests/vitest/structure/close-guard.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { create_modified_registry } from '$lib/structure/close-guard.svelte'
+
+describe('modified registry', () => {
+  it('tracks dirty tabs and clears on save', () => {
+    const r = create_modified_registry()
+    expect(r.is_modified('t1')).toBe(false)
+    r.mark('t1')
+    expect(r.is_modified('t1')).toBe(true)
+    expect(r.any_modified()).toBe(true)
+    r.clear('t1')
+    expect(r.is_modified('t1')).toBe(false)
+    expect(r.any_modified()).toBe(false)
+  })
+})

--- a/tests/vitest/structure/close-guard.test.ts
+++ b/tests/vitest/structure/close-guard.test.ts
@@ -14,6 +14,17 @@ describe('modified registry', () => {
     expect(r.is_modified('t1')).toBe(false)
     expect(r.any_modified()).toBe(false)
   })
+
+  it('clear_all wipes every dirty tab (Close-All completion)', () => {
+    const r = create_modified_registry()
+    r.mark('t1')
+    r.mark('t2')
+    expect(r.any_modified()).toBe(true)
+    r.clear_all()
+    expect(r.is_modified('t1')).toBe(false)
+    expect(r.is_modified('t2')).toBe(false)
+    expect(r.any_modified()).toBe(false)
+  })
 })
 
 describe('clear_modified_if_sole_pane', () => {

--- a/tests/vitest/structure/save-format.test.ts
+++ b/tests/vitest/structure/save-format.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { save_format_from_path } from '$lib/structure/save-format'
+
+describe(`save_format_from_path`, () => {
+  it(`maps every faithfully-serializable extension to its serializer format`, () => {
+    expect(save_format_from_path(`/a/b/model.cif`)).toBe(`cif`)
+    expect(save_format_from_path(`/a/b/model.xyz`)).toBe(`xyz`)
+    expect(save_format_from_path(`/a/b/model.extxyz`)).toBe(`extxyz`)
+    expect(save_format_from_path(`/a/b/model.poscar`)).toBe(`poscar`)
+    expect(save_format_from_path(`/a/b/model.vasp`)).toBe(`poscar`)
+    expect(save_format_from_path(`/a/b/model.contcar`)).toBe(`poscar`)
+    expect(save_format_from_path(`/a/b/model.json`)).toBe(`json`)
+    expect(save_format_from_path(`/a/b/model.mol2`)).toBe(`mol2`)
+    expect(save_format_from_path(`/a/b/model.pdb`)).toBe(`pdb`)
+  })
+
+  it(`is case-insensitive on the extension`, () => {
+    expect(save_format_from_path(`FOO.CIF`)).toBe(`cif`)
+    expect(save_format_from_path(`Foo.MOL2`)).toBe(`mol2`)
+    expect(save_format_from_path(`Foo.PDB`)).toBe(`pdb`)
+    expect(save_format_from_path(`Foo.ExtXYZ`)).toBe(`extxyz`)
+  })
+
+  it(`matches extension-less POSCAR/CONTCAR by filename (incl. suffixed variants)`, () => {
+    expect(save_format_from_path(`POSCAR`)).toBe(`poscar`)
+    expect(save_format_from_path(`CONTCAR`)).toBe(`poscar`)
+    expect(save_format_from_path(`/scratch/run/POSCAR`)).toBe(`poscar`)
+    expect(save_format_from_path(`/scratch/run/CONTCAR`)).toBe(`poscar`)
+    expect(save_format_from_path(`POSCAR_relaxed`)).toBe(`poscar`)
+    expect(save_format_from_path(`CONTCAR_1`)).toBe(`poscar`)
+    expect(save_format_from_path(`poscar`)).toBe(`poscar`) // lowercase
+  })
+
+  it(`handles Windows-style backslash paths`, () => {
+    expect(save_format_from_path(`C:\\Users\\me\\model.mol2`)).toBe(`mol2`)
+    expect(save_format_from_path(`C:\\Users\\me\\POSCAR`)).toBe(`poscar`)
+    expect(save_format_from_path(`C:\\Users\\me\\slab.pdb`)).toBe(`pdb`)
+  })
+
+  it(`refuses (null) sources with no faithful serializer`, () => {
+    // Formats CatGO can PARSE but has no faithful frontend serializer for.
+    expect(save_format_from_path(`/a/b/dump.data`)).toBeNull() // LAMMPS data
+    expect(save_format_from_path(`/a/b/model.xsf`)).toBeNull()
+    expect(save_format_from_path(`/a/b/model.lmp`)).toBeNull()
+    expect(save_format_from_path(`/a/b/OUTCAR`)).toBeNull()
+    expect(save_format_from_path(`/a/b/vasprun.xml`)).toBeNull()
+    // Extension-less non-POSCAR files must not be silently CIF-ified.
+    expect(save_format_from_path(`notes`)).toBeNull()
+    expect(save_format_from_path(`/a/b/README`)).toBeNull()
+  })
+
+  it(`refuses (null) compressed sources — never write plaintext into a .gz path`, () => {
+    expect(save_format_from_path(`/a/b/model.cif.gz`)).toBeNull()
+    expect(save_format_from_path(`/a/b/model.xyz.bz2`)).toBeNull()
+    expect(save_format_from_path(`/a/b/model.poscar.xz`)).toBeNull()
+    expect(save_format_from_path(`/a/b/model.pdb.zst`)).toBeNull()
+    expect(save_format_from_path(`/a/b/POSCAR.gz`)).toBeNull()
+  })
+
+  it(`ignores directory components that look like extensions`, () => {
+    // A ".cif" in a directory name must not be mistaken for the file format.
+    expect(save_format_from_path(`/home/user.cif/model.mol2`)).toBe(`mol2`)
+    expect(save_format_from_path(`/data.xyz/notes`)).toBeNull()
+  })
+})

--- a/tests/vitest/structure/save-on-close.test.ts
+++ b/tests/vitest/structure/save-on-close.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { guard_close } from '$lib/structure/save-on-close'
+
+describe('guard_close', () => {
+  it('clean tab closes without prompting', async () => {
+    const confirm = vi.fn()
+    expect(await guard_close({ modified: false, on_save: vi.fn(), confirm })).toBe(true)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+  it('save → runs save, closes when save succeeds', async () => {
+    const on_save = vi.fn().mockResolvedValue(true)
+    expect(await guard_close({ modified: true, on_save,
+      confirm: async () => 'save' })).toBe(true)
+    expect(on_save).toHaveBeenCalled()
+  })
+  it('save failure keeps the tab open', async () => {
+    expect(await guard_close({ modified: true, on_save: async () => false,
+      confirm: async () => 'save' })).toBe(false)
+  })
+  it('discard closes, cancel aborts', async () => {
+    expect(await guard_close({ modified: true, on_save: vi.fn(),
+      confirm: async () => 'discard' })).toBe(true)
+    expect(await guard_close({ modified: true, on_save: vi.fn(),
+      confirm: async () => 'cancel' })).toBe(false)
+  })
+})

--- a/tests/vitest/structure/save-on-close.test.ts
+++ b/tests/vitest/structure/save-on-close.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { guard_close } from '$lib/structure/save-on-close'
+import { apply_beforeunload_guard, guard_close } from '$lib/structure/save-on-close'
 
 describe('guard_close', () => {
   it('clean tab closes without prompting', async () => {
@@ -22,5 +22,20 @@ describe('guard_close', () => {
       confirm: async () => 'discard' })).toBe(true)
     expect(await guard_close({ modified: true, on_save: vi.fn(),
       confirm: async () => 'cancel' })).toBe(false)
+  })
+})
+
+describe('apply_beforeunload_guard', () => {
+  it('clean state → does not block unload', () => {
+    const event = { preventDefault: vi.fn(), returnValue: undefined as unknown }
+    expect(apply_beforeunload_guard(event, false)).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.returnValue).toBe(undefined)
+  })
+  it('modified → blocks unload (preventDefault + returnValue)', () => {
+    const event = { preventDefault: vi.fn(), returnValue: undefined as unknown }
+    expect(apply_beforeunload_guard(event, true)).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.returnValue).toBe('')
   })
 })


### PR DESCRIPTION
## Summary

Close/save guard for unsaved structure edits — both the VS Code extension and the desktop app now prompt to save (or Save As) instead of silently dropping edits, plus two batched VS Code fixes.

Plan: `docs/superpowers/plans/2026-07-09-close-save-guard.md` (executed task-by-task with per-task review + final whole-branch review).

### Part A — VS Code extension (editable custom editor)
- Webview emits `dirty` on every structure edit (new optional `on_structure_change` prop on `Structure.svelte`, explicit edit-funnel emission, microtask-coalesced, never fires on load/mount) and answers `requestContent` with a fresh serialization in the **source** file's format.
- `Provider` upgraded `CustomReadonlyEditorProvider` → `CustomEditorProvider` with a testable `CatgoDocument` core: native dirty dot, silent Ctrl+S overwrite, Save As, revert, hot-exit backup. Empty content = failed save (error surfaced, tab stays open); `.gz` targets re-gzipped; 15s timeout + dispose-rejection on the content round-trip.
- Plain structure files (`.xyz/.extxyz/.cif/.poscar/.mol2/.pdb`, bare `POSCAR*`) now open in the **guarded** CatGo editor by default (previously an unguarded auto-render panel — edits there were silently lost). The legacy name-substring match (`*relax*` etc.) stays opt-in via a second `option`-priority viewType so text files like `relax_notes.md` keep opening as text.

### Part B — Desktop app
- Per-tab modified registry (`SvelteSet`), marked via `on_structure_change`, cleared on load/replace with a sole-content-pane rule so saving one pane can't silently discharge a dirty sibling.
- Tab close and pane close gate on the registry: clean closes are silent; dirty closes prompt **Save / Don't Save / Cancel**. Save silently overwrites the source file in its original format (HPC-opened files write back over SFTP via `writeRemoteFile`); failure keeps the tab open with the error shown.
- Window close: `beforeunload` (web) / Tauri `onCloseRequested` → Close-All dialog (desktop). Rust teardown relocated `WindowEvent::CloseRequested` → `Destroyed` — with a JS close listener registered, tauri auto-prevents the close but still ran the Rust handler, so the old code `exit(0)`'d underneath the dialog on the first ✕ click.
- New shared `save_format_from_path` mapper (mol2/pdb/json covered; unknown/compressed → Save-As fallback or surfaced error) replaces three inline copies that silently rewrote unknown formats as CIF.

### Part C — VS Code fixes
- Cross-window atom copy/paste: copy also writes a marked envelope to the system clipboard; paste falls back to it when the in-memory clipboard is empty (two editor windows are separate JS contexts). Foreign clipboard text is ignored.
- The non-functional Full Screen button (blocked by the webview sandbox) is compiled out of the extension build.

## Decisions to ratify (made while the author was away)

1. **Silent overwrite on Save** (plan's global constraint) won over the B3 body's save-dialog sketch — local saves with a known path write directly, no dialog. Flip: route `on_save` through `save_with_dialog`.
2. **Guarded editor is now the default** for plain structure files in VS Code (text editor one `Reopen With` away). Flip: change `catgo.viewer` priority back to `option` in `extensions/vscode/package.json`.

## Test plan

- [x] 4460 vitest pass / 0 fail at final HEAD (19 new tests across registry/guard/serializer/format-mapper); `pnpm check` 0 errors; ext + desktop builds clean; cargo check clean
- [x] VS Code live-verified in an Extension Development Host: dirty dot, silent Ctrl+S (disk verified), close-prompt (human-confirmed), clean-close silent, Save As wired, fullscreen gone, selector routing (`.md` stays text / `.xyz` guarded / name-match opt-in)
- [ ] Desktop Tauri-native verification on a dev machine (**rebuild the Rust binary first** — a stale binary with the new frontend still exits under the dialog): clean ✕ silent exit; dirty ✕ → Close-All; Save & Close → no orphaned `catgo-server`/agent/PTY; Cancel keeps window; closing a popout leaves the backend alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
