### PR TITLE
feat(viewer): defer bond/polyhedra computation for very large (>8000-atom) structures

### DIFF
--- a/src/lib/i18n/en/structure.ts
+++ b/src/lib/i18n/en/structure.ts
@@ -16,6 +16,8 @@ const structure: Record<string, string> = {
   lattice_vectors: `Lattice Vectors`,
   bonds: `Bonds`,
   add_bond_rule: `+ Bond rule`,
+  bonds_deferred: `Bonds hidden for performance ({n} atoms)`,
+  compute_bonds: `Compute bonds`,
   camera: `Camera`,
   projection: `Projection`,
   auto_rotate_speed: `Auto-rotate speed`,
@@ -152,9 +154,11 @@ const structure: Record<string, string> = {
   failed_upgrade_trust: `Failed to upgrade trust level`,
   failed_update_plugin: `Failed to update plugin`,
   loading_installed_plugins: `Loading installed plugins...`,
-  no_plugins_installed: `No plugins installed yet. Browse the Hub to discover and install plugins.`,
+  no_plugins_installed:
+    `No plugins installed yet. Browse the Hub to discover and install plugins.`,
   plugins_none_installed_title: `No plugins installed`,
-  plugins_install_desc: `Install plugins to extend CatGo with new views, panels, and functionality.`,
+  plugins_install_desc:
+    `Install plugins to extend CatGo with new views, panels, and functionality.`,
   install_plugin: `Install Plugin`,
   plugins_installed_count: `{n} plugin(s) installed`,
   plugins_enabled_count: `{n} enabled`,
@@ -166,7 +170,8 @@ const structure: Record<string, string> = {
   plugin_drag_drop_zip: `Drag & drop plugin ZIP file here`,
   plugin_url: `Plugin URL`,
   plugin_fetch: `Fetch`,
-  plugin_url_hint: `Enter a URL to a plugin ZIP file or a plugin directory containing catgo-plugin.json`,
+  plugin_url_hint:
+    `Enter a URL to a plugin ZIP file or a plugin directory containing catgo-plugin.json`,
   plugin_loading: `Loading plugin...`,
   plugin_uninstall_confirm: `Are you sure you want to uninstall "{name}"?`,
   plugin_author_by: `By {author}`,
@@ -176,19 +181,24 @@ const structure: Record<string, string> = {
   plugin_requested_permissions: `Requested Permissions`,
   plugin_no_special_permissions: `This plugin requires no special permissions.`,
   plugin_error_rendering_panel: `Error rendering panel`,
-  plugin_no_active_for_panel: `No active plugins for this panel. Enable a plugin in the Plugins view.`,
+  plugin_no_active_for_panel:
+    `No active plugins for this panel. Enable a plugin in the Plugins view.`,
   plugin_panel_component_missing: `Panel component not found: {id}`,
   update_to_version: `Update to v{version}`,
-  promote_trust_title: `Promote from sandboxed to user trust level for in-process execution`,
+  promote_trust_title:
+    `Promote from sandboxed to user trust level for in-process execution`,
   upgrade_trust: `Upgrade Trust`,
   create_plugins_with_catbot: `Create Plugins with CatBot`,
-  create_plugins_desc: `CatBot can generate custom plugins for you. Open the AI Assistant and describe what you need.`,
+  create_plugins_desc:
+    `CatBot can generate custom plugins for you. Open the AI Assistant and describe what you need.`,
   example_prompts: `Example prompts:`,
   plugin_format: `Plugin format:`,
-  plugin_format_desc: `Every plugin is a Python file with a TOOL dict and an execute(context) function. CatBot handles the boilerplate -- just describe what computation you need.`,
+  plugin_format_desc:
+    `Every plugin is a Python file with a TOOL dict and an execute(context) function. CatBot handles the boilerplate -- just describe what computation you need.`,
   ui_extensions: `UI Extensions`,
   install_zip: `Install ZIP`,
-  no_ui_extensions: `No UI extensions installed. UI extensions add custom views, panels, and visualization hooks.`,
+  no_ui_extensions:
+    `No UI extensions installed. UI extensions add custom views, panels, and visualization hooks.`,
   failed_toggle_extension: `Failed to toggle extension`,
   failed_uninstall_extension: `Failed to uninstall extension`,
   install: `Install`,
@@ -211,11 +221,13 @@ const structure: Record<string, string> = {
   password: `Password`,
   key_file: `Key File`,
   key_file_hint: `(optional — specify if server needs a specific key)`,
-  key_file_imported: `Selected private key: {name}. It will be used for this connection only and will not be saved.`,
+  key_file_imported:
+    `Selected private key: {name}. It will be used for this connection only and will not be saved.`,
   scheduler: `Scheduler`,
   work_root: `Work root`,
   work_root_placeholder: `e.g. ~/projects/my-work or /work/home/user/project`,
-  work_root_hint: `Optional. When set, file browsing, upload/download, editing, and job work directories stay inside this root.`,
+  work_root_hint:
+    `Optional. When set, file browsing, upload/download, editing, and job work directories stay inside this root.`,
   work_root_boundary: `Work root boundary`,
   work_root_blocked: `This path is outside the configured work root.`,
   use_jump_host: `Use jump host (bastion)`,
@@ -284,12 +296,14 @@ const structure: Record<string, string> = {
   on_node: `on {node}`,
   open_catgo_localhost: `Open CatGO (localhost:{port})`,
   stop_disconnect: `Stop & Disconnect`,
-  install_remote_compute_desc: `Installs ML potentials (MACE, CHGNet, M3GNet) and generates a job script.`,
+  install_remote_compute_desc:
+    `Installs ML potentials (MACE, CHGNet, M3GNet) and generates a job script.`,
   installation_complete: `Installation complete!`,
   install_remote_compute: `Install Remote Compute`,
   re_check: `Re-check`,
   check_remote_setup: `Check Remote Setup`,
-  claude_code_remote_desc: `Configure Claude Code on this server to control CatGO remotely.`,
+  claude_code_remote_desc:
+    `Configure Claude Code on this server to control CatGO remotely.`,
   configuring: `Configuring...`,
   setup_claude_code: `Setup Claude Code`,
   establishing_ssh_connection: `Establishing SSH connection to {host}...`,
@@ -301,10 +315,12 @@ const structure: Record<string, string> = {
   active_count: `{n} active`,
   connection_status: `Connection status`,
   connecting_to_server: `Connecting to server...`,
-  keep_dialog_open_connecting: `Please keep this dialog open while the secure session is being established.`,
+  keep_dialog_open_connecting:
+    `Please keep this dialog open while the secure session is being established.`,
   verification_required: `Verification required`,
   connected_to_user_host: `Connected to {user}@{host}`,
-  connected_dialog_desc: `You can proceed with workflow execution or open another connection.`,
+  connected_dialog_desc:
+    `You can proceed with workflow execution or open another connection.`,
   connect_another: `Connect Another`,
   connection_failed: `Connection failed`,
   check_connection_details: `Check the connection details and try again.`,
@@ -318,7 +334,8 @@ const structure: Record<string, string> = {
   ssh_key_otp: `SSH Key + OTP`,
   ssh_config: `SSH Config`,
   ssh_config_controlmaster: `SSH Config (ControlMaster)`,
-  ssh_config_windows_hint: `Requires ControlMaster — not supported on Windows (no ControlPath/ControlPersist). Use SSH Key or SSH Key + OTP instead.`,
+  ssh_config_windows_hint:
+    `Requires ControlMaster — not supported on Windows (no ControlPath/ControlPersist). Use SSH Key or SSH Key + OTP instead.`,
   ssh_alias: `SSH Alias`,
   ssh_alias_hint: `(from ~/.ssh/config)`,
   ssh_alias_placeholder: `e.g. Shaheen`,
@@ -345,7 +362,8 @@ const structure: Record<string, string> = {
   failed_load_file: `Failed to load {name}: {error}`,
   unknown_error: `Unknown error`,
   file_empty_or_unreadable: `File {name} is empty or could not be read`,
-  loaded_trajectory_from_dir: `Loaded {pattern} trajectory from {dir}/ — view in Structure panel`,
+  loaded_trajectory_from_dir:
+    `Loaded {pattern} trajectory from {dir}/ — view in Structure panel`,
   no_pattern_files_in_dir: `No {pattern} files found in subdirectories of {dir}/`,
   merge_failed: `Merge failed: {error}`,
   workflow_new_with_structure: `New Workflow with Structure`,
@@ -365,7 +383,8 @@ const structure: Record<string, string> = {
   send_structure: `Send Structure`,
   sending: `Sending...`,
   no_steps_yet: `No steps yet`,
-  import_trajectory_hint: `Import a trajectory file (.xyz, .pdb, .gro, etc.) to enable MD analysis.`,
+  import_trajectory_hint:
+    `Import a trajectory file (.xyz, .pdb, .gro, etc.) to enable MD analysis.`,
   import_trajectory: `Import Trajectory`,
   load_trajectory: `Load Trajectory`,
   select_trajectory_md: `Select a trajectory file for MD analysis.`,
@@ -409,7 +428,8 @@ const structure: Record<string, string> = {
   clear_clipping: `Clear clipping`,
   save_export: `Save / Export`,
   select_element: `Select Element:`,
-  load_periodic_for_symmetry: `Load a periodic crystal structure to run symmetry analysis.`,
+  load_periodic_for_symmetry:
+    `Load a periodic crystal structure to run symmetry analysis.`,
   symmetry: `Symmetry`,
   precision: `Precision`,
   algorithm: `Algorithm`,
@@ -444,13 +464,17 @@ const structure: Record<string, string> = {
   selected_elem: `Selected: {elem}`,
   text: `Text`,
   background_label: `Background`,
-  ml_potentials_need_server: `ML potentials (MACE, CHGNet, xTB, etc.) require a running compute server.`,
+  ml_potentials_need_server:
+    `ML potentials (MACE, CHGNet, xTB, etc.) require a running compute server.`,
   atoms_frozen: `{n} atoms frozen`,
   atoms_selected: `{n} atoms selected`,
   extract_as_isolated_molecule: `Extract as isolated molecule`,
-  selected_atoms_extract_hint: `Selected atoms will be extracted and optimized without periodic boundary conditions, then placed back.`,
-  selected_atoms_fixed_hint: `Unselected atoms will be fixed in place during optimization.`,
-  requires_periodic_lattice: `This tool requires a periodic lattice. Use the {tab} tab to add one first.`,
+  selected_atoms_extract_hint:
+    `Selected atoms will be extracted and optimized without periodic boundary conditions, then placed back.`,
+  selected_atoms_fixed_hint:
+    `Unselected atoms will be fixed in place during optimization.`,
+  requires_periodic_lattice:
+    `This tool requires a periodic lattice. Use the {tab} tab to add one first.`,
   slow_growth_post_processing: `Slow-Growth Post-Processing`,
   upload_report: `Upload REPORT`,
   paste_report: `Paste REPORT`,
@@ -496,9 +520,11 @@ const structure: Record<string, string> = {
   export_xyz_hint: `Export frames {start}-{end} as multi-frame XYZ`,
   export_png_sequence_hint: `Export frames as numbered PNGs in a ZIP`,
   export_webm_hint: `Export as WebM video`,
-  export_mp4_hint: `Browsers can't record MP4 -- downloads a WebM and copies an ffmpeg command to your clipboard to convert it to MP4`,
+  export_mp4_hint:
+    `Browsers can't record MP4 -- downloads a WebM and copies an ffmpeg command to your clipboard to convert it to MP4`,
   export_info: `{seconds}s ({frames} frames: {start}-{end})`,
-  export_started: `Export started: {filename}. Check your browser downloads or the system default Downloads folder.`,
+  export_started:
+    `Export started: {filename}. Check your browser downloads or the system default Downloads folder.`,
   export_failed: `Failed to export {what}: {message}`,
   export_no_plot_data: `No exportable data is available for this plot.`,
   export_plot_loading: `Plot is still loading. Please try again in a moment.`,
@@ -528,7 +554,8 @@ const structure: Record<string, string> = {
   mace_model: `MACE Model`,
   model_path: `Model Path`,
   device: `Device`,
-  server_not_connected_hint: `Server not connected. Start the compute server or use Local (UFF) mode.`,
+  server_not_connected_hint:
+    `Server not connected. Start the compute server or use Local (UFF) mode.`,
   check_server: `Check Server`,
   vsepr_settings: `VSEPR Settings`,
   iterations: `Iterations`,
@@ -644,19 +671,22 @@ const structure: Record<string, string> = {
   md_dihedral_failed: `Dihedral computation failed`,
   md_reference_frame: `Reference frame`,
   md_atom_indices_optional: `Atom indices (optional)`,
-  md_atom_indices_all_hint: `Comma-separated 0-indexed atom indices. Leave blank for all atoms.`,
+  md_atom_indices_all_hint:
+    `Comma-separated 0-indexed atom indices. Leave blank for all atoms.`,
   md_precentered: `Precentered`,
   md_compute_rmsd: `Compute RMSD`,
   md_frames_label_count: `Frames: {n}`,
   md_atoms_used_count: `Atoms used: {n}`,
   md_reference_frame_optional: `Reference frame (optional)`,
-  md_reference_frame_hint: `Frame index for reference. Leave blank to use average structure.`,
+  md_reference_frame_hint:
+    `Frame index for reference. Leave blank to use average structure.`,
   md_compute_rmsf: `Compute RMSF`,
   md_atoms_label_count: `Atoms: {n}`,
   md_ref_label: `Ref: {ref}`,
   md_bond_angles: `Bond Angles`,
   md_atom_triplets_semicolon: `Atom triplets (semicolon-separated)`,
-  md_atom_triplets_hint: `Semicolon-separated atom triplets. Middle atom is the vertex. e.g. 0,1,2 ; 3,4,5`,
+  md_atom_triplets_hint:
+    `Semicolon-separated atom triplets. Middle atom is the vertex. e.g. 0,1,2 ; 3,4,5`,
   md_compute_angles: `Compute Angles`,
   md_angles_label_count: `Angles: {n}`,
   md_atom_quartets_semicolon: `Atom quartets (semicolon-separated)`,
@@ -697,7 +727,8 @@ const structure: Record<string, string> = {
   md_hbond_lifetime: `H-bond Lifetime`,
   md_time_step_ps: `Time step (ps)`,
   md_max_lag_frames: `Max lag (frames)`,
-  md_hbond_lifetime_note: `Uses detection parameters above (method, cutoffs, periodicity).`,
+  md_hbond_lifetime_note:
+    `Uses detection parameters above (method, cutoffs, periodicity).`,
   md_compute_lifetime: `Compute Lifetime`,
   md_average_lifetime_ps: `Average lifetime: {value} ps`,
   md_hbonds_tracked: `{n} H-bonds tracked`,
@@ -715,7 +746,8 @@ const structure: Record<string, string> = {
   md_cavity_volume_ang3: `Cavity volume V (Å³)`,
   md_lcw_cav_vs_volume: `LCW: ΔG_cav vs cavity volume`,
   md_cav_free_energy_profile: `Cavitation free energy profile`,
-  md_probe_radii_invalid: `Probe radii must be a comma-separated list of positive numbers`,
+  md_probe_radii_invalid:
+    `Probe radii must be a comma-separated list of positive numbers`,
   md_lcw_cav_free_energy: `LCW cavitation free energy ΔG_cav(R, z)`,
   md_solvent_element: `Solvent element`,
   md_probe_radii_comma: `Probe radii (Å, comma-separated)`,
@@ -816,7 +848,8 @@ const structure: Record<string, string> = {
   gesture_in_browser_no_key: `In-browser, no API key`,
   gesture_cloud: `Cloud`,
   gesture_openai_needs_key: `OpenAI API, needs key`,
-  gesture_web_speech_unavailable: `Web Speech API not available. Use Chrome/Edge or switch to Whisper.`,
+  gesture_web_speech_unavailable:
+    `Web Speech API not available. Use Chrome/Edge or switch to Whisper.`,
   gesture_backend: `Backend`,
   gesture_model: `Model`,
   gesture_loading_model: `Loading model...`,
@@ -887,7 +920,8 @@ const structure: Record<string, string> = {
   cube_slice_orientation: `Plane orientation`,
   cube_slice_center: `center`,
   cube_slice_extent: `extent`,
-  cube_slice_fit: `Fit the 2D view to the atoms (crop away vacuum); click to toggle full cell`,
+  cube_slice_fit:
+    `Fit the 2D view to the atoms (crop away vacuum); click to toggle full cell`,
   nanotube_use_loaded_structure: `Use loaded structure`,
   nanotube_manual_input: `Manual input`,
   nanotube_2d_material: `2D Material`,
@@ -924,19 +958,28 @@ const structure: Record<string, string> = {
   nanoscroll_thickness: `Monolayer thickness`,
   nanoscroll_strain: `Max bending strain`,
   // Tooltips (practical, physically-informed guidance)
-  nanoscroll_tip_monolayer: `Roll the structure currently in the viewer. It must be a single 2D layer (one monolayer) — rolling a 3D bulk is meaningless. Cut/extract a monolayer first if needed.`,
-  nanoscroll_tip_inner_radius: `Radius of the innermost winding. Larger = less bending strain at the core; too small overlaps or breaks bonds. Keep it ≥ ~10–15 Å for typical 2D layers, and raise it if you see the strain warning.`,
-  nanoscroll_tip_turns: `Number of spiral windings. More turns = larger outer radius and more atoms (atom count grows roughly linearly with turns), so increase gradually.`,
-  nanoscroll_tip_interlayer_gap: `Van-der-Waals spacing between adjacent windings. Set per material: graphene ~3.35, hBN ~3.33, MoS₂ ~6.15 Å (default ~3.3).`,
-  nanoscroll_tip_length: `Scroll height along the axis (z). Independent of the spiral — controls how tall the scroll is, not how tightly it rolls.`,
-  nanoscroll_tip_roll_dir: `Which in-plane lattice vector is rolled into the spiral (a1 or a2). The other vector stays straight along the axis.`,
+  nanoscroll_tip_monolayer:
+    `Roll the structure currently in the viewer. It must be a single 2D layer (one monolayer) — rolling a 3D bulk is meaningless. Cut/extract a monolayer first if needed.`,
+  nanoscroll_tip_inner_radius:
+    `Radius of the innermost winding. Larger = less bending strain at the core; too small overlaps or breaks bonds. Keep it ≥ ~10–15 Å for typical 2D layers, and raise it if you see the strain warning.`,
+  nanoscroll_tip_turns:
+    `Number of spiral windings. More turns = larger outer radius and more atoms (atom count grows roughly linearly with turns), so increase gradually.`,
+  nanoscroll_tip_interlayer_gap:
+    `Van-der-Waals spacing between adjacent windings. Set per material: graphene ~3.35, hBN ~3.33, MoS₂ ~6.15 Å (default ~3.3).`,
+  nanoscroll_tip_length:
+    `Scroll height along the axis (z). Independent of the spiral — controls how tall the scroll is, not how tightly it rolls.`,
+  nanoscroll_tip_roll_dir:
+    `Which in-plane lattice vector is rolled into the spiral (a1 or a2). The other vector stays straight along the axis.`,
   heterostructure: `Heterostructure`,
   heterostructure_mode_slab: `Slab (pre-cut)`,
   heterostructure_mode_bulk: `Bulk + Miller`,
   heterostructure_mode_lateral: `Lateral (in-plane)`,
-  heterostructure_hint_slab: `Provide two pre-cut slabs. Vacuum is auto-stripped before matching.`,
-  heterostructure_hint_bulk: `Provide two bulk crystals. Slabs are cut automatically via intermat.`,
-  heterostructure_hint_lateral: `Join two 2D slabs side by side. Only one edge direction is matched.`,
+  heterostructure_hint_slab:
+    `Provide two pre-cut slabs. Vacuum is auto-stripped before matching.`,
+  heterostructure_hint_bulk:
+    `Provide two bulk crystals. Slabs are cut automatically via intermat.`,
+  heterostructure_hint_lateral:
+    `Join two 2D slabs side by side. Only one edge direction is matched.`,
   heterostructure_substrate_loaded: `Substrate (loaded structure)`,
   heterostructure_film: `Film`,
   heterostructure_upload: `Upload`,
@@ -945,16 +988,19 @@ const structure: Record<string, string> = {
   reticular_mode_preset: `Preset`,
   reticular_mode_advanced: `Advanced`,
   reticular_hint_preset: `Pick a curated MOF/COF recipe and build in one click.`,
-  reticular_hint_advanced: `Choose an RCSR topology, then assign a building block to each node/edge type.`,
+  reticular_hint_advanced:
+    `Choose an RCSR topology, then assign a building block to each node/edge type.`,
   reticular_preset: `Preset`,
   reticular_topology: `Topology (net)`,
   reticular_node_bb: `Node building block`,
   reticular_edge_bb: `Edge building block`,
   reticular_build: `Build framework`,
   reticular_mode_search: `Search`,
-  reticular_hint_search: `Search the MOFX-DB database and load an existing MOF structure.`,
+  reticular_hint_search:
+    `Search the MOFX-DB database and load an existing MOF structure.`,
   reticular_search_name: `Name`,
-  reticular_search_name_hint: `MOFX-DB has no common names — leave empty to browse the database, or use a CSD refcode (CoREMOF/CSD) or hMOF-N id. For named MOFs (MOF-5, UiO-66…) use the Preset tab.`,
+  reticular_search_name_hint:
+    `MOFX-DB has no common names — leave empty to browse the database, or use a CSD refcode (CoREMOF/CSD) or hMOF-N id. For named MOFs (MOF-5, UiO-66…) use the Preset tab.`,
   reticular_search_database: `Database`,
   reticular_search_button: `Search`,
   reticular_search_load: `Load`,
@@ -967,8 +1013,10 @@ const structure: Record<string, string> = {
   touch_move_atoms: `Move`,
   touch_rotate_atoms: `Rotate`,
   touch_box_select_hint: `Box-select mode: drag to select atoms (replaces Ctrl/Cmd-drag)`,
-  touch_move_atoms_hint: `Move mode: drag to move selected atoms (replaces Shift+Alt-drag)`,
-  touch_rotate_atoms_hint: `Rotate mode: drag to rotate selected atoms (replaces Shift-drag)`,
+  touch_move_atoms_hint:
+    `Move mode: drag to move selected atoms (replaces Shift+Alt-drag)`,
+  touch_rotate_atoms_hint:
+    `Rotate mode: drag to rotate selected atoms (replaces Shift-drag)`,
   touch_delete_atoms: `Delete`,
   touch_delete_atoms_hint: `Delete the selected atoms (replaces the Delete key)`,
   add_atoms: `Add single atoms`,
@@ -1004,7 +1052,8 @@ const structure: Record<string, string> = {
   go: `Go`,
   plugin_hub: `Plugin Hub`,
   large_system_mode: `Large-system performance mode`,
-  large_system_mode_unavailable: `Large-system mode — WebGPU unavailable in this browser (enable Unsafe WebGPU / Vulkan flags)`,
+  large_system_mode_unavailable:
+    `Large-system mode — WebGPU unavailable in this browser (enable Unsafe WebGPU / Vulkan flags)`,
   ai_assistant: `AI Assistant`,
   restore_terminal: `Restore terminal`,
   minimize_terminal: `Minimize terminal`,
@@ -1148,17 +1197,21 @@ const structure: Record<string, string> = {
   tip_camera: `Camera`,
   tip_camera_desc: `Left-drag to rotate, middle-drag to pan, scroll to zoom`,
   tip_camera_reset: `Camera Reset`,
-  tip_camera_reset_desc: `Use the toolbar reset button to reset the camera; double-click empty space clears the selection`,
+  tip_camera_reset_desc:
+    `Use the toolbar reset button to reset the camera; double-click empty space clears the selection`,
   tip_selection: `Selection`,
-  tip_selection_desc: `Click an atom to toggle its selection; use the right-click menu to select all`,
+  tip_selection_desc:
+    `Click an atom to toggle its selection; use the right-click menu to select all`,
   tip_rotate_atoms: `Rotate Atoms`,
-  tip_rotate_atoms_desc: `Shift+drag to rotate selected atoms — drag horizontally for yaw, vertically for pitch (one axis locks per drag); right-drag for roll`,
+  tip_rotate_atoms_desc:
+    `Shift+drag to rotate selected atoms — drag horizontally for yaw, vertically for pitch (one axis locks per drag); right-drag for roll`,
   tip_move_atoms: `Move Atoms`,
   tip_move_atoms_desc: `Shift+Alt+Arrow (or Ctrl+Arrow) to move selected atoms`,
   tip_trajectory: `Trajectory`,
   tip_trajectory_desc: `A/D to prev/next frame, Space to play/pause`,
   tip_undo_redo: `Undo/Redo`,
-  tip_undo_redo_desc: `Ctrl+Z to undo, Ctrl+Shift+Z (or Ctrl+Y) to redo structure changes`,
+  tip_undo_redo_desc:
+    `Ctrl+Z to undo, Ctrl+Shift+Z (or Ctrl+Y) to redo structure changes`,
   tip_measure: `Measure`,
   tip_measure_desc: `Click atoms then pick distance/angle mode to measure`,
   tip_colors: `Colors`,
@@ -1168,13 +1221,16 @@ const structure: Record<string, string> = {
 
   // Search Modal
   search_limitations: `Search Limitations`,
-  search_limitations_desc: `Online database searching is limited in the browser due to security (CORS) restrictions. For full access to Materials Project, PubChem, and all OPTIMADE providers, use the CatGo desktop app.`,
+  search_limitations_desc:
+    `Online database searching is limited in the browser due to security (CORS) restrictions. For full access to Materials Project, PubChem, and all OPTIMADE providers, use the CatGo desktop app.`,
   search_database: `Search Database`,
   only_elements: `Only Elements`,
   at_least_elements: `At Least Elements`,
   formula_label: `Formula`,
-  select_only_elements: `Select elements to search for materials with only these elements`,
-  select_at_least_elements: `Select elements to search for materials containing at least these elements`,
+  select_only_elements:
+    `Select elements to search for materials with only these elements`,
+  select_at_least_elements:
+    `Select elements to search for materials containing at least these elements`,
   selected_elements: `selected:`,
   database: `Database:`,
   loading_providers: `Loading providers...`,
@@ -1204,10 +1260,14 @@ const structure: Record<string, string> = {
   api_key_invalid: `Invalid API key. Please check and try again.`,
   providers_not_loaded: `Providers not loaded yet. Please wait...`,
   search_failed: `Search failed: {error}`,
-  structure_parse_failed: `Failed to parse structure data. The structure format may be unsupported.`,
-  structure_fetch_failed: `Could not fetch structure from {provider}. The server may be temporarily unavailable. Try a different database or try again later.`,
-  provider_unavailable_503: `The {provider} server is temporarily unavailable (503). Please try again later or select a different database.`,
-  provider_network_error: `Network error connecting to {provider}. The server may be down or blocking requests.`,
+  structure_parse_failed:
+    `Failed to parse structure data. The structure format may be unsupported.`,
+  structure_fetch_failed:
+    `Could not fetch structure from {provider}. The server may be temporarily unavailable. Try a different database or try again later.`,
+  provider_unavailable_503:
+    `The {provider} server is temporarily unavailable (503). Please try again later or select a different database.`,
+  provider_network_error:
+    `Network error connecting to {provider}. The server may be down or blocking requests.`,
   structure_import_failed: `Failed to import structure: {error}`,
   structure_conversion_failed: `Failed to convert compound structure`,
   compound_fetch_failed: `Failed to fetch compound data`,
@@ -1265,7 +1325,8 @@ const structure: Record<string, string> = {
   format: `Format:`,
   custom_filename: `Or custom filename:`,
   paste_content_desc: `Paste POSCAR/CONTCAR or other structure file content:`,
-  paste_hint: `Supports POSCAR/CONTCAR, CIF, XYZ, Extended XYZ formats. Press Ctrl+Enter to import.`,
+  paste_hint:
+    `Supports POSCAR/CONTCAR, CIF, XYZ, Extended XYZ formats. Press Ctrl+Enter to import.`,
 
   // Lattice Editor
   lattice_editor: `Lattice Editor`,
@@ -1295,10 +1356,13 @@ const structure: Record<string, string> = {
 
   // Doping Pane
   combinatorial_doping: `Combinatorial Doping`,
-  doping_help_1: `Each <b>Group</b> defines one substitution site. Choose target atoms by element or by selecting atoms in the 3D viewer.`,
-  doping_help_2: `In the <b>Periodic Table</b> window, click elements to add replacement candidates (shown as green chips). Drag across elements for quick multi-select.`,
+  doping_help_1:
+    `Each <b>Group</b> defines one substitution site. Choose target atoms by element or by selecting atoms in the 3D viewer.`,
+  doping_help_2:
+    `In the <b>Periodic Table</b> window, click elements to add replacement candidates (shown as green chips). Drag across elements for quick multi-select.`,
   doping_help_3: `Add more groups to substitute multiple sites simultaneously.`,
-  doping_help_4: `Click <b>Generate Structures</b> to create all combinatorial substitutions, then <b>Open as Trajectory</b> to browse them.`,
+  doping_help_4:
+    `Click <b>Generate Structures</b> to create all combinatorial substitutions, then <b>Open as Trajectory</b> to browse them.`,
   group_n: `Group {n}`,
   by_element: `By Element`,
   by_selection: `By Selection`,
@@ -1323,9 +1387,12 @@ const structure: Record<string, string> = {
   mode_combinatorial: `Combinatorial`,
   mode_random: `Random`,
   random_dopants_label: `Random dopants`,
-  random_help_1: `Pick the <b>host pool</b> — all atoms of an element, or capture a selection from the 3D viewer.`,
-  random_help_2: `Click elements in the <b>Periodic Table</b> to add dopants, then set how many of each (by count or percent).`,
-  random_help_3: `Generate <b>N</b> random arrangements (deduplicated), then <b>Open as Trajectory</b> to browse them.`,
+  random_help_1:
+    `Pick the <b>host pool</b> — all atoms of an element, or capture a selection from the 3D viewer.`,
+  random_help_2:
+    `Click elements in the <b>Periodic Table</b> to add dopants, then set how many of each (by count or percent).`,
+  random_help_3:
+    `Generate <b>N</b> random arrangements (deduplicated), then <b>Open as Trajectory</b> to browse them.`,
   random_pool: `Pool: {n} {el} atoms`,
   random_pool_generic: `pool`,
   amount_by: `Amount by:`,
@@ -1337,9 +1404,11 @@ const structure: Record<string, string> = {
   random_dedup: `Deduplicate identical arrangements`,
   random_seed: `Seed:`,
   random_seed_ph: `random`,
-  random_preview: `Replace <strong>{replace}</strong> of {pool} {el} at random → {remain} remain`,
+  random_preview:
+    `Replace <strong>{replace}</strong> of {pool} {el} at random → {remain} remain`,
   random_over_pool: `{replace} substitutions exceed the pool of {pool} sites`,
-  random_err_invalid: `Pick a host pool and at least one dopant (total must not exceed the pool)`,
+  random_err_invalid:
+    `Pick a host pool and at least one dopant (total must not exceed the pool)`,
   // -- Moiré Bilayer pane --
   moire_bilayer: `Moiré Bilayer`,
   moire_builder_title: `Moiré Bilayer Builder`,
@@ -1383,7 +1452,8 @@ const structure: Record<string, string> = {
   moire_vacuum: `Vacuum (Å)`,
   moire_building: `Building...`,
   moire_build_bilayer: `Build Bilayer`,
-  moire_err_needs_periodic: `Moiré construction requires a periodic structure with a lattice. Use Manual input mode with presets instead.`,
+  moire_err_needs_periodic:
+    `Moiré construction requires a periodic structure with a lattice. Use Manual input mode with presets instead.`,
 
   // Electronic analysis panes
   browse_local: `Browse Local`,
@@ -1411,7 +1481,8 @@ const structure: Record<string, string> = {
   charge_compute_diff_failed: `Compute diff failed: {reason}`,
   charge_drop_file: `Drag & drop charge file`,
   charge_density_isosurface: `Charge Density Isosurface`,
-  charge_density_desc: `Load CHGCAR, LOCPOT, ELFCAR, PARCHG, or .cube for 3D isosurface visualization`,
+  charge_density_desc:
+    `Load CHGCAR, LOCPOT, ELFCAR, PARCHG, or .cube for 3D isosurface visualization`,
   difference_charge_density: `Difference Charge Density`,
   difference_charge_density_desc: `Compute ρ(AB) − ρ(A) − ρ(B) from three CHGCAR files`,
   select_chgcar_ab: `Select CHGCAR_AB`,
@@ -1512,7 +1583,8 @@ const structure: Record<string, string> = {
   dos_kurtosis: `Kurtosis`,
   dos_band_edges: `Band edges`,
   dos_load_data: `Load DOS Data`,
-  dos_load_data_desc: `Select a vaspout.h5 or PROCAR file, or provide a remote directory containing PROCAR + OUTCAR + CONTCAR.`,
+  dos_load_data_desc:
+    `Select a vaspout.h5 or PROCAR file, or provide a remote directory containing PROCAR + OUTCAR + CONTCAR.`,
   dos_upload_procar: `Upload PROCAR`,
   dos_drop_or_browse: `Drop or browse`,
   dos_without_outcar: `Without OUTCAR, Fermi energy defaults to 0`,
@@ -1523,8 +1595,10 @@ const structure: Record<string, string> = {
   band_projection_failed: `Projection failed`,
   band_parsing: `Parsing...`,
   band_kpoints_optional: `KPOINTS (optional):`,
-  band_kpoints_required: `This band run needs a line-mode KPOINTS file. Pick it in the KPOINTS field above first, then re-select vasprun.xml.`,
-  band_kpoints_hint: `Tip: a band structure along symmetry lines also needs its line-mode KPOINTS file. Set it below BEFORE choosing vasprun.xml.`,
+  band_kpoints_required:
+    `This band run needs a line-mode KPOINTS file. Pick it in the KPOINTS field above first, then re-select vasprun.xml.`,
+  band_kpoints_hint:
+    `Tip: a band structure along symmetry lines also needs its line-mode KPOINTS file. Set it below BEFORE choosing vasprun.xml.`,
   band_metal_status: `Metal?`,
   band_metal: `metal`,
   band_semicond: `semicond`,
@@ -1537,7 +1611,8 @@ const structure: Record<string, string> = {
   band_e_max_ev: `E max (eV):`,
   band_fat_scale: `Fat band scale:`,
   band_load_structure: `Load Band Structure`,
-  band_load_structure_desc: `Select a vasprun.xml file or provide a remote directory containing vasprun.xml (+ optional KPOINTS).`,
+  band_load_structure_desc:
+    `Select a vasprun.xml file or provide a remote directory containing vasprun.xml (+ optional KPOINTS).`,
   cohp_session_label: `COHP ({n} bonds)`,
   cohp_icohplist_upload_failed: `ICOHPLIST upload failed`,
   cohp_load_failed: `Failed to load COHP data`,
@@ -1567,7 +1642,8 @@ const structure: Record<string, string> = {
   cohp_upload_icohplist: `Upload ICOHPLIST.lobster`,
   cohp_bond: `Bond`,
   cohp_load_cohpcar: `Load COHPCAR.lobster`,
-  cohp_load_cohpcar_desc: `Select a COHPCAR.lobster file from local, remote HPC, or workflow output.`,
+  cohp_load_cohpcar_desc:
+    `Select a COHPCAR.lobster file from local, remote HPC, or workflow output.`,
   ads_site_no_structure_loaded: `No structure loaded`,
   ads_site_finder: `Adsorption Site Finder`,
   ads_site_find_sites: `Find Sites`,
@@ -1620,7 +1696,8 @@ const structure: Record<string, string> = {
   ads_place_click_site: `Click a site to place (ESC to cancel)`,
   ads_place_enable_mode: `Enable placement mode`,
   ads_place_post_placement: `Post-placement`,
-  ads_place_placed_hint: `{n} adsorbate atom(s) placed (indices {indices}) — only adsorbate moves`,
+  ads_place_placed_hint:
+    `{n} adsorbate atom(s) placed (indices {indices}) — only adsorbate moves`,
 
   // Phase diagram controls and stats
   phase_diagram_controls: `Phase Diagram Controls`,
@@ -1629,7 +1706,8 @@ const structure: Record<string, string> = {
   phase_energy_source: `Energy source`,
   phase_use_precomputed_energy: `Use precomputed formation energies (E<sub>form</sub>)`,
   phase_precomputed: `Precomputed`,
-  phase_compute_on_the_fly_hint: `Compute formation energies and hull distances on the fly`,
+  phase_compute_on_the_fly_hint:
+    `Compute formation energies and hull distances on the fly`,
   phase_on_the_fly: `On the fly`,
   phase_color_mode: `Color mode`,
   phase_color_by_stability: `Color points by stable/unstable`,
@@ -1659,7 +1737,8 @@ const structure: Record<string, string> = {
   phase_hull_face_opacity: `Hull face opacity`,
   phase_hull_face_opacity_hint: `Hull face opacity (0 = transparent, 1 = opaque)`,
   phase_camera: `Camera`,
-  phase_elevation_hint: `Elevation angle (0° = look down z-axis, 90° = side view, 180° = look up z-axis)`,
+  phase_elevation_hint:
+    `Elevation angle (0° = look down z-axis, 90° = side view, 180° = look up z-axis)`,
   phase_elev: `Elev`,
   phase_azimuth_hint: `Azimuth rotation around z-axis`,
   phase_azim: `Azim`,
@@ -1723,7 +1802,8 @@ const structure: Record<string, string> = {
   // Trajectory loader
   trajectory_load_title: `Load Trajectory`,
   trajectory_load_hint: `Drop a trajectory file here or use the buttons below`,
-  trajectory_load_description: `Select an XDATCAR, vaspout.h5, .xyz, or other trajectory file from a local file, remote HPC server, or workflow.`,
+  trajectory_load_description:
+    `Select an XDATCAR, vaspout.h5, .xyz, or other trajectory file from a local file, remote HPC server, or workflow.`,
   trajectory_supported_formats: `Supported formats`,
   trajectory_format_xdatcar: `VASP XDATCAR files`,
   trajectory_format_xyz: `Multi-frame XYZ (.xyz, .extxyz)`,

--- a/src/lib/i18n/zh/structure.ts
+++ b/src/lib/i18n/zh/structure.ts
@@ -16,6 +16,8 @@ const structure: Record<string, string> = {
   lattice_vectors: `晶格向量`,
   bonds: `成键`,
   add_bond_rule: `+ 成键规则`,
+  bonds_deferred: `为性能已隐藏成键（{n} 个原子）`,
+  compute_bonds: `计算成键`,
   camera: `相机`,
   projection: `投影`,
   auto_rotate_speed: `自动旋转速度`,
@@ -185,7 +187,8 @@ const structure: Record<string, string> = {
   create_plugins_desc: `CatBot 可以为你生成自定义插件。打开 AI 助手并描述你的需求。`,
   example_prompts: `示例提示：`,
   plugin_format: `插件格式：`,
-  plugin_format_desc: `每个插件都是一个 Python 文件，包含 TOOL 字典和 execute(context) 函数。CatBot 会处理样板代码——只需描述你需要的计算。`,
+  plugin_format_desc:
+    `每个插件都是一个 Python 文件，包含 TOOL 字典和 execute(context) 函数。CatBot 会处理样板代码——只需描述你需要的计算。`,
   ui_extensions: `UI 扩展`,
   install_zip: `安装 ZIP`,
   no_ui_extensions: `尚未安装 UI 扩展。UI 扩展可以添加自定义视图、面板和可视化钩子。`,
@@ -215,7 +218,8 @@ const structure: Record<string, string> = {
   scheduler: `调度器`,
   work_root: `工作根目录`,
   work_root_placeholder: `例如 ~/projects/my-work 或 /work/home/user/project`,
-  work_root_hint: `可选。填写后，文件浏览、上传下载、编辑和作业工作目录都会限制在这里面。`,
+  work_root_hint:
+    `可选。填写后，文件浏览、上传下载、编辑和作业工作目录都会限制在这里面。`,
   work_root_boundary: `工作根目录边界`,
   work_root_blocked: `这个路径不在已配置的工作根目录内。`,
   use_jump_host: `使用跳板机（堡垒机）`,
@@ -318,7 +322,8 @@ const structure: Record<string, string> = {
   ssh_key_otp: `SSH 密钥 + OTP`,
   ssh_config: `SSH 配置`,
   ssh_config_controlmaster: `SSH 配置 (ControlMaster)`,
-  ssh_config_windows_hint: `需要 ControlMaster——Windows 不支持（无 ControlPath/ControlPersist）。请改用 SSH 密钥或 SSH 密钥 + OTP。`,
+  ssh_config_windows_hint:
+    `需要 ControlMaster——Windows 不支持（无 ControlPath/ControlPersist）。请改用 SSH 密钥或 SSH 密钥 + OTP。`,
   ssh_alias: `SSH 别名`,
   ssh_alias_hint: `（来自 ~/.ssh/config）`,
   ssh_alias_placeholder: `例如 Shaheen`,
@@ -444,11 +449,13 @@ const structure: Record<string, string> = {
   selected_elem: `已选择：{elem}`,
   text: `文本`,
   background_label: `背景`,
-  ml_potentials_need_server: `机器学习势（MACE、CHGNet、xTB 等）需要正在运行的计算服务器。`,
+  ml_potentials_need_server:
+    `机器学习势（MACE、CHGNet、xTB 等）需要正在运行的计算服务器。`,
   atoms_frozen: `已冻结 {n} 个原子`,
   atoms_selected: `已选择 {n} 个原子`,
   extract_as_isolated_molecule: `提取为孤立分子`,
-  selected_atoms_extract_hint: `选中的原子会被提取并在非周期边界条件下优化，然后放回原结构。`,
+  selected_atoms_extract_hint:
+    `选中的原子会被提取并在非周期边界条件下优化，然后放回原结构。`,
   selected_atoms_fixed_hint: `未选中的原子会在优化过程中固定。`,
   requires_periodic_lattice: `此工具需要周期性晶格。请先使用 {tab} 标签页添加晶格。`,
   slow_growth_post_processing: `Slow-Growth 后处理`,
@@ -816,7 +823,8 @@ const structure: Record<string, string> = {
   gesture_in_browser_no_key: `浏览器内运行，无需 API Key`,
   gesture_cloud: `云端`,
   gesture_openai_needs_key: `OpenAI API，需要 Key`,
-  gesture_web_speech_unavailable: `Web Speech API 不可用。请使用 Chrome/Edge，或切换到 Whisper。`,
+  gesture_web_speech_unavailable:
+    `Web Speech API 不可用。请使用 Chrome/Edge，或切换到 Whisper。`,
   gesture_backend: `后端`,
   gesture_model: `模型`,
   gesture_loading_model: `正在加载模型...`,
@@ -924,12 +932,18 @@ const structure: Record<string, string> = {
   nanoscroll_thickness: `单层厚度`,
   nanoscroll_strain: `最大弯曲应变`,
   // 提示（结合物理意义的实用建议）
-  nanoscroll_tip_monolayer: `卷曲当前视图中的结构。它必须是单层二维材料（单原子层）——卷曲三维体相没有物理意义。如有需要请先切出单层。`,
-  nanoscroll_tip_inner_radius: `最内圈的半径。越大则核心处弯曲应变越小；过小会导致键重叠或断裂。典型二维层应保持 ≥ 约 10–15 Å，若出现应变警告请调大。`,
-  nanoscroll_tip_turns: `螺旋圈数。圈数越多外半径越大、原子越多（原子数随圈数近似线性增长），请逐步增加。`,
-  nanoscroll_tip_interlayer_gap: `相邻卷层之间的范德华间距。按材料设置：石墨烯约 3.35，hBN 约 3.33，MoS₂ 约 6.15 Å（默认约 3.3）。`,
-  nanoscroll_tip_length: `沿轴向 (z) 的卷高。与螺旋无关——只控制卷的高度，不影响卷曲松紧。`,
-  nanoscroll_tip_roll_dir: `选择卷曲哪个面内晶格矢量（a1 或 a2）。另一个矢量沿轴向保持平直。`,
+  nanoscroll_tip_monolayer:
+    `卷曲当前视图中的结构。它必须是单层二维材料（单原子层）——卷曲三维体相没有物理意义。如有需要请先切出单层。`,
+  nanoscroll_tip_inner_radius:
+    `最内圈的半径。越大则核心处弯曲应变越小；过小会导致键重叠或断裂。典型二维层应保持 ≥ 约 10–15 Å，若出现应变警告请调大。`,
+  nanoscroll_tip_turns:
+    `螺旋圈数。圈数越多外半径越大、原子越多（原子数随圈数近似线性增长），请逐步增加。`,
+  nanoscroll_tip_interlayer_gap:
+    `相邻卷层之间的范德华间距。按材料设置：石墨烯约 3.35，hBN 约 3.33，MoS₂ 约 6.15 Å（默认约 3.3）。`,
+  nanoscroll_tip_length:
+    `沿轴向 (z) 的卷高。与螺旋无关——只控制卷的高度，不影响卷曲松紧。`,
+  nanoscroll_tip_roll_dir:
+    `选择卷曲哪个面内晶格矢量（a1 或 a2）。另一个矢量沿轴向保持平直。`,
   heterostructure: `异质结构`,
   heterostructure_mode_slab: `表面模型（预切）`,
   heterostructure_mode_bulk: `体相 + Miller`,
@@ -954,7 +968,8 @@ const structure: Record<string, string> = {
   reticular_mode_search: `搜索`,
   reticular_hint_search: `搜索 MOFX-DB 数据库，加载已有 MOF 结构。`,
   reticular_search_name: `名称`,
-  reticular_search_name_hint: `MOFX-DB 没有俗名 —— 留空可浏览全库，或用 CSD refcode（CoREMOF/CSD）、hMOF-编号。要 MOF-5、UiO-66 这类命名 MOF 请用 Preset 标签页。`,
+  reticular_search_name_hint:
+    `MOFX-DB 没有俗名 —— 留空可浏览全库，或用 CSD refcode（CoREMOF/CSD）、hMOF-编号。要 MOF-5、UiO-66 这类命名 MOF 请用 Preset 标签页。`,
   reticular_search_database: `数据库`,
   reticular_search_button: `搜索`,
   reticular_search_load: `加载`,
@@ -1004,7 +1019,8 @@ const structure: Record<string, string> = {
   go: `前往`,
   plugin_hub: `插件中心`,
   large_system_mode: `大体系性能模式`,
-  large_system_mode_unavailable: `大体系性能模式 —— 此浏览器不支持 WebGPU（需开启 Unsafe WebGPU / Vulkan 标志）`,
+  large_system_mode_unavailable:
+    `大体系性能模式 —— 此浏览器不支持 WebGPU（需开启 Unsafe WebGPU / Vulkan 标志）`,
   ai_assistant: `AI 助手`,
   restore_terminal: `还原终端`,
   minimize_terminal: `最小化终端`,
@@ -1152,7 +1168,8 @@ const structure: Record<string, string> = {
   tip_selection: `原子选择`,
   tip_selection_desc: `点击原子切换选中状态；右键菜单可全选`,
   tip_rotate_atoms: `旋转原子`,
-  tip_rotate_atoms_desc: `Shift+拖拽旋转选中原子 — 水平拖拽偏航、垂直拖拽俯仰（每次拖拽锁定一个轴），右键拖拽滚动`,
+  tip_rotate_atoms_desc:
+    `Shift+拖拽旋转选中原子 — 水平拖拽偏航、垂直拖拽俯仰（每次拖拽锁定一个轴），右键拖拽滚动`,
   tip_move_atoms: `移动原子`,
   tip_move_atoms_desc: `Shift+Alt+方向键 (或 Ctrl+方向键) 移动选中的原子`,
   tip_trajectory: `轨迹播放`,
@@ -1168,7 +1185,8 @@ const structure: Record<string, string> = {
 
   // Search Modal
   search_limitations: `搜索限制`,
-  search_limitations_desc: `由于浏览器安全限制 (CORS)，在线数据库搜索受到限制。若要完整访问 Materials Project、PubChem 以及所有 OPTIMADE 提供商，请使用 CatGo 桌面应用。`,
+  search_limitations_desc:
+    `由于浏览器安全限制 (CORS)，在线数据库搜索受到限制。若要完整访问 Materials Project、PubChem 以及所有 OPTIMADE 提供商，请使用 CatGo 桌面应用。`,
   search_database: `搜索数据库`,
   only_elements: `仅包含所选元素`,
   at_least_elements: `至少包含所选元素`,
@@ -1205,9 +1223,12 @@ const structure: Record<string, string> = {
   providers_not_loaded: `提供商尚未加载完成，请稍候...`,
   search_failed: `搜索失败：{error}`,
   structure_parse_failed: `解析结构数据失败，可能是不支持的结构格式。`,
-  structure_fetch_failed: `无法从 {provider} 获取结构。服务器可能暂时不可用，请稍后重试或切换到其他数据库。`,
-  provider_unavailable_503: `{provider} 服务器暂时不可用（503）。请稍后重试或选择其他数据库。`,
-  provider_network_error: `连接 {provider} 时出现网络错误。服务器可能不可用或阻止了请求。`,
+  structure_fetch_failed:
+    `无法从 {provider} 获取结构。服务器可能暂时不可用，请稍后重试或切换到其他数据库。`,
+  provider_unavailable_503:
+    `{provider} 服务器暂时不可用（503）。请稍后重试或选择其他数据库。`,
+  provider_network_error:
+    `连接 {provider} 时出现网络错误。服务器可能不可用或阻止了请求。`,
   structure_import_failed: `导入结构失败：{error}`,
   structure_conversion_failed: `转换化合物结构失败`,
   compound_fetch_failed: `获取化合物数据失败`,
@@ -1295,10 +1316,13 @@ const structure: Record<string, string> = {
 
   // Doping Pane
   combinatorial_doping: `组合掺杂`,
-  doping_help_1: `每个<b>组 (Group)</b> 定义一个取代位点。通过元素或在 3D 查看器中选择目标原子。`,
-  doping_help_2: `在<b>元素周期表</b>窗口中，点击元素以添加替换候选者（显示为绿色标签）。拖拽可选多个元素。`,
+  doping_help_1:
+    `每个<b>组 (Group)</b> 定义一个取代位点。通过元素或在 3D 查看器中选择目标原子。`,
+  doping_help_2:
+    `在<b>元素周期表</b>窗口中，点击元素以添加替换候选者（显示为绿色标签）。拖拽可选多个元素。`,
   doping_help_3: `添加更多组以同时取代多个位点。`,
-  doping_help_4: `点击<b>生成结构</b>来创建所有组合取代结果，然后点击<b>作为轨迹打开</b>来浏览它们。`,
+  doping_help_4:
+    `点击<b>生成结构</b>来创建所有组合取代结果，然后点击<b>作为轨迹打开</b>来浏览它们。`,
   group_n: `组 {n}`,
   by_element: `按元素`,
   by_selection: `按选择`,
@@ -1324,8 +1348,10 @@ const structure: Record<string, string> = {
   mode_random: `随机`,
   random_dopants_label: `随机掺杂元素`,
   random_help_1: `选择<b>替换池</b>——某个元素的全部原子，或在 3D 查看器中捕获选区。`,
-  random_help_2: `在<b>元素周期表</b>中点击元素以添加掺杂元素，再设定各自数量（按个数或百分比）。`,
-  random_help_3: `生成 <b>N</b> 个随机排布（自动去重），然后<b>作为轨迹打开</b>逐一浏览。`,
+  random_help_2:
+    `在<b>元素周期表</b>中点击元素以添加掺杂元素，再设定各自数量（按个数或百分比）。`,
+  random_help_3:
+    `生成 <b>N</b> 个随机排布（自动去重），然后<b>作为轨迹打开</b>逐一浏览。`,
   random_pool: `替换池：{n} 个 {el} 原子`,
   random_pool_generic: `替换池`,
   amount_by: `数量按：`,
@@ -1337,7 +1363,8 @@ const structure: Record<string, string> = {
   random_dedup: `去除重复排布`,
   random_seed: `随机种子：`,
   random_seed_ph: `随机`,
-  random_preview: `从 {pool} 个 {el} 中随机替换 <strong>{replace}</strong> 个 → 剩余 {remain} 个`,
+  random_preview:
+    `从 {pool} 个 {el} 中随机替换 <strong>{replace}</strong> 个 → 剩余 {remain} 个`,
   random_over_pool: `替换数 {replace} 超过了替换池的 {pool} 个位点`,
   random_err_invalid: `请选择替换池并至少添加一个掺杂元素（总数不能超过替换池）`,
   // -- 莫尔超晶格面板 --
@@ -1383,7 +1410,8 @@ const structure: Record<string, string> = {
   moire_vacuum: `真空层 (Å)`,
   moire_building: `构建中...`,
   moire_build_bilayer: `构建双层`,
-  moire_err_needs_periodic: `莫尔构建需要带晶格的周期性结构。请改用手动输入模式并使用预设。`,
+  moire_err_needs_periodic:
+    `莫尔构建需要带晶格的周期性结构。请改用手动输入模式并使用预设。`,
 
   // 电子结构分析面板
   browse_local: `浏览本地`,
@@ -1411,7 +1439,8 @@ const structure: Record<string, string> = {
   charge_compute_diff_failed: `差分电荷计算失败：{reason}`,
   charge_drop_file: `将电荷文件拖放到这里`,
   charge_density_isosurface: `电荷密度等值面`,
-  charge_density_desc: `加载 CHGCAR、LOCPOT、ELFCAR、PARCHG 或 .cube 进行三维等值面可视化`,
+  charge_density_desc:
+    `加载 CHGCAR、LOCPOT、ELFCAR、PARCHG 或 .cube 进行三维等值面可视化`,
   difference_charge_density: `差分电荷密度`,
   difference_charge_density_desc: `由三个 CHGCAR 文件计算 ρ(AB) − ρ(A) − ρ(B)`,
   select_chgcar_ab: `选择 CHGCAR_AB`,
@@ -1512,7 +1541,8 @@ const structure: Record<string, string> = {
   dos_kurtosis: `峰度`,
   dos_band_edges: `能带边缘`,
   dos_load_data: `加载 DOS 数据`,
-  dos_load_data_desc: `选择 vaspout.h5 或 PROCAR 文件，或提供包含 PROCAR + OUTCAR + CONTCAR 的远程目录。`,
+  dos_load_data_desc:
+    `选择 vaspout.h5 或 PROCAR 文件，或提供包含 PROCAR + OUTCAR + CONTCAR 的远程目录。`,
   dos_upload_procar: `上传 PROCAR`,
   dos_drop_or_browse: `拖放或浏览`,
   dos_without_outcar: `未提供 OUTCAR 时，费米能级默认设为 0`,
@@ -1523,8 +1553,10 @@ const structure: Record<string, string> = {
   band_projection_failed: `投影计算失败`,
   band_parsing: `正在解析...`,
   band_kpoints_optional: `KPOINTS（可选）：`,
-  band_kpoints_required: `该能带需要 line-mode 的 KPOINTS 文件。请先在上方 KPOINTS 栏选择，再重新选 vasprun.xml。`,
-  band_kpoints_hint: `提示：沿对称线的能带还需要 line-mode 的 KPOINTS 文件。请在下方设置，并在选 vasprun.xml 之前先设好。`,
+  band_kpoints_required:
+    `该能带需要 line-mode 的 KPOINTS 文件。请先在上方 KPOINTS 栏选择，再重新选 vasprun.xml。`,
+  band_kpoints_hint:
+    `提示：沿对称线的能带还需要 line-mode 的 KPOINTS 文件。请在下方设置，并在选 vasprun.xml 之前先设好。`,
   band_metal_status: `金属性？`,
   band_metal: `金属`,
   band_semicond: `半导体`,
@@ -1537,7 +1569,8 @@ const structure: Record<string, string> = {
   band_e_max_ev: `能量最大值 (eV)：`,
   band_fat_scale: `胖能带缩放：`,
   band_load_structure: `加载能带结构`,
-  band_load_structure_desc: `选择 vasprun.xml 文件，或提供包含 vasprun.xml（可选 KPOINTS）的远程目录。`,
+  band_load_structure_desc:
+    `选择 vasprun.xml 文件，或提供包含 vasprun.xml（可选 KPOINTS）的远程目录。`,
   cohp_session_label: `COHP（{n} 个键）`,
   cohp_icohplist_upload_failed: `ICOHPLIST 上传失败`,
   cohp_load_failed: `加载 COHP 数据失败`,
@@ -1723,7 +1756,8 @@ const structure: Record<string, string> = {
   // 轨迹加载入口
   trajectory_load_title: `加载轨迹`,
   trajectory_load_hint: `将轨迹文件拖放到这里，或使用下方按钮加载`,
-  trajectory_load_description: `从本地文件、远程 HPC 服务器或工作流中选择 XDATCAR、vaspout.h5、.xyz 或其他轨迹文件。`,
+  trajectory_load_description:
+    `从本地文件、远程 HPC 服务器或工作流中选择 XDATCAR、vaspout.h5、.xyz 或其他轨迹文件。`,
   trajectory_supported_formats: `支持的格式`,
   trajectory_format_xdatcar: `VASP XDATCAR 文件`,
   trajectory_format_xyz: `多帧 XYZ (.xyz, .extxyz)`,

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -408,8 +408,14 @@
   // immediately and defer bond (and polyhedra) computation until the user asks.
   // `user_requested_bonds` un-defers when the banner button is clicked.
   let user_requested_bonds = $state(false)
-  // @ts-ignore - structure is declared later via $props() but $derived is reactive
-  let deferred_atom_count = $derived(structure?.sites?.length ?? 0)
+  // Canonical (non-image) atom count. `structure.sites` here is PBC-image-
+  // expanded for rendering, so `.length` overcounts (e.g. 10976 → 14895);
+  // `num_original_sites` is the real structure size when images are present.
+  // Gate on the canonical count so a small structure whose boundary images
+  // push the scene over the threshold isn't falsely deferred, and the banner
+  // shows the number the user recognises.
+  // @ts-ignore - structure/num_original_sites are declared later via $props() but $derived is reactive
+  let deferred_atom_count = $derived(num_original_sites ?? (structure?.sites?.length ?? 0))
   const bonds_deferred = $derived(should_defer_bonds(deferred_atom_count, user_requested_bonds))
   // Re-defer whenever a new structure is loaded. We key off sites.length (not
   // object identity) so that in-place position edits — which reuse the same atom

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -117,7 +117,10 @@
     apply_atom_add_incremental,
     apply_atom_replace_incremental,
     apply_atom_move_incremental,
+    DEFER_BONDS_ABOVE_ATOMS,
+    should_defer_bonds,
   } from './bond-computation-controller.svelte'
+  import { t, load_i18n_module } from '$lib/i18n/index.svelte'
   import {
     compute_charge_label_entries,
     setup_charge_label_drag,
@@ -393,6 +396,32 @@
 
   // @ts-ignore - structure is declared later via $props() but $derived is reactive
   let is_large_structure = $derived((structure?.sites?.length ?? 0) > LARGE_STRUCTURE_THRESHOLD)
+
+  // i18n for the "bonds deferred" banner. The parent (Structure.svelte) already
+  // loads this module; the call is a no-op if it's already cached.
+  load_i18n_module(`structure`)
+
+  // ─── Defer bonds for very large structures ───
+  // Bonds default to `show_bonds = always`, so a huge structure (e.g. an 11k-atom
+  // LAMMPS model) computes bond connectivity eagerly on load — the jank source.
+  // For structures above DEFER_BONDS_ABOVE_ATOMS we render atoms + the unit cell
+  // immediately and defer bond (and polyhedra) computation until the user asks.
+  // `user_requested_bonds` un-defers when the banner button is clicked.
+  let user_requested_bonds = $state(false)
+  // @ts-ignore - structure is declared later via $props() but $derived is reactive
+  let deferred_atom_count = $derived(structure?.sites?.length ?? 0)
+  const bonds_deferred = $derived(should_defer_bonds(deferred_atom_count, user_requested_bonds))
+  // Re-defer whenever a new structure is loaded. We key off sites.length (not
+  // object identity) so that in-place position edits — which reuse the same atom
+  // count via `structure = { ...structure, sites }` — do NOT re-hide bonds the
+  // user asked to compute. Self-guarded write mirrors last_align_trigger below.
+  let last_bonds_defer_count = $state(-1)
+  $effect(() => {
+    const n = deferred_atom_count
+    if (n === last_bonds_defer_count) return
+    last_bonds_defer_count = n
+    user_requested_bonds = false
+  })
 
   // Global pointerdown listener to handle measurement label selection.
   // Uses pointerdown instead of click because Threlte's interactivity system
@@ -2335,10 +2364,14 @@
     // trajectories drive this slow path per frame (no fast-path positions), so
     // it triggers the extension-only solid_angle -> atom_radii downgrade inside
     // compute_bond_connectivity. Static structures keep step_idx === -1 → false.
+    // `bonds_deferred` (last arg) short-circuits the compute for huge structures
+    // — the function clears bonds and returns like the `never` branch. Reading it
+    // here makes this $effect.pre re-fire when the user clicks "Compute bonds".
     compute_bond_connectivity(
       bond_state, (pairs) => { bond_pairs = pairs },
       bond_input, show_bonds, lattice, bonding_strategy,
       bonding_options_eff, external_dragging, trajectory_step_idx >= 0,
+      bonds_deferred,
     )
   })
 
@@ -2350,10 +2383,13 @@
   // with the reactive bond effect above (that would loop on bond_state writes).
   $effect(() => on_ferrox_wasm_ready(() => untrack(() => {
     invalidate_bonds_for_recompute(bond_state, bond_input)
+    // Honour the huge-structure defer gate here too (read untracked — current
+    // value at wasm-ready time): a deferred structure stays bond-free until the
+    // user asks, rather than recomputing the moment WASM loads.
     compute_bond_connectivity(
       bond_state, (pairs) => { bond_pairs = pairs },
       bond_input, show_bonds, lattice, bonding_strategy,
-      bonding_options_eff, external_dragging,
+      bonding_options_eff, external_dragging, false, bonds_deferred,
     )
   })))
 
@@ -2886,7 +2922,11 @@
 
   // --- Polyhedra computation (bond-graph: uses filtered_bond_pairs) ---
   let polyhedra_data = $derived.by(() => {
-    if (!show_polyhedra || !structure?.sites) return []
+    // Polyhedra depend on a synchronous atom_radii bond compute (compute_bonds_sync
+    // below), which is exactly the main-thread cost we defer for huge structures.
+    // When bonds are deferred, polyhedra wait too — they recompute once the user
+    // clicks "Compute bonds" (bonds_deferred flips false → this re-derives).
+    if (!show_polyhedra || !structure?.sites || bonds_deferred) return []
     try {
       // Compute on the UNIT-CELL structure only. When image atoms are shown,
       // `structure.sites` is expanded with boundary image copies appended after
@@ -6092,6 +6132,26 @@
   </div>
 {/if}
 
+<!-- ═══ Bonds-deferred banner ═══ -->
+<!-- Shown only for genuinely huge structures whose bonds were deferred on load.
+     Portaled into the Threlte DOM container (same as site labels); the button
+     overrides the container's pointer-events:none so it stays clickable. -->
+{#if bonds_deferred && show_bonds !== `never`}
+  <div
+    use:site_label_portal
+    class="bonds-deferred-banner"
+    style:position="absolute"
+    style:bottom="12px"
+    style:left="50%"
+    style:transform="translateX(-50%)"
+  >
+    <span>{t(`structure.bonds_deferred`, { n: deferred_atom_count })}</span>
+    <button type="button" onclick={() => (user_requested_bonds = true)}>
+      {t(`structure.compute_bonds`)}
+    </button>
+  </div>
+{/if}
+
 <style>
   :global(.structure .responsive-gizmo) {
     width: clamp(70px, 18cqmin, 100px) !important;
@@ -6146,6 +6206,36 @@
     font-size: 0.75em;
     white-space: nowrap;
     pointer-events: none;
+  }
+  .bonds-deferred-banner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px 4px 10px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.72);
+    color: #f1f1f1;
+    font-size: 0.75em;
+    white-space: nowrap;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    z-index: 5;
+  }
+  .bonds-deferred-banner button {
+    font: inherit;
+    cursor: pointer;
+    border: none;
+    border-radius: 4px;
+    padding: 2px 8px;
+    background: #3b82f6;
+    color: #fff;
+  }
+  .bonds-deferred-banner button:hover {
+    background: #2563eb;
+  }
+  /* The Threlte HTML wrapper forces pointer-events:none on all descendants
+     (see `.structure canvas + div *` below). Re-enable clicks on the button. */
+  :global(.structure .bonds-deferred-banner button) {
+    pointer-events: auto !important;
   }
   .elements {
     margin-bottom: var(--canvas-tooltip-elements-margin);

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -7,8 +7,12 @@ import type { ShowBonds } from '$lib/settings'
 import type { BondingStrategy } from './bonding'
 import { compute_bond_transform, detect_hydrogen_bonds } from './bonding'
 import { BOND_KIND, type BondManager } from './bonding/bond-manager.svelte'
-import { compute_bonds_async, compute_bonds_sync, compute_hbonds_worker } from './workers/bond-worker-api'
-import { should_show_bonds, filter_bonds_during_drag } from './scene'
+import {
+  compute_bonds_async,
+  compute_bonds_sync,
+  compute_hbonds_worker,
+} from './workers/bond-worker-api'
+import { filter_bonds_during_drag, should_show_bonds } from './scene'
 import { get_element_fingerprint, get_position_hash } from './scene'
 import * as math from '$lib/math'
 import covalent_radii_data from '$lib/element/single_bond_covalent_radii.json'
@@ -18,6 +22,31 @@ import type { Crystal } from './index'
  *  sync path directly (avoids worker round-trip). Trajectories where the
  *  base atom count fits this budget never need the async path. */
 const TRAJ_SYNC_THRESHOLD = 1000
+
+/**
+ * Atom-count threshold above which bond (and polyhedra) connectivity is
+ * DEFERRED on structure load: atoms + the unit cell render immediately and
+ * bonds are only computed once the user explicitly asks for them.
+ *
+ * Deliberately set well above the 1000-atom sync threshold and the 2000-atom
+ * GPU-picking threshold (`LARGE_STRUCTURE_THRESHOLD`) so only genuinely huge
+ * structures defer — e.g. the 11k-atom LAMMPS kerogen case where computing
+ * bonds on load is the jank source. Below this, behaviour is unchanged. */
+export const DEFER_BONDS_ABOVE_ATOMS = 8000
+
+/**
+ * Pure decision helper: should bond connectivity be deferred for a structure
+ * of `atom_count` atoms? True only when the structure exceeds
+ * `DEFER_BONDS_ABOVE_ATOMS` AND the user has not yet requested bonds. Extracted
+ * as a pure function for unit testing; the runtime wiring (state + banner)
+ * lives in StructureScene.
+ */
+export function should_defer_bonds(
+  atom_count: number,
+  user_requested: boolean,
+): boolean {
+  return atom_count > DEFER_BONDS_ABOVE_ATOMS && !user_requested
+}
 
 /** Maximum number of trajectory frames retained in the frame-keyed cache.
  *  LRU-evicted; revisits within the window are O(1). Sized to comfortably
@@ -58,7 +87,14 @@ let ext_traj_solid_angle_downgrade_logged = false
  * entry per visited frame; revisits are O(1).
  */
 type BondConnEntry = {
-  bond_connectivity: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }>
+  bond_connectivity: Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage: [number, number, number]
+    }
+  >
   fingerprint: string
   elem_fingerprint: string
   strategy_key: string
@@ -132,7 +168,8 @@ function build_trajectory_overlay_structure(
   const sites = structure.sites
   const traj_max = Math.floor(traj.length / 3)
   const new_sites: Site[] = new Array(sites.length)
-  const lattice_matrix = (structure as { lattice?: { matrix?: number[][] } }).lattice?.matrix
+  const lattice_matrix = (structure as { lattice?: { matrix?: number[][] } })
+    .lattice?.matrix
   const inv = lattice_matrix ? invert_3x3(lattice_matrix) : null
   for (let i = 0; i < sites.length; i++) {
     const orig = sites[i]
@@ -168,9 +205,21 @@ function invert_3x3(m: number[][]): number[][] | null {
   if (Math.abs(det) < 1e-12) return null
   const inv_det = 1 / det
   return [
-    [(e * i - f * h) * inv_det, (c * h - b * i) * inv_det, (b * f - c * e) * inv_det],
-    [(f * g - d * i) * inv_det, (a * i - c * g) * inv_det, (c * d - a * f) * inv_det],
-    [(d * h - e * g) * inv_det, (b * g - a * h) * inv_det, (a * e - b * d) * inv_det],
+    [
+      (e * i - f * h) * inv_det,
+      (c * h - b * i) * inv_det,
+      (b * f - c * e) * inv_det,
+    ],
+    [
+      (f * g - d * i) * inv_det,
+      (a * i - c * g) * inv_det,
+      (c * d - a * f) * inv_det,
+    ],
+    [
+      (d * h - e * g) * inv_det,
+      (b * g - a * h) * inv_det,
+      (a * e - b * d) * inv_det,
+    ],
   ]
 }
 
@@ -179,7 +228,16 @@ function invert_3x3(m: number[][]): number[][] | null {
  * Must be called from component `<script>` context (Svelte 5 $state).
  */
 export function create_bond_state() {
-  let bond_connectivity = $state<Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }>>([])
+  let bond_connectivity = $state<
+    Array<
+      {
+        site_idx_1: number
+        site_idx_2: number
+        strength: number
+        jimage: [number, number, number]
+      }
+    >
+  >([])
   let last_bond_structure = $state<AnyStructure | null>(null)
   let last_bond_strategy = $state(``)
   let last_bond_fingerprint = $state(``)
@@ -195,26 +253,66 @@ export function create_bond_state() {
   let traj_pending_frame: Float32Array | null = null
 
   return {
-    get bond_connectivity() { return bond_connectivity },
-    set bond_connectivity(v) { bond_connectivity = v },
-    get last_bond_structure() { return last_bond_structure },
-    set last_bond_structure(v) { last_bond_structure = v },
-    get last_bond_strategy() { return last_bond_strategy },
-    set last_bond_strategy(v) { last_bond_strategy = v },
-    get last_bond_fingerprint() { return last_bond_fingerprint },
-    set last_bond_fingerprint(v) { last_bond_fingerprint = v },
-    get last_elem_fingerprint() { return last_elem_fingerprint },
-    set last_elem_fingerprint(v) { last_elem_fingerprint = v },
-    get bond_worker_pending() { return bond_worker_pending },
-    set bond_worker_pending(v) { bond_worker_pending = v },
-    get bond_computation_gen() { return bond_computation_gen },
-    set bond_computation_gen(v) { bond_computation_gen = v },
-    get traj_computation_gen() { return traj_computation_gen },
-    set traj_computation_gen(v) { traj_computation_gen = v },
-    get traj_in_flight_frame() { return traj_in_flight_frame },
-    set traj_in_flight_frame(v) { traj_in_flight_frame = v },
-    get traj_pending_frame() { return traj_pending_frame },
-    set traj_pending_frame(v) { traj_pending_frame = v },
+    get bond_connectivity() {
+      return bond_connectivity
+    },
+    set bond_connectivity(v) {
+      bond_connectivity = v
+    },
+    get last_bond_structure() {
+      return last_bond_structure
+    },
+    set last_bond_structure(v) {
+      last_bond_structure = v
+    },
+    get last_bond_strategy() {
+      return last_bond_strategy
+    },
+    set last_bond_strategy(v) {
+      last_bond_strategy = v
+    },
+    get last_bond_fingerprint() {
+      return last_bond_fingerprint
+    },
+    set last_bond_fingerprint(v) {
+      last_bond_fingerprint = v
+    },
+    get last_elem_fingerprint() {
+      return last_elem_fingerprint
+    },
+    set last_elem_fingerprint(v) {
+      last_elem_fingerprint = v
+    },
+    get bond_worker_pending() {
+      return bond_worker_pending
+    },
+    set bond_worker_pending(v) {
+      bond_worker_pending = v
+    },
+    get bond_computation_gen() {
+      return bond_computation_gen
+    },
+    set bond_computation_gen(v) {
+      bond_computation_gen = v
+    },
+    get traj_computation_gen() {
+      return traj_computation_gen
+    },
+    set traj_computation_gen(v) {
+      traj_computation_gen = v
+    },
+    get traj_in_flight_frame() {
+      return traj_in_flight_frame
+    },
+    set traj_in_flight_frame(v) {
+      traj_in_flight_frame = v
+    },
+    get traj_pending_frame() {
+      return traj_pending_frame
+    },
+    set traj_pending_frame(v) {
+      traj_pending_frame = v
+    },
   }
 }
 
@@ -261,6 +359,7 @@ export function compute_bond_connectivity(
   bonding_options: Record<string, unknown>,
   external_dragging: boolean,
   is_trajectory_frame: boolean = false,
+  skip_compute: boolean = false,
 ): void {
   if (!structure?.sites) {
     bond_state.bond_connectivity = []
@@ -273,7 +372,12 @@ export function compute_bond_connectivity(
 
   const bonds_visible = should_show_bonds(show_bonds, lattice)
 
-  if (!bonds_visible || (show_bonds as string) === `never`) {
+  // `skip_compute` is the "defer bonds for huge structures" gate (set by
+  // StructureScene via should_defer_bonds when the atom count exceeds
+  // DEFER_BONDS_ABOVE_ATOMS and the user has not yet asked for bonds). Handled
+  // exactly like the `never` branch: clear any bonds, bump the generation to
+  // kill in-flight async workers, and return so atoms + cell render immediately.
+  if (skip_compute || !bonds_visible || (show_bonds as string) === `never`) {
     bond_state.bond_computation_gen++ // invalidate any in-flight async workers
     bond_state.bond_worker_pending = false
     bond_pairs_setter([])
@@ -295,10 +399,10 @@ export function compute_bond_connectivity(
   // solid_angle). Gated on the build-time token so desktop/web are
   // byte-identical; only local params are reassigned, never the saved setting.
   if (
-    is_trajectory_frame
-    && typeof __CATGO_VSCODE_EXTENSION__ !== `undefined`
-    && __CATGO_VSCODE_EXTENSION__
-    && bonding_strategy === `solid_angle`
+    is_trajectory_frame &&
+    typeof __CATGO_VSCODE_EXTENSION__ !== `undefined` &&
+    __CATGO_VSCODE_EXTENSION__ &&
+    bonding_strategy === `solid_angle`
   ) {
     bonding_strategy = `atom_radii`
     bonding_options = {}
@@ -333,7 +437,10 @@ export function compute_bond_connectivity(
   // every frame after the first, matching Phase 6's old behavior.
   if (structure_changed && !strategy_changed && !external_dragging) {
     const cached = bond_conn_cache.get(structure as unknown as object)
-    if (cached && cached.elem_fingerprint === elem_fp && cached.strategy_key === strategy_key) {
+    if (
+      cached && cached.elem_fingerprint === elem_fp &&
+      cached.strategy_key === strategy_key
+    ) {
       bond_state.bond_connectivity = cached.bond_connectivity
       bond_state.last_bond_structure = structure
       bond_state.last_bond_strategy = cached.strategy_key
@@ -354,18 +461,23 @@ export function compute_bond_connectivity(
 
     // Synchronous path (small structures, <=200 atoms)
     const sync_bonds = compute_bonds_sync(
-      bond_structure, bonding_strategy, bonding_options as Record<string, number>,
+      bond_structure,
+      bonding_strategy,
+      bonding_options as Record<string, number>,
     )
     if (sync_bonds) {
-      const lattice_pbc = (bond_structure as { lattice?: { pbc?: boolean[] } }).lattice?.pbc
-      bond_state.bond_connectivity = sync_bonds.map(b => {
+      const lattice_pbc = (bond_structure as { lattice?: { pbc?: boolean[] } })
+        .lattice?.pbc
+      bond_state.bond_connectivity = sync_bonds.map((b) => {
         const ji = (b.jimage ?? [0, 0, 0]) as [number, number, number]
         // Dev-only invariant: when an axis is non-periodic, jimage must be 0.
         if (import.meta.env.DEV && lattice_pbc) {
           for (let i = 0; i < 3; i++) {
             if (lattice_pbc[i] === false && ji[i] !== 0) {
               console.warn(
-                `[bonds] jimage[${i}]=${ji[i]} on non-periodic axis (pbc=${JSON.stringify(lattice_pbc)})`,
+                `[bonds] jimage[${i}]=${ji[i]} on non-periodic axis (pbc=${
+                  JSON.stringify(lattice_pbc)
+                })`,
                 b,
               )
             }
@@ -406,20 +518,27 @@ export function compute_bond_connectivity(
 
     bond_state.bond_worker_pending = true
     const gen = ++bond_state.bond_computation_gen
-    const lattice_pbc_async = (captured_structure as { lattice?: { pbc?: boolean[] } }).lattice?.pbc
-    compute_bonds_async(captured_structure, captured_strategy, captured_options as Record<string, number>)
+    const lattice_pbc_async = (captured_structure as { lattice?: { pbc?: boolean[] } })
+      .lattice?.pbc
+    compute_bonds_async(
+      captured_structure,
+      captured_strategy,
+      captured_options as Record<string, number>,
+    )
       .then((new_bonds) => {
         if (gen !== bond_state.bond_computation_gen) {
           bond_state.bond_worker_pending = false
           return
         }
-        bond_state.bond_connectivity = new_bonds.map(b => {
+        bond_state.bond_connectivity = new_bonds.map((b) => {
           const ji = (b.jimage ?? [0, 0, 0]) as [number, number, number]
           if (import.meta.env.DEV && lattice_pbc_async) {
             for (let i = 0; i < 3; i++) {
               if (lattice_pbc_async[i] === false && ji[i] !== 0) {
                 console.warn(
-                  `[bonds] jimage[${i}]=${ji[i]} on non-periodic axis (pbc=${JSON.stringify(lattice_pbc_async)})`,
+                  `[bonds] jimage[${i}]=${ji[i]} on non-periodic axis (pbc=${
+                    JSON.stringify(lattice_pbc_async)
+                  })`,
                   b,
                 )
               }
@@ -446,7 +565,9 @@ export function compute_bond_connectivity(
       })
       .catch((e) => {
         console.debug(`[StructureScene] Bond computation failed:`, e)
-        if (gen === bond_state.bond_computation_gen) bond_state.bond_worker_pending = false
+        if (gen === bond_state.bond_computation_gen) {
+          bond_state.bond_worker_pending = false
+        }
       })
   }
 }
@@ -505,9 +626,9 @@ export function compute_bond_connectivity_for_frame(
   // static-structure bonds still honor the user's saved solid_angle. Only
   // local params are reassigned; the saved setting is never mutated.
   if (
-    typeof __CATGO_VSCODE_EXTENSION__ !== `undefined`
-    && __CATGO_VSCODE_EXTENSION__
-    && bonding_strategy === `solid_angle`
+    typeof __CATGO_VSCODE_EXTENSION__ !== `undefined` &&
+    __CATGO_VSCODE_EXTENSION__ &&
+    bonding_strategy === `solid_angle`
   ) {
     bonding_strategy = `atom_radii`
     bonding_options = {}
@@ -526,28 +647,33 @@ export function compute_bond_connectivity_for_frame(
   // 1. Frame cache hit (O(1)).
   const cached = frame_conn_cache.get(traj_positions)
   if (
-    cached
-    && cached.strategy_key === strategy_key
-    && cached.elem_fingerprint === elem_fp
+    cached &&
+    cached.strategy_key === strategy_key &&
+    cached.elem_fingerprint === elem_fp
   ) {
     frame_cache_touch(traj_positions, cached)
     return cached.bond_connectivity
   }
 
   const n_sites = sites.length
-  const overlay_structure = build_trajectory_overlay_structure(structure, traj_positions)
+  const overlay_structure = build_trajectory_overlay_structure(
+    structure,
+    traj_positions,
+  )
 
   // 2. Sync path for small structures — fastest, no scheduling overhead.
   if (n_sites <= TRAJ_SYNC_THRESHOLD) {
     const sync_bonds = compute_bonds_sync(
-      overlay_structure, bonding_strategy, bonding_options as Record<string, number>,
+      overlay_structure,
+      bonding_strategy,
+      bonding_options as Record<string, number>,
     )
     if (sync_bonds) {
-      const new_conn = sync_bonds.map(b => ({
+      const new_conn = sync_bonds.map((b) => ({
         site_idx_1: b.site_idx_1,
         site_idx_2: b.site_idx_2,
         strength: b.strength,
-        jimage: ((b.jimage ?? [0, 0, 0]) as [number, number, number]),
+        jimage: (b.jimage ?? [0, 0, 0]) as [number, number, number],
       }))
       frame_cache_set(traj_positions, {
         bond_connectivity: new_conn,
@@ -556,7 +682,9 @@ export function compute_bond_connectivity_for_frame(
         strategy_key,
       })
       if (import.meta.env?.DEV) {
-        console.log(`[bonds-traj] sync compute | ${n_sites} sites | ${new_conn.length} bonds`)
+        console.log(
+          `[bonds-traj] sync compute | ${n_sites} sites | ${new_conn.length} bonds`,
+        )
       }
       return new_conn
     }
@@ -567,8 +695,14 @@ export function compute_bond_connectivity_for_frame(
   if (bond_state.traj_in_flight_frame === null) {
     bond_state.traj_in_flight_frame = traj_positions
     dispatch_traj_async(
-      bond_state, traj_positions, overlay_structure, structure,
-      strategy_key, elem_fp, bonding_strategy, bonding_options,
+      bond_state,
+      traj_positions,
+      overlay_structure,
+      structure,
+      strategy_key,
+      elem_fp,
+      bonding_strategy,
+      bonding_options,
     )
   } else if (bond_state.traj_in_flight_frame !== traj_positions) {
     // Latest-wins: just remember which frame the user is currently on.
@@ -598,7 +732,9 @@ function dispatch_traj_async(
 ): void {
   const gen = ++bond_state.traj_computation_gen
   if (import.meta.env?.DEV) {
-    console.log(`[bonds-traj] dispatch async | ${overlay_structure.sites.length} sites | gen=${gen}`)
+    console.log(
+      `[bonds-traj] dispatch async | ${overlay_structure.sites.length} sites | gen=${gen}`,
+    )
   }
   // Helper: clear throttle slots that still reference this dispatch's
   // frame_key. Safe to call from any exit path — only nulls slots we own.
@@ -610,7 +746,11 @@ function dispatch_traj_async(
       bond_state.traj_pending_frame = null
     }
   }
-  compute_bonds_async(overlay_structure, bonding_strategy, bonding_options as Record<string, number>)
+  compute_bonds_async(
+    overlay_structure,
+    bonding_strategy,
+    bonding_options as Record<string, number>,
+  )
     .then((new_bonds) => {
       // Stale generation — trajectory torn down, strategy changed, or another
       // traj dispatch superseded this one. Drop the result and release slots
@@ -620,11 +760,11 @@ function dispatch_traj_async(
         return
       }
 
-      const new_conn = new_bonds.map(b => ({
+      const new_conn = new_bonds.map((b) => ({
         site_idx_1: b.site_idx_1,
         site_idx_2: b.site_idx_2,
         strength: b.strength,
-        jimage: ((b.jimage ?? [0, 0, 0]) as [number, number, number]),
+        jimage: (b.jimage ?? [0, 0, 0]) as [number, number, number],
       }))
       // Always cache — even if the user has moved on, the entry will be
       // useful on revisit (and bounded by the LRU cap).
@@ -652,10 +792,19 @@ function dispatch_traj_async(
         // already cached so a future revisit will hit O(1).
         bond_state.traj_in_flight_frame = pending
         bond_state.traj_pending_frame = null
-        const next_overlay = build_trajectory_overlay_structure(base_structure, pending)
+        const next_overlay = build_trajectory_overlay_structure(
+          base_structure,
+          pending,
+        )
         dispatch_traj_async(
-          bond_state, pending, next_overlay, base_structure,
-          strategy_key, elem_fp, bonding_strategy, bonding_options,
+          bond_state,
+          pending,
+          next_overlay,
+          base_structure,
+          strategy_key,
+          elem_fp,
+          bonding_strategy,
+          bonding_options,
         )
       }
     })
@@ -675,7 +824,9 @@ function apply_jimage(
   lattice_matrix: number[][] | undefined,
 ): Vec3 {
   const [dx, dy, dz] = jimage
-  if ((dx | dy | dz) === 0 || !lattice_matrix || lattice_matrix.length !== 3) return base
+  if ((dx | dy | dz) === 0 || !lattice_matrix || lattice_matrix.length !== 3) {
+    return base
+  }
   const [ax, ay, az] = lattice_matrix[0] as Vec3
   const [bx, by, bz] = lattice_matrix[1] as Vec3
   const [cx, cy, cz] = lattice_matrix[2] as Vec3
@@ -697,15 +848,26 @@ function apply_jimage(
  * position per plan §2.1 to keep the drag-recompute dependency explicit.
  */
 export function build_bond_pairs(
-  bond_connectivity: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage?: [number, number, number] }>,
+  bond_connectivity: Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage?: [number, number, number]
+    }
+  >,
   last_bond_structure: AnyStructure | null,
   structure: AnyStructure | undefined,
   realtime_position_overrides: Map<number, Vec3> | null,
   external_dragging: boolean,
   selected_sites: number[],
 ): BondPair[] {
-  const has_overrides = realtime_position_overrides && realtime_position_overrides.size > 0
-  const bond_struct = (has_overrides ? last_bond_structure : last_bond_structure ?? structure) as typeof structure
+  const has_overrides = realtime_position_overrides &&
+    realtime_position_overrides.size > 0
+  const bond_struct =
+    (has_overrides
+      ? last_bond_structure
+      : last_bond_structure ?? structure) as typeof structure
 
   if (!bond_struct?.sites || bond_connectivity.length === 0) {
     return []
@@ -714,18 +876,24 @@ export function build_bond_pairs(
   // During dragging: hide cross-bonds (one atom selected, one not)
   let bonds_to_render = bond_connectivity
   if (external_dragging && selected_sites.length > 0) {
-    bonds_to_render = filter_bonds_during_drag(bond_connectivity, selected_sites)
+    bonds_to_render = filter_bonds_during_drag(
+      bond_connectivity,
+      selected_sites,
+    )
   }
 
   const pos_struct = has_overrides ? bond_struct : (structure ?? bond_struct)
-  const lattice_matrix = (bond_struct as { lattice?: { matrix?: number[][] } }).lattice?.matrix
-  return bonds_to_render.map(conn => {
+  const lattice_matrix = (bond_struct as { lattice?: { matrix?: number[][] } })
+    .lattice?.matrix
+  return bonds_to_render.map((conn) => {
     const base_pos_1 = pos_struct.sites[conn.site_idx_1]?.xyz
     const base_pos_2 = pos_struct.sites[conn.site_idx_2]?.xyz
     if (!base_pos_1 || !base_pos_2) return null
 
-    const pos_1 = realtime_position_overrides?.get(conn.site_idx_1) ?? base_pos_1
-    const pos_2 = realtime_position_overrides?.get(conn.site_idx_2) ?? base_pos_2
+    const pos_1 = realtime_position_overrides?.get(conn.site_idx_1) ??
+      base_pos_1
+    const pos_2 = realtime_position_overrides?.get(conn.site_idx_2) ??
+      base_pos_2
 
     const jimage = conn.jimage ?? [0, 0, 0]
     const b_eff = apply_jimage(pos_2, jimage, lattice_matrix)
@@ -764,7 +932,14 @@ export function build_bond_pairs(
  *   4. null endpoint → bond filtered out
  */
 export function build_trajectory_bond_pairs(
-  bond_connectivity: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage?: [number, number, number] }>,
+  bond_connectivity: Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage?: [number, number, number]
+    }
+  >,
   trajectory_frame_positions: Float32Array,
   overrides?: Map<number, Vec3> | null,
   atom_manager?: {
@@ -817,7 +992,10 @@ export function build_trajectory_bond_pairs(
     }
     const elem = majority.element
     if (!elem) return null
-    const entry = (covalent_radii_data as Record<string, { covalent_radius_pm?: number } | undefined>)[elem]
+    const entry = (covalent_radii_data as Record<
+      string,
+      { covalent_radius_pm?: number } | undefined
+    >)[elem]
     const pm = entry?.covalent_radius_pm
     if (typeof pm !== `number` || pm <= 0) return null
     return pm / 100 // pm → Å
@@ -827,7 +1005,7 @@ export function build_trajectory_bond_pairs(
     : DEFAULT_BOND_TOLERANCE
   const lat = lattice_matrix ?? undefined
   let filtered_count = 0
-  const out = bond_connectivity.map(conn => {
+  const out = bond_connectivity.map((conn) => {
     const pos_1 = lookup_pos(conn.site_idx_1)
     const pos_2 = lookup_pos(conn.site_idx_2)
     if (pos_1 === null || pos_2 === null) return null
@@ -860,7 +1038,9 @@ export function build_trajectory_bond_pairs(
     return pair
   }).filter((b): b is BondPair => b !== null)
   if (import.meta.env?.DEV && filtered_count > 0) {
-    console.log(`[bond-stale-filter] dropped ${filtered_count} stale bonds out of ${bond_connectivity.length}`)
+    console.log(
+      `[bond-stale-filter] dropped ${filtered_count} stale bonds out of ${bond_connectivity.length}`,
+    )
   }
   return out
 }
@@ -875,10 +1055,18 @@ export function create_hbond_state() {
   let hbond_computation_gen = 0
 
   return {
-    get h_bond_connectivity() { return h_bond_connectivity },
-    set h_bond_connectivity(v) { h_bond_connectivity = v },
-    get hbond_computation_gen() { return hbond_computation_gen },
-    set hbond_computation_gen(v) { hbond_computation_gen = v },
+    get h_bond_connectivity() {
+      return h_bond_connectivity
+    },
+    set h_bond_connectivity(v) {
+      h_bond_connectivity = v
+    },
+    get hbond_computation_gen() {
+      return hbond_computation_gen
+    },
+    set hbond_computation_gen(v) {
+      hbond_computation_gen = v
+    },
   }
 }
 
@@ -913,7 +1101,11 @@ export function compute_hbond_connectivity(
 
   try {
     if (current_bond_pairs.length === 0) {
-      const sync = compute_bonds_sync(current_structure, bonding_strategy, bonding_options as Record<string, number>)
+      const sync = compute_bonds_sync(
+        current_structure,
+        bonding_strategy,
+        bonding_options as Record<string, number>,
+      )
       if (sync) {
         current_bond_pairs = sync
       } else {
@@ -924,7 +1116,11 @@ export function compute_hbond_connectivity(
     }
 
     // JS computation first for immediate rendering (no flash)
-    const js_hbonds = detect_hydrogen_bonds(current_structure, current_bond_pairs, hbond_options)
+    const js_hbonds = detect_hydrogen_bonds(
+      current_structure,
+      current_bond_pairs,
+      hbond_options,
+    )
     // Extract topology from JS BondPair results.
     hbond_state.h_bond_connectivity = js_hbonds.map((b): HBondConnectivity => ({
       site_idx_1: b.site_idx_1,
@@ -954,7 +1150,9 @@ export function compute_hbond_connectivity(
       const connectivity: HBondConnectivity[] = []
       for (const hb of result) {
         const h_or_donor_idx = hb.h_idx ?? hb.donor_idx
-        if (!sites[h_or_donor_idx]?.xyz || !sites[hb.acceptor_idx]?.xyz) continue
+        if (!sites[h_or_donor_idx]?.xyz || !sites[hb.acceptor_idx]?.xyz) {
+          continue
+        }
         connectivity.push({
           site_idx_1: h_or_donor_idx,
           site_idx_2: hb.acceptor_idx,
@@ -984,14 +1182,19 @@ export function build_hbond_pairs(
   try {
     if (h_bond_connectivity.length === 0) return []
 
-    const has_overrides = realtime_position_overrides && realtime_position_overrides.size > 0
-    const bond_struct = (has_overrides ? last_bond_structure : last_bond_structure ?? structure) as typeof structure
-    if (!bond_struct?.sites) return []
+    const has_overrides = realtime_position_overrides &&
+      realtime_position_overrides.size > 0
+    const bond_struct = (has_overrides
+      ? last_bond_structure
+      : last_bond_structure ?? structure) as typeof structure
+    if (!bond_struct?.sites) {
+      return []
+    }
 
     let conns_to_render = h_bond_connectivity
     if (external_dragging && selected_sites.length > 0) {
       const selected_set = new Set(selected_sites)
-      conns_to_render = h_bond_connectivity.filter(conn => {
+      conns_to_render = h_bond_connectivity.filter((conn) => {
         const a_sel = selected_set.has(conn.site_idx_1)
         const b_sel = selected_set.has(conn.site_idx_2)
         return a_sel === b_sel
@@ -999,15 +1202,23 @@ export function build_hbond_pairs(
     }
 
     const pos_struct = has_overrides ? bond_struct : (structure ?? bond_struct)
-    return conns_to_render.map(conn => {
+    return conns_to_render.map((conn) => {
       const base_pos_1 = pos_struct.sites[conn.site_idx_1]?.xyz
       const base_pos_2 = pos_struct.sites[conn.site_idx_2]?.xyz
-      if (!base_pos_1 || !base_pos_2) return null
+      if (!base_pos_1 || !base_pos_2) {
+        return null
+      }
 
-      const pos_1 = realtime_position_overrides?.get(conn.site_idx_1) ?? base_pos_1
-      const pos_2 = realtime_position_overrides?.get(conn.site_idx_2) ?? base_pos_2
+      const pos_1 = realtime_position_overrides?.get(conn.site_idx_1) ??
+        base_pos_1
+      const pos_2 = realtime_position_overrides?.get(conn.site_idx_2) ??
+        base_pos_2
 
-      const bond_length = Math.hypot(pos_2[0] - pos_1[0], pos_2[1] - pos_1[1], pos_2[2] - pos_1[2])
+      const bond_length = Math.hypot(
+        pos_2[0] - pos_1[0],
+        pos_2[1] - pos_1[1],
+        pos_2[2] - pos_1[2],
+      )
       return {
         pos_1,
         pos_2,
@@ -1019,7 +1230,9 @@ export function build_hbond_pairs(
         bond_type: `hydrogen` as const,
         jimage: [0, 0, 0] as [number, number, number],
       }
-    }).filter(b => b !== null) as BondPair[]
+    }).filter((b) =>
+      b !== null
+    ) as BondPair[]
   } catch {
     return []
   }
@@ -1061,7 +1274,11 @@ export function apply_atom_delete_incremental(
   if (deleted_set.size === 0) {
     if (import.meta.env?.DEV) {
       // eslint-disable-next-line no-console
-      console.log(`[atoms-X4] apply_atom_delete_incremental: 0 atom(s), ${(performance.now() - t0).toFixed(2)}ms`)
+      console.log(
+        `[atoms-X4] apply_atom_delete_incremental: 0 atom(s), ${
+          (performance.now() - t0).toFixed(2)
+        }ms`,
+      )
     }
     return
   }
@@ -1083,10 +1300,19 @@ export function apply_atom_delete_incremental(
 
   // Filter + reindex bond_connectivity.
   const prev = bond_state.bond_connectivity
-  const next: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> = []
+  const next: Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage: [number, number, number]
+    }
+  > = []
   for (let i = 0; i < prev.length; i++) {
     const c = prev[i]
-    if (deleted_set.has(c.site_idx_1) || deleted_set.has(c.site_idx_2)) continue
+    if (deleted_set.has(c.site_idx_1) || deleted_set.has(c.site_idx_2)) {
+      continue
+    }
     next.push({
       site_idx_1: c.site_idx_1 - count_less_than(c.site_idx_1),
       site_idx_2: c.site_idx_2 - count_less_than(c.site_idx_2),
@@ -1105,7 +1331,9 @@ export function apply_atom_delete_incremental(
   // treats our state as already up-to-date. Strategy is unchanged.
   const elem_fp = get_element_fingerprint(current_sites)
   bond_state.last_elem_fingerprint = elem_fp
-  bond_state.last_bond_fingerprint = `${elem_fp}|${get_position_hash(current_sites).toFixed(4)}`
+  bond_state.last_bond_fingerprint = `${elem_fp}|${
+    get_position_hash(current_sites).toFixed(4)
+  }`
 
   // `last_bond_structure` is consulted by build_bond_pairs as the position
   // source when `realtime_position_overrides` is active. Its sites were
@@ -1129,7 +1357,11 @@ export function apply_atom_delete_incremental(
 
   if (import.meta.env?.DEV) {
     // eslint-disable-next-line no-console
-    console.log(`[atoms-X4] apply_atom_delete_incremental: ${deleted_set.size} atom(s), ${(performance.now() - t0).toFixed(2)}ms`)
+    console.log(
+      `[atoms-X4] apply_atom_delete_incremental: ${deleted_set.size} atom(s), ${
+        (performance.now() - t0).toFixed(2)
+      }ms`,
+    )
   }
 }
 
@@ -1179,13 +1411,26 @@ function __recompute_bonds_sync(
   structure_with_sites: AnyStructure,
   bonding_strategy: BondingStrategy,
   bonding_options: Record<string, unknown>,
-): Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> | null {
+):
+  | Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage: [number, number, number]
+    }
+  >
+  | null {
   // Phase 5: caller passes the pre-ghost structure. PBC stays enabled so
   // the detector emits cross-cell bonds with `image` populated; the
   // renderer handles half-cylinder placement against the lattice.
-  const result = compute_bonds_sync(structure_with_sites, bonding_strategy, bonding_options as Record<string, number>)
+  const result = compute_bonds_sync(
+    structure_with_sites,
+    bonding_strategy,
+    bonding_options as Record<string, number>,
+  )
   if (!result) return null
-  return result.map(b => ({
+  return result.map((b) => ({
     site_idx_1: b.site_idx_1,
     site_idx_2: b.site_idx_2,
     strength: b.strength,
@@ -1226,8 +1471,15 @@ export function apply_atom_add_incremental(
   if (current_sites.length > X6_SMALL_THRESHOLD) return false
 
   // Fresh bond set for the post-add structure.
-  const structure_with_next_sites = { ...current_structure, sites: current_sites } as AnyStructure
-  const fresh = __recompute_bonds_sync(structure_with_next_sites, bonding_strategy, bonding_options)
+  const structure_with_next_sites = {
+    ...current_structure,
+    sites: current_sites,
+  } as AnyStructure
+  const fresh = __recompute_bonds_sync(
+    structure_with_next_sites,
+    bonding_strategy,
+    bonding_options,
+  )
   if (fresh === null) return false
 
   // Index existing bonds by canonical key so we can identify new ones.
@@ -1241,7 +1493,14 @@ export function apply_atom_add_incremental(
   // all new bonds must involve at least one of the added site_ids — we
   // could filter by that, but `prev_keys` is already tight and saves us
   // from having to materialize the added-sid set for the check.
-  const added_bonds: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> = []
+  const added_bonds: Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage: [number, number, number]
+    }
+  > = []
   for (let i = 0; i < fresh.length; i++) {
     const c = fresh[i]
     if (!prev_keys.has(__bond_key(c.site_idx_1, c.site_idx_2))) {
@@ -1271,7 +1530,9 @@ export function apply_atom_add_incremental(
   // Bump fingerprints + shallow-merge last_bond_structure (see X4 comment).
   const elem_fp = get_element_fingerprint(current_sites)
   bond_state.last_elem_fingerprint = elem_fp
-  bond_state.last_bond_fingerprint = `${elem_fp}|${get_position_hash(current_sites).toFixed(4)}`
+  bond_state.last_bond_fingerprint = `${elem_fp}|${
+    get_position_hash(current_sites).toFixed(4)
+  }`
   if (bond_state.last_bond_structure !== null) {
     bond_state.last_bond_structure = {
       ...bond_state.last_bond_structure,
@@ -1285,7 +1546,11 @@ export function apply_atom_add_incremental(
 
   if (import.meta.env?.DEV) {
     // eslint-disable-next-line no-console
-    console.log(`[atoms-X6] apply_atom_add_incremental: ${added.length} atom(s), +${added_bonds.length} bond(s), ${(performance.now() - t0).toFixed(2)}ms`)
+    console.log(
+      `[atoms-X6] apply_atom_add_incremental: ${added.length} atom(s), +${added_bonds.length} bond(s), ${
+        (performance.now() - t0).toFixed(2)
+      }ms`,
+    )
   }
   return true
 }
@@ -1316,15 +1581,32 @@ export function apply_atom_replace_incremental(
   if (replacements.length === 0) return true
   if (current_sites.length > X6_SMALL_THRESHOLD) return false
 
-  const structure_with_next_sites = { ...current_structure, sites: current_sites } as AnyStructure
-  const fresh = __recompute_bonds_sync(structure_with_next_sites, bonding_strategy, bonding_options)
+  const structure_with_next_sites = {
+    ...current_structure,
+    sites: current_sites,
+  } as AnyStructure
+  const fresh = __recompute_bonds_sync(
+    structure_with_next_sites,
+    bonding_strategy,
+    bonding_options,
+  )
   if (fresh === null) return false
 
-  __apply_full_bond_diff(bond_state, fresh, bond_manager, current_sites, structure_with_next_sites)
+  __apply_full_bond_diff(
+    bond_state,
+    fresh,
+    bond_manager,
+    current_sites,
+    structure_with_next_sites,
+  )
 
   if (import.meta.env?.DEV) {
     // eslint-disable-next-line no-console
-    console.log(`[atoms-X6] apply_atom_replace_incremental: ${replacements.length} atom(s), ${(performance.now() - t0).toFixed(2)}ms`)
+    console.log(
+      `[atoms-X6] apply_atom_replace_incremental: ${replacements.length} atom(s), ${
+        (performance.now() - t0).toFixed(2)
+      }ms`,
+    )
   }
   return true
 }
@@ -1356,15 +1638,32 @@ export function apply_atom_move_incremental(
   if (moved.length === 0) return true
   if (current_sites.length > X6_SMALL_THRESHOLD) return false
 
-  const structure_with_next_sites = { ...current_structure, sites: current_sites } as AnyStructure
-  const fresh = __recompute_bonds_sync(structure_with_next_sites, bonding_strategy, bonding_options)
+  const structure_with_next_sites = {
+    ...current_structure,
+    sites: current_sites,
+  } as AnyStructure
+  const fresh = __recompute_bonds_sync(
+    structure_with_next_sites,
+    bonding_strategy,
+    bonding_options,
+  )
   if (fresh === null) return false
 
-  __apply_full_bond_diff(bond_state, fresh, bond_manager, current_sites, structure_with_next_sites)
+  __apply_full_bond_diff(
+    bond_state,
+    fresh,
+    bond_manager,
+    current_sites,
+    structure_with_next_sites,
+  )
 
   if (import.meta.env?.DEV) {
     // eslint-disable-next-line no-console
-    console.log(`[atoms-X6] apply_atom_move_incremental: ${moved.length} atom(s), ${(performance.now() - t0).toFixed(2)}ms`)
+    console.log(
+      `[atoms-X6] apply_atom_move_incremental: ${moved.length} atom(s), ${
+        (performance.now() - t0).toFixed(2)
+      }ms`,
+    )
   }
   return true
 }
@@ -1382,7 +1681,14 @@ export function apply_atom_move_incremental(
  */
 function __apply_full_bond_diff(
   bond_state: ReturnType<typeof create_bond_state>,
-  fresh: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }>,
+  fresh: Array<
+    {
+      site_idx_1: number
+      site_idx_2: number
+      strength: number
+      jimage: [number, number, number]
+    }
+  >,
   bond_manager: BondManager | null,
   current_sites: Site[],
   structure_with_next_sites: AnyStructure,
@@ -1419,7 +1725,9 @@ function __apply_full_bond_diff(
     // Brand-new bonds → append.
     const add_list: Array<{ site_idx_1: number; site_idx_2: number }> = []
     for (let i = 0; i < fresh.length; i++) {
-      if (!prev_keys.has(__bond_key(fresh[i].site_idx_1, fresh[i].site_idx_2))) {
+      if (
+        !prev_keys.has(__bond_key(fresh[i].site_idx_1, fresh[i].site_idx_2))
+      ) {
         add_list.push(fresh[i])
       }
     }
@@ -1439,7 +1747,9 @@ function __apply_full_bond_diff(
   // Fingerprints + last_bond_structure (same pattern as X4).
   const elem_fp = get_element_fingerprint(current_sites)
   bond_state.last_elem_fingerprint = elem_fp
-  bond_state.last_bond_fingerprint = `${elem_fp}|${get_position_hash(current_sites).toFixed(4)}`
+  bond_state.last_bond_fingerprint = `${elem_fp}|${
+    get_position_hash(current_sites).toFixed(4)
+  }`
   if (bond_state.last_bond_structure !== null) {
     bond_state.last_bond_structure = {
       ...bond_state.last_bond_structure,

--- a/tests/vitest/structure/bonding/defer-bonds.test.ts
+++ b/tests/vitest/structure/bonding/defer-bonds.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the "defer connectivity for very large structures" gate.
+ *
+ * Covers the pure decision helper `should_defer_bonds(atom_count, user_requested)`
+ * and the `DEFER_BONDS_ABOVE_ATOMS` threshold. Runtime wiring (state + banner)
+ * lives in StructureScene and is not unit-tested here.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  DEFER_BONDS_ABOVE_ATOMS,
+  should_defer_bonds,
+} from '$lib/structure/bond-computation-controller.svelte'
+
+describe(`should_defer_bonds`, () => {
+  it(`is conservative: threshold sits well above the sync/GPU thresholds`, () => {
+    // Must be far above the 1000-atom sync threshold and 2000-atom GPU threshold
+    // so normal structures never defer.
+    expect(DEFER_BONDS_ABOVE_ATOMS).toBe(8000)
+    expect(DEFER_BONDS_ABOVE_ATOMS).toBeGreaterThan(2000)
+  })
+
+  it(`does NOT defer normal-size structures`, () => {
+    expect(should_defer_bonds(0, false)).toBe(false)
+    expect(should_defer_bonds(100, false)).toBe(false)
+    expect(should_defer_bonds(2000, false)).toBe(false)
+    expect(should_defer_bonds(DEFER_BONDS_ABOVE_ATOMS, false)).toBe(false) // boundary: exactly at threshold is NOT deferred
+  })
+
+  it(`defers a genuinely huge structure that the user has not acted on`, () => {
+    expect(should_defer_bonds(DEFER_BONDS_ABOVE_ATOMS + 1, false)).toBe(true)
+    expect(should_defer_bonds(11000, false)).toBe(true) // the kerogen case
+  })
+
+  it(`un-defers once the user requests bonds, regardless of size`, () => {
+    expect(should_defer_bonds(11000, true)).toBe(false)
+    expect(should_defer_bonds(DEFER_BONDS_ABOVE_ATOMS + 1, true)).toBe(false)
+  })
+
+  it(`user request has no effect below the threshold (already non-deferred)`, () => {
+    expect(should_defer_bonds(500, true)).toBe(false)
+    expect(should_defer_bonds(500, false)).toBe(false)
+  })
+})


### PR DESCRIPTION
Ported from pretty-lattice. Very large structures compute bonds eagerly on load today (show_bonds defaults to `always`), which janks the viewer for 10k+ atom systems (e.g. LAMMPS kerogen). This defers bond+polyhedra computation for huge structures: atoms + unit cell render immediately, and a banner offers to compute bonds on demand.

## Design (conservative)
- `DEFER_BONDS_ABOVE_ATOMS = 8000` (strictly `>`) — well above the 1000 sync / 2000 GPU thresholds. **Below 8000 canonical atoms, behavior is byte-identical to today.**
- Gate = a `skip_compute` param on `compute_bond_connectivity` that reuses the existing `never`-branch clear (clears bonds, bumps generation, kills in-flight workers). Passed into the bond `$effect.pre`, the ferrox-ready recompute, and the polyhedra path.
- Count is the **canonical** atom count (`num_original_sites`), not the PBC-image-expanded scene count — so a small structure whose boundary images push the scene over 8000 isn't falsely deferred, and the banner shows the real number.
- Re-defers on each new structure load (keyed off atom count, not object identity, so in-place edits don't re-hide user-requested bonds).
- UI: a small "Bonds hidden for performance (N atoms) · Compute bonds" banner; clicking un-defers via the normal reactive path. Gated on `show_bonds !== 'never'`. i18n en+zh.

## Verification (live, CDP)
Loaded a 10976-atom Cu FCC supercell: atoms + cell rendered immediately, banner showed **"Bonds hidden for performance (10976 atoms)"** (canonical count, after the count fix), clicking **Compute bonds** removed the banner and rendered the full bond network. `pnpm check` 0 errors; 5/5 unit tests for `should_defer_bonds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
