### PR TITLE
feat(trajectory): default display mode to structure-only

### DIFF
--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -101,7 +101,7 @@
     fullscreen_toggle = DEFAULTS.trajectory.fullscreen_toggle,
     auto_play = false,
     reduced_motion = false,
-    display_mode = $bindable(`structure+scatter`),
+    display_mode = $bindable(`structure`),
     step_labels = 5,
     on_play,
     on_pause,


### PR DESCRIPTION
Opening a trajectory previously defaulted to `structure+scatter`. The scatter pane is secondary for most MD-playback use; default to the structure view and let users opt into the plot via the view-mode button.

No mount site passes `display_mode` explicitly, so the `$bindable` default is the single switch. Verified live: loading a trajectory lands on the Structure view with no scatter rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)