### PR TITLE
fix(export): cap image export to the real WebGL drawing buffer (fixes black-margin/cropped high-DPI exports)

### DIFF
--- a/src/lib/io/__tests__/export.test.ts
+++ b/src/lib/io/__tests__/export.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { compute_export_render_plan, fit_plan_to_drawing_buffer } from '../export'
+
+describe(`fit_plan_to_drawing_buffer`, () => {
+  it(`returns the plan unchanged when it already fits the buffer`, () => {
+    const plan = compute_export_render_plan(1676, 905, 3352, 1810, 32768)
+    const fitted = fit_plan_to_drawing_buffer(plan, 7838, 4232)
+    expect(fitted).toBe(plan) // same reference — no scaling
+    expect(fitted.render_width).toBe(3352)
+    expect(fitted.render_height).toBe(1810)
+  })
+
+  it(`scales the plan down to the clamped drawing buffer, preserving aspect`, () => {
+    // High-DPI export requests 12000 wide but the browser clamps the buffer.
+    const plan = compute_export_render_plan(1676, 905, 12000, 6480, 32768)
+    expect(plan.render_width).toBe(12000)
+    const fitted = fit_plan_to_drawing_buffer(plan, 7838, 4232)
+    // Render must now fit inside the real buffer (the whole point of the fix).
+    expect(fitted.render_width).toBeLessThanOrEqual(7838)
+    expect(fitted.render_height).toBeLessThanOrEqual(4232)
+    // Aspect is preserved (12000/6480 ≈ 1.852).
+    const orig_aspect = 12000 / 6480
+    const new_aspect = fitted.render_width / fitted.render_height
+    expect(Math.abs(new_aspect - orig_aspect)).toBeLessThan(0.01)
+    // full_* scale by the same factor.
+    expect(fitted.full_width).toBeLessThanOrEqual(7838)
+  })
+
+  it(`scales the crop view_offset by the same factor`, () => {
+    const crop = { x: 100, y: 50, width: 800, height: 400 }
+    const plan = compute_export_render_plan(1676, 905, 16760, 9050, 32768, crop)
+    expect(plan.view_offset).toBeDefined()
+    const fitted = fit_plan_to_drawing_buffer(plan, 7838, 4232)
+    expect(fitted.render_width).toBeLessThanOrEqual(7838)
+    expect(fitted.view_offset).toBeDefined()
+    // The offset window must stay inside its (scaled) full frame.
+    const vo = fitted.view_offset!
+    expect(vo.x + vo.width).toBeLessThanOrEqual(vo.full_width + 1)
+    expect(vo.y + vo.height).toBeLessThanOrEqual(vo.full_height + 1)
+  })
+
+  it(`never returns a zero or negative dimension`, () => {
+    const plan = compute_export_render_plan(1676, 905, 40000, 21600, 32768)
+    const fitted = fit_plan_to_drawing_buffer(plan, 1, 1)
+    expect(fitted.render_width).toBeGreaterThanOrEqual(1)
+    expect(fitted.render_height).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -220,6 +220,41 @@ export function compute_export_render_plan(
   }
 }
 
+// Scale an export render plan down so its render size fits inside the actual
+// WebGL drawing buffer. Browsers (notably WebKitGTK/Tauri) clamp the drawing
+// buffer below the requested canvas size at a limit separate from — and often
+// far smaller than — MAX_RENDERBUFFER_SIZE; without this, readPixels reads past
+// the real buffer and the export gets black margins + a shifted, cropped image.
+// Returns the plan unchanged when it already fits; aspect is preserved.
+export function fit_plan_to_drawing_buffer(
+  plan: ExportRenderPlan,
+  buffer_width: number,
+  buffer_height: number,
+): ExportRenderPlan {
+  const bw = Math.max(1, Math.floor(buffer_width))
+  const bh = Math.max(1, Math.floor(buffer_height))
+  if (bw >= plan.render_width && bh >= plan.render_height) return plan
+
+  const scale = Math.min(bw / plan.render_width, bh / plan.render_height)
+  const view_offset = plan.view_offset
+    ? {
+      full_width: Math.max(1, Math.round(plan.view_offset.full_width * scale)),
+      full_height: Math.max(1, Math.round(plan.view_offset.full_height * scale)),
+      x: Math.round(plan.view_offset.x * scale),
+      y: Math.round(plan.view_offset.y * scale),
+      width: Math.max(1, Math.round(plan.view_offset.width * scale)),
+      height: Math.max(1, Math.round(plan.view_offset.height * scale)),
+    }
+    : undefined
+  return {
+    full_width: Math.max(1, Math.round(plan.full_width * scale)),
+    full_height: Math.max(1, Math.round(plan.full_height * scale)),
+    render_width: Math.max(1, Math.floor(plan.render_width * scale)),
+    render_height: Math.max(1, Math.floor(plan.render_height * scale)),
+    view_offset,
+  }
+}
+
 function prepare_camera_for_export(
   camera: THREE.Camera,
   full_width: number,
@@ -306,19 +341,40 @@ function render_and_read_pixels(
     // Render at target resolution (pixelRatio=1, exact pixel dimensions)
     renderer.setPixelRatio(1)
     renderer.setSize(plan.render_width, plan.render_height, false)
+
+    // The browser can clamp the WebGL drawing buffer BELOW the requested canvas
+    // size — a max-viewport / max-drawing-buffer-area limit that is separate from
+    // (and often much smaller than) MAX_RENDERBUFFER_SIZE, and is especially low
+    // on WebKitGTK/Tauri. When that happens `canvas.width` no longer matches the
+    // real buffer: three renders into an oversized viewport while readPixels reads
+    // past the actual buffer, producing black margins plus a shifted, cropped
+    // export. Re-sync the whole plan to the ACTUAL drawing-buffer size so the
+    // render viewport, camera aspect and readPixels rectangle all agree. The
+    // clamp preserves aspect, so a high-DPI export just caps at the largest the
+    // GPU/browser can produce instead of corrupting the image.
+    const fitted = fit_plan_to_drawing_buffer(
+      plan,
+      gl.drawingBufferWidth,
+      gl.drawingBufferHeight,
+    )
+    const read_w = fitted.render_width
+    const read_h = fitted.render_height
+    if (read_w !== plan.render_width || read_h !== plan.render_height) {
+      renderer.setSize(read_w, read_h, false)
+    }
+
     restore_camera = prepare_camera_for_export(
       camera,
-      plan.full_width,
-      plan.full_height,
-      plan.view_offset,
+      fitted.full_width,
+      fitted.full_height,
+      fitted.view_offset,
     )
     renderer.render(scene, camera)
 
-    // Read pixels synchronously — works regardless of preserveDrawingBuffer
+    // Read pixels synchronously — works regardless of preserveDrawingBuffer.
+    // read_w/read_h now match the real drawing buffer (see clamp above).
     const read_x = 0
     const read_y = 0
-    const read_w = plan.render_width
-    const read_h = plan.render_height
 
     const pixels = new Uint8Array(read_w * read_h * 4)
     gl.readPixels(read_x, read_y, read_w, read_h, gl.RGBA, gl.UNSIGNED_BYTE, pixels)


### PR DESCRIPTION
High-DPI figure exports (PNG/PDF/etc.) came out with **black margins and a shifted, cropped structure** — the exported image was incomplete.

## Root cause

Browsers — especially WebKitGTK/Tauri — clamp the WebGL **drawing buffer** below the requested canvas size at a max-viewport/area limit that is *separate from, and far smaller than,* `MAX_RENDERBUFFER_SIZE`. On the repro machine the buffer hard-caps at **7838×4232** while `MAX_RENDERBUFFER_SIZE` reports 32768.

The exporter set `canvas.width` to the requested (high-DPI) size, but three then rendered into an oversized viewport while `gl.readPixels` read past the real buffer — so everything beyond the clamp came back black and the content was mis-framed.

## Fix

After `setSize`, detect when `gl.drawingBufferWidth/Height` fell short of the requested render size and scale the whole render plan (render dims, camera aspect, crop view-offset) down to the **actual** buffer, re-syncing `setSize`. Aspect is preserved, so a too-high DPI now caps at the largest correct image the GPU/browser can produce instead of corrupting it. Extracted `fit_plan_to_drawing_buffer` as a pure, unit-tested helper.

## Verification

- **Live (CDP):** a 12000px-wide export request produced **751,681 black pixels before** the fix and **0 after** (rendered at the real 7664×4328 buffer, content correctly framed).
- **Unit tests:** 4 new tests for `fit_plan_to_drawing_buffer` (fits-unchanged, scale-down-preserving-aspect, crop-offset scaling, no zero dims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
