### PR TITLE
fix(trajectory): variable-cell playback — per-frame lattice through detection + CPU/GPU bond paths

### DIFF
--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -883,6 +883,9 @@
     trajectory_context,
     trajectory_frame_positions = null,
     trajectory_frame_forces = null as Float32Array | null,
+    // Variable-cell trajectory fast-path: displayed frame's lattice matrix
+    // (rows = a,b,c). Identity-stable across frames for fixed cells.
+    trajectory_frame_lattice = null as number[][] | null,
     trajectory_step_idx = -1,
     trajectory_positions_version = { v: 0, all: false },
     get_trajectory_frame_positions = null as ((i: number) => Float32Array | null) | null,
@@ -1058,6 +1061,9 @@
       trajectory_frame_positions?: Float32Array | null
       // Trajectory fast-path: flat Float32Array of forces (fx,fy,fz triples) for current frame
       trajectory_frame_forces?: Float32Array | null
+      // Variable-cell trajectory fast-path: displayed frame's lattice matrix
+      // (rows = a,b,c). Identity-stable across frames when the cell is fixed.
+      trajectory_frame_lattice?: number[][] | null
       // Active trajectory frame index (for per-frame bond cache).
       trajectory_step_idx?: number
       // Bumps when the current trajectory frame's positions change in place
@@ -4402,6 +4408,7 @@
             {webgl_suspended}
             {trajectory_frame_positions}
             {trajectory_frame_forces}
+            {trajectory_frame_lattice}
             {trajectory_step_idx}
             {...scene_props}
             {show_image_atoms}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -591,6 +591,12 @@
     trajectory_frame_positions = null as Float32Array | null,
     // Trajectory fast-path: flat Float32Array of forces (fx,fy,fz) for current frame
     trajectory_frame_forces = null as Float32Array | null,
+    // Variable-cell trajectory fast-path: the DISPLAYED frame's lattice matrix
+    // (rows = a,b,c, pymatgen convention). Identity-stable for fixed-cell
+    // trajectories (the supplier reuses the same reference while the nine
+    // numbers are unchanged), so every consumer below only re-fires per frame
+    // when the cell actually varies. null = use the (frozen) structure lattice.
+    trajectory_frame_lattice = null as number[][] | null,
     // Per-frame bond connectivity from the async trajectory bond cache. When
     // null (cache miss), we fall back to `bond_state.bond_connectivity`
     // (frame-0 static).
@@ -881,6 +887,9 @@
     trajectory_frame_positions?: Float32Array | null
     // Trajectory fast-path: flat Float32Array of forces (fx,fy,fz) per atom
     trajectory_frame_forces?: Float32Array | null
