### PR TITLE
feat(viewer): widen bond-thickness range + scale lattice axis arrows with cell line width

### DIFF
--- a/src/lib/structure/Lattice.svelte
+++ b/src/lib/structure/Lattice.svelte
@@ -40,6 +40,12 @@
   } = $props()
 
   let hovered_idx = $state<number | null>(null) // track hovered vector
+  // Scale the a/b/c axis-arrow thickness with the cell line-width control so it
+  // tracks the cell edges. Divisor is the config default, so scale === 1 (today's
+  // look) at cell_edge_width = 1.5.
+  let axis_width_scale = $derived(
+    cell_edge_width / DEFAULTS.structure.cell_edge_width,
+  )
   let lattice_center = $derived(
     matrix
       ? (math.scale(math.add(...matrix), 0.5) satisfies Vec3)
@@ -170,7 +176,9 @@
             onpointerenter={() => hovered_idx = idx}
             onpointerleave={() => hovered_idx = null}
           >
-            <T.CylinderGeometry args={[0.05, 0.05, shaft_length, 16]} />
+            <T.CylinderGeometry
+              args={[0.05 * axis_width_scale, 0.05 * axis_width_scale, shaft_length, 16]}
+            />
             <T.MeshBasicMaterial color={vector_colors[idx]} />
           </T.Mesh>
 
@@ -181,7 +189,7 @@
             onpointerenter={() => hovered_idx = idx}
             onpointerleave={() => hovered_idx = null}
           >
-            <T.ConeGeometry args={[0.175, 0.5, 16]} />
+            <T.ConeGeometry args={[0.175 * axis_width_scale, 0.5, 16]} />
             <T.MeshBasicMaterial color={vector_colors[idx]} />
           </T.Mesh>
         {/each}

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -1142,16 +1142,16 @@
         {t('structure.thickness')}
         <input
           type="number"
-          min={0.05}
-          max={0.5}
-          step={0.05}
+          min={SETTINGS_CONFIG.structure.bond_thickness.minimum}
+          max={SETTINGS_CONFIG.structure.bond_thickness.maximum}
+          step={0.01}
           bind:value={scene_props.bond_thickness}
         />
         <input
           type="range"
-          min={0.05}
-          max={0.5}
-          step={0.05}
+          min={SETTINGS_CONFIG.structure.bond_thickness.minimum}
+          max={SETTINGS_CONFIG.structure.bond_thickness.maximum}
+          step={0.01}
           bind:value={scene_props.bond_thickness}
         />
       </label>


### PR DESCRIPTION
Ported from pretty-lattice's "adjustable structure line widths". CatGo already had `bond_thickness` (bond cylinder radius) and `cell_edge_width` (cell line width) as user sliders that feed exported figures automatically, so this is a small **gap-fill**, not a new control system.

## Changes
- **Widen the bond-thickness slider** to the config bounds: min 0.05→**0.01**, max 0.5→**1.0**, step 0.05→**0.01**, now read from `SETTINGS_CONFIG.structure.bond_thickness` (matches the cell_edge_width / bond_scale sliders' config-driven pattern).
- **Lattice a/b/c axis arrows now respect `cell_edge_width`**: their shaft (0.05) and cone-tip (0.175) radii scale by `cell_edge_width / 1.5`, so the width control affects the axis arrows too. Scale === 1 at the default 1.5 → today's look reproduced exactly; arrow proportions (length, cone height) unchanged.

`pnpm check` clean (0 errors). No new setting, no i18n change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
