### PR TITLE
fix(trajectory): keep bonds visible every frame on indexed/streaming trajectories

### DIFF
--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -25,6 +25,7 @@
   import { tooltip } from 'svelte-multiselect/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
   import { full_data_extractor } from './extract'
+  import { create_frame_position_cache } from './frame-positions'
   import type {
     ParseProgress,
     TrajectoryDataExtractor,
@@ -503,6 +504,10 @@
   let position_cache: Float32Array[] | null = null
   // Force cache: flat Float32Array of [fx,fy,fz] per atom per frame (null if no forces)
   let force_cache: Float32Array[] | null = null
+  // Indexed/streaming trajectories get no position_cache; this memoizes a
+  // transient positions array per frame index instead (stable Float32Array
+  // reference = bond frame-connectivity cache key stays valid on revisit).
+  const frame_pos_cache = create_frame_position_cache()
 
   // B3: null caches when the underlying frames array identity changes — i.e. a
   // real trajectory swap (loader assignment OR bind:trajectory parent reassignment
@@ -640,6 +645,9 @@
   $effect(() => {
     trajectory // track
     topology_initialized = false
+    // New trajectory identity (load, swap, or flush_pending_ops spread):
+    // memoized per-frame position arrays are stale — drop them.
+    frame_pos_cache.clear()
   })
 
   $effect(() => {
@@ -690,11 +698,33 @@
       // limitation; acceptable until a non-cascading writeback path exists.
     } else {
       // Indexed/streaming trajectories: no Float32Array cache available.
-      // Fall back to per-frame structure writes (slow path). This is the
-      // pre-Phase-4 behavior and is acceptable for the large-file workflow.
-      current_structure = frame.structure
-      trajectory_frame_positions = null
-      trajectory_frame_forces = null
+      // Constant-topology frames still get Architecture-P-style playback:
+      // materialize a memoized per-frame positions array and keep
+      // current_structure static, so the scene's trajectory bond fast-path
+      // (frame-connectivity cache + latest-wins async + stale-render) keeps
+      // bonds visible every frame. Before this, each frame re-wrote
+      // current_structure and re-entered the static bond pipeline, whose
+      // generation counter dropped almost every in-flight worker result
+      // during playback — bonds flashed only on the few frames where the
+      // worker beat the next frame advance (>1000-atom indexed files).
+      // Topology changes (variable atom count), force_slow_path sources
+      // (element-swap frames), and pending edit ops keep the true
+      // per-frame structure-write path.
+      const frame_sites = frame.structure.sites
+      if (
+        !force_slow_path && topology_initialized &&
+        current_structure?.sites.length === frame_sites.length &&
+        pending_ops.length === 0
+      ) {
+        const entry = frame_pos_cache.get(current_step_idx, frame_sites)
+        trajectory_frame_positions = entry.positions
+        trajectory_frame_forces = entry.forces
+      } else {
+        current_structure = frame.structure
+        topology_initialized = !force_slow_path && pending_ops.length === 0
+        trajectory_frame_positions = null
+        trajectory_frame_forces = null
+      }
     }
   })
 

--- a/src/lib/trajectory/frame-positions.ts
+++ b/src/lib/trajectory/frame-positions.ts
@@ -1,0 +1,67 @@
+/**
+ * Transient per-frame position/force arrays for indexed/streaming
+ * trajectories (the ones that get no `position_cache` in Trajectory.svelte).
+ *
+ * Entries are memoized per frame index so the Float32Array REFERENCE stays
+ * stable across revisits: the bond frame-connectivity cache in
+ * `bond-computation-controller.svelte.ts` keys on that reference
+ * (`frame_conn_cache.get(traj_positions)`), so scrub-back and looped
+ * playback hit the connectivity cache instead of re-dispatching detection.
+ * LRU-capped — 512 frames of a 1600-atom trajectory is ~10 MB.
+ */
+
+export const FRAME_POS_CACHE_MAX = 512
+
+export interface FramePositionEntry {
+  positions: Float32Array
+  forces: Float32Array | null
+}
+
+interface SiteLike {
+  xyz: readonly number[]
+  properties?: Record<string, unknown>
+}
+
+export function create_frame_position_cache(max: number = FRAME_POS_CACHE_MAX) {
+  const cache = new Map<number, FramePositionEntry>()
+
+  function get(frame_idx: number, sites: ReadonlyArray<SiteLike>): FramePositionEntry {
+    const hit = cache.get(frame_idx)
+    if (hit && hit.positions.length === sites.length * 3) {
+      // LRU touch: Map preserves insertion order; re-insert to move to back.
+      cache.delete(frame_idx)
+      cache.set(frame_idx, hit)
+      return hit
+    }
+    const n_sites = sites.length
+    const positions = new Float32Array(n_sites * 3)
+    let forces: Float32Array | null = null
+    for (let idx = 0; idx < n_sites; idx++) {
+      const xyz = sites[idx].xyz
+      positions[idx * 3] = xyz[0]
+      positions[idx * 3 + 1] = xyz[1]
+      positions[idx * 3 + 2] = xyz[2]
+      const force = sites[idx].properties?.force as number[] | undefined
+      if (force && force.length === 3) {
+        forces ??= new Float32Array(n_sites * 3)
+        forces[idx * 3] = force[0]
+        forces[idx * 3 + 1] = force[1]
+        forces[idx * 3 + 2] = force[2]
+      }
+    }
+    const entry: FramePositionEntry = { positions, forces }
+    cache.set(frame_idx, entry)
+    while (cache.size > max) {
+      const oldest = cache.keys().next().value
+      if (oldest === undefined) break
+      cache.delete(oldest)
+    }
+    return entry
+  }
+
+  return {
+    get,
+    clear: () => cache.clear(),
+    size: () => cache.size,
+  }
+}

