### PR TITLE
feat(viewer): reduced-motion preference (gate viewer animations + honor OS setting)

### DIFF
--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -24,6 +24,7 @@ const structure: Record<string, string> = {
   pan_speed: `Pan speed`,
   zoom_to_cursor: `Zoom to cursor`,
   rotation_damping: `Rotation damping`,
+  reduced_motion: `Reduce motion`,
   rotation: `Rotation`,
   radius: `Radius (Å)`,
   same_size_atoms: `Same size atoms`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -24,6 +24,7 @@ const structure: Record<string, string> = {
   pan_speed: `平移速度`,
   zoom_to_cursor: `缩放至光标`,
   rotation_damping: `旋转阻尼`,
+  reduced_motion: `减少动效`,
   rotation: `旋转`,
   radius: `半径 (Å)`,
   same_size_atoms: `原子等大`,

--- a/src/lib/settings/config.ts
+++ b/src/lib/settings/config.ts
@@ -370,6 +370,11 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       minimum: 0,
       maximum: 10,
     },
+    reduced_motion: {
+      value: false,
+      description:
+        `Reduce or disable viewer animations (also honors the OS reduced-motion setting)`,
+    },
     rotation: {
       value: [0, 0, 0] as const,
       description:

--- a/src/lib/settings/index.ts
+++ b/src/lib/settings/index.ts
@@ -4,6 +4,7 @@
 export * from './types'
 export * from './config'
 export * from './defaults'
+export * from './reduced-motion'
 
 // Runtime backend-URL control (Model C) + its store/persistence helpers.
 export { default as BackendUrlSettings } from './BackendUrlSettings.svelte'

--- a/src/lib/settings/reduced-motion.ts
+++ b/src/lib/settings/reduced-motion.ts
@@ -1,0 +1,20 @@
+// Reduced-motion preference helper — shared by the 3D viewer + trajectory playback.
+//
+// The viewer suppresses continuous animations (selection pulse, vibration
+// auto-play, camera auto-rotate, trackball inertia, trajectory auto-play) when
+// EITHER an explicit user setting (`reduced_motion`) is on OR the OS-level
+// `prefers-reduced-motion: reduce` media query matches. This pure helper
+// combines the two so the rAF-gating call sites stay trivial (and unit-testable
+// without a real `matchMedia`).
+
+/** True when continuous viewer animations should be suppressed. */
+export function should_reduce_motion(setting: boolean, media_matches: boolean): boolean {
+  return Boolean(setting) || Boolean(media_matches)
+}
+
+/** Reads the OS-level `prefers-reduced-motion: reduce` media query.
+ *  SSR-safe: returns false when `matchMedia` is unavailable. */
+export function os_prefers_reduced_motion(): boolean {
+  return typeof matchMedia !== `undefined` &&
+    matchMedia(`(prefers-reduced-motion: reduce)`).matches
+}

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -187,6 +187,7 @@ export interface SettingsConfig {
     max_zoom: SettingType<number | undefined>
     min_zoom: SettingType<number | undefined>
     auto_rotate: SettingType<number>
+    reduced_motion: SettingType<boolean>
     // Manual rotation controls [x, y, z] in radians
     rotation: SettingType<Vec3>
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -486,6 +486,7 @@
       pan_speed: scene_props.pan_speed,
       zoom_to_cursor: scene_props.zoom_to_cursor,
       rotation_damping: scene_props.rotation_damping,
+      reduced_motion: scene_props.reduced_motion,
     }}
     on_reset={() => {
       scene_props.camera_projection = DEFAULTS.structure.camera_projection
@@ -495,6 +496,7 @@
       scene_props.pan_speed = DEFAULTS.structure.pan_speed
       scene_props.zoom_to_cursor = DEFAULTS.structure.zoom_to_cursor
       scene_props.rotation_damping = DEFAULTS.structure.rotation_damping
+      scene_props.reduced_motion = DEFAULTS.structure.reduced_motion
     }}
   >
     <label>
@@ -616,6 +618,12 @@
         step={0.01}
         bind:value={scene_props.rotation_damping}
       />
+    </label>
+    <label
+      {@attach tooltip({ content: SETTINGS_CONFIG.structure.reduced_motion.description })}
+    >
+      <input type="checkbox" bind:checked={scene_props.reduced_motion} />
+      <span>{t('structure.reduced_motion')}</span>
     </label>
   </SettingsSection>
 

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -5,7 +5,7 @@
   import { resolve_css_var } from '$lib/css-utils'
   import { format_num } from '$lib/labels'
   import * as math from '$lib/math'
-  import { type CameraProjection, DEFAULTS, type LightingProfile, type RenderStyle, type ShowBonds } from '$lib/settings'
+  import { type CameraProjection, DEFAULTS, type LightingProfile, type RenderStyle, should_reduce_motion, type ShowBonds } from '$lib/settings'
   import { colors } from '$lib/state.svelte'
   import { Arrow, Cylinder, get_rotation_center, Lattice } from '$lib/structure'
   import * as measure from '$lib/structure/measure'
@@ -159,6 +159,11 @@
     const has_selection = (selected_sites?.length ?? 0) + (active_sites?.length ?? 0) > 0
     if (!has_selection) {
       __pulse_opacity = 1
+      return
+    }
+    // Reduced motion: hold the highlight at a steady (non-pulsing) opacity.
+    if (reduce_motion) {
+      __pulse_opacity = 0.9
       return
     }
     let raf_id = 0
@@ -462,6 +467,7 @@
     hovered_site = $bindable(null),
     float_fmt = `.3~f`,
     auto_rotate = DEFAULTS.structure.auto_rotate,
+    reduced_motion = DEFAULTS.structure.reduced_motion,
     bond_thickness = DEFAULTS.structure.bond_thickness,
     bond_color = DEFAULTS.structure.bond_color,
     incomplete_periodic_edge_mode = DEFAULTS.structure.incomplete_periodic_edge_mode,
@@ -733,6 +739,10 @@
     hovered_site?: Site | null
     float_fmt?: string
     auto_rotate?: number
+    // When true (or when the OS prefers-reduced-motion matches), suppress
+    // continuous viewer animations (selection pulse / vibration auto-play /
+    // camera auto-rotate / trackball inertia). Byte-identical when false + no OS pref.
+    reduced_motion?: boolean
     initial_zoom?: number
     bond_thickness?: number
     incomplete_periodic_edge_mode?: boolean
@@ -961,6 +971,18 @@
     // Vibration mode animation
     vibration_data?: { eigenvector: number[][]; base_positions: number[][]; amplitude: number; playing: boolean } | null
   } = $props()