+    // Variable-cell trajectory fast-path: displayed frame's lattice matrix
+    // (rows = a,b,c). Identity-stable across frames when the cell is fixed.
+    trajectory_frame_lattice?: number[][] | null
     // Per-frame bond connectivity (from trajectory bond cache). Null = fall back to static.
     /** WebGPU large-system overlay active. When true the WebGL scene is fully
      *  covered by the overlay and `autoRender` is off, so this scene must do
@@ -2748,6 +2757,10 @@
     const sel = selected_sites
     const overrides_size = overrides?.size ?? 0
     const traj_positions = trajectory_frame_positions
+    // Variable-cell: identity changes only when the cell actually varies, and
+    // always alongside a traj_positions identity change — so the memo guards
+    // below need no extra lattice term.
+    const frame_lat = trajectory_frame_lattice
 
     // Plan v3 Phase 3 trajectory fast-path: when a trajectory is active,
     // bypass the slow build_bond_pairs path and use position-indexed
@@ -2764,6 +2777,7 @@
       const traj_conn = compute_bond_connectivity_for_frame(
         bond_state, traj_positions, bond_input,
         show_bonds, lattice, bonding_strategy, bonding_options,
+        frame_lat,
       )
       const __traj_tol_v = (() => {
         const raw = (bonding_options as Record<string, unknown> | undefined)?.tolerance
@@ -2792,7 +2806,7 @@
           traj_conn === __td_prev_conn &&
           traj_positions === __td_prev_pos
         ) return
-        const td_lat =
+        const td_lat = frame_lat ??
           (bond_input as { lattice?: { matrix?: number[][] } } | undefined)
             ?.lattice?.matrix ?? null
         const td_sites =
@@ -2858,7 +2872,9 @@
         traj_positions,
         overrides as unknown as Map<number, Vec3> | null,
         atom_manager,
-        (bond_input as { lattice?: { matrix?: number[][] } } | undefined)?.lattice?.matrix ?? null,
+        frame_lat ??
+          (bond_input as { lattice?: { matrix?: number[][] } } | undefined)?.lattice?.matrix ??
+          null,
         (bond_input as { sites?: ReadonlyArray<Site> } | undefined)?.sites ?? null,
         __traj_tol_v,
       )
@@ -4514,6 +4530,20 @@
     return out
   })
 
+  // Variable-cell trajectory frame lattice, flattened for BondManagerInstances
+  // (same row-major layout as bond_lattice_matrix). Re-derives only when the
+  // frame lattice identity changes — i.e. per frame ONLY when the cell truly
+  // varies (the supplier keeps the reference stable for fixed cells).
+  let bond_frame_lattice_matrix = $derived.by((): Float64Array | null => {
+    const m = trajectory_frame_lattice
+    if (!m || m.length !== 3) return null
+    const out = new Float64Array(9)
+    out[0] = m[0][0]; out[1] = m[0][1]; out[2] = m[0][2]
+    out[3] = m[1][0]; out[4] = m[1][1]; out[5] = m[1][2]
+    out[6] = m[2][0]; out[7] = m[2][1]; out[8] = m[2][2]
+    return out
+  })
+
   // Flat linear-RGB buffer for BondManagerInstances' gradient shader.
   // One xyz triple per site; bonds look up colors by site_idx at render time.
   // Per-site color overrides (from the right-click "Set Color" picker)
@@ -5961,6 +5991,7 @@
           {bond_opacity_overrides}
           periodic_bond_opacity={image_atom_opacity}
           lattice_matrix={bond_lattice_matrix}
+          frame_lattice_matrix={bond_frame_lattice_matrix}
           {incomplete_periodic_edge_mode}
           {incomplete_edge_length_scale}
           {hide_incomplete_bonds}
@@ -6165,7 +6196,13 @@
       {/if}
 
       {#if lattice && show_cell && show_bulk_atoms}
-        <Lattice matrix={lattice.matrix} {...lattice_props} />
+        <!-- Variable-cell playback: draw the displayed frame's cell, not the
+             frozen frame-0 lattice. Single wireframe box — per-frame rebuild
+             is negligible, and fixed-cell identity stability skips it. -->
+        <Lattice
+          matrix={(trajectory_frame_lattice as [Vec3, Vec3, Vec3] | null) ?? lattice.matrix}
+          {...lattice_props}
+        />
       {/if}
 
       <!-- Miller Slab Cutting - WYSIWYG Slab Preview -->

--- a/src/lib/structure/bond-computation-controller.svelte.ts
+++ b/src/lib/structure/bond-computation-controller.svelte.ts
@@ -152,6 +152,7 @@ export function clear_trajectory_bond_frame_cache(
     bond_state.traj_computation_gen++
     bond_state.traj_in_flight_frame = null
     bond_state.traj_pending_frame = null
+    bond_state.traj_pending_lattice = null
   }
 }
 
@@ -167,16 +168,26 @@ export function clear_trajectory_bond_frame_cache(
  *  finds neighbors at frame-0 fractional positions while the user sees
  *  frame-N Cartesian positions. Convention: `xyz = abc @ lattice` (rows
  *  of lattice.matrix are vectors a,b,c — pymatgen style), so
- *  `abc = xyz @ inv(lattice)`. */
-function build_trajectory_overlay_structure(
+ *  `abc = xyz @ inv(lattice)`.
+ *
+ *  `frame_lattice` (variable-cell trajectories): the displayed frame's
+ *  lattice matrix. When given, it replaces the base structure's (frozen
+ *  frame-0) lattice for BOTH the abc recompute and the overlay's own
+ *  `lattice.matrix` — the detector's PBC image search must use the cell
+ *  the positions actually live in. Exported for tests. */
+export function build_trajectory_overlay_structure(
   structure: AnyStructure,
   traj: Float32Array,
+  frame_lattice?: number[][] | null,
 ): AnyStructure {
   const sites = structure.sites
   const traj_max = Math.floor(traj.length / 3)
   const new_sites: Site[] = new Array(sites.length)
-  const lattice_matrix = (structure as { lattice?: { matrix?: number[][] } })
-    .lattice?.matrix
+  const base_lattice = (structure as { lattice?: { matrix?: number[][] } })
+    .lattice
+  const lattice_matrix =
+    (frame_lattice && frame_lattice.length === 3 ? frame_lattice : null) ??
+      base_lattice?.matrix
   const inv = lattice_matrix ? invert_3x3(lattice_matrix) : null
   for (let i = 0; i < sites.length; i++) {
     const orig = sites[i]
@@ -197,6 +208,20 @@ function build_trajectory_overlay_structure(
     } else {
       new_sites[i] = orig
     }
+  }
+  // Variable-cell: the overlay must carry the frame's lattice so the WASM
+  // detector enumerates PBC images in the right cell. Derived lattice params
+  // (a/b/c/angles/volume) go stale in the copy — detection only reads
+  // `matrix`, and the overlay never escapes this module.
+  if (
+    frame_lattice && frame_lattice.length === 3 && base_lattice &&
+    frame_lattice !== base_lattice.matrix
+  ) {
+    return {
+      ...structure,
+      sites: new_sites,
+      lattice: { ...base_lattice, matrix: frame_lattice },
+    } as AnyStructure
   }
   return { ...structure, sites: new_sites } as AnyStructure
 }