--- a/tests/vitest/trajectory/frame-positions.test.ts
+++ b/tests/vitest/trajectory/frame-positions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+import { create_frame_position_cache } from '$lib/trajectory/frame-positions'
+
+const site = (x: number, y: number, z: number, force?: number[]) => ({
+  xyz: [x, y, z],
+  properties: force ? { force } : {},
+})
+
+describe(`create_frame_position_cache`, () => {
+  test(`builds a flat positions array from sites`, () => {
+    const cache = create_frame_position_cache()
+    const { positions, forces } = cache.get(0, [site(1, 2, 3), site(4, 5, 6)])
+    expect(Array.from(positions)).toEqual([1, 2, 3, 4, 5, 6])
+    expect(forces).toBeNull()
+  })
+
+  test(`extracts forces when present on any site`, () => {
+    const cache = create_frame_position_cache()
+    const { forces } = cache.get(0, [site(0, 0, 0, [0.1, 0.2, 0.3]), site(1, 1, 1)])
+    expect(forces).not.toBeNull()
+    expect(Array.from(forces!.slice(0, 3)).map((v) => Number(v.toFixed(6))))
+      .toEqual([0.1, 0.2, 0.3])
+    expect(Array.from(forces!.slice(3))).toEqual([0, 0, 0])
+  })
+
+  test(`returns the SAME Float32Array reference on revisit (bond-cache key stability)`, () => {
+    const cache = create_frame_position_cache()
+    const sites = [site(1, 2, 3)]
+    const first = cache.get(7, sites)
+    const again = cache.get(7, sites)
+    expect(again.positions).toBe(first.positions)
+  })
+
+  test(`rebuilds when the site count changed for the same frame index`, () => {
+    const cache = create_frame_position_cache()
+    const first = cache.get(0, [site(1, 2, 3)])
+    const grown = cache.get(0, [site(1, 2, 3), site(4, 5, 6)])
+    expect(grown.positions).not.toBe(first.positions)
+    expect(grown.positions.length).toBe(6)
+  })
+
+  test(`evicts least-recently-used entries beyond max`, () => {
+    const cache = create_frame_position_cache(2)
+    const s = [site(1, 1, 1)]
+    const e0 = cache.get(0, s)
+    cache.get(1, s)
+    cache.get(0, s) // touch 0 → 1 is now LRU
+    cache.get(2, s) // evicts 1
+    expect(cache.size()).toBe(2)
+    expect(cache.get(0, s).positions).toBe(e0.positions) // 0 survived
+    const e1_rebuilt = cache.get(1, s) // 1 was evicted → new array
+    expect(e1_rebuilt.positions.length).toBe(3)
+    expect(cache.size()).toBe(2)
+  })
+
+  test(`clear() drops all entries`, () => {
+    const cache = create_frame_position_cache()
+    const first = cache.get(0, [site(1, 2, 3)])
+    cache.clear()
+    expect(cache.size()).toBe(0)
+    expect(cache.get(0, [site(1, 2, 3)]).positions).not.toBe(first.positions)
+  })
+})


### PR DESCRIPTION
## Problem

Playing a large trajectory (e.g. 300MB / 1600-atom / 5000-frame LAMMPS `dump.xyz`) showed bonds only every few frames, irregularly.

## Root cause

Files over the 50MB text threshold (`MAX_TEXT_FILE_SIZE`) load via `load_with_indexing` → `frame_loader` attached → `position_cache` disabled → Architecture P fast-path off. Playback fell into the slow path: `current_structure` rewritten every frame, re-entering the **static** bond pipeline, whose generation counter drops nearly every in-flight worker result during playback (worker ~30-40ms vs frame advance). Bonds only rendered on frames where the worker won the race. Console evidence: zero `[bonds-traj]` logs during playback; 35+ worker completions vs ~5 `build_bond_pairs` in 6s.

## Fix

Extend Architecture-P-style playback to indexed trajectories with constant topology:

- New `src/lib/trajectory/frame-positions.ts`: memoized per-frame `Float32Array` builder (LRU-capped at 512 frames ≈ 10MB @1600 atoms). Stable array reference per frame index keeps the bond frame-connectivity cache (`frame_conn_cache`, keyed by reference) valid on scrub-back / looped playback.
- `Trajectory.svelte` slow path: constant-topology frames feed `trajectory_frame_positions` (+ forces when present) and leave `current_structure` static → the scene's trajectory bond fast-path (frame cache + latest-wins async + stale-render) keeps bonds visible every frame.
- Variable atom counts, `force_slow_path` sources (element-swap frames), and pending edit ops keep the old per-frame structure-write path; the memo cache clears on any trajectory identity change.

## Verification

- Live against the 300MB dump.xyz: `[bonds-traj]` dispatch cadence, `build_trajectory_bond_pairs` on **every** frame (~1700-2050 pairs), stale-filter dropping only single-digit stretched pairs, bonds visible throughout playback (screenshot-verified mid-play at frame 230/5000).
- `tests/vitest/trajectory`: 420 passed; +6 new unit tests for the frame-position cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)