+
+  // Reduced-motion: honor the explicit user setting OR the OS-level
+  // `prefers-reduced-motion: reduce` media query. Gates every continuous rAF
+  // animation below (pulse / vibration / auto-rotate) plus trackball inertia.
+  // When false + no OS pref, the viewer's animation behavior is byte-identical.
+  const reduce_motion = $derived(
+    should_reduce_motion(
+      reduced_motion,
+      typeof matchMedia !== `undefined` &&
+        matchMedia(`(prefers-reduced-motion: reduce)`).matches,
+    ),
+  )
 
   const threlte = useThrelte()
 
@@ -2726,6 +2748,15 @@
     }
     const { eigenvector, base_positions, amplitude } = vib
     if (!eigenvector?.length || !base_positions?.length) return
+
+    // Reduced motion: don't oscillate. Show the un-displaced (base) structure
+    // by clearing the per-frame overrides instead of scheduling the rAF loop.
+    if (reduce_motion) {
+      if (untrack(() => realtime_position_overrides)) {
+        realtime_position_overrides = null
+      }
+      return
+    }
 
     let frame_id: number
     function tick() {
@@ -4958,7 +4989,8 @@
     // Disable pan when atom operations are in progress
     noPan: pan_speed === 0 || axis_lock_active || external_dragging ||
       is_box_selecting || is_rotating_atoms,
-    staticMoving: !Boolean(rotation_damping), // Opposite of damping
+    // Reduced motion forces staticMoving (no inertia/damping glide after release).
+    staticMoving: reduce_motion || !Boolean(rotation_damping), // Opposite of damping
     dynamicDampingFactor: rotation_damping || 0.2,
     minDistance: min_zoom,
     maxDistance: max_zoom,
@@ -5097,6 +5129,8 @@
   // Auto-rotation effect - continuously rotate camera around structure
   $effect(() => {
     if (!auto_rotate || auto_rotate <= 0) return
+    // Reduced motion: skip the continuous camera auto-rotation.
+    if (reduce_motion) return
     if (!orbit_controls || !camera) return
 
     let frame_id = 0

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -18,7 +18,7 @@
   import { format_num, trajectory_property_config } from '$lib/labels'
   import type { ControlsConfig, DataSeries, Orientation, Point } from '$lib/plot'
   import { Histogram, ScatterPlot } from '$lib/plot'
-  import { DEFAULTS } from '$lib/settings'
+  import { DEFAULTS, should_reduce_motion } from '$lib/settings'
   import { scaleLinear } from 'd3-scale'
   import type { ComponentProps, Snippet } from 'svelte'
   import { untrack } from 'svelte'
@@ -100,6 +100,7 @@
     show_controls = true,
     fullscreen_toggle = DEFAULTS.trajectory.fullscreen_toggle,
     auto_play = false,
+    reduced_motion = false,
     display_mode = $bindable(`structure+scatter`),
     step_labels = 5,
     on_play,
@@ -172,6 +173,9 @@
     fullscreen_toggle?: Snippet<[]> | boolean
     // automatically start playing when trajectory data is loaded
     auto_play?: boolean
+    // When true (or when the OS prefers-reduced-motion matches), don't
+    // auto-start playback. Manual play (▶) still works.
+    reduced_motion?: boolean
     // display mode: 'structure+scatter' (default), 'structure' (only structure), 'scatter' (only scatter), 'histogram' (only histogram), 'structure+histogram' (structure with histogram)
     display_mode?:
       | `structure+scatter`
@@ -432,9 +436,19 @@
     !!remote_origin && !!current_frame_source && !!current_frame?.structure,
   )
 
-  // Auto-play when trajectory changes (handles both props and file loading)
+  // Auto-play when trajectory changes (handles both props and file loading).
+  // Reduced motion (explicit setting or OS prefers-reduced-motion) suppresses
+  // the auto-start; the user can still press ▶ manually.
   $effect(() => {
-    if (auto_play && trajectory && !untrack(() => is_playing) && total_frames > 1) {
+    const reduce = should_reduce_motion(
+      reduced_motion,
+      typeof matchMedia !== `undefined` &&
+        matchMedia(`(prefers-reduced-motion: reduce)`).matches,
+    )
+    if (
+      !reduce && auto_play && trajectory && !untrack(() => is_playing) &&
+      total_frames > 1
+    ) {
       start_playback()
     }
   })

--- a/tests/vitest/reduced-motion.test.ts
+++ b/tests/vitest/reduced-motion.test.ts
@@ -1,0 +1,27 @@
+import { should_reduce_motion } from '$lib/settings/reduced-motion'
+import { describe, expect, test } from 'vitest'
+
+describe(`should_reduce_motion`, () => {
+  test.each([
+    { setting: false, media: false, expected: false },
+    { setting: true, media: false, expected: true },
+    { setting: false, media: true, expected: true },
+    { setting: true, media: true, expected: true },
+  ])(
+    `setting=$setting + media=$media → $expected`,
+    ({ setting, media, expected }) => {
+      expect(should_reduce_motion(setting, media)).toBe(expected)
+    },
+  )
+
+  test(`default (off setting, no OS pref) does not reduce motion`, () => {
+    // Byte-identical viewer behavior when neither source asks to reduce.
+    expect(should_reduce_motion(false, false)).toBe(false)
+  })
+
+  test(`coerces truthy/falsy inputs to a boolean`, () => {
+    // OS media query may pass through undefined when matchMedia is unavailable.
+    expect(should_reduce_motion(false, undefined as unknown as boolean)).toBe(false)
+    expect(should_reduce_motion(undefined as unknown as boolean, false)).toBe(false)
+  })
+})


### PR DESCRIPTION
Ported from pretty-lattice. Adds a **Reduce motion** viewer setting (default off) that, when on — OR when the OS `prefers-reduced-motion: reduce` matches — suppresses the viewer's continuous animations.

## What it gates
- Pulsing selection highlight (rAF)
- Vibration-mode auto-play atom oscillation (rAF)
- Camera auto-rotate (rAF)
- Trackball inertia/damping (forces `staticMoving`)
- Trajectory auto-play (won't auto-start)

## Design
- Pure helper `should_reduce_motion(setting, mediaMatches)` = `setting || mediaMatches`; `os_prefers_reduced_motion()` is SSR-safe. Each rAF `$effect` early-returns when reduced (mirrors the existing phase-diagram pattern), so toggling on mid-animation cancels the running loop via effect cleanup.
- New `reduced_motion` boolean setting (config + types + i18n en/zh + checkbox in the camera settings section). Flows to StructureScene via the existing `{...scene_props}` spread.
- **Off + OS pref unset ⇒ byte-identical to today** (every gate is an early-return/OR that only fires when reduced).

Trajectory auto-start guard landed at the real auto-start `$effect` (Trajectory.svelte:436), not the setInterval driver.

Tests: 6/6 in `tests/vitest/reduced-motion.test.ts`; `pnpm check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
