### PR TITLE
fix(atoms,bonds): never destroy pending GPU update ranges on renderer sync

### DIFF
--- a/src/lib/structure/atoms/atom-instanced-renderer.ts
+++ b/src/lib/structure/atoms/atom-instanced-renderer.ts
@@ -255,11 +255,16 @@ export class AtomInstancedRenderer {
 			)
 		}
 
-		this.#position_attr.clearUpdateRanges()
-		this.#radius_attr.clearUpdateRanges()
-		this.#color_attr.clearUpdateRanges()
-		this.#opacity_attr.clearUpdateRanges()
-		this.#saturation_attr.clearUpdateRanges()
+		// NOTE: never call clearUpdateRanges() here. Three.js consumes (uploads)
+		// an attribute's updateRanges at DRAW time and clears them itself
+		// (WebGLAttributes.updateBuffer). Svelte can flush this sync several
+		// times before the next RAF draw — e.g. a supercell apply grows the
+		// manager in one flush and appends image atoms in the next. Clearing at
+		// sync start destroyed the previous flush's not-yet-uploaded ranges, so
+		// freshly grown slots kept their allocation-time zeros on the GPU
+		// (radius 0 → invisible atoms) while manager.count / mesh.count / the
+		// CPU arrays were all correct. Ranges must accumulate until the draw;
+		// three merges overlapping ranges before uploading.
 
 		const positions = manager.positions_buffer
 		const radii = manager.radii_buffer
@@ -410,11 +415,10 @@ export class AtomInstancedRenderer {
 			)
 		}
 
-		this.#position_attr.clearUpdateRanges()
-		this.#radius_attr.clearUpdateRanges()
-		this.#color_attr.clearUpdateRanges()
-		this.#opacity_attr.clearUpdateRanges()
-		this.#saturation_attr.clearUpdateRanges()
+		// No clearUpdateRanges() — see the note in sync(). The [0, count)
+		// ranges added below subsume any pending smaller ranges after three's
+		// merge pass; stale pending ranges beyond `count` (post-shrink) upload
+		// in-bounds array data for slots the draw never reads — harmless.
 
 		if (count > 0) {
 			const positions = manager.positions_buffer

--- a/src/lib/structure/bonding/bond-instanced-renderer.ts
+++ b/src/lib/structure/bonding/bond-instanced-renderer.ts
@@ -253,11 +253,12 @@ export class BondInstancedRenderer {
 			);
 		}
 
-		matrix_attr.clearUpdateRanges();
-		this.#kind_attr.clearUpdateRanges();
-		this.#color_start_attr?.clearUpdateRanges();
-		this.#color_end_attr?.clearUpdateRanges();
-		this.#opacity_attr?.clearUpdateRanges();
+		// NOTE: never call clearUpdateRanges() here — three.js consumes and
+		// clears updateRanges at DRAW time (WebGLAttributes.updateBuffer).
+		// Clearing at sync start destroys the previous flush's not-yet-uploaded
+		// ranges when several syncs land between draws (the atom-renderer
+		// supercell vanish bug — same defect class). Ranges accumulate until
+		// the draw; three merges overlaps before uploading.
 
 		// Hoist buffer refs once per sync — avoid per-slot getter + closure overhead.
 		const pairs = manager.pairs_buffer;
@@ -359,11 +360,8 @@ export class BondInstancedRenderer {
 			);
 		}
 
-		matrix_attr.clearUpdateRanges();
-		this.#kind_attr.clearUpdateRanges();
-		this.#color_start_attr?.clearUpdateRanges();
-		this.#color_end_attr?.clearUpdateRanges();
-		this.#opacity_attr?.clearUpdateRanges();
+		// No clearUpdateRanges() — see the note in sync(). The full-extent
+		// ranges added below subsume pending smaller ones after three's merge.
 
 		const pairs = manager.pairs_buffer;
 		const kinds = manager.kinds_buffer;
