### PR TITLE
fix(workflow): allow extensionless POSCAR import

### DIFF
--- a/src/lib/workflow/StructureInputDialog.svelte
+++ b/src/lib/workflow/StructureInputDialog.svelte
@@ -746,10 +746,10 @@
             >
               <div class="drop-icon">&#128196;</div>
               <div class="drop-text">{t('workflow.si_drop_here')}</div>
-              <div class="drop-formats">.cif, .xyz, POSCAR, .json, .vasp, .mol2, .pdb, .traj, .h5, XDATCAR, .data, .lammps, .lmp</div>
+              <div class="drop-formats">POSCAR, CONTCAR, .cif, .xyz, .extxyz, .json, .vasp, .mol2, .pdb, .traj, .h5, XDATCAR, .data, .lammps, .lmp</div>
               <label class="file-btn">
                 {t('workflow.si_browse_files')}
-                <input type="file" accept=".cif,.xyz,.json,.vasp,.poscar,.mol2,.pdb,.traj,.h5,.hdf5,.xdatcar,.data,.lammps,.lmp" onchange={on_file_input} hidden />
+                <input type="file" onchange={on_file_input} hidden />
               </label>
             </div>
           </section>


### PR DESCRIPTION
## Summary

This PR fixes the workflow structure import dialog so users can select extensionless VASP structure files such as `POSCAR` and `CONTCAR`.

## Root cause

The dialog advertised `POSCAR` as a supported format, but the hidden file input used an `accept` list containing only file extensions. On Windows file pickers, extensionless files like `POSCAR` and `CONTCAR` are filtered out, so users could not select them even though the parser can handle them.

## Changes

- Removed the restrictive `accept` attribute from the structure file input.
- Updated the supported-format hint to explicitly list `POSCAR`, `CONTCAR`, and `.extxyz`.

## Validation

- Ran `corepack pnpm check`.
- Result: 0 errors; existing Svelte warnings are unrelated to this change.