### PR TITLE
feat(viewer): soften glossy material default lighting (az0/el5, dir 0.62, amb 0.5, hl 1.5)

### DIFF
--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -17,14 +17,15 @@ import type { LightingProfile, RenderStyle, SettingsConfig, ShowBonds } from './
  */
 export const LIGHTING_PROFILE_DEFAULTS: Readonly<Record<RenderStyle, LightingProfile>> = {
   glossy: {
-    // Physically-based key: ambient fill + a near-head-on camera-relative key at
-    // HDR intensity 2.2 (offset ≈ az0/el5), fed through the GGX shader + ACES.
-    // Muted colours, a small centred specular hot spot.
+    // Physically-based key: ambient fill + a near-head-on camera-relative key
+    // (offset ≈ az0/el5), fed through the GGX shader + ACES. Muted colours, a
+    // small centred specular hot spot. Key/ambient/highlight tuned in the live
+    // panel to a softer, less blown-out default.
     light_azimuth: 0,
     light_elevation: 5,
-    directional_light: 2.2,
-    ambient_light: 0.6,
-    highlight_strength: 1.0,
+    directional_light: 0.62,
+    ambient_light: 0.5,
+    highlight_strength: 1.5,
   },
   // Metallic reuses the glossy (specular) shader branch but at higher roughness
   // + metalness, for a bigger, softer, element-tinted highlight (not a compact


### PR DESCRIPTION
Softens the default lighting for the **glossy** material to the values tuned live in the lighting panel:

| param | old | new |
|---|---|---|
| directional (平行光) | 2.2 | 0.62 |
| ambient (环境光) | 0.6 | 0.5 |
| highlight (高光强度) | 1.0 | 1.5 |

Azimuth (方位角 0) and elevation (仰角 5) unchanged. Less blown-out default glossy look; per-scene sliders still work. Values were user-verified live in the viewer before baking as defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
