### PR TITLE
perf(trajectory): cut the per-frame reactive cascade during 20k-atom playback (stacked on #514)

### DIFF
--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1366,11 +1366,18 @@
         `Supercell-extra atoms frozen at topology-load positions.`,
       )
     }
-    for (let slot = 0; slot < max_slot; slot++) {
-      const sid = mgr.site_ids_buffer[slot]
-      if (overrides?.has(sid)) continue // drag wins
-      const base = sid * 3
-      mgr.set_position(slot, traj[base], traj[base + 1], traj[base + 2])
+    // Batched: one reactive `version` bump for the whole frame instead of
+    // one $state write per atom (20k/frame).
+    mgr.begin_positions_batch()
+    try {
+      for (let slot = 0; slot < max_slot; slot++) {
+        const sid = mgr.site_ids_buffer[slot]
+        if (overrides?.has(sid)) continue // drag wins
+        const base = sid * 3
+        mgr.set_position(slot, traj[base], traj[base + 1], traj[base + 2])
+      }
+    } finally {
+      mgr.commit_positions_batch()
     }
   })
 
@@ -2630,6 +2637,14 @@
   // throttle inside push_loop coalesces rapid edits (e.g. atom drag at
   // 60fps) into ≤20 pushes/sec.
   $effect(() => {
+    // Trajectory playback: bridge_structure (= the current frame's structure)
+    // changes identity EVERY frame, and deep-stringifying a 20k-site $state
+    // proxy per frame (~300k proxy traps + a multi-MB throwaway string) was
+    // the single largest main-thread cost of large-trajectory playback. No
+    // edits happen mid-playback, so pushes pause; reading the gate reactively
+    // means teardown/pause (positions → null) re-fires this effect and
+    // pushes the final state. The 5s MCP heartbeat still covers listeners.
+    if (trajectory_frame_positions != null) return
     const published = bridge_structure ?? structure
     if (!published) return
     void JSON.stringify(published)

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -3327,39 +3327,57 @@
       return has_visible_element && prop_visible
     }
 
+    // Fast-path guards. This $derived re-runs twice per trajectory frame
+    // (bond_pairs churns), and with nothing hidden/deleted the old
+    // unconditional path still paid ~52k is_site_visible proxy reads plus
+    // 26k bond-key strings per pass at 20k atoms.
+    const nothing_hidden = _hidden_size === 0 && _hs_size === 0 && _hpv_size === 0
+    const check_deleted = _deleted_size > 0
+
     // Start from the rule-aware bonds; filter out deleted, hidden, and invalid transforms
     let result = ruled_bonds.filter((bond) => {
-      if (!bond.transform_matrix || bond.transform_matrix.some((v) => !Number.isFinite(v))) return false
+      const tm = bond.transform_matrix
+      if (!tm) return false
+      for (let idx = 0; idx < tm.length; idx++) {
+        if (!Number.isFinite(tm[idx])) return false
+      }
       // Hard cap on rendered bond length. No real covalent bond exceeds this;
       // anything longer is a PBC/image rendering artifact (e.g. a bond drawn
       // straight across the cell instead of via the minimum image), so drop it.
       if (bond.bond_length > MAX_BOND_LENGTH) return false
-      const key = get_bond_key(bond.site_idx_1, bond.site_idx_2)
-      if (_deleted_bond_keys.has(key)) return false
-      if (!is_site_visible(bond.site_idx_1) || !is_site_visible(bond.site_idx_2)) return false
+      if (check_deleted) {
+        const key = get_bond_key(bond.site_idx_1, bond.site_idx_2)
+        if (_deleted_bond_keys.has(key)) return false
+      }
+      if (
+        !nothing_hidden &&
+        (!is_site_visible(bond.site_idx_1) || !is_site_visible(bond.site_idx_2))
+      ) return false
       return true
     })
 
     // Append manual bonds (that aren't already in auto-detected set)
-    const auto_keys = new Set(result.map(b => get_bond_key(b.site_idx_1, b.site_idx_2)))
-    for (const mb of manual_bonds) {
-      const key = get_bond_key(mb.site_idx_1, mb.site_idx_2)
-      if (auto_keys.has(key)) continue // Already present via auto-detection
-      const pos_1 = bond_struct.sites[mb.site_idx_1]?.xyz
-      const pos_2 = bond_struct.sites[mb.site_idx_2]?.xyz
-      if (!pos_1 || !pos_2) continue
-      const diff = math.subtract(pos_2, pos_1)
-      const bond_length = Math.hypot(diff[0], diff[1], diff[2])
-      result.push({
-        pos_1,
-        pos_2,
-        site_idx_1: mb.site_idx_1,
-        site_idx_2: mb.site_idx_2,
-        bond_length,
-        strength: 1.0,
-        transform_matrix: compute_bond_transform(pos_1, pos_2),
-        jimage: [0, 0, 0],
-      })
+    if (manual_bonds.length > 0) {
+      const auto_keys = new Set(result.map(b => get_bond_key(b.site_idx_1, b.site_idx_2)))
+      for (const mb of manual_bonds) {
+        const key = get_bond_key(mb.site_idx_1, mb.site_idx_2)
+        if (auto_keys.has(key)) continue // Already present via auto-detection
+        const pos_1 = bond_struct.sites[mb.site_idx_1]?.xyz
+        const pos_2 = bond_struct.sites[mb.site_idx_2]?.xyz
+        if (!pos_1 || !pos_2) continue
+        const diff = math.subtract(pos_2, pos_1)
+        const bond_length = Math.hypot(diff[0], diff[1], diff[2])
+        result.push({
+          pos_1,
+          pos_2,
+          site_idx_1: mb.site_idx_1,
+          site_idx_2: mb.site_idx_2,
+          bond_length,
+          strength: 1.0,
+          transform_matrix: compute_bond_transform(pos_1, pos_2),
+          jimage: [0, 0, 0],
+        })
+      }
     }
 
     return result
@@ -3427,6 +3445,34 @@
   // cell-internal hits use, so selection / hover code paths converge.
   // Built in O(count + N) per derive: single pass over BondManager seeds a
   // content-keyed table, then each filtered pair looks up its slot.
+  // Numeric bond keys for the per-frame hot maps (slot_to_filtered_idx and
+  // the bond_manager shadow-sync diff below). String keys allocated ~100k
+  // short-lived strings per trajectory frame at 26k bonds — a large share of
+  // playback GC pressure. Packs (a, b, jimage) into one float64-exact
+  // integer (< 2^51); falls back to strings for out-of-range inputs
+  // (>262k atoms or |jimage| > 15), which may share one Map with the
+  // numeric keys.
+  const BOND_KEY_MAX_IDX = 1 << 18
+  const BOND_KEY_JLIM = 15
+  function pack_bond_key(
+    site_a: number,
+    site_b: number,
+    jx: number,
+    jy: number,
+    jz: number,
+  ): number | string {
+    if (
+      site_a < BOND_KEY_MAX_IDX && site_b < BOND_KEY_MAX_IDX &&
+      jx >= -BOND_KEY_JLIM && jx <= BOND_KEY_JLIM &&
+      jy >= -BOND_KEY_JLIM && jy <= BOND_KEY_JLIM &&
+      jz >= -BOND_KEY_JLIM && jz <= BOND_KEY_JLIM
+    ) {
+      return (site_a * BOND_KEY_MAX_IDX + site_b) * 32768 +
+        ((jx + 16) * 1024 + (jy + 16) * 32 + (jz + 16))
+    }
+    return `${site_a}-${site_b}-${jx},${jy},${jz}`
+  }
+
   // Orphans (entry not yet shadow-synced) leave the slot at -1 — decorator
   // hits on those return null (degraded but harmless).
   let slot_to_filtered_idx = $derived.by((): Int32Array => {
@@ -3437,25 +3483,27 @@
     if (count === 0 || filtered_bond_pairs.length === 0) return out
     const pairs = bond_manager.pairs_buffer
     const jimg = bond_manager.jimages_buffer
-    const key_to_slot = new Map<string, number>()
+    const key_to_slot = new Map<number | string, number>()
     for (let s = 0; s < count; s++) {
       const a = pairs[s * 2]
       const b = pairs[s * 2 + 1]
       const jx = jimg[s * 3]
       const jy = jimg[s * 3 + 1]
       const jz = jimg[s * 3 + 2]
-      key_to_slot.set(`${a},${b},${jx},${jy},${jz}`, s)
+      key_to_slot.set(pack_bond_key(a, b, jx, jy, jz), s)
     }
     for (let i = 0; i < filtered_bond_pairs.length; i++) {
       const bp = filtered_bond_pairs[i]
       const ji = bp.jimage ?? [0, 0, 0]
-      const direct = `${bp.site_idx_1},${bp.site_idx_2},${ji[0]},${ji[1]},${ji[2]}`
-      let slot = key_to_slot.get(direct)
+      let slot = key_to_slot.get(
+        pack_bond_key(bp.site_idx_1, bp.site_idx_2, ji[0], ji[1], ji[2]),
+      )
       if (slot === undefined) {
         // Stored as (b, a, -jimage) — direction-aware swap mirrors
         // BondManager.find_slot_by_pair semantics.
-        const swapped = `${bp.site_idx_2},${bp.site_idx_1},${-ji[0]},${-ji[1]},${-ji[2]}`
-        slot = key_to_slot.get(swapped)
+        slot = key_to_slot.get(
+          pack_bond_key(bp.site_idx_2, bp.site_idx_1, -ji[0], -ji[1], -ji[2]),
+        )
       }
       if (slot !== undefined) out[slot] = i
     }
@@ -3484,7 +3532,10 @@
     // different lattice translations (e.g. (3, 7, [0,0,0]) vs (3, 7, [1,0,0]))
     // are kept as separate slots — failing to disambiguate would let the
     // shadow sync collapse them into one and silently drop the other.
-    const desired = new Map<string, {
+    // Keys are packed numbers (pack_bond_key) — this diff runs twice per
+    // trajectory frame over ~26k bonds and string keys dominated playback GC.
+    const has_manual = manual_keys.size > 0
+    const desired = new Map<number | string, {
       a: number
       b: number
       k: BondKind
@@ -3506,11 +3557,14 @@
       const cdx = swap ? -jx : jx
       const cdy = swap ? -jy : jy
       const cdz = swap ? -jz : jz
-      const key = `${lo}-${hi}-${cdx},${cdy},${cdz}`
+      const key = pack_bond_key(lo, hi, cdx, cdy, cdz)
       desired.set(key, {
         a: bp.site_idx_1,
         b: bp.site_idx_2,
-        k: manual_keys.has(get_bond_key(bp.site_idx_1, bp.site_idx_2)) ? BOND_KIND.MANUAL : BOND_KIND.AUTO,
+        k: has_manual &&
+            manual_keys.has(get_bond_key(bp.site_idx_1, bp.site_idx_2))
+          ? BOND_KIND.MANUAL
+          : BOND_KIND.AUTO,
         jx,
         jy,
         jz,
@@ -3541,7 +3595,7 @@
       const cdx = swap ? -sjx : sjx
       const cdy = swap ? -sjy : sjy
       const cdz = swap ? -sjz : sjz
-      const key = `${lo}-${hi}-${cdx},${cdy},${cdz}`
+      const key = pack_bond_key(lo, hi, cdx, cdy, cdz)
       const want = desired.get(key)
       if (want !== undefined) {
         // Bond is in both sets. If kind drifted, patch it.
@@ -4196,13 +4250,20 @@
     if (import.meta.env?.DEV) __probe_apb_meaningful++
     // Buffer is indexed by site_idx (bond_connectivity uses site_idx).
     // Initial fill from sites covers the mount window before X2 shadow sync
-    // populates the manager.
+    // populates the manager. During trajectory playback the manager covers
+    // every base site (same invariant as the Phase 5.5 X2 gate) and the
+    // overlay below overwrites every slot — skip the ~N proxied sites[i].xyz
+    // reads per frame.
     const buf = new Float32Array(sites.length * 3)
-    for (let i = 0; i < sites.length; i++) {
-      const xyz = sites[i].xyz
-      buf[i * 3]     = xyz[0]
-      buf[i * 3 + 1] = xyz[1]
-      buf[i * 3 + 2] = xyz[2]
+    const overlay_covers_all = trajectory_frame_positions != null &&
+      mgr.count >= sites.length
+    if (!overlay_covers_all) {
+      for (let i = 0; i < sites.length; i++) {
+        const xyz = sites[i].xyz
+        buf[i * 3]     = xyz[0]
+        buf[i * 3 + 1] = xyz[1]
+        buf[i * 3 + 2] = xyz[2]
+      }
     }
     // Overlay manager positions (slot → site_idx via site_ids_buffer). After
     // Phase 4 this is the only path that updates per-frame.
@@ -4400,12 +4461,37 @@
   //
   // handle_bond_hitbox_click decodes `instanceId >>> 1` to bond index, so
   // clicking either stub resolves to the same logical bond.
+  //
+  // Playback throttle state: rebuilding 2×26k hitbox matrices per trajectory
+  // frame costs ~100ms+/frame for picking accuracy nobody can exploit while
+  // atoms are moving. During playback the rebuild runs at most every 500ms,
+  // with a trailing rebuild (via the retrigger tick) so picking settles
+  // correct within 500ms of the last frame — including after pause.
+  let __hitbox_retrigger = $state(0)
+  let __hitbox_last_ms = 0
+  let __hitbox_trailing: ReturnType<typeof setTimeout> | null = null
   $effect(() => {
     if (!bond_hitbox_mesh) return
     const bonds = filtered_bond_pairs
     const layout = image_atom_layout
     const partner_drawn = partner_drawn_lookup
     const slot_lookup = slot_to_filtered_idx
+    void __hitbox_retrigger // trailing-rebuild tick (see throttle below)
+    if (trajectory_frame_positions != null) {
+      const now = performance.now()
+      if (now - __hitbox_last_ms < 500) {
+        if (__hitbox_trailing === null) {
+          __hitbox_trailing = setTimeout(() => {
+            __hitbox_trailing = null
+            __hitbox_retrigger++
+          }, 500)
+        }
+        return
+      }
+      __hitbox_last_ms = now
+    } else {
+      __hitbox_last_ms = 0
+    }
     const cell_inst = bonds.length * 2
     const decorator_inst =
       layout !== null && bond_manager.count > 0 ? layout.bonds_csr.length * 2 : 0

--- a/src/lib/structure/atoms/atom-manager.svelte.ts
+++ b/src/lib/structure/atoms/atom-manager.svelte.ts
@@ -200,6 +200,12 @@ export class AtomManager {
 	#opacities_batch_changed = false
 	#saturations_batch_depth = 0
 	#saturations_batch_changed = false
+	// Positions batch: trajectory playback writes every atom's position each
+	// frame; without batching that is one reactive `#version` $state write
+	// PER ATOM (20k/frame — the dominant main-thread cost of playback, worse
+	// in dev where each write also captures a stack trace).
+	#positions_batch_depth = 0
+	#positions_batch_changed = false
 
 	constructor(initial_capacity: number = INITIAL_CAPACITY) {
 		const cap = Math.max(1, initial_capacity | 0)
@@ -861,7 +867,20 @@ export class AtomManager {
 		this.#positions[base + 1] = fy
 		this.#positions[base + 2] = fz
 		this.#touch_position(slot)
-		this.#version++
+		if (this.#positions_batch_depth > 0) this.#positions_batch_changed = true
+		else this.#version++
+	}
+
+	begin_positions_batch(): void {
+		this.#positions_batch_depth++
+	}
+	commit_positions_batch(): void {
+		if (this.#positions_batch_depth === 0) return
+		this.#positions_batch_depth--
+		if (this.#positions_batch_depth === 0 && this.#positions_batch_changed) {
+			this.#positions_batch_changed = false
+			this.#version++
+		}
 	}
 
 	set_radius(slot: number, radius: number): void {

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -862,16 +862,22 @@ function dispatch_traj_async(
       strategy_key,
     })
 
+    // ALWAYS publish the resolved connectivity — it is the freshest result
+    // available. Reassigning bond_connectivity here is safe because we're in
+    // the promise resolve callback, NOT inside the trajectory $effect.pre
+    // body. The previous code published only when no newer frame was queued;
+    // during continuous playback a newer frame is ALWAYS queued, so the
+    // visible connectivity stayed frozen at the pre-playback detection for
+    // the whole run (the stale-bond filter then dropped hundreds of bonds
+    // per frame against moved atoms).
+    bond_state.bond_connectivity = new_conn
+    bond_state.last_bond_structure = base_structure
+    bond_state.last_bond_strategy = strategy_key
+    bond_state.last_elem_fingerprint = elem_fp
+    bond_state.last_bond_fingerprint = `${elem_fp}|frame`
+
     const pending = bond_state.traj_pending_frame
     if (pending === null) {
-      // No newer frame queued → the resolved frame is the latest visible.
-      // Reassigning bond_connectivity here is safe because we're in the
-      // promise resolve callback, NOT inside the trajectory $effect.pre body.
-      bond_state.bond_connectivity = new_conn
-      bond_state.last_bond_structure = base_structure
-      bond_state.last_bond_strategy = strategy_key
-      bond_state.last_elem_fingerprint = elem_fp
-      bond_state.last_bond_fingerprint = `${elem_fp}|frame`
       bond_state.traj_in_flight_frame = null
     } else {
       // User moved on while async was running. Drain the latest-wins queue:

--- a/src/lib/structure/scene/visibility.ts
+++ b/src/lib/structure/scene/visibility.ts
@@ -167,10 +167,18 @@ export function compute_structure_size(lattice: PymatgenLattice | null): number 
  * it uniformly toward the background. Fog range should use THIS instead.
  * Returns null when there are no atoms.
  */
+// Memoized on structure identity: callers invoke this from the per-render
+// task whenever depth cueing or outlines are on, and the O(N) proxied site
+// walk is constant for a given structure object (during trajectory playback
+// the structure stays frozen while only typed-array positions change).
+const atom_span_cache = new WeakMap<object, number>()
+
 export function compute_atom_span_radius(
   structure: AnyStructure | undefined,
 ): number | null {
   if (!structure?.sites?.length) return null
+  const cached = atom_span_cache.get(structure as object)
+  if (cached !== undefined) return cached
   let min_x = Infinity, max_x = -Infinity
   let min_y = Infinity, max_y = -Infinity
   let min_z = Infinity, max_z = -Infinity
@@ -183,7 +191,9 @@ export function compute_atom_span_radius(
     if (z < min_z) min_z = z
     if (z > max_z) max_z = z
   }
-  return Math.max(max_x - min_x, max_y - min_y, max_z - min_z) / 2
+  const span = Math.max(max_x - min_x, max_y - min_y, max_z - min_z) / 2
+  atom_span_cache.set(structure as object, span)
+  return span
 }
 
 /**

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1584,17 +1584,30 @@
     _apply_topology_op({ kind: `replace`, site_indices: event.site_indices, new_element: event.new_element })
   }
 
+  // Memoized on structure identity: the manifest refresh effect re-runs per
+  // frame (it reads current_frame), and this used to walk all sites through
+  // the $state proxy twice per refresh. During fixed-topology playback
+  // current_structure is frozen → O(1) per frame; slow-path trajectories
+  // (doping element swaps) replace current_structure per frame and correctly
+  // recompute.
+  const manifest_formula_cache = new WeakMap<object, string>()
   function manifest_formula(): string {
-    const structure = current_frame?.structure ?? trajectory?.frames?.[current_step_idx]?.structure
+    const structure = current_structure ?? current_frame?.structure ??
+      trajectory?.frames?.[current_step_idx]?.structure
+    if (!structure) return ``
+    const cached = manifest_formula_cache.get(structure as object)
+    if (cached !== undefined) return cached
     const counts = new Map<string, number>()
-    for (const site of structure?.sites ?? []) {
+    for (const site of structure.sites ?? []) {
       const el = site.species?.[0]?.element ?? site.label ?? `?`
       counts.set(el, (counts.get(el) ?? 0) + 1)
     }
-    return [...counts.entries()]
+    const formula = [...counts.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([el, n]) => n === 1 ? el : `${el}${n}`)
       .join(``)
+    manifest_formula_cache.set(structure as object, formula)
+    return formula
   }
 
   function inspect_trajectory_atoms() {


### PR DESCRIPTION
**Stacked on #514** — merge that first, then rebase this onto main (or merge #514 into main and retarget).

## What

Trace-guided elimination of per-frame reactive work during streamed fixed-topology trajectory playback. A CPU profile showed the main thread with zero idle: Svelte proxy traversal + GC dominated, none of it bond *computation* (that was fixed in #514).

Cuts (each anchored to a profiled hot chain):

1. **MCP push effect gate** (Structure.svelte) — `bridge_structure` (= current frame's structure) churns identity every frame; `JSON.stringify` deep-walked a 20k-site `$state` proxy per frame (~300k proxy traps + multi-MB throwaway string — the single largest cost, ~4s per 25s window in dev). Gated while `trajectory_frame_positions` streams; teardown re-fires and pushes final state; the 5s MCP heartbeat still covers listeners.
2. **AtomManager positions batch** — `set_position` bumped the reactive `#version` `$state` once **per atom** (20k reactive writes/frame from the position-write loop; 3.8s of dev stack-capture alone). New `begin/commit_positions_batch` (same pattern as colors/opacities); one bump per frame.
3. **manifest_formula memoized** on structure identity (was two full proxied site walks per frame via the manifest-refresh effect; frozen structure → O(1), doping trajectories swap identity → recompute correctly).
4. **compute_atom_span_radius memoized** on structure identity (was recomputed per rendered frame by the depth-cue task).
5. **atom_positions_buffer** skips the proxied `sites[]` base-fill during playback when the manager covers every site.
6. **visible_bond_pairs fast paths** — skip ~52k `is_site_visible` proxy reads/frame when nothing hidden, deleted-key strings when nothing deleted, manual-merge set when no manual bonds; `Float32Array.some(closure)` → plain loop.
7. **Numeric bond keys** (`pack_bond_key`, float64-exact packing with string fallback) for `slot_to_filtered_idx` and the bond_manager shadow-sync diff — was ~100k short-lived key strings per frame, a large share of the 4-5s/25s GC.
8. **Bond hitbox rebuild throttled** to 500ms during playback (was 2×26k Matrix4 rebuilds per frame for hover picking nobody can use while atoms move), with a trailing rebuild so picking settles correct after pause.
9. **Bug fix: latest-wins drain never published.** `dispatch_traj_async`'s resolve only wrote `bond_connectivity` when no newer frame was queued — during continuous playback one always is, so the visible connectivity stayed frozen at the pre-playback detection for the whole run while the stale filter silently dropped hundreds of moved bonds per frame. Resolve now always publishes the freshest connectivity before draining.

## Measured (dev build, 20k-atom streamed dump.traj, same box)

- Playback: 0.27 fps (pre-#514) → ~0.5–1.1 fps (high run-to-run variance from streaming-chunk timing). Not "flight" yet — see below.
- Dev-only Svelte stack-capture (`get_stack`) eliminated from the profile after the positions batch.
- Bond correctness: connectivity now updates each resolve instead of freezing at frame 0.

## Remaining bottleneck (next task, precisely located)

The bond render chain rebuilds ~26k `BondPair` objects per frame and re-diffs them through `visible_bond_pairs → filtered_bond_pairs → slot_to_filtered_idx → bond_manager mirror` twice per frame. The structural fix is typed-connectivity straight into the instanced buffers (revive the deferred "render side consumes typed table" task). Also worth benchmarking a production build — dev-mode proxy interceptors inflate every remaining site read.

## Tests

Full vitest 4496 passed / 0 failed; svelte-check 0 errors. Live-verified on the 20k dump.traj (bond counts now track per frame; no visual regressions on the water demo / static structures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)