### PR TITLE
fix(server,viewer): streamed trajectory frames carry the cell + Compute-bonds banner receives real clicks

### DIFF
--- a/server/catgo/routers/trajectory_stream.py
+++ b/server/catgo/routers/trajectory_stream.py
@@ -340,13 +340,27 @@ def _atoms_to_frame(n: int, atoms: Any) -> dict[str, Any]:
         props["energy"] = float(atoms.get_potential_energy())
     except Exception:
         pass
-    return {
+    frame: dict[str, Any] = {
         "frame_number": n,
         "elements": list(atoms.get_chemical_symbols()),
         "positions": atoms.get_positions().tolist(),
         "comment": "",
         "properties": props,
     }
+    # Periodic frames must carry their cell. Without it the viewer builds a
+    # lattice-less structure, ferrox-wasm falls back to pbc=[F,F,F] brute-force
+    # neighbor search, and a 20k-atom .traj frame takes ~4s instead of ~0.1s
+    # per bond pass (and cross-cell bonds are wrong). ASE .traj and LAMMPS
+    # dump frames both land here; XDATCAR has its own reader that already
+    # emits `lattice`.
+    try:
+        if getattr(atoms, "pbc", None) is not None and atoms.pbc.any():
+            cell = atoms.get_cell()
+            if cell is not None and abs(float(cell.volume)) > 1e-9:
+                frame["lattice"] = [list(map(float, row)) for row in cell]
+    except Exception:
+        pass
+    return frame
 
 
 def _read_lammps_frame(p: Path, idx: _TrajIndex, n: int) -> dict[str, Any]:

--- a/server/tests/test_trajectory_stream_lattice.py
+++ b/server/tests/test_trajectory_stream_lattice.py
@@ -1,0 +1,41 @@
+"""Streamed trajectory frames must carry the cell for periodic structures.
+
+Regression test for the 20k-atom playback slowdown: `_atoms_to_frame`
+dropped `atoms.cell`, so the viewer built lattice-less structures and
+ferrox-wasm fell back to pbc=[F,F,F] brute-force neighbor search
+(~4s/frame at 20k atoms instead of ~0.1s with the cell list).
+"""
+
+import numpy as np
+import pytest
+
+ase = pytest.importorskip("ase")
+from ase import Atoms  # noqa: E402
+
+from catgo.routers.trajectory_stream import _atoms_to_frame  # noqa: E402
+
+
+def test_periodic_atoms_frame_carries_lattice():
+    cell = [[80.36, 0.0, 0.0], [0.0, 78.952, 0.0], [0.0, 0.0, 52.568]]
+    atoms = Atoms("SiO2", positions=[[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+                  cell=cell, pbc=True)
+    frame = _atoms_to_frame(3, atoms)
+    assert frame["frame_number"] == 3
+    assert frame["elements"] == ["Si", "O", "O"]
+    assert "lattice" in frame
+    assert np.allclose(frame["lattice"], cell)
+    # JSON-serializable plain floats, not numpy scalars
+    assert isinstance(frame["lattice"][0][0], float)
+
+
+def test_molecule_frame_has_no_lattice():
+    atoms = Atoms("H2O", positions=[[0, 0, 0], [0.96, 0, 0], [-0.24, 0.93, 0]])
+    frame = _atoms_to_frame(0, atoms)
+    assert "lattice" not in frame
+
+
+def test_zero_volume_cell_is_skipped():
+    # pbc flags set but degenerate (zero) cell — must not emit a bogus lattice.
+    atoms = Atoms("H2", positions=[[0, 0, 0], [0.74, 0, 0]], pbc=True)
+    frame = _atoms_to_frame(0, atoms)
+    assert "lattice" not in frame

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -4838,6 +4838,24 @@
     return { destroy: () => el.remove() }
   }
 
+  // Interactive overlays must NOT go through site_label_portal: threlte.dom
+  // forms its own stacking context that sits under sibling overlays like the
+  // atom legend (z-index 1), so a child's z-index can never lift it above
+  // them — real mouse clicks land on the legend while programmatic .click()
+  // still "works" (no hit test). Mount interactive banners one level up,
+  // as a sibling of those overlays, where their z-index actually applies.
+  function interactive_overlay_portal(el: HTMLDivElement) {
+    // The canvas-area wrapper between threlte.dom and .structure-main has
+    // z-index:0 (its own stacking context), so nothing inside it can ever
+    // stack above the atom legend, which is a DIRECT child of
+    // .structure-main. Mount interactive overlays on .structure-main itself.
+    const target = threlte.dom?.closest(`.structure-main`) ??
+      threlte.dom?.parentElement ?? threlte.dom
+    if (!target) return
+    target.append(el)
+    return { destroy: () => el.remove() }
+  }
+
   // Trigger a frame when label visibility changes, so the site-label
   // useTask can project the overlay DOM positions on its next run.
   $effect(() => {
@@ -6178,7 +6196,7 @@
      overrides the container's pointer-events:none so it stays clickable. -->
 {#if bonds_deferred && show_bonds !== `never`}
   <div
-    use:site_label_portal
+    use:interactive_overlay_portal
     class="bonds-deferred-banner"
     style:position="absolute"
     style:bottom="12px"
@@ -6258,7 +6276,10 @@
     font-size: 0.75em;
     white-space: nowrap;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-    z-index: 5;
+    /* Above the atom legend (z-index 1) — the banner is interactive and the
+       two can overlap at narrow widths; the legend must not eat its clicks. */
+    z-index: 10;
+    pointer-events: auto;
   }
   .bonds-deferred-banner button {
     font: inherit;


### PR DESCRIPTION
Two fixes discovered while chasing the same user report (20k-atom `dump.traj` playback: bonds missing, laggy, 'Compute bonds' button dead).

## 1. Backend: `_atoms_to_frame` dropped `atoms.cell` (the big one)

Every streamed `.traj` / `.lammpstrj` frame reached the viewer **lattice-less** (the landing-page Open File streams files >20MB through the backend). Downstream, ferrox-wasm treats a lattice-less structure as a molecule (`pbc=[F,F,F]`), forcing the O(N²) brute-force neighbor path instead of the cell list:

| | pbc | in-wasm detect (19968 atoms) |
|---|---|---|
| before | `[false,false,false]` | **3790–4321 ms** |
| after | `[true,true,true]` | **45–66 ms** (~70×) |

Native bench for reference: cell-list 75ms vs pbc-off 4.8s at 19683 atoms. Cross-cell bonds were also wrong without the cell. XDATCAR had its own reader that already emitted `lattice`; `.traj`/LAMMPS-dump now match. Emitted only for periodic, non-degenerate cells — molecules stay lattice-less. +3 backend tests.

## 2. Viewer: Compute-bonds banner never received real mouse clicks

The bonds-deferred banner (#507) was portaled into `threlte.dom`, whose canvas-area wrapper has `z-index:0` (own stacking context) — the banner could never stack above the atom legend (`z-index:1`, direct child of `.structure-main`). Where the two overlapped, every real click landed on the legend LABEL; programmatic `.click()` bypasses hit-testing, which is why it 'worked' in automation but not for the user. New `interactive_overlay_portal` mounts interactive overlays on `.structure-main` (sibling of the legend); banner raised to z-index 10. Verified via `elementFromPoint`: LABEL before → BUTTON after.

## Diagnosis trail

Native bench → staged in-wasm timings → worker-payload probe (`keys=[sites]`) → `console.trace` → `App.svelte stream_file_if_large` → `remote-frame-loader` (frontend lattice passthrough was already correct; the backend simply never sent one).

Pairs with #510 (playback fast-path) — together they take the 20k case from 'bonds flash every ~10s, seconds-long stalls' to bonds-every-frame at interactive rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)