### PR TITLE
perf(trajectory): typed-array WASM bond boundary + kill redundant per-frame pipelines (20k-atom playback)

### DIFF
--- a/extensions/rust/src/wasm.rs
+++ b/extensions/rust/src/wasm.rs
@@ -5320,6 +5320,198 @@ pub fn detect_bonds_solid_angle(
     result.unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e))
 }
 
+/// Typed-array bond-detection result. Avoids serde JSON on the WASM boundary:
+/// each getter copies a flat typed array out of WASM memory (~500 KB total for
+/// 26k bonds, sub-millisecond) instead of serializing/parsing a multi-MB JSON
+/// string (~60 ms round trip at 20k atoms).
+#[wasm_bindgen]
+pub struct BondTable {
+    /// Site-index pairs, flat [i0, j0, i1, j1, ...] — 2 per bond.
+    pairs: Vec<u32>,
+    /// Periodic image offsets, flat [x0, y0, z0, x1, ...] — 3 per bond.
+    images: Vec<i8>,
+    /// Bond lengths in Å — 1 per bond.
+    lengths: Vec<f32>,
+    /// Bond strength estimates — 1 per bond.
+    strengths: Vec<f32>,
+}
+
+#[wasm_bindgen]
+impl BondTable {
+    #[wasm_bindgen(getter)]
+    pub fn count(&self) -> u32 {
+        (self.pairs.len() / 2) as u32
+    }
+    #[wasm_bindgen(getter)]
+    pub fn pairs(&self) -> Vec<u32> {
+        self.pairs.clone()
+    }
+    #[wasm_bindgen(getter)]
+    pub fn images(&self) -> Vec<i8> {
+        self.images.clone()
+    }
+    #[wasm_bindgen(getter)]
+    pub fn lengths(&self) -> Vec<f32> {
+        self.lengths.clone()
+    }
+    #[wasm_bindgen(getter)]
+    pub fn strengths(&self) -> Vec<f32> {
+        self.strengths.clone()
+    }
+}
+
+/// Detect bonds (atom_radii strategy) from raw typed arrays — no JSON on
+/// either side of the boundary. Built for per-frame trajectory bonding where
+/// the serde round trip dominates.
+///
+/// * `positions` — Cartesian coordinates, flat `[x0,y0,z0, x1,...]`, length 3N (Å)
+/// * `atomic_numbers` — element Z per site, length N
+/// * `lattice` — row-major 3×3 lattice matrix (9 values), or empty for
+///   non-periodic systems (a bounding-box lattice with pbc=[false;3] is
+///   derived, matching the JSON path's molecule handling)
+/// * `pbc` — per-axis periodicity flags (3 values, 0/1). Ignored when
+///   `lattice` is empty; defaults to fully periodic when empty but a lattice
+///   is given
+/// * `options_json` — optional `AtomRadiiOptions` JSON (same schema as
+///   `detect_bonds_radii`)
+#[wasm_bindgen]
+pub fn detect_bonds_radii_typed(
+    positions: &[f32],
+    atomic_numbers: &[u8],
+    lattice: &[f64],
+    pbc: &[u8],
+    options_json: Option<String>,
+) -> Result<BondTable, JsValue> {
+    let n_sites = atomic_numbers.len();
+    if positions.len() != n_sites * 3 {
+        return Err(JsValue::from_str(&format!(
+            "positions length {} != 3 * atomic_numbers length {}",
+            positions.len(),
+            n_sites
+        )));
+    }
+    if !lattice.is_empty() && lattice.len() != 9 {
+        return Err(JsValue::from_str(&format!(
+            "lattice must have 0 or 9 values, got {}",
+            lattice.len()
+        )));
+    }
+
+    let options: crate::bonding::AtomRadiiOptions = match options_json {
+        Some(ref json) => serde_json::from_str(json)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?,
+        None => crate::bonding::AtomRadiiOptions::default(),
+    };
+
+    let cart: Vec<nalgebra::Vector3<f64>> = (0..n_sites)
+        .map(|i| {
+            nalgebra::Vector3::new(
+                positions[i * 3] as f64,
+                positions[i * 3 + 1] as f64,
+                positions[i * 3 + 2] as f64,
+            )
+        })
+        .collect();
+
+    let (lat, pbc_arr, frac_coords) = if lattice.len() == 9 {
+        let matrix = nalgebra::Matrix3::from_row_slice(lattice);
+        let pbc_arr = if pbc.len() == 3 {
+            [pbc[0] != 0, pbc[1] != 0, pbc[2] != 0]
+        } else {
+            [true, true, true]
+        };
+        let lat = crate::lattice::Lattice::from_matrix_with_pbc(matrix, pbc_arr);
+        let frac = lat.get_fractional_coords(&cart);
+        (lat, pbc_arr, frac)
+    } else {
+        // Non-periodic: bounding-box lattice, mirroring io.rs molecule parsing
+        // (10 Å padding per side, 20 Å minimum box, frac offset from min).
+        let mut min = [f64::MAX; 3];
+        let mut max = [f64::MIN; 3];
+        for c in &cart {
+            for axis in 0..3 {
+                min[axis] = min[axis].min(c[axis]);
+                max[axis] = max[axis].max(c[axis]);
+            }
+        }
+        if cart.is_empty() {
+            min = [0.0; 3];
+            max = [0.0; 3];
+        }
+        let padding = 10.0;
+        let size = [
+            (max[0] - min[0] + 2.0 * padding).max(20.0),
+            (max[1] - min[1] + 2.0 * padding).max(20.0),
+            (max[2] - min[2] + 2.0 * padding).max(20.0),
+        ];
+        let matrix = nalgebra::Matrix3::new(
+            size[0], 0.0, 0.0, 0.0, size[1], 0.0, 0.0, 0.0, size[2],
+        );
+        let lat = crate::lattice::Lattice::from_matrix_with_pbc(
+            matrix,
+            [false, false, false],
+        );
+        let frac: Vec<nalgebra::Vector3<f64>> = cart
+            .iter()
+            .map(|c| {
+                nalgebra::Vector3::new(
+                    (c[0] - min[0] + padding) / size[0],
+                    (c[1] - min[1] + padding) / size[1],
+                    (c[2] - min[2] + padding) / size[2],
+                )
+            })
+            .collect();
+        (lat, [false, false, false], frac)
+    };
+
+    let site_occupancies: Vec<crate::species::SiteOccupancy> = atomic_numbers
+        .iter()
+        .enumerate()
+        .map(|(idx, &z)| {
+            crate::element::Element::from_atomic_number(z)
+                .map(|el| {
+                    crate::species::SiteOccupancy::ordered(
+                        crate::species::Species::neutral(el),
+                    )
+                })
+                .ok_or_else(|| {
+                    JsValue::from_str(&format!(
+                        "site {idx}: unknown atomic number {z}"
+                    ))
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let structure = crate::structure::Structure::try_new_full(
+        lat,
+        site_occupancies,
+        frac_coords,
+        pbc_arr,
+        0.0,
+        std::collections::HashMap::new(),
+    )
+    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let bonds = crate::bonding::detect_bonds_atom_radii(&structure, &options);
+
+    let mut table = BondTable {
+        pairs: Vec::with_capacity(bonds.len() * 2),
+        images: Vec::with_capacity(bonds.len() * 3),
+        lengths: Vec::with_capacity(bonds.len()),
+        strengths: Vec::with_capacity(bonds.len()),
+    };
+    for bond in &bonds {
+        table.pairs.push(bond.site_idx_1 as u32);
+        table.pairs.push(bond.site_idx_2 as u32);
+        table.images.push(bond.image[0] as i8);
+        table.images.push(bond.image[1] as i8);
+        table.images.push(bond.image[2] as i8);
+        table.lengths.push(bond.bond_length as f32);
+        table.strengths.push(bond.strength as f32);
+    }
+    Ok(table)
+}
+
 /// Find adsorption sites on a surface structure using GASCAP-like algorithm.
 /// Returns JSON AdsorptionSiteResult: { sites, n_top, n_bridge, n_hollow }
 #[wasm_bindgen]

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -14,7 +14,6 @@
 
   import { DEFAULTS, type ShowBonds } from '$lib/settings'
   import type { BondingStrategy } from './bonding'
-  import { create_trajectory_bond_cache, wire_trajectory_bond_cache } from './trajectory-bond-cache.svelte'
   import { colors, atom_clipboard } from '$lib/state.svelte'
   import type { PymatgenStructure } from '$lib/structure'
   import {
@@ -1297,10 +1296,6 @@
   // Track if structure has been aligned to prevent re-alignment
   let structure_aligned_id = $state<string | null>(null)
   let trajectory_active = $derived(trajectory_frame_positions != null)
-  // Per-frame bond cache lives below — needs supercell_structure ($derived
-  // declared further down) in its driver effect. Declared placeholder so
-  // template references still resolve before the real binding initializes.
-  let trajectory_bond_connectivity_for_frame: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> | null = $state(null)
 
   // T5 pause writeback (search "T5 pause writeback" in src/lib/trajectory/Trajectory.svelte):
   // a $effect lived here that watched trajectory_active (= trajectory_frame_positions
@@ -1991,28 +1986,15 @@
   let supercell_structure = $derived(transform.supercell_structure)
   let supercell_loading = $derived(transform.supercell_loading)
 
-  // Per-frame bond cache for trajectory playback. Effects (clear / drive /
-  // push) live in trajectory-bond-cache.svelte.ts to keep this file lean.
-  const trajectory_bond_cache = create_trajectory_bond_cache()
-  wire_trajectory_bond_cache(trajectory_bond_cache, {
-    get_structure: () => structure,
-    get_base: () => supercell_structure ?? structure,
-    get_step_idx: () => trajectory_step_idx,
-    get_positions_version: () => trajectory_positions_version.v,
-    get_positions_invalidate_all: () => trajectory_positions_version.all,
-    get_trajectory_active: () => trajectory_active,
-    get_positions: () => get_trajectory_frame_positions,
-    get_strategy: () => (scene_props?.bonding_strategy ?? `atom_radii`) as BondingStrategy,
-    get_show_bonds: () => (scene_props?.show_bonds ?? `always`) as string,
-    get_options: () => (scene_props?.bonding_options ?? {}) as Record<string, number>,
-    set_connectivity: (v) => { trajectory_bond_connectivity_for_frame = v },
-    get_connectivity: () => trajectory_bond_connectivity_for_frame,
-    // WebGPU overlay active ⇒ suspend the per-frame async bond recompute. The
-    // overlay computes its own GPU bonds and does not read
-    // trajectory_bond_connectivity_for_frame. Read reactively inside the driver
-    // effect so toggle-OFF re-primes the current frame's connectivity.
-    get_suspended: () => webgl_suspended,
-  })
+  // The per-frame TrajectoryBondCache pipeline (create_trajectory_bond_cache +
+  // wire_trajectory_bond_cache) was removed here: its only sink was the
+  // `trajectory_bond_connectivity` prop on StructureScene, which nothing in
+  // StructureScene reads — the trajectory fast path in
+  // bond-computation-controller (compute_bond_connectivity_for_frame) owns
+  // per-frame bonds. The wire cost one full worker bond detection per frame
+  // plus a prefetch burst (each with a 20k-site structure clone) at 20k
+  // atoms, all discarded. Module + unit tests remain for the isolated cache;
+  // delete them in a follow-up if no consumer reappears.
 
   // Track selection to restore after atom movement
   let saved_selection: number[] | null = null
@@ -4402,7 +4384,6 @@
             {trajectory_frame_positions}
             {trajectory_frame_forces}
             {trajectory_step_idx}
-            trajectory_bond_connectivity={trajectory_bond_connectivity_for_frame}
             {...scene_props}
             {show_image_atoms}
             {clip_center}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -592,7 +592,6 @@
     // Per-frame bond connectivity from the async trajectory bond cache. When
     // null (cache miss), we fall back to `bond_state.bond_connectivity`
     // (frame-0 static).
-    trajectory_bond_connectivity = null as Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> | null,
     webgl_suspended = false,
     on_reset_rotation,
     on_atom_context_menu,
@@ -881,7 +880,6 @@
     // Trajectory fast-path: flat Float32Array of forces (fx,fy,fz) per atom
     trajectory_frame_forces?: Float32Array | null
     // Per-frame bond connectivity (from trajectory bond cache). Null = fall back to static.
-    trajectory_bond_connectivity?: Array<{ site_idx_1: number; site_idx_2: number; strength: number; jimage: [number, number, number] }> | null
     /** WebGPU large-system overlay active. When true the WebGL scene is fully
      *  covered by the overlay and `autoRender` is off, so this scene must do
      *  ZERO per-frame work: the trajectory bond-pair rebuild is skipped. Read
@@ -2388,6 +2386,19 @@
     scale: bond_scale,
   })
   $effect.pre(() => {
+    // Fixed-topology trajectory playback: the trajectory fast-path
+    // (compute_bond_connectivity_for_frame + build_trajectory_bond_pairs in
+    // the bond-pairs effect below) owns bond state while frame positions
+    // stream. On indexed/streaming trajectories the per-frame structure
+    // cascade still reaches this effect (bond_input identity changes each
+    // frame); without this gate the async path clears bond_connectivity and
+    // re-runs a full worker detection per frame — at 20k atoms that's two
+    // redundant ~130ms JSON computes plus three bond-pair rebuilds per frame
+    // fighting the fast path. Read reactively so trajectory teardown
+    // (positions → null) re-fires this effect and recomputes static bonds.
+    // Variable-N trajectories keep trajectory_frame_positions === null and
+    // still take this path per frame — it is their only bond source.
+    if (trajectory_frame_positions != null) return
     // `trajectory_step_idx >= 0` is the trajectory-active signal: variable-N
     // trajectories drive this slow path per frame (no fast-path positions), so
     // it triggers the extension-only solid_angle -> atom_radii downgrade inside

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -917,6 +917,63 @@ export function build_bond_pairs(
   }).filter((b): b is BondPair => b !== null)
 }
 
+/** Per-bond stale-distance thresholds, memoized on connectivity identity.
+ *
+ * The per-frame fast path used to resolve each endpoint's majority species
+ * and covalent radius from the JSON table twice per bond per frame — ~52k
+ * dictionary lookups per frame for a 26k-bond trajectory, the dominant cost
+ * of `build_trajectory_bond_pairs` (~120ms/frame at 20k atoms). Connectivity
+ * and sites are stable across playback frames, so the thresholds are
+ * computed once per connectivity refresh and reused every frame.
+ *
+ * Entries where either radius is unavailable hold NaN — the caller's
+ * `bond_length > max_dist` check is then always false, preserving the
+ * skip-when-unavailable behavior of the old per-bond lookup. Out-of-range
+ * site indices (supercell extras beyond `sites`) also yield NaN. */
+const traj_max_dist_cache = new WeakMap<object, {
+  sites: ReadonlyArray<Site>
+  tol: number
+  max_dists: Float64Array
+}>()
+
+function get_traj_max_dists(
+  bond_connectivity: ReadonlyArray<{ site_idx_1: number; site_idx_2: number }>,
+  sites: ReadonlyArray<Site>,
+  tol: number,
+): Float64Array {
+  const cached = traj_max_dist_cache.get(bond_connectivity)
+  if (cached && cached.sites === sites && cached.tol === tol) return cached.max_dists
+
+  const n_sites = sites.length
+  const radii = new Float64Array(n_sites).fill(NaN)
+  for (let idx = 0; idx < n_sites; idx++) {
+    const species = sites[idx]?.species
+    if (!species || species.length === 0) continue
+    let majority = species[0]
+    for (let sp = 1; sp < species.length; sp++) {
+      if (species[sp].occu > majority.occu) majority = species[sp]
+    }
+    if (!majority.element) continue
+    const entry = (covalent_radii_data as Record<
+      string,
+      { covalent_radius_pm?: number } | undefined
+    >)[majority.element]
+    const pm = entry?.covalent_radius_pm
+    if (typeof pm === `number` && pm > 0) radii[idx] = pm / 100 // pm → Å
+  }
+
+  const max_dists = new Float64Array(bond_connectivity.length)
+  for (let bond = 0; bond < bond_connectivity.length; bond++) {
+    const conn = bond_connectivity[bond]
+    // Float64Array OOB reads give undefined → NaN after arithmetic, matching
+    // the radius-unavailable skip semantics.
+    max_dists[bond] = (radii[conn.site_idx_1] + radii[conn.site_idx_2]) * tol *
+      STALE_DISTANCE_FACTOR
+  }
+  traj_max_dist_cache.set(bond_connectivity, { sites, tol, max_dists })
+  return max_dists
+}
+
 /**
  * Build bond_pairs from trajectory frame positions (flat Float32Array).
  * Used for trajectory fast-path playback.
@@ -982,34 +1039,13 @@ export function build_trajectory_bond_pairs(
     }
     return null
   }
-  // Stale-bond pre-filter: resolve majority-species element for site_idx and
-  // look up its single-bond covalent radius (Å). Returns null if the species
-  // is missing or the element isn't in the radii table — in that case the
-  // distance check is skipped for the bond (preserves prior behavior).
-  function covalent_radius_for(site_idx: number): number | null {
-    if (!sites) return null
-    const site = sites[site_idx]
-    if (!site || !site.species || site.species.length === 0) return null
-    let majority = site.species[0]
-    for (let i = 1; i < site.species.length; i++) {
-      if (site.species[i].occu > majority.occu) majority = site.species[i]
-    }
-    const elem = majority.element
-    if (!elem) return null
-    const entry = (covalent_radii_data as Record<
-      string,
-      { covalent_radius_pm?: number } | undefined
-    >)[elem]
-    const pm = entry?.covalent_radius_pm
-    if (typeof pm !== `number` || pm <= 0) return null
-    return pm / 100 // pm → Å
-  }
   const tol = typeof bond_tolerance === `number` && bond_tolerance > 0
     ? bond_tolerance
     : DEFAULT_BOND_TOLERANCE
+  const max_dists = sites ? get_traj_max_dists(bond_connectivity, sites, tol) : null
   const lat = lattice_matrix ?? undefined
   let filtered_count = 0
-  const out = bond_connectivity.map((conn) => {
+  const out = bond_connectivity.map((conn, bond_idx) => {
     const pos_1 = lookup_pos(conn.site_idx_1)
     const pos_2 = lookup_pos(conn.site_idx_2)
     if (pos_1 === null || pos_2 === null) return null
@@ -1019,15 +1055,11 @@ export function build_trajectory_bond_pairs(
     const dy = b_eff[1] - pos_1[1]
     const dz = b_eff[2] - pos_1[2]
     const bond_length = Math.hypot(dx, dy, dz)
-    // Stale-distance pre-filter (skipped silently when radii unavailable).
-    const r_a = covalent_radius_for(conn.site_idx_1)
-    const r_b = covalent_radius_for(conn.site_idx_2)
-    if (r_a !== null && r_b !== null) {
-      const max_dist = (r_a + r_b) * tol * STALE_DISTANCE_FACTOR
-      if (bond_length > max_dist) {
-        filtered_count++
-        return null
-      }
+    // Stale-distance pre-filter. NaN max_dist (radius unavailable) makes the
+    // comparison false, silently skipping the check for that bond.
+    if (max_dists && bond_length > max_dists[bond_idx]) {
+      filtered_count++
+      return null
     }
     const pair: BondPair = {
       pos_1,

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -10,7 +10,10 @@ import { BOND_KIND, type BondManager } from './bonding/bond-manager.svelte'
 import {
   compute_bonds_async,
   compute_bonds_sync,
+  compute_bonds_typed_worker,
   compute_hbonds_worker,
+  effective_strategy,
+  type TypedBondTable,
 } from './workers/bond-worker-api'
 import { filter_bonds_during_drag, should_show_bonds } from './scene'
 import { get_element_fingerprint, get_position_hash } from './scene'
@@ -660,13 +663,13 @@ export function compute_bond_connectivity_for_frame(
   }
 
   const n_sites = sites.length
-  const overlay_structure = build_trajectory_overlay_structure(
-    structure,
-    traj_positions,
-  )
 
   // 2. Sync path for small structures — fastest, no scheduling overhead.
   if (n_sites <= TRAJ_SYNC_THRESHOLD) {
+    const overlay_structure = build_trajectory_overlay_structure(
+      structure,
+      traj_positions,
+    )
     const sync_bonds = compute_bonds_sync(
       overlay_structure,
       bonding_strategy,
@@ -701,7 +704,6 @@ export function compute_bond_connectivity_for_frame(
     dispatch_traj_async(
       bond_state,
       traj_positions,
-      overlay_structure,
       structure,
       strategy_key,
       elem_fp,
@@ -720,14 +722,92 @@ export function compute_bond_connectivity_for_frame(
   return bond_state.bond_connectivity
 }
 
+/** Per-site atomic numbers for the typed worker path, memoized on the sites
+ *  array identity (stable across trajectory frames). `null` (also cached)
+ *  means at least one site's majority element has no table entry — the typed
+ *  path can't represent it, so callers use the JSON path. */
+const traj_z_cache = new WeakMap<object, Uint8Array | null>()
+
+/** Exported for tests. */
+export function get_traj_atomic_numbers(
+  sites: ReadonlyArray<Site>,
+): Uint8Array | null {
+  const cached = traj_z_cache.get(sites)
+  if (cached !== undefined) return cached
+  const zs = new Uint8Array(sites.length)
+  let ok = true
+  for (let idx = 0; idx < sites.length; idx++) {
+    const species = sites[idx]?.species
+    if (!species || species.length === 0) {
+      ok = false
+      break
+    }
+    let majority = species[0]
+    for (let sp = 1; sp < species.length; sp++) {
+      if (species[sp].occu > majority.occu) majority = species[sp]
+    }
+    const z = (covalent_radii_data as Record<
+      string,
+      { atomic_number?: number } | undefined
+    >)[majority.element]?.atomic_number
+    if (typeof z !== `number` || z < 1 || z > 255) {
+      ok = false
+      break
+    }
+    zs[idx] = z
+  }
+  const result = ok ? zs : null
+  traj_z_cache.set(sites, result)
+  return result
+}
+
+/** Convert a typed bond table to connectivity objects, applying the same
+ *  cross-cell self-image filter as `wasm_bonds_to_pairs` (drop a==b bonds
+ *  with a non-zero image — the "starburst" stubs around cell-face atoms).
+ *  Exported for tests. */
+export function typed_table_to_conn(
+  table: TypedBondTable,
+): Array<
+  {
+    site_idx_1: number
+    site_idx_2: number
+    strength: number
+    jimage: [number, number, number]
+  }
+> {
+  const n_bonds = table.pairs.length / 2
+  const conn = []
+  for (let idx = 0; idx < n_bonds; idx++) {
+    const site_a = table.pairs[idx * 2]
+    const site_b = table.pairs[idx * 2 + 1]
+    const jx = table.images[idx * 3]
+    const jy = table.images[idx * 3 + 1]
+    const jz = table.images[idx * 3 + 2]
+    if (site_a === site_b && (jx | jy | jz) !== 0) continue
+    conn.push({
+      site_idx_1: site_a,
+      site_idx_2: site_b,
+      strength: table.strengths[idx],
+      jimage: [jx, jy, jz] as [number, number, number],
+    })
+  }
+  return conn
+}
+
 /** Async bond detection for a trajectory frame. Race-protected via
  *  `traj_computation_gen`. On resolve, caches the result; if the frame is
  *  still current, also writes to `bond_state.bond_connectivity` to trigger
- *  a fresh render. Throttle slots are released on every exit path. */
+ *  a fresh render. Throttle slots are released on every exit path.
+ *
+ *  Route selection: when the effective strategy is atom_radii (always the
+ *  case for large trajectories — solid_angle downgrades above 8k atoms) and
+ *  every element maps to an atomic number, positions go to the worker as a
+ *  transferred Float32Array and bonds come back as flat typed arrays — no
+ *  overlay-structure build, no JSON. Anything else (exotic species, other
+ *  strategies, worker failure) falls back to the JSON path. */
 function dispatch_traj_async(
   bond_state: ReturnType<typeof create_bond_state>,
   frame_key: Float32Array,
-  overlay_structure: AnyStructure,
   base_structure: AnyStructure,
   strategy_key: string,
   elem_fp: string,
@@ -735,9 +815,10 @@ function dispatch_traj_async(
   bonding_options: Record<string, unknown>,
 ): void {
   const gen = ++bond_state.traj_computation_gen
+  const n_sites = base_structure.sites.length
   if (import.meta.env?.DEV) {
     console.log(
-      `[bonds-traj] dispatch async | ${overlay_structure.sites.length} sites | gen=${gen}`,
+      `[bonds-traj] dispatch async | ${n_sites} sites | gen=${gen}`,
     )
   }
   // Helper: clear throttle slots that still reference this dispatch's
@@ -750,72 +831,120 @@ function dispatch_traj_async(
       bond_state.traj_pending_frame = null
     }
   }
-  compute_bonds_async(
-    overlay_structure,
-    bonding_strategy,
-    bonding_options as Record<string, number>,
-  )
-    .then((new_bonds) => {
-      // Stale generation — trajectory torn down, strategy changed, or another
-      // traj dispatch superseded this one. Drop the result and release slots
-      // so the next dispatch can proceed.
-      if (gen !== bond_state.traj_computation_gen) {
-        release_slots()
-        return
-      }
 
-      const new_conn = new_bonds.map((b) => ({
-        site_idx_1: b.site_idx_1,
-        site_idx_2: b.site_idx_2,
-        strength: b.strength,
-        jimage: (b.jimage ?? [0, 0, 0]) as [number, number, number],
-      }))
-      // Always cache — even if the user has moved on, the entry will be
-      // useful on revisit (and bounded by the LRU cap).
-      frame_cache_set(frame_key, {
-        bond_connectivity: new_conn,
-        fingerprint: `${elem_fp}|frame`,
-        elem_fingerprint: elem_fp,
-        strategy_key,
-      })
-
-      const pending = bond_state.traj_pending_frame
-      if (pending === null) {
-        // No newer frame queued → the resolved frame is the latest visible.
-        // Reassigning bond_connectivity here is safe because we're in the
-        // promise resolve callback, NOT inside the trajectory $effect.pre body.
-        bond_state.bond_connectivity = new_conn
-        bond_state.last_bond_structure = base_structure
-        bond_state.last_bond_strategy = strategy_key
-        bond_state.last_elem_fingerprint = elem_fp
-        bond_state.last_bond_fingerprint = `${elem_fp}|frame`
-        bond_state.traj_in_flight_frame = null
-      } else {
-        // User moved on while async was running. Drain the latest-wins queue:
-        // dispatch detection for the pending frame. The resolved frame is
-        // already cached so a future revisit will hit O(1).
-        bond_state.traj_in_flight_frame = pending
-        bond_state.traj_pending_frame = null
-        const next_overlay = build_trajectory_overlay_structure(
-          base_structure,
-          pending,
-        )
-        dispatch_traj_async(
-          bond_state,
-          pending,
-          next_overlay,
-          base_structure,
-          strategy_key,
-          elem_fp,
-          bonding_strategy,
-          bonding_options,
-        )
+  // Shared resolve flow for both routes. Conversion to connectivity objects
+  // happens before this call; everything after (gen check, frame cache,
+  // latest-wins drain) is route-independent.
+  const handle_conn = (
+    new_conn: Array<
+      {
+        site_idx_1: number
+        site_idx_2: number
+        strength: number
+        jimage: [number, number, number]
       }
-    })
-    .catch((e) => {
-      console.debug(`[bonds-traj] async failed:`, e)
+    >,
+  ) => {
+    // Stale generation — trajectory torn down, strategy changed, or another
+    // traj dispatch superseded this one. Drop the result and release slots
+    // so the next dispatch can proceed.
+    if (gen !== bond_state.traj_computation_gen) {
       release_slots()
+      return
+    }
+
+    // Always cache — even if the user has moved on, the entry will be
+    // useful on revisit (and bounded by the LRU cap).
+    frame_cache_set(frame_key, {
+      bond_connectivity: new_conn,
+      fingerprint: `${elem_fp}|frame`,
+      elem_fingerprint: elem_fp,
+      strategy_key,
     })
+
+    const pending = bond_state.traj_pending_frame
+    if (pending === null) {
+      // No newer frame queued → the resolved frame is the latest visible.
+      // Reassigning bond_connectivity here is safe because we're in the
+      // promise resolve callback, NOT inside the trajectory $effect.pre body.
+      bond_state.bond_connectivity = new_conn
+      bond_state.last_bond_structure = base_structure
+      bond_state.last_bond_strategy = strategy_key
+      bond_state.last_elem_fingerprint = elem_fp
+      bond_state.last_bond_fingerprint = `${elem_fp}|frame`
+      bond_state.traj_in_flight_frame = null
+    } else {
+      // User moved on while async was running. Drain the latest-wins queue:
+      // dispatch detection for the pending frame. The resolved frame is
+      // already cached so a future revisit will hit O(1).
+      bond_state.traj_in_flight_frame = pending
+      bond_state.traj_pending_frame = null
+      dispatch_traj_async(
+        bond_state,
+        pending,
+        base_structure,
+        strategy_key,
+        elem_fp,
+        bonding_strategy,
+        bonding_options,
+      )
+    }
+  }
+
+  const run_json = () => {
+    const overlay_structure = build_trajectory_overlay_structure(
+      base_structure,
+      frame_key,
+    )
+    compute_bonds_async(
+      overlay_structure,
+      bonding_strategy,
+      bonding_options as Record<string, number>,
+    )
+      .then((new_bonds) =>
+        handle_conn(new_bonds.map((b) => ({
+          site_idx_1: b.site_idx_1,
+          site_idx_2: b.site_idx_2,
+          strength: b.strength,
+          jimage: (b.jimage ?? [0, 0, 0]) as [number, number, number],
+        })))
+      )
+      .catch((e) => {
+        console.debug(`[bonds-traj] async failed:`, e)
+        release_slots()
+      })
+  }
+
+  const zs = effective_strategy(bonding_strategy, n_sites) === `atom_radii`
+    ? get_traj_atomic_numbers(base_structure.sites)
+    : null
+  if (zs && frame_key.length === n_sites * 3) {
+    const crystal = base_structure as Crystal
+    const pbc_raw = crystal.lattice?.pbc
+    const pbc = Array.isArray(pbc_raw) && pbc_raw.length === 3
+      ? [!!pbc_raw[0], !!pbc_raw[1], !!pbc_raw[2]] as [boolean, boolean, boolean]
+      : null
+    compute_bonds_typed_worker(
+      frame_key,
+      zs,
+      crystal.lattice?.matrix ?? null,
+      pbc,
+      bonding_options as Record<string, number>,
+    )
+      .then((table) => {
+        if (table === null) {
+          run_json()
+          return
+        }
+        handle_conn(typed_table_to_conn(table))
+      })
+      .catch((e) => {
+        console.debug(`[bonds-traj] typed path failed, falling back:`, e)
+        run_json()
+      })
+  } else {
+    run_json()
+  }
 }
 
 /**

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -1064,15 +1064,15 @@ const traj_max_dist_cache = new WeakMap<object, {
   tol: number
   max_dists: Float64Array
 }>()
+/** Per-site covalent radii keyed by the sites array identity. Sites are
+ *  Svelte 5 deep proxies at 20k atoms — scanning species per site costs
+ *  ~30ms per pass, so it must run once per trajectory, not once per
+ *  connectivity refresh (connectivity identity changes every frame). */
+const traj_site_radii_cache = new WeakMap<object, Float64Array>()
 
-function get_traj_max_dists(
-  bond_connectivity: ReadonlyArray<{ site_idx_1: number; site_idx_2: number }>,
-  sites: ReadonlyArray<Site>,
-  tol: number,
-): Float64Array {
-  const cached = traj_max_dist_cache.get(bond_connectivity)
-  if (cached && cached.sites === sites && cached.tol === tol) return cached.max_dists
-
+function get_traj_site_radii(sites: ReadonlyArray<Site>): Float64Array {
+  const cached = traj_site_radii_cache.get(sites)
+  if (cached) return cached
   const n_sites = sites.length
   const radii = new Float64Array(n_sites).fill(NaN)
   for (let idx = 0; idx < n_sites; idx++) {
@@ -1090,7 +1090,19 @@ function get_traj_max_dists(
     const pm = entry?.covalent_radius_pm
     if (typeof pm === `number` && pm > 0) radii[idx] = pm / 100 // pm → Å
   }
+  traj_site_radii_cache.set(sites, radii)
+  return radii
+}
 
+function get_traj_max_dists(
+  bond_connectivity: ReadonlyArray<{ site_idx_1: number; site_idx_2: number }>,
+  sites: ReadonlyArray<Site>,
+  tol: number,
+): Float64Array {
+  const cached = traj_max_dist_cache.get(bond_connectivity)
+  if (cached && cached.sites === sites && cached.tol === tol) return cached.max_dists
+
+  const radii = get_traj_site_radii(sites)
   const max_dists = new Float64Array(bond_connectivity.length)
   for (let bond = 0; bond < bond_connectivity.length; bond++) {
     const conn = bond_connectivity[bond]

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -50,61 +50,72 @@ function get_majority_species(site: Site) {
 
 // Compute 4x4 transformation matrix for bond cylinder between two positions.
 // Uses Y-up, right-handed coordinate system convention for Three.js compatibility.
+// Runs once per bond per trajectory frame (26k calls/frame at 20k atoms) —
+// written allocation-free apart from the returned matrix; no intermediate
+// arrays or destructuring tuples.
 export function compute_bond_transform(pos_1: Vec3, pos_2: Vec3): Float32Array {
-  const [dx, dy, dz] = math.subtract(pos_2, pos_1)
+  const dx = pos_2[0] - pos_1[0]
+  const dy = pos_2[1] - pos_1[1]
+  const dz = pos_2[2] - pos_1[2]
   const height = Math.hypot(dx, dy, dz)
 
+  const out = new Float32Array(16) // flattened column-major 4x4 for Three.js
+  out[15] = 1
   if (height < 1e-10) {
-    return new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+    out[0] = 1
+    out[5] = 1
+    out[10] = 1
+    return out
   }
 
-  const [dir_x, dir_y, dir_z] = [dx / height, dy / height, dz / height]
-  let [m00, m01, m02, m10, m11, m12, m20, m21, m22] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+  const dir_x = dx / height
+  const dir_y = dy / height
+  const dir_z = dz / height
+  let m00 = 0, m01 = 0, m02 = 0, m10 = 0, m11 = 0, m12 = 0, m20 = 0, m21 = 0, m22 = 0
 
   // Special case: bond pointing straight up (+Y)
   if (Math.abs(dir_y - 1.0) < 1e-10) {
-    ;[m00, m01, m02, m10, m11, m12, m20, m21, m22] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    m00 = 1
+    m11 = 1
+    m22 = 1
   } else if (Math.abs(dir_y + 1.0) < 1e-10) {
     // Special case: bond pointing straight down (-Y)
-    ;[m00, m01, m02, m10, m11, m12, m20, m21, m22] = [1, 0, 0, 0, -1, 0, 0, 0, 1]
+    m00 = 1
+    m11 = -1
+    m22 = 1
   } else {
     // General case: construct orthonormal basis (right, dir, up)
     // Right vector: perpendicular to dir in XZ plane
-    const [rx, rz] = [-dir_z, dir_x]
+    const rx = -dir_z
+    const rz = dir_x
     const r_len = Math.hypot(rx, rz)
-    const [right_x, right_z] = [rx / r_len, rz / r_len]
+    const right_x = rx / r_len
+    const right_z = rz / r_len
     // Up vector: cross product of dir and right
-    const [up_x, up_y, up_z] = [
-      dir_y * right_z,
-      dir_z * right_x - dir_x * right_z,
-      -dir_y * right_x,
-    ]
-    ;[m00, m01, m02, m10, m11, m12, m20, m21, m22] = [
-      right_x,
-      dir_x,
-      up_x,
-      0,
-      dir_y,
-      up_y,
-      right_z,
-      dir_z,
-      up_z,
-    ]
+    m00 = right_x
+    m01 = dir_x
+    m02 = dir_y * right_z
+    m11 = dir_y
+    m12 = dir_z * right_x - dir_x * right_z
+    m20 = right_z
+    m21 = dir_z
+    m22 = -dir_y * right_x
   }
 
+  out[0] = m00
+  out[1] = m10
+  out[2] = m20
+  out[4] = m01 * height
+  out[5] = m11 * height
+  out[6] = m21 * height
+  out[8] = m02
+  out[9] = m12
+  out[10] = m22
   // Position at midpoint between the two atoms
-  const [px, py, pz] = [
-    (pos_1[0] + pos_2[0]) / 2,
-    (pos_1[1] + pos_2[1]) / 2,
-    (pos_1[2] + pos_2[2]) / 2,
-  ]
-
-  return new Float32Array([ // Return flattened column-major 4x4 matrix for Three.js
-    ...[m00, m10, m20, 0],
-    ...[m01 * height, m11 * height, m21 * height, 0],
-    ...[m02, m12, m22, 0],
-    ...[px, py, pz, 1],
-  ])
+  out[12] = (pos_1[0] + pos_2[0]) / 2
+  out[13] = (pos_1[1] + pos_2[1]) / 2
+  out[14] = (pos_1[2] + pos_2[2]) / 2
+  return out
 }
 
 // Update bond positions based on current atom positions without recalculating connectivity.

--- a/src/lib/structure/workers/bond-worker-api.ts
+++ b/src/lib/structure/workers/bond-worker-api.ts
@@ -56,7 +56,7 @@ async function init_worker(): Promise<void> {
 
       // 3. Set up message handler for ongoing communication
       w.onmessage = (e: MessageEvent) => {
-        const { id, type: msg_type, result, error, dt } = e.data
+        const { id, type: msg_type, error } = e.data
         if (msg_type === `ready`) {
           return
         }
@@ -66,7 +66,9 @@ async function init_worker(): Promise<void> {
         if (error) {
           p.reject(new Error(error))
         } else {
-          p.resolve({ result, dt })
+          // Resolve the whole payload — JSON replies carry {result, dt},
+          // typed replies carry {pairs, images, lengths, strengths, dt}.
+          p.resolve(e.data)
         }
       }
 
@@ -147,10 +149,11 @@ function reset_worker(reason: string): void {
   pending.clear()
 }
 
-function worker_request(
+function worker_request<T = { result: string; dt: string }>(
   data: Record<string, unknown>,
   timeout_ms = 20_000,
-): Promise<{ result: string; dt: string }> {
+  transfer?: Transferable[],
+): Promise<T> {
   return new Promise((resolve, reject) => {
     if (!worker || !worker_ready) { reject(new Error(`Worker unavailable`)); return }
     const id = next_id++
@@ -178,7 +181,7 @@ function worker_request(
         reject(e)
       },
     })
-    worker.postMessage({ ...data, id })
+    worker.postMessage({ ...data, id }, transfer ?? [])
   })
 }
 
@@ -379,7 +382,7 @@ async function try_main_thread_wasm(
 const SOLID_ANGLE_MAX_ATOMS = 8000
 let solid_angle_downgrade_logged = false
 
-function effective_strategy(strategy: BondingStrategy, n_sites: number): BondingStrategy {
+export function effective_strategy(strategy: BondingStrategy, n_sites: number): BondingStrategy {
   if (strategy === `solid_angle` && n_sites > SOLID_ANGLE_MAX_ATOMS) {
     if (!solid_angle_downgrade_logged) {
       solid_angle_downgrade_logged = true
@@ -445,6 +448,82 @@ export function compute_bonds_async(
       })
     })
   })
+}
+
+/** Flat typed-array bond table returned by the typed worker path. Layouts:
+ *  pairs [i0,j0, i1,j1, ...], images [x0,y0,z0, x1,...] (periodic image
+ *  offsets), lengths/strengths one per bond. */
+export interface TypedBondTable {
+  pairs: Uint32Array
+  images: Int8Array
+  lengths: Float32Array
+  strengths: Float32Array
+}
+
+/** Typed-array bond computation via Web Worker (atom_radii strategy only) —
+ *  no JSON, no structure objects, transfer lists both directions. Built for
+ *  per-frame trajectory bonding at 10k+ atoms where JSON serialization of a
+ *  20k-site structure costs more than the detection itself.
+ *
+ *  `positions` and `atomic_numbers` are copied before transfer — the caller
+ *  keeps ownership (frame positions are also the render source).
+ *  Returns null when the worker is unavailable or errors; callers fall back
+ *  to the JSON path. */
+export async function compute_bonds_typed_worker(
+  positions: Float32Array,
+  atomic_numbers: Uint8Array,
+  lattice_matrix: number[][] | null,
+  pbc: [boolean, boolean, boolean] | null,
+  options: Record<string, number>,
+): Promise<TypedBondTable | null> {
+  if (worker_failed) return null
+  try {
+    await init_worker()
+
+    const pos_copy = positions.slice()
+    const z_copy = atomic_numbers.slice()
+    const lattice = lattice_matrix && lattice_matrix.length === 3
+      ? new Float64Array([...lattice_matrix[0], ...lattice_matrix[1], ...lattice_matrix[2]])
+      : new Float64Array(0)
+    const pbc_arr = pbc
+      ? new Uint8Array([pbc[0] ? 1 : 0, pbc[1] ? 1 : 0, pbc[2] ? 1 : 0])
+      : new Uint8Array(0)
+    const n_sites = atomic_numbers.length
+    const timeout_ms = Math.max(20_000, n_sites * 4)
+    const t0 = performance.now()
+    const resp = await worker_request<TypedBondTable & { dt: string }>(
+      {
+        type: `bonds_typed`,
+        positions: pos_copy,
+        atomic_numbers: z_copy,
+        lattice,
+        pbc: pbc_arr,
+        options_json: JSON.stringify(options),
+      },
+      timeout_ms,
+      [pos_copy.buffer, z_copy.buffer, lattice.buffer, pbc_arr.buffer],
+    )
+    if (import.meta.env?.DEV) {
+      const total = (performance.now() - t0).toFixed(1)
+      console.log(
+        `[bonds] Worker typed | atom_radii | ${n_sites} atoms | ${
+          resp.pairs.length / 2
+        } bonds | wasm ${resp.dt}ms / total ${total}ms`,
+      )
+    }
+    return {
+      pairs: resp.pairs,
+      images: resp.images,
+      lengths: resp.lengths,
+      strengths: resp.strengths,
+    }
+  } catch (err) {
+    console.warn(
+      `[bonds] typed worker path failed — falling back to JSON path:`,
+      err instanceof Error ? err.message : err,
+    )
+    return null
+  }
 }
 
 /** Compute hydrogen bonds via Web Worker.

--- a/src/lib/structure/workers/bond-worker.ts
+++ b/src/lib/structure/workers/bond-worker.ts
@@ -12,6 +12,7 @@
 import {
   initSync,
   detect_bonds_radii,
+  detect_bonds_radii_typed,
   detect_bonds_electronegativity,
   detect_bonds_solid_angle,
   detect_hydrogen_bonds,
@@ -41,6 +42,32 @@ self.onmessage = (e: MessageEvent) => {
   const { structure_json, strategy, options_json, covalent_bonds_json } = e.data
 
   try {
+    if (type === `bonds_typed`) {
+      // Typed-array fast path (atom_radii only): Float32Array positions in,
+      // flat typed bond table out. Both directions use transfer lists — no
+      // JSON, no structured-clone of large payloads.
+      const t0 = performance.now()
+      const table = detect_bonds_radii_typed(
+        e.data.positions,
+        e.data.atomic_numbers,
+        e.data.lattice,
+        e.data.pbc,
+        options_json ?? undefined,
+      )
+      const pairs = table.pairs
+      const images = table.images
+      const lengths = table.lengths
+      const strengths = table.strengths
+      table.free()
+      const dt = (performance.now() - t0).toFixed(1)
+      // Worker-scope postMessage(message, transfer) overload — cast because
+      // this file type-checks under the DOM lib where self is a Window.
+      ;(self.postMessage as (msg: unknown, transfer: Transferable[]) => void)(
+        { id, pairs, images, lengths, strengths, dt },
+        [pairs.buffer, images.buffer, lengths.buffer, strengths.buffer],
+      )
+      return
+    }
     if (type === `bonds`) {
       const t0 = performance.now()
       let result: string

--- a/tests/vitest/structure/trajectory-bond-pairs.test.ts
+++ b/tests/vitest/structure/trajectory-bond-pairs.test.ts
@@ -1,7 +1,11 @@
 // Behavior guard for build_trajectory_bond_pairs — the per-frame trajectory
 // fast path. Locks in stale-bond filtering + jimage semantics so the
 // radius-precompute optimization can't change observable output.
-import { build_trajectory_bond_pairs } from '$lib/structure/bond-computation-controller.svelte'
+import {
+  build_trajectory_bond_pairs,
+  get_traj_atomic_numbers,
+  typed_table_to_conn,
+} from '$lib/structure/bond-computation-controller.svelte'
 import type { Site } from '$lib'
 import { describe, expect, test } from 'vitest'
 
@@ -153,6 +157,40 @@ describe(`build_trajectory_bond_pairs`, () => {
     expect(pairs).toHaveLength(1)
     expect(pairs[0].bond_length).toBeCloseTo(1.4, 4)
     expect(pairs[0].jimage).toEqual([-1, 0, 0])
+  })
+
+  test(`typed_table_to_conn converts flat arrays and drops self-image bonds`, () => {
+    const table = {
+      // bond 0: normal 0-1; bond 1: self-image starburst 2-2@[1,0,0] (drop);
+      // bond 2: cross-cell 0-2@[0,-1,0] (keep); bond 3: degenerate 3-3@[0,0,0] (keep)
+      pairs: new Uint32Array([0, 1, 2, 2, 0, 2, 3, 3]),
+      images: new Int8Array([0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0, 0]),
+      lengths: new Float32Array([1.4, 2.8, 1.5, 0]),
+      strengths: new Float32Array([1, 0.5, 0.8, 0.1]),
+    }
+    const conn = typed_table_to_conn(table)
+    expect(conn).toHaveLength(3)
+    expect(conn[0]).toEqual({
+      site_idx_1: 0,
+      site_idx_2: 1,
+      strength: 1,
+      jimage: [0, 0, 0],
+    })
+    expect(conn[1].jimage).toEqual([0, -1, 0])
+    expect(conn[1].strength).toBeCloseTo(0.8, 5)
+    expect(conn[2].site_idx_1).toBe(3)
+  })
+
+  test(`get_traj_atomic_numbers maps elements and memoizes on sites identity`, () => {
+    const sites = [carbon_site([0, 0, 0]), carbon_site([1, 0, 0])]
+    const zs = get_traj_atomic_numbers(sites)
+    expect(zs).toBeInstanceOf(Uint8Array)
+    expect([...zs!]).toEqual([6, 6])
+    // memoized: same identity → same array back
+    expect(get_traj_atomic_numbers(sites)).toBe(zs)
+    // unknown element → null (typed path unusable)
+    const bad = [carbon_site([0, 0, 0]), unknown_site([1, 0, 0])]
+    expect(get_traj_atomic_numbers(bad)).toBeNull()
   })
 
   test(`overrides take precedence over trajectory positions`, () => {

--- a/tests/vitest/structure/trajectory-bond-pairs.test.ts
+++ b/tests/vitest/structure/trajectory-bond-pairs.test.ts
@@ -1,0 +1,173 @@
+// Behavior guard for build_trajectory_bond_pairs — the per-frame trajectory
+// fast path. Locks in stale-bond filtering + jimage semantics so the
+// radius-precompute optimization can't change observable output.
+import { build_trajectory_bond_pairs } from '$lib/structure/bond-computation-controller.svelte'
+import type { Site } from '$lib'
+import { describe, expect, test } from 'vitest'
+
+function carbon_site(xyz: [number, number, number]): Site {
+  return {
+    species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
+    abc: [0, 0, 0],
+    xyz,
+    label: `C`,
+    properties: {},
+  } as unknown as Site
+}
+
+function unknown_site(xyz: [number, number, number]): Site {
+  return {
+    species: [{ element: `Xx`, occu: 1, oxidation_state: 0 }],
+    abc: [0, 0, 0],
+    xyz,
+    label: `Xx`,
+    properties: {},
+  } as unknown as Site
+}
+
+const conn = (pairs: Array<[number, number]>) =>
+  pairs.map(([site_idx_1, site_idx_2]) => ({ site_idx_1, site_idx_2, strength: 1 }))
+
+describe(`build_trajectory_bond_pairs`, () => {
+  test(`builds pairs from flat positions`, () => {
+    const positions = new Float32Array([0, 0, 0, 1.4, 0, 0])
+    const sites = [carbon_site([0, 0, 0]), carbon_site([1.4, 0, 0])]
+    const pairs = build_trajectory_bond_pairs(
+      conn([[0, 1]]),
+      positions,
+      null,
+      null,
+      null,
+      sites,
+    )
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].bond_length).toBeCloseTo(1.4, 5)
+    expect(pairs[0].pos_1).toEqual([0, 0, 0])
+    expect(pairs[0].pos_2[0]).toBeCloseTo(1.4, 5)
+  })
+
+  test(`drops stale bonds beyond (r_a+r_b)*tol*1.5`, () => {
+    // C-C covalent radii sum ~1.5 Å → max_dist ≈ 1.5*1.1*1.5 ≈ 2.5 Å.
+    // A 10 Å separation is unambiguously stale.
+    const positions = new Float32Array([0, 0, 0, 10, 0, 0])
+    const sites = [carbon_site([0, 0, 0]), carbon_site([10, 0, 0])]
+    const pairs = build_trajectory_bond_pairs(
+      conn([[0, 1]]),
+      positions,
+      null,
+      null,
+      null,
+      sites,
+    )
+    expect(pairs).toHaveLength(0)
+  })
+
+  test(`keeps bonds when covalent radius unknown (filter skipped)`, () => {
+    const positions = new Float32Array([0, 0, 0, 10, 0, 0])
+    const sites = [unknown_site([0, 0, 0]), unknown_site([10, 0, 0])]
+    const pairs = build_trajectory_bond_pairs(
+      conn([[0, 1]]),
+      positions,
+      null,
+      null,
+      null,
+      sites,
+    )
+    expect(pairs).toHaveLength(1)
+  })
+
+  test(`tolerance changes re-filter with the same connectivity identity`, () => {
+    // Same conn array reference across calls — memoized radii must not
+    // freeze the tolerance. 3.0 Å C-C: dropped at tol 1.1 (max ~2.5),
+    // kept at tol 2.0 (max ~4.5).
+    const shared_conn = conn([[0, 1]])
+    const positions = new Float32Array([0, 0, 0, 3, 0, 0])
+    const sites = [carbon_site([0, 0, 0]), carbon_site([3, 0, 0])]
+    const strict = build_trajectory_bond_pairs(
+      shared_conn,
+      positions,
+      null,
+      null,
+      null,
+      sites,
+      1.1,
+    )
+    const loose = build_trajectory_bond_pairs(
+      shared_conn,
+      positions,
+      null,
+      null,
+      null,
+      sites,
+      2.0,
+    )
+    expect(strict).toHaveLength(0)
+    expect(loose).toHaveLength(1)
+  })
+
+  test(`sites identity change invalidates cached radii`, () => {
+    const shared_conn = conn([[0, 1]])
+    const positions = new Float32Array([0, 0, 0, 10, 0, 0])
+    const carbon_sites = [carbon_site([0, 0, 0]), carbon_site([10, 0, 0])]
+    const unknown_sites = [unknown_site([0, 0, 0]), unknown_site([10, 0, 0])]
+    const filtered = build_trajectory_bond_pairs(
+      shared_conn,
+      positions,
+      null,
+      null,
+      null,
+      carbon_sites,
+    )
+    const kept = build_trajectory_bond_pairs(
+      shared_conn,
+      positions,
+      null,
+      null,
+      null,
+      unknown_sites,
+    )
+    expect(filtered).toHaveLength(0)
+    expect(kept).toHaveLength(1)
+  })
+
+  test(`cross-cell jimage offsets bond geometry via lattice`, () => {
+    const lattice_matrix = [[10, 0, 0], [0, 10, 0], [0, 0, 10]]
+    // Atom 1 sits at x=9.3; its jimage [-1,0,0] partner image is at -0.7,
+    // 1.4 Å from atom 0 at 0.7 — a valid C-C bond across the cell face.
+    const positions = new Float32Array([0.7, 0, 0, 9.3, 0, 0])
+    const sites = [carbon_site([0.7, 0, 0]), carbon_site([9.3, 0, 0])]
+    const with_image = [{
+      site_idx_1: 0,
+      site_idx_2: 1,
+      strength: 1,
+      jimage: [-1, 0, 0] as [number, number, number],
+    }]
+    const pairs = build_trajectory_bond_pairs(
+      with_image,
+      positions,
+      null,
+      null,
+      lattice_matrix,
+      sites,
+    )
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].bond_length).toBeCloseTo(1.4, 4)
+    expect(pairs[0].jimage).toEqual([-1, 0, 0])
+  })
+
+  test(`overrides take precedence over trajectory positions`, () => {
+    const positions = new Float32Array([0, 0, 0, 10, 0, 0])
+    const sites = [carbon_site([0, 0, 0]), carbon_site([10, 0, 0])]
+    const overrides = new Map<number, [number, number, number]>([[1, [1.4, 0, 0]]])
+    const pairs = build_trajectory_bond_pairs(
+      conn([[0, 1]]),
+      positions,
+      overrides,
+      null,
+      null,
+      sites,
+    )
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].bond_length).toBeCloseTo(1.4, 5)
+  })
+})

--- a/tests/vitest/trajectory/traj-bond-scheduling.test.ts
+++ b/tests/vitest/trajectory/traj-bond-scheduling.test.ts
@@ -18,6 +18,10 @@ vi.mock('$lib/structure/workers/bond-worker-api', () => ({
   compute_bonds_sync: vi.fn(() => null),
   compute_bonds_async: vi.fn(() => Promise.resolve([])),
   compute_hbonds_worker: vi.fn(() => Promise.resolve([])),
+  // Typed worker unavailable → dispatch falls back to the JSON path, keeping
+  // these tests' compute_bonds_async assertions meaningful.
+  compute_bonds_typed_worker: vi.fn(() => Promise.resolve(null)),
+  effective_strategy: vi.fn((strategy: string) => strategy),
 }))
 
 import {


### PR DESCRIPTION
## Problem

20k-atom streamed trajectory (`dump.traj`, 19968 atoms / ~26k bonds) playback was bond-bound on the main thread. Live profiling showed **three full bond detections per frame** plus three pair rebuilds:

| per frame | cost |
|---|---|
| static pipeline JSON detection ×2 (stampede via structure cascade) | 2 × ~130ms worker + main-thread JSON parse/convert |
| TrajectoryBondCache JSON detection + prefetch bursts | ~130ms each + 20k-site structure clone |
| trajectory fast-path detection (JSON) | ~130ms + 13ms stringify + 50ms serde parse |
| `build_trajectory_bond_pairs` ×3 | 122–136ms each (52k radii dict lookups/frame + alloc churn) |

## Changes

1. **ferrox typed entry** (`detect_bonds_radii_typed`): Float32Array positions + Uint8Array atomic numbers + flat lattice/pbc in, `BondTable` (pairs u32 / images i8 / lengths & strengths f32) out. No serde JSON on either side. Node parity smoke vs `detect_bonds_radii`: identical bond sets incl. cross-boundary images (PBC crystal + lattice-less molecule).
2. **Worker boundary**: new `bonds_typed` message with transfer lists both directions; positions copied before transfer (caller keeps ownership). Falls back to the JSON path on worker failure / exotic species / non-atom_radii strategies.
3. **Dispatch routing**: `dispatch_traj_async` picks the typed route when the effective strategy is atom_radii (always true above the 8k solid_angle downgrade); overlay-structure build is now lazy (JSON fallback only). Same self-image starburst filter as `wasm_bonds_to_pairs`.
4. **Static pipeline gate**: StructureScene's bond `$effect.pre` now early-returns while `trajectory_frame_positions` streams — it was clearing `bond_connectivity` and re-detecting every frame in parallel with the fast path. Variable-N trajectories (positions === null) keep the slow path — it is their only bond source.
5. **Dead pipeline removed**: `TrajectoryBondCache` wiring in Structure.svelte computed per-frame connectivity + prefetch whose only sink was a prop **nothing reads**. Wiring + prop removed; module & unit tests left for a follow-up deletion.
6. **Pair-rebuild optimization**: per-bond stale thresholds memoized (per-site radii keyed on sites identity — one ~30ms Svelte-proxy scan per trajectory; thresholds per connectivity identity); `compute_bond_transform` rewritten allocation-free (same output, covered by existing 28 bonding tests).

## Measured (live, 20k atoms, Chrome dev build)

- Bond detection per frame: 3 full JSON computes → **1 typed compute, ~50ms off-thread** (JSON path wasm was ~130ms + ~65ms boundary tax)
- `build_trajectory_bond_pairs`: 122–136ms → **15–29ms** (typed-conn pass; node micro-bench 35.2→17.1ms for the pure loop)
- Boundary tax: ~55ms serde+JSON.parse → **~0.4ms** typed-array getters
- Static-pipeline stampede and `bond_connectivity = []` churn: **gone** (console-verified)

## Not fixed here (follow-ups)

- Playback fps at 20k atoms is now dominated by the **per-frame structure cascade** (Svelte proxy traversal `get`/`proxy` ≈ 8s + GC 3.8s per 25s trace window, plus dev-mode `get_stack` tracing) and streamed-chunk fetch — tracked separately with the trace file.
- Delete `trajectory-bond-cache.svelte.ts` + its tests once confirmed no consumer reappears.
- First rebuild per frame (interim render with previous connectivity) still ~180ms in dev — suspected proxy/GC, revisit on a prod build.

## Tests

- Full vitest: 4496 passed / 0 failed (one unrelated flake on a prior run, green on re-run)
- svelte-check: 0 errors
- New: `tests/vitest/structure/trajectory-bond-pairs.test.ts` (9 cases: stale filter, jimage geometry, tolerance/sites cache invalidation, typed→conn conversion, Z-array memoization)
- cargo check --features wasm: 0 errors; wasm pkg rebuilt with wasm-pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)