@@ -463,12 +461,7 @@ export class BondInstancedRenderer {
 
 		const site_attr = this.#site_attr!;
 		const jimage_attr = this.#gpu_jimage_attr!;
-		site_attr.clearUpdateRanges();
-		jimage_attr.clearUpdateRanges();
-		this.#kind_attr.clearUpdateRanges();
-		this.#color_start_attr?.clearUpdateRanges();
-		this.#color_end_attr?.clearUpdateRanges();
-		this.#opacity_attr?.clearUpdateRanges();
+		// No clearUpdateRanges() — see the note in sync().
 
 		const pairs = manager.pairs_buffer;
 		const kinds = manager.kinds_buffer;

--- a/tests/vitest/structure/atoms/atom-renderer-growth.test.ts
+++ b/tests/vitest/structure/atoms/atom-renderer-growth.test.ts
@@ -1,0 +1,182 @@
+/**
+ * AtomInstancedRenderer — GPU upload survival across multiple sync() calls
+ * between draws (the supercell atom-vanish bug).
+ *
+ * Three.js consumes an attribute's `updateRanges` at DRAW time
+ * (WebGLAttributes.updateBuffer): it uploads only the ranges present at that
+ * moment, then clears them; with zero ranges it uploads the whole array.
+ * Svelte can flush the renderer's sync $effect several times before the next
+ * RAF draw (e.g. a supercell apply: X2 shadow sync grows the manager, then
+ * the image-atom pass grows it again). If a later sync() destroys the ranges
+ * a previous sync() queued — via renderer-side clearUpdateRanges() — the
+ * covered slots never reach the GPU. Freshly grown slots keep their
+ * allocation-time zeros (radius 0 → invisible atoms) while manager.count,
+ * mesh.count and the CPU-side attribute arrays all look correct.
+ *
+ * The fake GPU below mirrors three's updateBuffer contract exactly
+ * (three@0.181 three.module.js L139-214): version-gated, ranges-or-full,
+ * clear-after-consume.
+ */
+import { AtomManager } from '$lib/structure/atoms/atom-manager.svelte'
+import { AtomInstancedRenderer } from '$lib/structure/atoms/atom-instanced-renderer'
+import * as THREE from 'three'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+const CAPACITY = 32
+const VISUAL_RADIUS_SCALE = 0.5 // renderer's logical→GPU radius scale
+
+let mesh: THREE.InstancedMesh
+let manager: AtomManager
+let renderer: AtomInstancedRenderer
+
+function make_mesh(): THREE.InstancedMesh {
+	const geometry = new THREE.PlaneGeometry(2, 2, 1, 1)
+	const material = new THREE.MeshBasicMaterial()
+	return new THREE.InstancedMesh(geometry, material, CAPACITY)
+}
+
+function attr(name: string): THREE.InstancedBufferAttribute {
+	return mesh.geometry.getAttribute(name) as THREE.InstancedBufferAttribute
+}
+
+// ─── Fake GPU: three.js WebGLAttributes.update / updateBuffer semantics ───
+// - first use: gl.bufferData with the full CPU array (createBuffer)
+// - later: only if attribute.version advanced (needsUpdate):
+//   - updateRanges empty → full-array gl.bufferSubData
+//   - else → upload ONLY those ranges, then attribute.clearUpdateRanges()
+const gpu = new Map<
+	THREE.InstancedBufferAttribute,
+	{ data: Float32Array; version: number }
+>()
+
+function draw_upload(attribute: THREE.InstancedBufferAttribute): Float32Array {
+	const cpu = attribute.array as Float32Array
+	let entry = gpu.get(attribute)
+	if (!entry) {
+		entry = { data: cpu.slice(), version: attribute.version }
+		gpu.set(attribute, entry)
+		return entry.data
+	}
+	if (entry.version === attribute.version) return entry.data
+	const ranges = attribute.updateRanges
+	if (ranges.length === 0) {
+		entry.data.set(cpu)
+	} else {
+		for (const range of ranges) {
+			for (let i = range.start; i < range.start + range.count; i++) {
+				entry.data[i] = cpu[i]
+			}
+		}
+		attribute.clearUpdateRanges()
+	}
+	entry.version = attribute.version
+	return entry.data
+}
+
+/** Simulate one WebGL draw: upload every instanced attribute the renderer owns. */
+function draw_all(): Record<string, Float32Array> {
+	const names = [
+		`instancePosition`,
+		`instanceRadius`,
+		`instanceAtomColor`,
+		`instanceOpacity`,
+		`instanceSaturation`,
+	]
+	const out: Record<string, Float32Array> = {}
+	for (const name of names) out[name] = draw_upload(attr(name))
+	return out
+}
+
+function add_batch(first_site: number, n: number, radius: number): void {
+	const site_ids = new Uint32Array(n)
+	const positions = new Float32Array(n * 3)
+	const elements = new Uint8Array(n)
+	const radii = new Float32Array(n)
+	for (let i = 0; i < n; i++) {
+		site_ids[i] = first_site + i
+		positions[i * 3] = first_site + i
+		positions[i * 3 + 1] = 1
+		positions[i * 3 + 2] = 2
+		elements[i] = 8
+		radii[i] = radius
+	}
+	manager.add_atoms(site_ids, positions, elements, radii)
+}
+
+beforeEach(() => {
+	gpu.clear()
+	mesh = make_mesh()
+	manager = new AtomManager(CAPACITY)
+	renderer = new AtomInstancedRenderer(mesh, manager, null)
+})
+
+describe(`AtomInstancedRenderer — in-place growth between draws`, () => {
+	test(`two growth syncs before one draw upload every grown slot`, () => {
+		// Initial structure: 2 atoms, synced and drawn (GPU is current).
+		add_batch(0, 2, 0.5)
+		renderer.sync()
+		draw_all()
+
+		// Growth #1: 2 → 4 (e.g. X2 shadow sync after a supercell apply).
+		add_batch(2, 2, 0.6)
+		renderer.sync()
+
+		// Growth #2 lands in the SAME task, before the browser draws
+		// (e.g. the image-atom pass appends boundary copies).
+		add_batch(4, 2, 0.7)
+		renderer.sync()
+
+		const gpu_state = draw_all()
+
+		expect(mesh.count).toBe(6)
+		// Every grown slot must have reached the GPU. The regression left
+		// growth #1's slots at their allocation-time zeros (radius 0 →
+		// invisible) because growth #2's sync destroyed the pending ranges.
+		for (let slot = 2; slot < 4; slot++) {
+			expect(gpu_state.instanceRadius[slot], `radius slot ${slot}`)
+				.toBeCloseTo(0.6 * VISUAL_RADIUS_SCALE)
+			expect(gpu_state.instancePosition[slot * 3], `pos.x slot ${slot}`)
+				.toBeCloseTo(slot)
+		}
+		for (let slot = 4; slot < 6; slot++) {
+			expect(gpu_state.instanceRadius[slot], `radius slot ${slot}`)
+				.toBeCloseTo(0.7 * VISUAL_RADIUS_SCALE)
+		}
+	})
+
+	test(`force_full_resync followed by a growth sync keeps full coverage (supercell signature)`, () => {
+		// "112-era" baseline: 3 atoms on the GPU.
+		add_batch(0, 3, 0.5)
+		renderer.sync()
+		draw_all()
+
+		// Supercell apply, one flush: grow 3 → 6 …
+		add_batch(3, 3, 0.6)
+		renderer.sync()
+		// … a modulation prop flips identity → the component calls
+		// force_full_resync() (covers [0, 6) on every attribute) …
+		renderer.force_full_resync()
+		// … then the image-atom pass grows 6 → 8 and syncs again. The
+		// regression: this sync destroyed the force's pending [0, 6) ranges,
+		// so slots 3..5 (never drawn since baseline) stayed radius-0 forever.
+		add_batch(6, 2, 0.7)
+		renderer.sync()
+
+		const gpu_state = draw_all()
+
+		expect(mesh.count).toBe(8)
+		for (let slot = 3; slot < 6; slot++) {
+			expect(gpu_state.instanceRadius[slot], `radius slot ${slot}`)
+				.toBeCloseTo(0.6 * VISUAL_RADIUS_SCALE)
+		}
+		for (let slot = 6; slot < 8; slot++) {
+			expect(gpu_state.instanceRadius[slot], `radius slot ${slot}`)
+				.toBeCloseTo(0.7 * VISUAL_RADIUS_SCALE)
+		}
+		// Baseline slots must still be intact.
+		for (let slot = 0; slot < 3; slot++) {
+			expect(gpu_state.instanceRadius[slot], `radius slot ${slot}`)
+				.toBeCloseTo(0.5 * VISUAL_RADIUS_SCALE)
+		}
+	})
+})


### PR DESCRIPTION
## Summary

Fixes the **supercell atom-vanish** bug reported on app.catgo-ucsd.org (and reproduced on local main): applying a supercell (viewer control or Build tools/LatticePane) left only the pre-growth atom instances visible — e.g. 112 of 448 spheres — while all bonds rendered; toggling Atoms visibility (remount) restored them.

## Root cause

`AtomInstancedRenderer.sync()` / `force_full_resync()` called `clearUpdateRanges()` at sync start. Three.js uploads only the update ranges present at draw time, and Svelte flushes the sync effect 2–3× between draws during a supercell apply — each later sync destroyed the previous flush's not-yet-uploaded gap ranges, so grown slots kept allocation-time zeros on the GPU (radius 0 → invisible) while `mgr.count`/`mesh.count`/CPU arrays were all correct.

**Regressed by #519** (persistent renderers): pre-#519 the mount effect rebuilt the renderer on every version bump, masking the race with full re-uploads.

## Fix

Remove renderer-side `clearUpdateRanges()` — ranges accumulate until Three consumes-and-clears them at draw (overlaps are merged). Same defect fixed at 3 sites in `bond-instanced-renderer.ts`.

## Verification

- New RED→GREEN regression: `tests/vitest/structure/atoms/atom-renderer-growth.test.ts` (fake GPU mirroring Three's upload contract; grown slots must not stay radius-0).
- Suites: structure 1351 passed, trajectory 429 passed; `svelte-check` 0 errors.
- Headless runtime verify on isolated build: 112-atom LiFePO4 → 2x2x1 all 448 atoms immediate, 2x2x2 (896), back to 1x1x1, Atoms toggle, and the LatticePane real-supercell path — all clean, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)