### PR TITLE
perf(trajectory): kill per-frame renderer rebuilds + conn deep-proxy tax (frame-supply round 1)

### DIFF
--- a/src/lib/structure/atoms/AtomManagerInstances.svelte
+++ b/src/lib/structure/atoms/AtomManagerInstances.svelte
@@ -480,20 +480,34 @@
   // `untrack` the modulation reads so the mount effect doesn't become a
   // reactive dependent of them — the main sync effect already handles changes.
   $effect(() => {
-    if (!opaque_mesh) return
-    const r = new AtomInstancedRenderer(opaque_mesh, atom_manager, hidden_site_ids ?? null)
-    untrack(() => {
+    // Tracked deps: ONLY the mesh binding and the manager's identity. The
+    // whole body below runs untracked — the renderer constructor and
+    // force_full_resync() read the manager's reactive internals
+    // (version/count are class $state fields), and a tracked read of those
+    // subscribed this mount effect to the per-frame version bump: every
+    // trajectory frame disposed and rebuilt the renderer, recreating all
+    // five instanced GL attributes (~36 MB of bufferData per frame). The
+    // main sync effect below owns per-version updates.
+    const mesh = opaque_mesh
+    const mgr = atom_manager
+    if (!mesh) return
+    if (import.meta.env?.DEV) {
+      const g = globalThis as unknown as { __amr_mount?: number }
+      g.__amr_mount = (g.__amr_mount ?? 0) + 1
+    }
+    return untrack(() => {
+      const r = new AtomInstancedRenderer(mesh, mgr, hidden_site_ids ?? null)
       r.set_cutting(cutting_active, cutting_visibility_map ?? null)
       r.set_atom_opacity_overrides(atom_opacity_overrides ?? null)
       r.set_image_atoms(num_original_sites, image_atom_opacity, image_to_original_map)
+      opaque_renderer = r
+      r.force_full_resync()
+      mark_dirty()
+      return () => {
+        r.dispose()
+        if (opaque_renderer === r) opaque_renderer = undefined
+      }
     })
-    opaque_renderer = r
-    r.force_full_resync()
-    mark_dirty()
-    return () => {
-      r.dispose()
-      if (opaque_renderer === r) opaque_renderer = undefined
-    }
   })
 
   // Track identity/size of each render-side modulation input — the manager

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -235,7 +235,14 @@ function invert_3x3(m: number[][]): number[][] | null {
  * Must be called from component `<script>` context (Svelte 5 $state).
  */
 export function create_bond_state() {
-  let bond_connectivity = $state<
+  // $state.raw, NOT $state: every write site reassigns the whole array
+  // (verified — no push/splice/index writes anywhere), so reassignment
+  // reactivity is all consumers need. The deep proxy cost real money: at
+  // 26k bonds every conn walk (conn_to_typed_topology, get_traj_max_dists,
+  // build_trajectory_bond_pairs, build_bond_pairs) paid ~5 proxy traps per
+  // bond — ~130k traps per pass, tens of ms per frame in dev — whenever the
+  // array came back through this getter instead of the raw frame cache.
+  let bond_connectivity = $state.raw<
     Array<
       {
         site_idx_1: number

--- a/src/lib/structure/bonding/BondManagerInstances.svelte
+++ b/src/lib/structure/bonding/BondManagerInstances.svelte
@@ -351,37 +351,48 @@
   const geometry = $derived(new CylinderGeometry(bond_radius, bond_radius, 1, 16))
 
   $effect(() => {
-    if (!mesh) return
-    const r = new BondInstancedRenderer(
-      mesh,
-      bond_manager,
-      () => atom_positions,
-      () => lattice_matrix ?? null,
-      () => ({
-        mode: incomplete_periodic_edge_mode,
-        scale: incomplete_edge_length_scale,
-        hide_incomplete: hide_incomplete_bonds,
-      }),
-      () => image_atom_layout ?? null,
-      () => partner_drawn_lookup ?? null,
-      // Bond colors are now sourced directly from the per-atom color buffer
-      // inside the renderer's matrix-write loop — same dirty-slot snapshot,
-      // no race between matrix and color writes. The atom_colors-change
-      // $effect below triggers `force_full_resync()` when the per-atom
-      // buffer identity changes (color-only updates don't bump
-      // bond_manager.version).
-      () => atom_colors ?? null,
-    )
-    // Apply the multi-bond flag BEFORE the first resync so the initial mesh
-    // layout uses the correct per-slot stride.
-    r.set_multibond(untrack(() => multibond_enabled), untrack(() => bond_radius))
-    renderer = r
-    r.force_full_resync()
-    mark_dirty()
-    return () => {
-      r.dispose()
-      if (renderer === r) renderer = undefined
-    }
+    // Tracked deps: ONLY the mesh binding and manager identity — the body
+    // runs untracked. The constructor and force_full_resync() read reactive
+    // manager internals (version/count) plus the layout/positions getters;
+    // tracked, those subscribed this effect to per-frame signals and every
+    // trajectory frame disposed + rebuilt the renderer, recreating the
+    // instanced GL attributes (kind/color/opacity — capacity-sized
+    // bufferData reallocations each frame).
+    const mesh_ref = mesh
+    const mgr = bond_manager
+    if (!mesh_ref) return
+    return untrack(() => {
+      const r = new BondInstancedRenderer(
+        mesh_ref,
+        mgr,
+        () => atom_positions,
+        () => lattice_matrix ?? null,
+        () => ({
+          mode: incomplete_periodic_edge_mode,
+          scale: incomplete_edge_length_scale,
+          hide_incomplete: hide_incomplete_bonds,
+        }),
+        () => image_atom_layout ?? null,
+        () => partner_drawn_lookup ?? null,
+        // Bond colors are now sourced directly from the per-atom color buffer
+        // inside the renderer's matrix-write loop — same dirty-slot snapshot,
+        // no race between matrix and color writes. The atom_colors-change
+        // $effect below triggers `force_full_resync()` when the per-atom
+        // buffer identity changes (color-only updates don't bump
+        // bond_manager.version).
+        () => atom_colors ?? null,
+      )
+      // Apply the multi-bond flag BEFORE the first resync so the initial mesh
+      // layout uses the correct per-slot stride.
+      r.set_multibond(multibond_enabled, bond_radius)
+      renderer = r
+      r.force_full_resync()
+      mark_dirty()
+      return () => {
+        r.dispose()
+        if (renderer === r) renderer = undefined
+      }
+    })
   })
 
   // Lattice matrix, incomplete-edge mode, image-atom layout, or per-atom
@@ -407,9 +418,14 @@
     const mb = multibond_enabled
     const br = bond_radius
     if (!renderer) return
-    renderer.set_multibond(mb, br)
-    renderer.force_full_resync()
-    mark_dirty()
+    // Untracked: force_full_resync reads manager $state (version/count);
+    // tracked it would subscribe this effect to every per-frame version
+    // bump and duplicate the version-sync effect's full pass.
+    untrack(() => {
+      renderer!.set_multibond(mb, br)
+      renderer!.force_full_resync()
+      mark_dirty()
+    })
   })
 
   let last_overrides_ref: Map<string, number> | ReadonlyMap<string, number> | undefined
@@ -509,8 +525,13 @@
     positions_version
     atom_positions
     if (!renderer) return
-    renderer.force_full_resync()
-    mark_dirty()
+    // Untracked: force_full_resync reads manager $state (version/count);
+    // tracked it would re-fire this effect on every version bump on top of
+    // the positions-identity dep above — a duplicate full matrix pass.
+    untrack(() => {
+      renderer!.force_full_resync()
+      mark_dirty()
+    })
   })
 </script>
 

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -67,6 +67,7 @@
   } from '$lib/structure/viewer-registry.svelte'
   import { scale_structure_geometry, validate_uniform_topology } from './operations'
   import type { PaneTrajectory } from './clone'
