### PR TITLE
feat(viewer): raise bond-deferral threshold 8000 → 30000 atoms

### DIFF
--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -30,9 +30,13 @@ const TRAJ_SYNC_THRESHOLD = 1000
  *
  * Deliberately set well above the 1000-atom sync threshold and the 2000-atom
  * GPU-picking threshold (`LARGE_STRUCTURE_THRESHOLD`) so only genuinely huge
- * structures defer — e.g. the 11k-atom LAMMPS kerogen case where computing
- * bonds on load is the jank source. Below this, behaviour is unchanged. */
-export const DEFER_BONDS_ABOVE_ATOMS = 8000
+ * structures defer. Originally 8000 (calibrated on the 11k-atom LAMMPS
+ * kerogen case), but that made routine 20k-atom systems (e.g. a zeolite +
+ * Pt-cluster trajectory, O13568 Si6144 Pt256) demand an extra click on every
+ * open; the one-time on-load pair build at that size is sub-second and the
+ * detection itself already runs async in the worker. Raised so only
+ * truly massive structures defer. Below this, behaviour is unchanged. */
+export const DEFER_BONDS_ABOVE_ATOMS = 30000
 
 /**
  * Pure decision helper: should bond connectivity be deferred for a structure

--- a/tests/vitest/structure/bonding/defer-bonds.test.ts
+++ b/tests/vitest/structure/bonding/defer-bonds.test.ts
@@ -16,7 +16,7 @@ describe(`should_defer_bonds`, () => {
   it(`is conservative: threshold sits well above the sync/GPU thresholds`, () => {
     // Must be far above the 1000-atom sync threshold and 2000-atom GPU threshold
     // so normal structures never defer.
-    expect(DEFER_BONDS_ABOVE_ATOMS).toBe(8000)
+    expect(DEFER_BONDS_ABOVE_ATOMS).toBe(30000)
     expect(DEFER_BONDS_ABOVE_ATOMS).toBeGreaterThan(2000)
   })
 
@@ -29,7 +29,10 @@ describe(`should_defer_bonds`, () => {
 
   it(`defers a genuinely huge structure that the user has not acted on`, () => {
     expect(should_defer_bonds(DEFER_BONDS_ABOVE_ATOMS + 1, false)).toBe(true)
-    expect(should_defer_bonds(11000, false)).toBe(true) // the kerogen case
+    // Mid-size systems compute on load since the threshold raise to 30000:
+    // 11k kerogen and 20k zeolite+Pt no longer demand a click on every open.
+    expect(should_defer_bonds(11000, false)).toBe(false)
+    expect(should_defer_bonds(19968, false)).toBe(false)
   })
 
   it(`un-defers once the user requests bonds, regardless of size`, () => {


### PR DESCRIPTION
The 8000-atom deferral (#507) made routine 20k-atom systems (zeolite + Pt-cluster trajectory, O13568 Si6144 Pt256) demand a 'Compute bonds' click on every open. The one-time on-load pair build at that size is sub-second and detection already runs async in the worker, so defer only truly massive structures. 11k kerogen / 20k zeolite now compute on load; tests updated to encode the new policy (5/5 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)