@@ -265,6 +290,10 @@ export function create_bond_state() {
   // Latest-wins throttle slots for trajectory async dispatches.
   let traj_in_flight_frame: Float32Array | null = null
   let traj_pending_frame: Float32Array | null = null
+  // Frame lattice paired with traj_pending_frame (variable-cell trajectories;
+  // null = frozen base lattice). The drain re-dispatch must use the PENDING
+  // frame's cell, not the cell of the dispatch that happens to drain it.
+  let traj_pending_lattice: number[][] | null = null
 
   return {
     get bond_connectivity() {
@@ -326,6 +355,12 @@ export function create_bond_state() {
     },
     set traj_pending_frame(v) {
       traj_pending_frame = v
+    },
+    get traj_pending_lattice() {
+      return traj_pending_lattice
+    },
+    set traj_pending_lattice(v) {
+      traj_pending_lattice = v
     },
   }
 }
@@ -624,6 +659,9 @@ export function compute_bond_connectivity_for_frame(
   lattice: Crystal['lattice'] | null,
   bonding_strategy: BondingStrategy,
   bonding_options: Record<string, unknown>,
+  // Variable-cell trajectories: the displayed frame's lattice matrix (rows =
+  // a,b,c). null/undefined = fixed cell, detect in the base structure's cell.
+  frame_lattice?: number[][] | null,
 ): typeof bond_state.bond_connectivity {
   if (!structure?.sites) return bond_state.bond_connectivity
 
@@ -676,6 +714,7 @@ export function compute_bond_connectivity_for_frame(
     const overlay_structure = build_trajectory_overlay_structure(
       structure,
       traj_positions,
+      frame_lattice,
     )
     const sync_bonds = compute_bonds_sync(
       overlay_structure,
@@ -716,10 +755,13 @@ export function compute_bond_connectivity_for_frame(
       elem_fp,
       bonding_strategy,
       bonding_options,
+      frame_lattice ?? null,
     )
   } else if (bond_state.traj_in_flight_frame !== traj_positions) {
-    // Latest-wins: just remember which frame the user is currently on.
+    // Latest-wins: just remember which frame the user is currently on
+    // (positions + the cell they live in).
     bond_state.traj_pending_frame = traj_positions
+    bond_state.traj_pending_lattice = frame_lattice ?? null
   }
 
   // While async is in flight, render with previous frame's connectivity.
@@ -820,6 +862,7 @@ function dispatch_traj_async(
   elem_fp: string,
   bonding_strategy: BondingStrategy,
   bonding_options: Record<string, unknown>,
+  frame_lattice: number[][] | null = null,
 ): void {
   const gen = ++bond_state.traj_computation_gen
   const n_sites = base_structure.sites.length
@@ -892,6 +935,8 @@ function dispatch_traj_async(
       // already cached so a future revisit will hit O(1).
       bond_state.traj_in_flight_frame = pending
       bond_state.traj_pending_frame = null
+      const pending_lattice = bond_state.traj_pending_lattice
+      bond_state.traj_pending_lattice = null
       dispatch_traj_async(
         bond_state,
         pending,
@@ -900,6 +945,7 @@ function dispatch_traj_async(
         elem_fp,
         bonding_strategy,
         bonding_options,
+        pending_lattice,
       )
     }
   }
@@ -908,6 +954,7 @@ function dispatch_traj_async(
     const overlay_structure = build_trajectory_overlay_structure(
       base_structure,
       frame_key,
+      frame_lattice,
     )
     compute_bonds_async(
       overlay_structure,
@@ -940,7 +987,7 @@ function dispatch_traj_async(
     compute_bonds_typed_worker(
       frame_key,
       zs,
-      crystal.lattice?.matrix ?? null,
+      frame_lattice ?? crystal.lattice?.matrix ?? null,
       pbc,
       bonding_options as Record<string, number>,
     )

--- a/src/lib/structure/bonding/BondManagerInstances.svelte
+++ b/src/lib/structure/bonding/BondManagerInstances.svelte
@@ -60,6 +60,15 @@
      */
     lattice_matrix?: Float64Array | null
     /**
+     * Variable-cell trajectory override: the DISPLAYED frame's lattice in the
+     * same row-major Float64Array(9) layout as `lattice_matrix`. Fed ONLY to
+     * the uLattice uniform and the renderer's per-slot lattice getter — the
+     * full-resync config effect keeps tracking the static `lattice_matrix`,
+     * so a per-frame identity change here costs one mat3 uniform write, not
+     * a full buffer rebuild. `null` = fixed cell (use `lattice_matrix`).
+     */
+    frame_lattice_matrix?: Float64Array | null
+    /**
      * VESTA-Mode-1 cell-edge style: when true, cross-cell bonds (jimage ≠ 0)
      * render as a single stub on atom A's side of the boundary instead of
      * paired stubs on both sides. Default false (paired stubs).
@@ -141,6 +150,7 @@
     bond_opacity_overrides,
     periodic_bond_opacity = 1,
     lattice_matrix = null,
+    frame_lattice_matrix = null,
     incomplete_periodic_edge_mode = false,
     incomplete_edge_length_scale = 0.5,
     hide_incomplete_bonds = true,
@@ -643,9 +653,12 @@
 
   // GPU-path scalar/matrix uniforms. lattice_matrix identity is stable
   // during playback (the per-frame structure cascade is cut), so this fires
-  // on load / lattice edits, not per frame.
+  // on load / lattice edits, not per frame. frame_lattice_matrix is the
+  // variable-cell exception: identity changes per frame there, and this
+  // effect's whole body is cheap uniform writes — that per-frame cost is
+  // exactly the point (cross-cell bonds must use the displayed frame's cell).
   $effect(() => {
-    const lat = lattice_matrix
+    const lat = frame_lattice_matrix ?? lattice_matrix
     const m = shader_material.uniforms.uLattice.value as Matrix3
     if (lat) m.fromArray(lat as unknown as number[])
     else m.fromArray(ZERO_LATTICE)
@@ -707,7 +720,10 @@
         mesh_ref,
         mgr,
         () => atom_positions,
-        () => lattice_matrix ?? null,
+        // Variable-cell playback: per-slot CPU matrix writes must use the
+        // displayed frame's cell. Read at call time inside the renderer's
+        // (untracked) sync bodies, so this adds no reactive subscription.
+        () => frame_lattice_matrix ?? lattice_matrix ?? null,
         () => ({
           mode: incomplete_periodic_edge_mode,
           scale: incomplete_edge_length_scale,

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -52,6 +52,7 @@
     compute_step_label_positions,
     get_view_mode_label,
     read_file_content,
+    stable_frame_lattice,
   } from './trajectory-utils'
   import {
     clamp_fps,
@@ -628,6 +629,12 @@
   let trajectory_frame_positions = $state<Float32Array | null>(null)
   // Trajectory frame forces for fast path (Float32Array of fx,fy,fz triples, null if no forces)
   let trajectory_frame_forces = $state<Float32Array | null>(null)
+  // Variable-cell fast path: displayed frame's lattice matrix (rows = a,b,c).
+  // $state.raw + the plain shadow below keep this identity-stable for fixed
+  // cells — the shadow is compared/updated without reading the signal, so the
+  // publishing effect never subscribes to its own output.
+  let trajectory_frame_lattice = $state.raw<number[][] | null>(null)
+  let last_frame_lattice: number[][] | null = null
 
   // Plan v3 Phase 4 (per plans/phase4-current-structure-investigation.md):
   // Gate `current_structure = frame.structure` behind a topology_initialized
@@ -657,8 +664,23 @@
       current_structure = undefined
       trajectory_frame_positions = null
       trajectory_frame_forces = null
+      last_frame_lattice = null
+      trajectory_frame_lattice = null
       topology_initialized = false
       return
+    }
+    // Variable-cell trajectories (NPT / cell relaxation): publish the frame's
+    // lattice so bond detection, cross-cell rendering (CPU + GPU uLattice) and
+    // the cell wireframe track the displayed cell. Identity-stable when the
+    // nine numbers don't change, so fixed-cell playback costs 9 compares/frame
+    // and fires no downstream effects.
+    const frame_lat = stable_frame_lattice(
+      last_frame_lattice,
+      (frame.structure as { lattice?: { matrix?: number[][] } }).lattice?.matrix,
+    )
+    if (frame_lat !== last_frame_lattice) {
+      last_frame_lattice = frame_lat
+      trajectory_frame_lattice = frame_lat
     }
     // Doping / substitution trajectories swap element identity per frame
     // while keeping positions constant; the position_cache fast-path freezes
@@ -966,9 +988,24 @@
       }
       return { ...site, xyz: [x, y, z] as [number, number, number] }
     })
-    // Bail if every site was passthrough (no actual change)
-    if (new_sites.every((s, i) => s === sites[i])) return
-    current_structure = { ...cur, sites: new_sites }
+    // Variable-cell: the paused frame's lattice must land in current_structure
+    // too — exports, the info pane and post-pause edits read structure.lattice.
+    // Take the frame's FULL lattice object (params a/b/c/angles included, from
+    // parse time) rather than patching only the matrix. Fixed-cell trajectories
+    // short-circuit on the identity-stable trajectory_frame_lattice being in
+    // sync with the current matrix already.
+    const cur_lattice = (cur as { lattice?: { matrix?: number[][] } }).lattice
+    const frame_lattice_obj =
+      (current_frame?.structure as { lattice?: { matrix?: number[][] } } | undefined)
+        ?.lattice
+    const lattice_changed = cur_lattice && frame_lattice_obj &&
+      stable_frame_lattice(cur_lattice.matrix ?? null, frame_lattice_obj.matrix) !==
+        (cur_lattice.matrix ?? null)
+    // Bail if every site was passthrough and the cell is unchanged
+    if (!lattice_changed && new_sites.every((s, i) => s === sites[i])) return
+    current_structure = lattice_changed
+      ? { ...cur, sites: new_sites, lattice: frame_lattice_obj } as typeof cur
+      : { ...cur, sites: new_sites }
   }
 
   // Play/pause functionality
@@ -2295,6 +2332,7 @@
           handle_viewer_command={handle_trajectory_command}
           {trajectory_frame_positions}
           {trajectory_frame_forces}
+          {trajectory_frame_lattice}
           trajectory_step_idx={current_step_idx}
           trajectory_positions_version={trajectory_positions_version}
           get_trajectory_frame_positions={(i: number) => {

--- a/src/lib/trajectory/trajectory-utils.ts
+++ b/src/lib/trajectory/trajectory-utils.ts
@@ -19,6 +19,39 @@ export function structures_compatible(a: AnyStructure, b: AnyStructure): boolean
 }
 
 /**
+ * Identity-stable per-frame lattice selector for variable-cell trajectories.
+ *
+ * Every materialized frame structure carries its own `lattice.matrix` array,
+ * so the reference changes each frame even when the cell is fixed. Downstream
+ * consumers (bond detection, GPU uLattice uniform, cell wireframe) key their
+ * re-work off the lattice IDENTITY — so fixed-cell playback must keep handing
+ * out the same reference. Returns `prev` when the nine numbers are unchanged,
+ * a plain-array SNAPSHOT of the frame's matrix otherwise (frame structures
+ * live behind Svelte's deep proxy — hot per-bond consumers must not pay proxy
+ * traps on every lat[r][c] read), and `null` when the frame has no 3×3 lattice.
+ */
+export function stable_frame_lattice(
+  prev: number[][] | null,
+  matrix: number[][] | null | undefined,
+): number[][] | null {
+  if (!matrix || matrix.length !== 3) return null
+  if (prev && prev.length === 3) {
+    let same = true
+    for (let row = 0; row < 3 && same; row++) {
+      const pr = prev[row]
+      const mr = matrix[row]
+      if (pr[0] !== mr[0] || pr[1] !== mr[1] || pr[2] !== mr[2]) same = false
+    }
+    if (same) return prev
+  }
+  return [
+    [matrix[0][0], matrix[0][1], matrix[0][2]],
+    [matrix[1][0], matrix[1][1], matrix[1][2]],
+    [matrix[2][0], matrix[2][1], matrix[2][2]],
+  ]
+}
+
+/**
  * Compute step label positions for the trajectory slider.
  * @param step_labels - positive number (ticks count), negative number (spacing), or array of exact indices
  * @param total_frames - total number of trajectory frames

--- a/tests/vitest/structure/trajectory-overlay-lattice.test.ts
+++ b/tests/vitest/structure/trajectory-overlay-lattice.test.ts
@@ -1,0 +1,110 @@
+import { build_trajectory_overlay_structure } from '$lib/structure/bond-computation-controller.svelte'
+import type { AnyStructure } from '$lib/structure'
+import { describe, expect, test } from 'vitest'
+
+// 2-atom cubic cell, a = 10 Å. Frame lattice grows the cell to 20 Å —
+// the abc recompute and the overlay's lattice must both use the FRAME cell,
+// not the frozen base cell (variable-cell / NPT trajectories).
+const BASE_MATRIX = [
+  [10, 0, 0],
+  [0, 10, 0],
+  [0, 0, 10],
+]
+const FRAME_MATRIX = [
+  [20, 0, 0],
+  [0, 20, 0],
+  [0, 0, 20],
+]
+
+function make_structure(): AnyStructure {
+  return {
+    lattice: {
+      matrix: BASE_MATRIX,
+      pbc: [true, true, true],
+      a: 10,
+      b: 10,
+      c: 10,
+      alpha: 90,
+      beta: 90,
+      gamma: 90,
+      volume: 1000,
+    },
+    sites: [
+      {
+        species: [{ element: `Na`, occu: 1, oxidation_state: 0 }],
+        abc: [0, 0, 0],
+        xyz: [0, 0, 0],
+        label: `Na1`,
+        properties: {},
+      },
+      {
+        species: [{ element: `Cl`, occu: 1, oxidation_state: 0 }],
+        abc: [0.5, 0.5, 0.5],
+        xyz: [5, 5, 5],
+        label: `Cl1`,
+        properties: {},
+      },
+    ],
+  } as unknown as AnyStructure
+}
+
+describe(`build_trajectory_overlay_structure — variable-cell frame lattice`, () => {
+  const traj = new Float32Array([0, 0, 0, 10, 10, 10]) // Cl moved to frame-cell center
+
+  test(`without frame_lattice: abc from the base cell, lattice untouched`, () => {
+    const base = make_structure()
+    const overlay = build_trajectory_overlay_structure(base, traj) as unknown as {
+      lattice: { matrix: number[][] }
+      sites: { abc: number[]; xyz: number[] }[]
+    }
+    expect(overlay.lattice.matrix).toBe(BASE_MATRIX)
+    // xyz (10,10,10) in the 10 Å base cell → abc (1,1,1)
+    expect(overlay.sites[1].abc[0]).toBeCloseTo(1, 10)
+    expect(overlay.sites[1].abc[1]).toBeCloseTo(1, 10)
+    expect(overlay.sites[1].abc[2]).toBeCloseTo(1, 10)
+  })
+
+  test(`with frame_lattice: abc from the frame cell AND overlay carries it`, () => {
+    const base = make_structure()
+    const overlay = build_trajectory_overlay_structure(
+      base,
+      traj,
+      FRAME_MATRIX,
+    ) as unknown as {
+      lattice: { matrix: number[][]; pbc: boolean[] }
+      sites: { abc: number[]; xyz: number[] }[]
+    }
+    // Overlay must detect PBC images in the frame's cell.
+    expect(overlay.lattice.matrix).toBe(FRAME_MATRIX)
+    // Non-matrix lattice fields survive the copy (pbc drives the detector).
+    expect(overlay.lattice.pbc).toEqual([true, true, true])
+    // xyz (10,10,10) in the 20 Å frame cell → abc (0.5,0.5,0.5)
+    expect(overlay.sites[1].abc[0]).toBeCloseTo(0.5, 10)
+    expect(overlay.sites[1].abc[1]).toBeCloseTo(0.5, 10)
+    expect(overlay.sites[1].abc[2]).toBeCloseTo(0.5, 10)
+    expect(overlay.sites[1].xyz).toEqual([10, 10, 10])
+  })
+
+  test(`input structure is never mutated`, () => {
+    const base = make_structure()
+    build_trajectory_overlay_structure(base, traj, FRAME_MATRIX)
+    const b = base as unknown as {
+      lattice: { matrix: number[][] }
+      sites: { xyz: number[] }[]
+    }
+    expect(b.lattice.matrix).toBe(BASE_MATRIX)
+    expect(b.sites[1].xyz).toEqual([5, 5, 5])
+  })
+
+  test(`frame_lattice identical to the base matrix reference skips the lattice copy`, () => {
+    const base = make_structure()
+    const overlay = build_trajectory_overlay_structure(
+      base,
+      traj,
+      BASE_MATRIX,
+    ) as unknown as { lattice: { matrix: number[][] } }
+    expect(overlay.lattice).toBe(
+      (base as unknown as { lattice: unknown }).lattice,
+    )
+  })
+})

--- a/tests/vitest/trajectory/frame-lattice.test.ts
+++ b/tests/vitest/trajectory/frame-lattice.test.ts
@@ -1,0 +1,55 @@
+import { stable_frame_lattice } from '$lib/trajectory/trajectory-utils'
+import { describe, expect, test } from 'vitest'
+
+const MAT = [
+  [10, 0, 0],
+  [0, 10, 0],
+  [0, 0, 10],
+]
+
+describe(`stable_frame_lattice`, () => {
+  test(`returns null for missing or malformed lattice`, () => {
+    expect(stable_frame_lattice(null, null)).toBeNull()
+    expect(stable_frame_lattice(null, undefined)).toBeNull()
+    expect(stable_frame_lattice(MAT, [[1, 0, 0]])).toBeNull()
+  })
+
+  test(`first adoption snapshots the matrix (new plain copy, not the input ref)`, () => {
+    const out = stable_frame_lattice(null, MAT)
+    expect(out).not.toBe(MAT)
+    expect(out).toEqual(MAT)
+    // Snapshot is detached: mutating the source must not leak through.
+    const src = MAT.map((row) => [...row])
+    const snap = stable_frame_lattice(null, src)!
+    src[1][1] = 99
+    expect(snap[1][1]).toBe(10)
+  })
+
+  test(`fixed cell keeps the previous reference across frames`, () => {
+    const prev = stable_frame_lattice(null, MAT)!
+    // A different array object with the same nine numbers (each materialized
+    // frame carries its own matrix arrays) must NOT produce a new identity.
+    const same_values = MAT.map((row) => [...row])
+    expect(stable_frame_lattice(prev, same_values)).toBe(prev)
+  })
+
+  test(`variable cell produces a new snapshot when any entry changes`, () => {
+    const prev = stable_frame_lattice(null, MAT)!
+    const grown = MAT.map((row) => [...row])
+    grown[2][2] = 10.05 // NPT c-axis breathing
+    const next = stable_frame_lattice(prev, grown)
+    expect(next).not.toBe(prev)
+    expect(next![2][2]).toBe(10.05)
+    // And a return to the original values re-snapshots (prev no longer matches)
+    const back = stable_frame_lattice(next, MAT)
+    expect(back).not.toBe(next)
+    expect(back).toEqual(MAT)
+  })
+
+  test(`off-diagonal (tilt) changes are detected`, () => {
+    const prev = stable_frame_lattice(null, MAT)!
+    const tilted = MAT.map((row) => [...row])
+    tilted[1][0] = 0.2
+    expect(stable_frame_lattice(prev, tilted)).not.toBe(prev)
+  })
+})


### PR DESCRIPTION
## Problem

NPT / cell-relaxation trajectories rendered cross-cell bonds — and the cell wireframe — with the frame-0 lattice frozen for the whole run. Detection recomputed fractional coords with the wrong inverse, `conn_to_typed_topology` and the object pipeline applied wrong `jimage` offsets, and the GPU path's `uLattice` uniform never updated. Anything with a breathing/tilting cell showed cross-cell bonds drifting off the atoms as playback advanced.

## Fix — one per-frame lattice threaded through all three layers

- **`Trajectory.svelte`** publishes `trajectory_frame_lattice` per frame via a new `stable_frame_lattice` helper: a 9-number compare that returns the *same reference* when the cell is unchanged, so fixed-cell playback stays identity-stable and fires zero downstream re-work. Variable cells hand out a fresh plain-array snapshot (de-proxied for the hot per-bond reads).
- **Detection** (`bond-computation-controller`): `build_trajectory_overlay_structure` + the typed-worker dispatch use the frame's cell for both the `abc` recompute and the overlay's own `lattice.matrix`; the latest-wins pending slot now pairs the pending frame's lattice so a drained re-dispatch uses the right cell.
- **CPU render** (`StructureScene`): frame lattice feeds `conn_to_typed_topology`, the object pipeline, the tail-sync ctx, and the cell wireframe.
- **GPU render** (`BondManagerInstances`): a new `frame_lattice_matrix` prop feeds *only* the `uLattice` uniform + the renderer's lattice getter — the full-resync config effect keeps tracking the static lattice, so a variable cell costs one `mat3` uniform write per frame, not a buffer rebuild.
- Pause writeback carries the paused frame's full lattice object into `current_structure` (exports / info pane / post-pause edits).

## Verification

- 9 new unit tests (`stable_frame_lattice` identity/snapshot semantics + overlay frame-cell abc recompute); full vitest **4544 passing**, `svelte-check` 0 errors.
- Browser: 64-atom NaCl 2×2×2 with a cubic cell breathing 11.28 → 12.41 Å over 40 frames. In-shader bond stats match the file's a/4 nearest-neighbour distance to 6 significant figures at every frame (min_len ×1.09992 at peak), `over_max`/`non_finite` = 0, cell wireframe scales with the atoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)