+  import { clone_structure } from '$lib/structure/clone'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module('structure')
@@ -720,7 +721,15 @@
         trajectory_frame_positions = entry.positions
         trajectory_frame_forces = entry.forces
       } else {
-        current_structure = frame.structure
+        // Streamed loaders no longer deep-clone every fetched frame (see
+        // fork_loader in ./clone.ts), so the loader-cached frame object must
+        // not become `current_structure` directly — the T5 pause writeback
+        // mutates current_structure.sites in place and would corrupt the
+        // cached frame for later revisits. Clone once per topology init
+        // (NOT per frame; the fast path above never re-enters here).
+        current_structure = (trajectory as PaneTrajectory | undefined)?.frame_loader
+          ? clone_structure(frame.structure)
+          : frame.structure
         topology_initialized = !force_slow_path && pending_ops.length === 0
         trajectory_frame_positions = null
         trajectory_frame_forces = null
@@ -734,6 +743,23 @@
   let step_label_positions = $derived(
     compute_step_label_positions(step_labels, total_frames, scaleLinear as any),
   )
+
+  // Streamed loads defer the whole-file plot-metadata scan so first render
+  // isn't blocked on it (see load_remote_trajectory) — adopt the result when
+  // it lands. The deep write through the $state proxy re-derives plot_series.
+  $effect(() => {
+    const traj = trajectory
+    const pending = traj?.plot_metadata_promise
+    if (!traj || !pending || traj.plot_metadata) return
+    let cancelled = false
+    void pending.then((md) => {
+      if (cancelled || !md?.length) return
+      if (trajectory === traj) traj.plot_metadata = md
+    })
+    return () => {
+      cancelled = true
+    }
+  })
 
   // Generate plot data - use pre-extracted metadata for indexed trajectories
   let plot_series = $derived.by(() => {

--- a/src/lib/trajectory/clone.ts
+++ b/src/lib/trajectory/clone.ts
@@ -175,9 +175,14 @@ function fork_loader(
       base.build_frame_index(data, sample_rate, on_progress),
     load_frame: async (data, frame_number) => {
       const frame = await base.load_frame(data, frame_number)
-      return frame
-        ? apply_trajectory_transformations(clone_frame(frame), transformations)
-        : null
+      if (!frame) return null
+      // With no pane transformations the clone is pure overhead — deep-copying
+      // a 20k-site structure costs ~70 ms + GC pressure per streamed frame.
+      // Loader-cached frames are treated as immutable by the playback path:
+      // edits target `current_structure` (the topology-init clone), never the
+      // fetched frame objects, and per-frame data flows via typed positions.
+      if (transformations.length === 0) return frame
+      return apply_trajectory_transformations(clone_frame(frame), transformations)
     },
     extract_plot_metadata: (data, options, on_progress) =>
       base.extract_plot_metadata(data, options, on_progress),

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -43,6 +43,11 @@ export interface TrajectoryType {
   total_frames?: number
   indexed_frames?: FrameIndex[]
   plot_metadata?: TrajectoryMetadata[]
+  /** Deferred plot-metadata scan for streamed loads — extracting it walks
+   *  every frame server-side (seconds for large files), so loaders may ship
+   *  the trajectory immediately and attach the in-flight scan here.
+   *  `Trajectory.svelte` adopts the result into `plot_metadata` on arrival. */
+  plot_metadata_promise?: Promise<TrajectoryMetadata[]>
   is_indexed?: boolean
 }
 

--- a/src/lib/trajectory/remote-frame-loader.ts
+++ b/src/lib/trajectory/remote-frame-loader.ts
@@ -280,7 +280,7 @@ export class RemoteFrameLoader implements FrameLoader {
 export async function load_remote_trajectory(
   path: string,
   filename: string,
-  initial = 10,
+  initial = 4,
 ): Promise<TrajectoryType> {
   const idx_resp = await fetch(
     `${API_BASE}/trajectory/index?path=${encodeURIComponent(path)}`,
@@ -300,14 +300,18 @@ export async function load_remote_trajectory(
   const frames: TrajectoryFrame[] = (fr_data.frames ?? [])
     .map(backend_frame_to_trajectory_frame)
 
+  // The plot-metadata scan walks every frame server-side (~2 s for a 48 MB
+  // file) — never block first render on it. Ship the trajectory now with the
+  // in-flight scan attached; Trajectory.svelte adopts it on arrival and the
+  // plot upgrades from the initial-frames series to the full sampled one.
   const stride = Math.max(1, Math.ceil(total / MAX_PLOT_POINTS))
-  const plot_metadata = await loader.extract_plot_metadata(``, { sample_rate: stride })
+  const plot_metadata_promise = loader.extract_plot_metadata(``, { sample_rate: stride })
 
   const trajectory: TrajectoryType = {
     frames,
     total_frames: total,
     is_indexed: true,
-    plot_metadata,
+    plot_metadata_promise,
     metadata: {
       filename,
       source: `remote-stream`,


### PR DESCRIPTION
## 帧供给链三刀:每帧 renderer 重建 + 深代理税(接力 #518)

live trace + WebGL 计数器归因(19968 原子流式 zeolite 轨迹,dev :3300):

### 三刀

1. **`bond_state.bond_connectivity`: `$state` → `$state.raw`**。全库核实所有写点都是整数组重赋值(无 push/splice/下标写),重赋值反应性就是消费方需要的全部。深代理让每次 26k-bond conn 走查付 ~13 万 proxy trap——凡是从 getter(而非裸 frame cache)拿到数组的路径都中招。typed_direct 探针:160/40ms → **5-7ms**/帧。

2. **两个 renderer mount effect 的追踪泄漏(大头)**。`AtomManagerInstances` / `BondManagerInstances` 的 mount effect 在追踪上下文里跑构造器 + `force_full_resync()`,而它们读 manager 的类字段 `$state`(version/count)→ effect 被订阅到**每帧 version bump** → 每帧 dispose + 重建两个 renderer + 重建全部 instanced GL attribute:实测 **bufferData ~36MB/帧,5 秒 1.16GB**(capacity 级 12MB vec3 ×2 + 4MB + …)。修法:effect 只追踪 mesh 绑定 + manager 身份两个合法依赖,body 整体 `untrack`(cleanup 经由 untrack 返回)。修后 12 秒播放:**renderer 重建 0 次、bufferData 0 次 0 MB**。

3. **layout-change / positions 两个效应同病**:body 里的 `force_full_resync()` 让它们也订阅 version → 每帧在本职依赖之外再各多跑一遍全量矩阵写(trace 里 `#write_slot` ×3/帧)。body untrack,各回归单一职责。

### 验证

- vitest 4502 pass;svelte-check 0 err
- live:播放/暂停键几何全程干净(over-4Å = 0);mount 计数器(DEV `__amr_mount`)播放期 0 增量
- fps:测量窗口恰逢两个 subagent 满负荷抢占 CPU/GPU,绝对值失真;干净基准随后补(计数类指标不受争用影响,已可证结构性收益)

### 追因方法(备忘)

Svelte 5 类字段 `$state` 会把"在 effect 里调用读它的方法"变成隐式订阅——mount-once effect 里调 `force_full_resync()` 这类"读 manager 内部状态的方法"必须 untrack。同类隐患 grep 面:`new .*Renderer\(` / effect 内 `force_full_resync|sync\(`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
