### PR TITLE
feat(sidebar): remove the 400px max width when dragging the file sidebar

### DIFF
--- a/desktop/App.svelte
+++ b/desktop/App.svelte
@@ -852,7 +852,7 @@
         // Show visual hint that it will collapse
         sidebar.width = 160
       } else {
-        sidebar.width = Math.max(160, Math.min(400, raw_w))
+        sidebar.width = Math.max(160, raw_w)
       }
     }
     function on_up(ev: MouseEvent) {


### PR DESCRIPTION
The file-sidebar divider drag clamped the width to 400px (`desktop/App.svelte`), which is too narrow for deep file trees and long filenames. Drop the upper clamp; the 160px minimum, drag-below-80px auto-collapse, and double-click reset to 240px are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)