### PR TITLE
feat(release): mirror release assets to Cloudflare R2 for mainland-China downloads

### DIFF
--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -1,0 +1,193 @@
+# Mirror release assets to Cloudflare R2 so users in mainland China (where
+# GitHub is often unreachable) can download CatGo and receive in-app updates.
+#
+# Layout in the bucket (keep-only-latest policy):
+#   <tag>/<asset>   e.g. v1.4.5/CatGo_1.4.5_x64-setup.exe
+#   latest.json     updater manifest with URLs rewritten to the mirror
+#   index.html      minimal bilingual download page listing the current assets
+# Older <tag>/ prefixes are pruned after a successful sync, so storage stays
+# within R2's 10 GB free tier (~2.8 GB per release). Egress from R2 is free.
+#
+# One-time setup (Cloudflare dashboard):
+#   1. R2 → Create bucket `catgo-releases`.
+#   2. Bucket → Settings → Custom Domains → add `dl.catgo-ucsd.org`
+#      (the zone is already on this Cloudflare account).
+#   3. R2 → Manage API Tokens → create a token with Object Read & Write on the
+#      bucket; add its credentials as repo secrets:
+#        R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY
+#      (CLOUDFLARE_ACCOUNT_ID already exists as a secret.)
+#   Optional repo variables (defaults in env below): R2_BUCKET, R2_PUBLIC_BASE_URL.
+#
+# Triggers: `release: published` — but note releases published by workflows
+# using GITHUB_TOKEN do NOT fire this event (same gotcha as pypi-publish.yml),
+# and manual asset uploads (e.g. the iOS .ipa) may land after publication.
+# When in doubt, run the workflow_dispatch form with the tag — the sync is
+# idempotent and safe to re-run any number of times.
+
+name: Mirror release to R2
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to mirror (e.g. v1.4.5); empty = latest release'
+        required: false
+        default: ''
+
+concurrency:
+  group: r2-release-mirror
+  cancel-in-progress: true
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  R2_BUCKET: ${{ vars.R2_BUCKET || 'catgo-releases' }}
+  R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL || 'https://dl.catgo-ucsd.org' }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: auto
+  AWS_ENDPOINT_URL: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+  # aws-cli >= 2.23 sends CRC checksums by default, which R2's S3 API rejects.
+  AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+  AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Check R2 credentials configured
+        id: creds
+        run: |
+          if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY secrets not set — skipping mirror." >> "$GITHUB_STEP_SUMMARY"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve tag
+        id: tag
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.tag }}" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Mirroring release: $tag"
+
+      - name: Wait for asset list to stabilize
+        # Build workflows attach assets asynchronously after the release is
+        # published. Poll until the asset count is unchanged for 3 consecutive
+        # minutes (skipped on manual dispatch — by then the release is done).
+        if: steps.creds.outputs.configured == 'true' && github.event_name == 'release'
+        run: |
+          tag='${{ steps.tag.outputs.tag }}'
+          prev=-1; stable=0
+          for i in $(seq 1 30); do
+            count=$(gh api "repos/${{ github.repository }}/releases/tags/$tag" --jq '.assets | length')
+            echo "poll $i: $count assets"
+            if [ "$count" = "$prev" ]; then
+              stable=$((stable + 1))
+              [ "$stable" -ge 3 ] && break
+            else
+              stable=0
+            fi
+            prev=$count
+            sleep 60
+          done
+
+      - name: Download release assets
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          mkdir -p dist
+          gh release download '${{ steps.tag.outputs.tag }}' \
+            --repo '${{ github.repository }}' --dir dist
+          ls -lh dist
+
+      - name: Rewrite latest.json URLs to the mirror
+        # latest.json is the Tauri updater manifest; its asset URLs point at
+        # github.com, which defeats the purpose for users behind the GFW.
+        # Point them at the mirror instead and serve the manifest from the
+        # bucket root (the updater endpoint in tauri.conf.json).
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          if [ -f dist/latest.json ]; then
+            jq --arg base "$R2_PUBLIC_BASE_URL" '
+              .platforms |= map_values(
+                .url |= sub("https://github.com/[^/]+/[^/]+/releases/download/"; $base + "/")
+              )' dist/latest.json > latest.mirror.json
+            jq . latest.mirror.json > /dev/null
+          else
+            echo "no latest.json in this release — skipping manifest rewrite"
+          fi
+
+      - name: Generate index.html download page
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          tag='${{ steps.tag.outputs.tag }}'
+          {
+            echo '<!doctype html><meta charset="utf-8">'
+            echo "<title>CatGo downloads — $tag</title>"
+            echo '<style>body{font-family:system-ui;max-width:720px;margin:3rem auto;padding:0 1rem}td{padding:.3rem .8rem}</style>'
+            echo "<h1>CatGo $tag</h1>"
+            echo '<p>中国大陆下载镜像 / China download mirror.'
+            echo '完整发布说明见 <a href="https://github.com/${{ github.repository }}/releases">GitHub Releases</a>.</p>'
+            echo '<table>'
+            for f in dist/*; do
+              name=$(basename "$f")
+              size=$(du -h "$f" | cut -f1)
+              echo "<tr><td><a href=\"$tag/$name\">$name</a></td><td>$size</td></tr>"
+            done
+            echo '</table>'
+          } > index.html
+
+      - name: Sync to R2
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          tag='${{ steps.tag.outputs.tag }}'
+          aws s3 sync dist/ "s3://$R2_BUCKET/$tag/"
+          if [ -f latest.mirror.json ]; then
+            aws s3 cp latest.mirror.json "s3://$R2_BUCKET/latest.json" \
+              --content-type application/json --cache-control 'public, max-age=300'
+          fi
+          aws s3 cp index.html "s3://$R2_BUCKET/index.html" \
+            --content-type 'text/html; charset=utf-8' --cache-control 'public, max-age=300'
+
+      - name: Prune older releases (keep only the latest)
+        # Only prune when the tag we just synced IS the repo's latest release —
+        # a manual backfill of an old tag must not delete the current one.
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          tag='${{ steps.tag.outputs.tag }}'
+          latest=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
+          if [ "$tag" != "$latest" ]; then
+            echo "synced $tag but latest is $latest — skipping prune"
+            exit 0
+          fi
+          aws s3api list-objects-v2 --bucket "$R2_BUCKET" --delimiter / \
+            --query 'CommonPrefixes[].Prefix' --output text 2>/dev/null | tr '\t' '\n' | \
+          while read -r prefix; do
+            [ -z "$prefix" ] || [ "$prefix" = "None" ] && continue
+            if [ "$prefix" != "$tag/" ]; then
+              echo "pruning stale prefix: $prefix"
+              aws s3 rm "s3://$R2_BUCKET/$prefix" --recursive
+            fi
+          done
+
+      - name: Summary
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          tag='${{ steps.tag.outputs.tag }}'
+          {
+            echo "### Mirrored $tag to R2"
+            echo ""
+            echo "- Download page: $R2_PUBLIC_BASE_URL/"
+            echo "- Updater manifest: $R2_PUBLIC_BASE_URL/latest.json"
+            echo "- Assets: $R2_PUBLIC_BASE_URL/$tag/<file>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/readme.md
+++ b/readme.md
@@ -287,7 +287,7 @@ Feature availability depends on the CatGo edition, installed optional dependenci
 
 Every link points at the **latest release**, so it stays current as new versions ship — current version: [![Latest release](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://github.com/Hello-QM/catgo-LRG/releases/latest). On the release page, pick the file for your platform (shown in the **File** column). For older versions and checksums, see [all Releases](https://github.com/Hello-QM/catgo-LRG/releases).
 
-> **China mirror / 中国大陆镜像:** if GitHub is unreachable, download the latest release from [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/), or install via a PyPI mirror: `pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`, then run `catgo`.
+> **China mirror / 中国大陆镜像:** if GitHub is unreachable, download the latest release from [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) — same full installers as GitHub Releases. As a fallback, a browser-based subset (no CatBot chat or desktop integration) installs via a PyPI mirror: `pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`, then run `catgo`.
 
 | System                    | Get the latest                                                      | File on the release page                                   |
 | ------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |

--- a/readme.md
+++ b/readme.md
@@ -287,6 +287,8 @@ Feature availability depends on the CatGo edition, installed optional dependenci
 
 Every link points at the **latest release**, so it stays current as new versions ship — current version: [![Latest release](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://github.com/Hello-QM/catgo-LRG/releases/latest). On the release page, pick the file for your platform (shown in the **File** column). For older versions and checksums, see [all Releases](https://github.com/Hello-QM/catgo-LRG/releases).
 
+> **China mirror / 中国大陆镜像:** if GitHub is unreachable, download the latest release from [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/), or install via a PyPI mirror: `pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`, then run `catgo`.
+
 | System                    | Get the latest                                                      | File on the release page                                   |
 | ------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **Windows**               | [⬇ Download](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_x64-setup.exe` or `CatGo_<ver>_x64_en-US.msi` |

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -288,6 +288,8 @@ catgo --help
 
 下表所有链接都指向**最新发布版**，随版本更新自动保持最新 —— 当前版本：[![最新版本](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://github.com/Hello-QM/catgo-LRG/releases/latest)。在发布页选择对应平台的文件（见 **文件** 列）。历史版本与校验和见 [全部 Releases](https://github.com/Hello-QM/catgo-LRG/releases)。
 
+> **中国大陆镜像：** 无法访问 GitHub 时，可从 [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) 下载最新版安装包；或通过 PyPI 镜像安装：`pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`，然后运行 `catgo`。
+
 | 系统                       | 获取最新版                                                         | 发布页上的文件                                                   |
 | ------------------------ | ------------------------------------------------------------- | --------------------------------------------------------- |
 | **Windows**              | [⬇ 下载](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_x64-setup.exe` 或 `CatGo_<ver>_x64_en-US.msi` |

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -288,7 +288,7 @@ catgo --help
 
 下表所有链接都指向**最新发布版**，随版本更新自动保持最新 —— 当前版本：[![最新版本](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://github.com/Hello-QM/catgo-LRG/releases/latest)。在发布页选择对应平台的文件（见 **文件** 列）。历史版本与校验和见 [全部 Releases](https://github.com/Hello-QM/catgo-LRG/releases)。
 
-> **中国大陆镜像：** 无法访问 GitHub 时，可从 [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) 下载最新版安装包；或通过 PyPI 镜像安装：`pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`，然后运行 `catgo`。
+> **中国大陆镜像：** 无法访问 GitHub 时，可从 [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) 下载最新版安装包（与 GitHub Releases 完全相同的完整版）。备选方案：通过 PyPI 镜像安装浏览器版（功能子集，不含 CatBot 聊天与桌面集成）：`pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`，然后运行 `catgo`。
 
 | 系统                       | 获取最新版                                                         | 发布页上的文件                                                   |
 | ------------------------ | ------------------------------------------------------------- | --------------------------------------------------------- |

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,8 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/Hello-QM/catgo-LRG/releases/latest/download/latest.json"
+        "https://github.com/Hello-QM/catgo-LRG/releases/latest/download/latest.json",
+        "https://dl.catgo-ucsd.org/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK",
       "windows": {


### PR DESCRIPTION
## Why

Users in mainland China report GitHub is unreachable — they can neither download CatGo installers nor receive in-app updates (the Tauri updater endpoint also points at github.com).

## What

- **New workflow `r2-release-mirror.yml`** — on `release: published` (or manual dispatch with a tag):
  - waits for the async build workflows to finish attaching assets (asset-count stabilization poll; skipped on manual dispatch)
  - `gh release download` → `aws s3 sync` to the R2 bucket under `<tag>/`
  - rewrites `latest.json` asset URLs from github.com to the mirror and uploads it to the bucket root
  - generates a minimal bilingual `index.html` download page
  - **keeps only the latest release** — older `<tag>/` prefixes are pruned (2.8 GB/release fits the 10 GB R2 free tier; R2 egress is free). Prune is skipped when the synced tag isn't the repo's latest, so backfilling an old tag can't delete the current one
  - no-ops gracefully (with a step-summary notice) until the R2 secrets are configured
- **`tauri.conf.json`** — adds `https://dl.catgo-ucsd.org/latest.json` as a fallback updater endpoint (GitHub stays first; Tauri falls through on failure), so installed apps behind the GFW can self-update
- **`readme.md` / `readme.zh.md`** — China-mirror note in the Download section (R2 mirror + Tsinghua PyPI mirror route)

## One-time setup (Cloudflare dashboard, ~5 min)

1. R2 → create bucket `catgo-releases`
2. Bucket → Settings → Custom Domains → `dl.catgo-ucsd.org` (zone already on this account)
3. R2 → Manage API Tokens → Object Read & Write on the bucket → add repo secrets `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` (`CLOUDFLARE_ACCOUNT_ID` already exists)
4. Optional repo vars `R2_BUCKET` / `R2_PUBLIC_BASE_URL` override the defaults

## Gotchas encoded in the workflow

- Releases published via `GITHUB_TOKEN` don't fire the `release` event (same as pypi-publish) — manual `workflow_dispatch` is the documented fallback and the sync is idempotent
- aws-cli ≥ 2.23 CRC checksums break R2's S3 API → `AWS_REQUEST_CHECKSUM_CALCULATION: when_required`
- Manually-uploaded assets (iOS .ipa) landing after publication → re-dispatch to pick them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)