### PR TITLE
perf(bonds): cylinder-segment LOD — 8 segments during large-system playback

### DIFF
--- a/src/lib/structure/bonding/BondManagerInstances.svelte
+++ b/src/lib/structure/bonding/BondManagerInstances.svelte
@@ -15,6 +15,7 @@
   } from 'three'
   import { get_bond_key } from '../bonding'
   import { BondInstancedRenderer, type PartnerDrawnLookup } from './bond-instanced-renderer'
+  import { bond_lod_segments } from './bond-lod'
   import type { BondManager } from './bond-manager.svelte'
   import type { ImageAtomLayout } from './image-atom-layout'
 
@@ -685,11 +686,27 @@
     })
   })
 
-  // Geometry rebuilds reactively when bond_radius changes. Threlte's
-  // `args` reconciliation reconstructs the InstancedMesh, which drops the
-  // mesh ref — the renderer effect below then reinitialises and
-  // force_full_resync()s every slot's matrix, preserving bond data.
-  const geometry = $derived(new CylinderGeometry(bond_radius, bond_radius, 1, 16))
+  // Geometry rebuilds reactively when bond_radius OR the LOD segment count
+  // changes. Threlte's `args` reconciliation reconstructs the InstancedMesh,
+  // which drops the mesh ref — the renderer effect below then reinitialises
+  // and force_full_resync()s every slot's matrix, preserving bond data.
+  //
+  // Segment LOD: a large system drops to fewer cylinder segments *while
+  // playing* (gpu_transform_active) and restores full segments on pause —
+  // motion hides the facets, a paused frame does not. The rebuild fires only
+  // on the play/pause EDGE (gpu_transform_active flips), never per frame:
+  // atom_positions gets a fresh identity every frame, so its length is read
+  // UNTRACKED (the count only matters at a play/pause edge, which re-runs this
+  // derived and re-reads it). Tracking it would rebuild the whole mesh every
+  // frame — the exact per-frame churn the trajectory fast-path exists to kill.
+  const geometry = $derived.by(() => {
+    const playing = gpu_transform_active
+    const radius = bond_radius
+    const segments = untrack(() =>
+      bond_lod_segments(atom_positions.length / 3, playing)
+    )
+    return new CylinderGeometry(radius, radius, 1, segments)
+  })
 
   $effect(() => {
     // Tracked deps: ONLY the mesh binding and manager identity — the body

--- a/src/lib/structure/bonding/bond-lod.ts
+++ b/src/lib/structure/bonding/bond-lod.ts
@@ -1,0 +1,24 @@
+// Cylinder-segment level-of-detail for bond rendering.
+//
+// The per-bond cylinder is the trajectory-playback vertex bottleneck: at ~52k
+// half-bond instances, a 16-sided cylinder is ~10x the vertices of an 8-sided
+// one. During playback the segment count is imperceptible (motion + attention
+// on the whole structure), so a large system drops to fewer segments while
+// playing and restores full segments the instant it pauses — where the eye
+// starts scrutinising individual bonds. Small systems never pay the price
+// (the GPU is not the bottleneck there), so they always render full segments.
+
+/** Full-quality cylinder segments — static frames, small systems. */
+export const BOND_SEGMENTS_FULL = 16
+/** Reduced segments during large-system playback (motion hides the facets). */
+export const BOND_SEGMENTS_LOD = 8
+/** Atom count above which playback engages the reduced segment count. */
+export const BOND_LOD_MIN_ATOMS = 2000
+
+/** Choose the cylinder segment count for the current frame. Full segments
+ *  unless the system is large AND actively playing; degenerate counts
+ *  (0 / negative / NaN) fall back to full. */
+export function bond_lod_segments(n_atoms: number, playing: boolean): number {
+  if (!(n_atoms > BOND_LOD_MIN_ATOMS)) return BOND_SEGMENTS_FULL
+  return playing ? BOND_SEGMENTS_LOD : BOND_SEGMENTS_FULL
+}

--- a/tests/vitest/structure/bonding/bond-lod.test.ts
+++ b/tests/vitest/structure/bonding/bond-lod.test.ts
@@ -1,0 +1,39 @@
+import {
+  BOND_LOD_MIN_ATOMS,
+  BOND_SEGMENTS_FULL,
+  BOND_SEGMENTS_LOD,
+  bond_lod_segments,
+} from '$lib/structure/bonding/bond-lod'
+import { describe, expect, test } from 'vitest'
+
+// Cylinder-segment LOD: playback of a large system drops the per-bond
+// cylinder to fewer segments (a static frame or a small system keeps full
+// segments). Motion hides the segment count; a paused/small view does not.
+describe(`bond_lod_segments`, () => {
+  test(`small system keeps full segments even during playback`, () => {
+    expect(bond_lod_segments(500, true)).toBe(BOND_SEGMENTS_FULL)
+    expect(bond_lod_segments(500, false)).toBe(BOND_SEGMENTS_FULL)
+  })
+
+  test(`large system drops segments only while playing`, () => {
+    expect(bond_lod_segments(20000, true)).toBe(BOND_SEGMENTS_LOD)
+    expect(bond_lod_segments(20000, false)).toBe(BOND_SEGMENTS_FULL)
+  })
+
+  test(`the threshold is exclusive — exactly MIN_ATOMS is still "small"`, () => {
+    expect(bond_lod_segments(BOND_LOD_MIN_ATOMS, true)).toBe(BOND_SEGMENTS_FULL)
+    expect(bond_lod_segments(BOND_LOD_MIN_ATOMS + 1, true)).toBe(BOND_SEGMENTS_LOD)
+  })
+
+  test(`degenerate atom counts fall back to full segments`, () => {
+    expect(bond_lod_segments(0, true)).toBe(BOND_SEGMENTS_FULL)
+    expect(bond_lod_segments(-1, true)).toBe(BOND_SEGMENTS_FULL)
+    expect(bond_lod_segments(Number.NaN, true)).toBe(BOND_SEGMENTS_FULL)
+  })
+
+  test(`LOD segment count is a real reduction, both even for clean geometry`, () => {
+    expect(BOND_SEGMENTS_LOD).toBeLessThan(BOND_SEGMENTS_FULL)
+    expect(BOND_SEGMENTS_FULL % 2).toBe(0)
+    expect(BOND_SEGMENTS_LOD % 2).toBe(0)
+  })
+})


### PR DESCRIPTION
## Why

Round-5 attribution pinned the trajectory-playback bottleneck as **GPU-bound, not CPU** (per-frame synchronous JS was 0.6ms after the round-4 proxy work). A drawingBuffer 1/16 shrink lifted fps only +46%, so the frame is split between fill (~14ms) and non-fill **vertex/upload work (~28ms)**. The per-bond cylinder dominates that vertex cost: at ~52k half-bond instances a 16-sided cylinder is ~2× the vertices of an 8-sided one.

## What

`bond_lod_segments(n_atoms, playing)`:
- **Large system (>2000 atoms) + playing** → 8 segments
- **Paused, or small system** → 16 segments (full)

Motion hides the facet count; a paused frame is where the eye scrutinises individual bonds, so it gets full quality back. Small systems always render full segments — the GPU isn't the bottleneck there. This is LOD, **not a global downgrade**: no static frame ever loses quality.

The `geometry` `$derived` rebuilds the InstancedMesh only on the **play/pause edge** (`gpu_transform_active` flips). `atom_positions` gets a fresh identity every frame, so its length is read `untrack`ed — the count only matters when the playback flag flips, which re-runs the derived. Tracking it would rebuild the mesh every frame (the exact churn the trajectory fast-path exists to prevent). The rebuild composes cleanly with the existing GPU-mode transition: the mount effect syncs `last_gpu_active`, so the mode-transition effect short-circuits.

## Verification

- 5 new pure-function unit tests (threshold, playing/paused, small/large, degenerate counts); full vitest **4534 passing**, `svelte-check` 0 errors.
- Runtime (20k-atom trajectory): the bond render mesh (count 51784) reads **16 segments while paused** — directly confirmed via scene traversal. The playing→8 transition is covered by the unit tests + the `gpu_transform_active`-driven `$derived` (a pre-existing dev/prod canvas-teardown artifact from failed backend fetches — unrelated to this change, no geometry/mesh errors in console — blocked the direct pixel read of the playing state).

## Follow-up (not in this PR)

impostor-cylinder spike (ray-cylinder in fragment shader, OVITO-style) as an isolated, artifact-debugged experiment — a larger vertex-side win but with real risks (flicker / card-plane artifacts / early-z fill cost) that must be resolved before it touches the live bond renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)