### PR TITLE
fix(render): trajectory packet-path material styles (#533) + per-frame GL buffer churn (#534)

### DIFF
--- a/src/lib/structure/atoms/AtomManagerInstances.svelte
+++ b/src/lib/structure/atoms/AtomManagerInstances.svelte
@@ -45,6 +45,9 @@
   import type { AtomManager } from './atom-manager.svelte'
   import { AtomInstancedRenderer, type CuttingVisibilityEntry } from './atom-instanced-renderer'
   import { get_atom_matcap, type MatcapPreset } from './matcap-texture'
+  // Shared style mapping (#533) — the legacy material and the packet/replica
+  // impostor path must agree on what each Appearance → Material style means.
+  import { render_style_to_int, style_pbr } from './render-style'
 
   interface Props {
     atom_manager: AtomManager
@@ -131,31 +134,6 @@
     max_capacity = 200_000,
     render_packet = null,
   }: Props = $props()
-
-  // glossy = 0, matte = 1, toon = 2 (matches the uRenderStyle branch order).
-  function render_style_to_int(
-    style: `glossy` | `metallic` | `matte` | `soft` | `flat` | `toon` | `matcap`,
-  ): number {
-    // Map onto the shader branches (0 glossy/Blinn-Phong, 1 matte diffuse,
-    // 2 toon, 3 matcap). Metallic reuses the specular branch; 2.5D-soft and
-    // 2D-flat reuse the matte branch — their distinct look comes from the
-    // per-style lighting profile, not a new GLSL branch.
-    if (style === `toon`) return 2
-    if (style === `matcap`) return 3
-    if (style === `matte` || style === `soft` || style === `flat`) return 1
-    return 0
-  }
-
-  // Per-render-style PBR (roughness, metalness) for the GGX specular branch,
-  // ported from pretty-lattice's material presets: glossy = crisp dielectric
-  // hot spot, metallic = a bigger/softer, element-colour-tinted highlight.
-  function style_pbr(
-    style: `glossy` | `metallic` | `matte` | `soft` | `flat` | `toon` | `matcap`,
-  ): { roughness: number; metalness: number } {
-    return style === `metallic`
-      ? { roughness: 0.4, metalness: 0.4 }
-      : { roughness: 0.2, metalness: 0.0 }
-  }
 
   const threlte = useThrelte()
 
@@ -691,6 +669,9 @@
     {ambient_light}
     {directional_light}
     {light_dir}
+    {render_style}
+    {matcap_preset}
+    {highlight_strength}
     ghost_opacity={image_atom_opacity}
   />
 {:else}

--- a/src/lib/structure/atoms/render-style.ts
+++ b/src/lib/structure/atoms/render-style.ts
@@ -1,0 +1,41 @@
+/**
+ * Appearance → Material style mapping shared by the legacy InstancedMesh
+ * atom material (AtomManagerInstances) and the packet/replica impostor path
+ * (WebGLReplicaLayer → AtomReplicaRenderer, #533). One source of truth so the
+ * two paths can never disagree on what a style means.
+ */
+
+export type AtomRenderStyle =
+  | `glossy`
+  | `metallic`
+  | `matte`
+  | `soft`
+  | `flat`
+  | `toon`
+  | `matcap`
+
+/**
+ * Map onto the shader branches (0 glossy/Blinn-Phong, 1 matte diffuse,
+ * 2 toon, 3 matcap). Metallic reuses the specular branch; 2.5D-soft and
+ * 2D-flat reuse the matte branch — their distinct look comes from the
+ * per-style lighting profile, not a new GLSL branch.
+ */
+export function render_style_to_int(style: AtomRenderStyle): number {
+  if (style === `toon`) return 2
+  if (style === `matcap`) return 3
+  if (style === `matte` || style === `soft` || style === `flat`) return 1
+  return 0
+}
+
+/**
+ * Per-render-style PBR (roughness, metalness) for the GGX specular branch,
+ * ported from pretty-lattice's material presets: glossy = crisp dielectric
+ * hot spot, metallic = a bigger/softer, element-colour-tinted highlight.
+ */
+export function style_pbr(
+  style: AtomRenderStyle,
+): { roughness: number; metalness: number } {
+  return style === `metallic`
+    ? { roughness: 0.4, metalness: 0.4 }
+    : { roughness: 0.2, metalness: 0.0 }
+}

--- a/src/lib/structure/gpu/WebGLReplicaLayer.svelte
+++ b/src/lib/structure/gpu/WebGLReplicaLayer.svelte
@@ -14,6 +14,12 @@
   import { untrack } from 'svelte'
   import { T, useThrelte } from '@threlte/core'
   import { Vector2, Vector3 } from 'three'
+  import { get_atom_matcap, type MatcapPreset } from '../atoms/matcap-texture'
+  import {
+    type AtomRenderStyle,
+    render_style_to_int,
+    style_pbr,
+  } from '../atoms/render-style'
   import type { RenderPacket } from '../scene/render-packet'
   import { AtomReplicaRenderer } from './webgl2/atom-replica-renderer'
   import { BondReplicaRenderer } from './webgl2/bond-replica-renderer'
@@ -30,6 +36,10 @@
     directional_light?: number
     /** View-space headlamp direction (kept live in both materials). */
     light_dir?: Vector3
+    /** Appearance → Material style for the atom impostors (#533). */
+    render_style?: AtomRenderStyle
+    matcap_preset?: string
+    highlight_strength?: number
     /** Main bond-draw opacity (ignored by atom-only layers). */
     opacity?: number
     /** Opacity multiplier for ghost-image instances (sparse second draws). */
@@ -45,6 +55,9 @@
     ambient_light = 0.7,
     directional_light = 0.3,
     light_dir = new Vector3(0.4, 0.7, 0.6).normalize(),
+    render_style = `glossy`,
+    matcap_preset = `ceramic`,
+    highlight_strength = 1.0,
     opacity = 1,
     ghost_opacity = 1,
   }: Props = $props()
@@ -123,6 +136,24 @@
     bond_renderer?.set_stub_scale(incomplete_edge_length_scale)
     bond_renderer?.set_opacity(opacity)
     bond_renderer?.set_ghost_opacity(ghost_opacity)
+    mark_dirty()
+  })
+
+  // Appearance → Material (#533): uniform-int branch switch, zero recompile.
+  // The baked matcap texture is built lazily ONLY while MatCap is active
+  // (same gating as the legacy material — non-matcap renders never touch
+  // matcap code; cached per preset).
+  $effect(() => {
+    if (!atom_renderer) return
+    const matcap = render_style === `matcap`
+      ? get_atom_matcap(matcap_preset as MatcapPreset, mark_dirty)
+      : null
+    atom_renderer.set_render_style(
+      render_style_to_int(render_style),
+      style_pbr(render_style),
+      matcap,
+    )
+    atom_renderer.set_highlight_strength(highlight_strength)
     mark_dirty()
   })
 

--- a/src/lib/structure/gpu/webgl2/atom-replica-renderer.ts
+++ b/src/lib/structure/gpu/webgl2/atom-replica-renderer.ts
@@ -269,12 +269,25 @@ const GHOST_VERTEX_SHADER = /* glsl */ `
 // gl_FragDepth). The intersection uses the cross-product formulation copied
 // from AtomManagerInstances: the algebraic form loses precision for large
 // view-space centers (periodic replicas!) and shows concentric banding.
+//
+// Material styles (#533): the packet path must honor Appearance → Material
+// exactly like the legacy InstancedMesh path, so the uRenderStyle branches
+// (0 glossy/GGX, 1 matte, 2 toon, 3 matcap) are ported verbatim from
+// AtomManagerInstances' fragment shader — same uniforms, same constants.
 const FRAGMENT_SHADER = /* glsl */ `
   uniform bool uIsOrthographic;
   uniform vec3 uLightDir;
   uniform float uAmbientIntensity;
   uniform float uDirectionalIntensity;
   uniform float uOpacityScale;
+  uniform int uRenderStyle;  // 0 = glossy, 1 = matte, 2 = toon, 3 = matcap
+  uniform float uShadowThreshold;
+  uniform float uHighlightThreshold;
+  uniform float uShadowBrightness;
+  uniform float uSpecStrength;
+  uniform float uRoughness;
+  uniform float uMetalness;
+  uniform sampler2D uMatcap;
   uniform mat4 projectionMatrix;
   varying vec3 vCenter;
   varying float vRadius;
@@ -288,6 +301,12 @@ const FRAGMENT_SHADER = /* glsl */ `
       linear.g <= 0.0031308 ? linear.g * 12.92 : 1.055 * pow(linear.g, 1.0 / 2.4) - 0.055,
       linear.b <= 0.0031308 ? linear.b * 12.92 : 1.055 * pow(linear.b, 1.0 / 2.4) - 0.055
     );
+  }
+
+  // ACES filmic tonemap — rolls off bright specular so glossy highlights read
+  // soft/desaturated instead of hard clipped dots (legacy parity).
+  vec3 aces_tonemap(vec3 x) {
+    return clamp((x * (2.51 * x + 0.03)) / (x * (2.43 * x + 0.59) + 0.14), 0.0, 1.0);
   }
 
   void main() {
@@ -326,11 +345,52 @@ const FRAGMENT_SHADER = /* glsl */ `
 
     vec3 light_dir = normalize(uLightDir);
     vec3 view_dir = uIsOrthographic ? vec3(0.0, 0.0, 1.0) : normalize(-hit_pos);
-    float diffuse = max(dot(normal, light_dir), 0.0);
-    vec3 half_dir = normalize(light_dir + view_dir);
-    float spec = pow(max(dot(normal, half_dir), 0.0), 48.0);
-    vec3 color = vColor * (uAmbientIntensity + uDirectionalIntensity * diffuse) +
-      vec3(0.5) * spec * uDirectionalIntensity;
+    vec3 base_color = vColor;
+
+    vec3 color;
+    if (uRenderStyle == 2) {
+      // ── Toon: 3-band cel shading (legacy AtomManagerInstances parity) ──
+      float diffuse = dot(normal, light_dir);
+      if (diffuse > uHighlightThreshold) {
+        color = vec3(1.0, 1.0, 1.0);
+      } else if (diffuse > uShadowThreshold) {
+        color = base_color;
+      } else {
+        color = base_color * uShadowBrightness;
+      }
+    } else if (uRenderStyle == 1) {
+      // ── Matte: diffuse-only Lambert, no specular highlight ──
+      float diffuse = max(dot(normal, light_dir), 0.0);
+      color = base_color * (uAmbientIntensity + uDirectionalIntensity * diffuse);
+    } else if (uRenderStyle == 3) {
+      // ── MatCap: sample the baked studio sphere by the view-space normal,
+      //    tinted by the element colour ──
+      vec2 muv = normal.xy * 0.5 + 0.5;
+      color = base_color * texture(uMatcap, muv).rgb;
+    } else {
+      // ── Glossy / Metallic: Cook-Torrance GGX (legacy parity — roughness /
+      //    metalness are per-style, ACES rolls the key light back down) ──
+      float rough = uRoughness;
+      float a = rough * rough;
+      float a2 = a * a;
+      float NdotL = max(dot(normal, light_dir), 0.0);
+      float NdotV = max(dot(normal, view_dir), 1e-4);
+      vec3 half_dir = normalize(light_dir + view_dir);
+      float NdotH = max(dot(normal, half_dir), 0.0);
+      float VdotH = max(dot(view_dir, half_dir), 0.0);
+      float dn = (NdotH * NdotH) * (a2 - 1.0) + 1.0;
+      float D = a2 / (3.14159265 * dn * dn);
+      float k = a * 0.5;
+      float G = (NdotV / (NdotV * (1.0 - k) + k)) * (NdotL / (NdotL * (1.0 - k) + k));
+      vec3 F0 = mix(vec3(0.04), base_color, uMetalness);
+      vec3 F = F0 + (vec3(1.0) - F0) * pow(1.0 - VdotH, 5.0);
+      vec3 specular = (D * G) * F / (4.0 * NdotV * NdotL + 1e-4);
+      vec3 diffuse_color = base_color * (1.0 - uMetalness);
+      vec3 lit = diffuse_color * (uAmbientIntensity + uDirectionalIntensity * NdotL * 0.31831)
+        + specular * uDirectionalIntensity * NdotL * uSpecStrength;
+      lit *= mix(0.6, 1.0, smoothstep(0.0, 0.5, NdotV));
+      color = aces_tonemap(lit);
+    }
     fragColor = vec4(linear_to_srgb(color), uOpacityScale * coverage);
   }
 `
@@ -392,6 +452,18 @@ export class AtomReplicaRenderer {
       uLightDir: { value: new THREE.Vector3(0.4, 0.7, 0.6).normalize() },
       uAmbientIntensity: { value: options.ambient_light ?? 0.7 },
       uDirectionalIntensity: { value: options.directional_light ?? 0.3 },
+      // Material style (#533) — shared uniform OBJECTS so the main and ghost
+      // draws switch styles together. Defaults mirror the legacy material
+      // (glossy GGX at roughness 0.2 / metalness 0, toon thresholds from
+      // AtomCanvas ToonHighlightMaterial).
+      uRenderStyle: { value: 0 },
+      uShadowThreshold: { value: 0.3 },
+      uHighlightThreshold: { value: 0.97 },
+      uShadowBrightness: { value: 0.5 },
+      uSpecStrength: { value: 1 },
+      uRoughness: { value: 0.2 },
+      uMetalness: { value: 0 },
+      uMatcap: { value: null as THREE.Texture | null },
     }
 
     this.material = new THREE.ShaderMaterial({
@@ -437,6 +509,29 @@ export class AtomReplicaRenderer {
   /** Live ghost appearance update — no geometry/material reconstruction. */
   set_ghost_opacity(opacity: number): void {
     set_material_opacity(this.ghost_material, `uOpacityScale`, opacity)
+  }
+
+  /**
+   * Appearance → Material for the packet path (#533). `style` is the shader
+   * branch int (0 glossy/GGX, 1 matte, 2 toon, 3 matcap) with the per-style
+   * GGX params; `matcap` is the baked studio-sphere texture (only sampled by
+   * branch 3). Uniform-only writes on the SHARED objects — main + ghost draws
+   * update together, no recompile, no material swap.
+   */
+  set_render_style(
+    style: number,
+    pbr: { roughness: number; metalness: number },
+    matcap: THREE.Texture | null = null,
+  ): void {
+    this.material.uniforms.uRenderStyle.value = style
+    this.material.uniforms.uRoughness.value = pbr.roughness
+    this.material.uniforms.uMetalness.value = pbr.metalness
+    if (matcap !== null || style === 3) this.material.uniforms.uMatcap.value = matcap
+  }
+
+  /** Glossy specular highlight multiplier (Appearance slider). */
+  set_highlight_strength(strength: number): void {
+    this.material.uniforms.uSpecStrength.value = strength
   }
 
   /** Apply a render packet. Minimal work per `diff_render_packet` category. */

--- a/src/lib/structure/gpu/webgl2/bond-replica-renderer.ts
+++ b/src/lib/structure/gpu/webgl2/bond-replica-renderer.ts
@@ -460,7 +460,15 @@ export class BondReplicaRenderer {
   #prev: RenderPacket | null = null
   #pos_texture: THREE.DataTexture | null = null
 
-  // Per-half base attributes (2B-sized CPU mirrors).
+  // Per-half base attributes — capacity-sized CPU mirrors, grow-only.
+  // MD playback changes the bond count nearly every frame; reallocating these
+  // per count change re-installed 4 fresh attributes per frame, which cost a
+  // VAO rebuild + 4 new GL buffers (the old ones were never deleted) + full
+  // capacity-size uploads on every played frame (#534). The live span is
+  // `#half_count`; `instanceCount` and update ranges cover only that prefix,
+  // so a bond-count change is an in-place rewrite on stable identities.
+  #half_capacity = 0
+  #half_count = 0
   #sites = new Float32Array(0)
   #jimages = new Int8Array(0)
   #halves = new Float32Array(0)
@@ -627,13 +635,20 @@ export class BondReplicaRenderer {
     const graph = packet.topology.bond_graph
     const bond_count = graph !== undefined ? graph.pairs.length / 2 : 0
     const half_count = bond_count * 2
-    if (this.#halves.length !== half_count) {
-      this.#sites = new Float32Array(half_count * 2)
-      this.#jimages = new Int8Array(half_count * 3)
-      this.#halves = new Float32Array(half_count)
-      this.#colors = new Float32Array(half_count * 3)
+    if (half_count > this.#half_capacity) {
+      // Grow-only ×1.5: a fresh attribute install (and its one-time VAO
+      // rebuild + full upload) happens O(log growth) times, never per frame.
+      this.#half_capacity = Math.max(
+        half_count,
+        Math.ceil(this.#half_capacity * 1.5),
+      )
+      this.#sites = new Float32Array(this.#half_capacity * 2)
+      this.#jimages = new Int8Array(this.#half_capacity * 3)
+      this.#halves = new Float32Array(this.#half_capacity)
+      this.#colors = new Float32Array(this.#half_capacity * 3)
     }
-    if (graph === undefined) return
+    this.#half_count = half_count
+    if (graph === undefined || half_count === 0) return
     const { colors, atom_count } = packet.topology
     const color_stride = colors.length === atom_count * 4 ? 4 : 3
     for (let bi = 0; bi < bond_count; bi++) {
@@ -661,19 +676,26 @@ export class BondReplicaRenderer {
       }
     }
     for (const name of [`a_site`, `a_jimage`, `a_half`, `a_color`]) {
-      const attribute = this.#geometry.getAttribute(name)
-      if (attribute) attribute.needsUpdate = true
+      const attribute = this.#geometry.getAttribute(name) as
+        | THREE.InstancedBufferAttribute
+        | undefined
+      if (!attribute) continue
+      // Upload only the live prefix. Add WITHOUT clearing: three consumes and
+      // clears ranges at draw time and merges overlaps, so multiple syncs
+      // between draws accumulate safely (#532 contract).
+      attribute.addUpdateRange(0, half_count * attribute.itemSize)
+      attribute.needsUpdate = true
     }
   }
 
   #apply_replicas(packet: RenderPacket): void {
     const dims = packet.replicas.dims
     const cc = cell_count_of(dims)
-    ensure_instanced_attr(this.#geometry, `a_site`, this.#sites, 2, cc)
-    ensure_instanced_attr(this.#geometry, `a_jimage`, this.#jimages, 3, cc)
-    ensure_instanced_attr(this.#geometry, `a_half`, this.#halves, 1, cc)
-    ensure_instanced_attr(this.#geometry, `a_color`, this.#colors, 3, cc)
-    this.#geometry.instanceCount = this.#halves.length * cc
+    ensure_instanced_attr(this.#geometry, `a_site`, this.#sites, 2, cc, true)
+    ensure_instanced_attr(this.#geometry, `a_jimage`, this.#jimages, 3, cc, true)
+    ensure_instanced_attr(this.#geometry, `a_half`, this.#halves, 1, cc, true)
+    ensure_instanced_attr(this.#geometry, `a_color`, this.#colors, 3, cc, true)
+    this.#geometry.instanceCount = this.#half_count * cc
     const dims_val = this.material.uniforms.uDims.value as Int32Array
     dims_val[0] = dims[0]
     dims_val[1] = dims[1]

--- a/tests/vitest/structure/gpu/webgl2-replica-atoms.test.ts
+++ b/tests/vitest/structure/gpu/webgl2-replica-atoms.test.ts
@@ -494,3 +494,53 @@ describe(`legacy AtomInstancedRenderer bypass wiring`, () => {
     expect(pos[0]).toBeCloseTo(1, 5)
   })
 })
+
+describe(`Appearance → Material on the packet path (#533)`, () => {
+  test(`fragment shader carries the legacy style branches`, () => {
+    const renderer = new AtomReplicaRenderer()
+    const fragment = renderer.material.fragmentShader
+    // 0 glossy/GGX, 1 matte, 2 toon, 3 matcap — legacy AtomManagerInstances
+    // branch order; the packet path must not silently render one fixed look.
+    expect(fragment).toContain(`uRenderStyle`)
+    expect(fragment).toContain(`uRoughness`)
+    expect(fragment).toContain(`uMetalness`)
+    expect(fragment).toContain(`uSpecStrength`)
+    expect(fragment).toContain(`uMatcap`)
+    expect(fragment).toContain(`uShadowThreshold`)
+    renderer.dispose()
+  })
+
+  test(`set_render_style routes uniforms to BOTH main and ghost draws`, () => {
+    const renderer = new AtomReplicaRenderer()
+    // Shared uniform objects: one write must update the ghost material too.
+    expect(renderer.ghost_material.uniforms.uRenderStyle)
+      .toBe(renderer.material.uniforms.uRenderStyle)
+
+    renderer.set_render_style(2, { roughness: 0.4, metalness: 0.4 })
+    expect(renderer.material.uniforms.uRenderStyle.value).toBe(2)
+    expect(renderer.material.uniforms.uRoughness.value).toBeCloseTo(0.4)
+    expect(renderer.material.uniforms.uMetalness.value).toBeCloseTo(0.4)
+    expect(renderer.ghost_material.uniforms.uRenderStyle.value).toBe(2)
+
+    const matcap = new THREE.Texture()
+    renderer.set_render_style(3, { roughness: 0.2, metalness: 0 }, matcap)
+    expect(renderer.material.uniforms.uMatcap.value).toBe(matcap)
+    expect(renderer.ghost_material.uniforms.uMatcap.value).toBe(matcap)
+
+    renderer.set_highlight_strength(1.7)
+    expect(renderer.material.uniforms.uSpecStrength.value).toBeCloseTo(1.7)
+    renderer.dispose()
+    matcap.dispose()
+  })
+
+  test(`style changes touch uniforms only — no material or geometry swap`, () => {
+    const renderer = new AtomReplicaRenderer()
+    const material = renderer.material
+    const geometry = renderer.mesh.geometry
+    renderer.set_render_style(1, { roughness: 0.2, metalness: 0 })
+    renderer.set_render_style(0, { roughness: 0.2, metalness: 0 })
+    expect(renderer.material).toBe(material)
+    expect(renderer.mesh.geometry).toBe(geometry)
+    renderer.dispose()
+  })
+})

--- a/tests/vitest/structure/gpu/webgl2-replica-bonds.test.ts
+++ b/tests/vitest/structure/gpu/webgl2-replica-bonds.test.ts
@@ -612,3 +612,93 @@ describe(`legacy BondInstancedRenderer bypass wiring`, () => {
     expect(mesh.count).toBe(2)
   })
 })
+
+describe(`per-frame bond-count churn stays identity-stable (#534)`, () => {
+  // MD playback changes the bond count nearly every frame. The renderer must
+  // absorb that as an in-place rewrite on capacity-stable attributes — a
+  // fresh-attribute install per frame costs a VAO rebuild + a new GL buffer
+  // per attribute per frame (the old ones leak until GC) + full-capacity
+  // uploads, which is the #534 playback regression.
+  const HALF_ATTRS = [`a_site`, `a_jimage`, `a_half`, `a_color`] as const
+
+  function packet_with_bonds(
+    builder: ReturnType<typeof create_render_packet_builder>,
+    n: number,
+  ): RenderPacket {
+    const bonds: PacketBondConnectivity[] = Array.from({ length: n }, (_, idx) => ({
+      site_idx_1: idx % 3,
+      site_idx_2: (idx + 1) % 3,
+    }))
+    return builder.build({
+      structure: make_structure(3),
+      bond_connectivity: bonds,
+      dims: [1, 1, 1],
+      positions_version: n,
+    })
+  }
+
+  test(`shrink + regrow within capacity keep attribute and array identities`, () => {
+    const builder = create_render_packet_builder()
+    const renderer = new BondReplicaRenderer()
+    renderer.update(packet_with_bonds(builder, 4))
+    const attrs0 = HALF_ATTRS.map((name) => attr(renderer.mesh, name))
+    const arrays0 = attrs0.map((attribute) => attribute.array)
+    expect(geo(renderer.mesh).instanceCount).toBe(8)
+
+    // Shrink 4 → 3 bonds: same attributes, same backing arrays, live span 6.
+    renderer.update(packet_with_bonds(builder, 3))
+    HALF_ATTRS.forEach((name, idx) => {
+      const attribute = attr(renderer.mesh, name)
+      expect(attribute).toBe(attrs0[idx])
+      expect(attribute.array).toBe(arrays0[idx])
+    })
+    expect(geo(renderer.mesh).instanceCount).toBe(6)
+
+    // Regrow 3 → 4 bonds (fits capacity): still the same identities.
+    renderer.update(packet_with_bonds(builder, 4))
+    HALF_ATTRS.forEach((name, idx) => {
+      expect(attr(renderer.mesh, name)).toBe(attrs0[idx])
+    })
+    expect(geo(renderer.mesh).instanceCount).toBe(8)
+    renderer.dispose()
+  })
+
+  test(`rewrites cover exactly the live prefix via accumulated update ranges`, () => {
+    const builder = create_render_packet_builder()
+    const renderer = new BondReplicaRenderer()
+    renderer.update(packet_with_bonds(builder, 4))
+    renderer.update(packet_with_bonds(builder, 3))
+    for (const name of HALF_ATTRS) {
+      const attribute = attr(renderer.mesh, name)
+      expect(attribute.needsUpdate || attribute.version > 0).toBe(true)
+      // Ranges accumulate until the draw consumes them (#532 contract); the
+      // latest one must span the full live prefix of 6 halves.
+      const last = attribute.updateRanges.at(-1)!
+      expect(last.start).toBe(0)
+      expect(last.count).toBe(6 * attribute.itemSize)
+    }
+    renderer.dispose()
+  })
+
+  test(`growth beyond capacity installs fresh attributes and drops the draw clamp`, () => {
+    const builder = create_render_packet_builder()
+    const renderer = new BondReplicaRenderer()
+    renderer.update(packet_with_bonds(builder, 2))
+    const before = HALF_ATTRS.map((name) => attr(renderer.mesh, name))
+    ;(geo(renderer.mesh) as unknown as { _maxInstanceCount?: number })
+      ._maxInstanceCount = 4
+
+    renderer.update(packet_with_bonds(builder, 8))
+    HALF_ATTRS.forEach((name, idx) => {
+      const attribute = attr(renderer.mesh, name)
+      expect(attribute).not.toBe(before[idx])
+      expect(attribute.array.length).toBeGreaterThanOrEqual(16 * attribute.itemSize)
+    })
+    expect(geo(renderer.mesh).instanceCount).toBe(16)
+    expect(
+      (geo(renderer.mesh) as unknown as { _maxInstanceCount?: number })
+        ._maxInstanceCount,
+    ).toBeUndefined()
+    renderer.dispose()
+  })
+})

--- a/tests/vitest/structure/gpu/webgl2-replica-managers-harness.svelte
+++ b/tests/vitest/structure/gpu/webgl2-replica-managers-harness.svelte
@@ -46,6 +46,8 @@
   let stub_scale = $state(0.25)
   let bond_opacity = $state(0.8)
   let appearance_alt = $state(false)
+  // #533 — Appearance → Material must reach the packet-path impostor material.
+  let render_style = $state<'glossy' | 'toon' | 'metallic'>('glossy')
 
   // -1 = no packet: AtomManagerInstances falls back to the legacy
   // InstancedMesh path, mirroring a static structure at 1×1×1.
@@ -60,11 +62,14 @@
 <button data-testid="factor-2" onclick={() => packet_idx = 1}>2x</button>
 <button data-testid="factor-8" onclick={() => packet_idx = 2}>8x</button>
 <button data-testid="appearance" onclick={() => appearance_alt = true}>appearance</button>
+<button data-testid="style-toon" onclick={() => render_style = 'toon'}>toon</button>
+<button data-testid="style-metallic" onclick={() => render_style = 'metallic'}>metallic</button>
 
 {#if mode === 'atom'}
   <AtomManagerInstances
     {atom_manager}
     render_packet={packet}
+    {render_style}
     image_atom_opacity={live_ghost_opacity}
     max_capacity={16}
   />

--- a/tests/vitest/structure/gpu/webgl2-replica-managers.test.ts
+++ b/tests/vitest/structure/gpu/webgl2-replica-managers.test.ts
@@ -516,3 +516,24 @@ describe(`replica manager live appearance props`, () => {
     expect(ghost_material.alphaToCoverage).toBe(false)
   })
 })
+
+describe(`packet-path material style (#533)`, () => {
+  test(`Appearance → Material reaches the replica impostor uniforms live`, async () => {
+    const { dom, scene } = await mount_manager(`atom`)
+    const main = meshes(scene).find((mesh) => mesh.visible)!
+    const material = main.material as THREE.ShaderMaterial
+    // Default glossy → branch 0 with the dielectric GGX profile.
+    expect(material.uniforms.uRenderStyle.value).toBe(0)
+    expect(material.uniforms.uRoughness.value).toBeCloseTo(0.2)
+    expect(material.uniforms.uMetalness.value).toBeCloseTo(0)
+
+    await click(dom, `style-toon`)
+    expect(main.material).toBe(material) // uniform switch, no material swap
+    expect(material.uniforms.uRenderStyle.value).toBe(2)
+
+    await click(dom, `style-metallic`)
+    expect(material.uniforms.uRenderStyle.value).toBe(0)
+    expect(material.uniforms.uRoughness.value).toBeCloseTo(0.4)
+    expect(material.uniforms.uMetalness.value).toBeCloseTo(0.4)
+  })
+})


### PR DESCRIPTION
## 中文摘要

修复 #533(轨迹态 Material 选择器失效)与 #534(dump.traj 播放逐帧延迟)——两者同属 packet/replica GPU 管线,基于 `feat/impostor-bond-mvp` @ f79c1e33,两个原子提交:

- `74ffbbcc` **perf(render): capacity-stable bond replica attributes**(#534)
- `b247708a` **fix(render): honor Appearance → Material on the packet/replica path**(#533)

**定性:功能修复完成,软件层回归全部通过;仅保留一项硬件性能复验作为 merge 前 checklist(见文末)。**

---

## #534 归因(数据裁决,非推断)

**结论:回归不是 `886e23c9..8a3bed35` 窗口内某次提交引入的——它是 packet 路径自 `49e8546a`(接线进真实场景)起固有的逐帧 GPU buffer 翻建 + 泄漏。** 同机同负载 A/B(19,968 原子 × 100 帧合成 MD extxyz,页内 GL 调用计数器——精确计数,不受软件光栅速度影响):

| 树 | createBuffer/帧 | bufferData/帧 | bufferSubData/帧 | deleteBuffer/帧 | 位置纹理/帧 | 主线程忙时/帧 |
|---|---|---|---|---|---|---|
| main `fcb6b687`(23.8 fps 参照) | 0.9 | 0.9 次 / 1.33 MB | 0.5 次 / 0.33 MB | 0.5 | ~0 | 195 ms |
| Gate A `49e8546a`("流畅") | **4** | 4 次 / 2.95 MB | 8.8 次 / 10.45 MB | **0** | 1 × 328 KB | 6214 ms |
| 窗口尾 `8a3bed35`(被报卡顿) | **4** | 4 次 / 2.97 MB | 7.9 次 / 3.46 MB | **0** | 1 × 328 KB | 2704 ms |
| **本 PR `74ffbbcc`** | **0.1**(装载+一次增容) | 0.1 次 / 0.09 MB | 11.8 次(活跃前缀 ranged)/ 6.4 MB | 0 | 1 × 328 KB | 2407 ms |

注:窗口尾反而比 Gate A 快 ~2×(T5 关掉了 hitbox 重建)。"Gate A 流畅"是硬件短时吸收了翻建成本;**泄漏(每帧 4 个 GL buffer 从不 delete)随播放时长累积,越放越卡**——正是"逐帧延迟"的机制。

**根因:** MD 播放键数几乎每帧变化 → `BondReplicaRenderer.#rebuild_half_attrs` 每帧重分配 4 个 per-half 属性数组 → `ensure_instanced_attr` 每帧安装 4 个全新 `InstancedBufferAttribute` → 每帧 4×`createBuffer` + 4×全容量 `bufferData`(~3 MB)+ 整 VAO 重建 + 0×`deleteBuffer` + 全量重传。

**修复:** half 属性改为 grow-only 容量模型(×1.5 余量):活跃区间 `#half_count` 驱动 `instanceCount` 与 update ranges(只加不清,遵守 #532 的 draw 时消费契约);键数变化 = 稳定身份上的原地重写;容量增长(对数次摊销)才走 fresh-attribute 路径。

**五个嫌疑逐一裁决:** ① `49102db3` 守卫逐帧误触—否(capacity 比较播放中恒等,divisor 不变即 no-op);② 逐帧 packet 重建—部分成立,但慢的是渲染器的属性翻建而非 packet 对象;③ #532 ranges 互作—否(legacy mesh 未挂载不绘制);④ Bonds T6 逐帧重跑键检测—否(与 main 行为一致,帧连通性缓存在位);⑤ T5 ID-pass 泄入—否(播放窗口 `readPixels`=0,T5 反而砍半了逐帧成本)。

## #533 根因与修复

轨迹态 packet 路径的 `AtomReplicaRenderer` impostor shader 只有一套硬编码 Blinn-Phong,从不消费 `render_style`;实现样式的 legacy 材质在 packet 模式下不挂载 → Material 选择器整体失效。修复:legacy 的 `uRenderStyle` 四分支(glossy/metallic GGX+ACES、matte、toon 三段 cel、matcap)**逐字移植**进 replica shader;映射抽到共享模块 `atoms/render-style.ts`;`AtomManagerInstances` 把 `render_style`/`matcap_preset`/`highlight_strength` 透传 `WebGLReplicaLayer`,uniform 实时(共享 uniform 对象,主/ghost 同步;零重编译零换装)。键 impostor 与 legacy 键材质对齐(本就无样式分支,两路径一致)。

---

## 验证

### 单测 / 类型

- `tests/vitest/structure/gpu` **155 pass / 6 skipped**(+10 个新回归测试:容量契约 ×3、样式 shader/uniform ×3、组件级穿透 ×1、及配套)
- `tests/vitest/trajectory` **497 pass / 1 skipped**
- `pnpm check` **0 errors**(304 个既有 warning)
- 全量 vitest:**4920 pass / 2 fail** — 两个红项均有基线裁决,不阻塞(见下)

### Known test failures 基线裁决(非本 PR 回归)

| 用例 | 现象 | 裁决 |
|---|---|---|
| `cube/periodic-cube-lattice` › `find_pbc_images_fast preserves the lattice` | worker 5 s timeout | **baseline/environment failure**:在不含本 PR 的 `f79c1e33` 基线上同环境复现(5004 ms 同样超时);2026-07-17 已有同类记录 |
| `xrd/calc-xrd` › `compare XRD for mp-1204603.json` | 全量负载下偶发 | **test flake**:isolated run 30/30 通过 |

### 真实 UI 运行时验收(隔离静态前端,11/11 PASS)

1. 轨迹经真实 drop handler 加载,packet 路径自 1× 接管
2. 真实 interval Play 帧推进
3. **播放稳态窗口 `createBuffer = 0` / `deleteBuffer = 0`** —— 直接验证 #534 的修复机制本身(buffer 翻建与泄漏消除),而非仅"看起来不卡"
4. Play/Pause ×3 干净切换
5. 跳帧 5 → 末帧 → 5
6. **播放中**连切 5 种材质(toon/glossy/matcap/matte/flat)无崩溃
7. 暂停态 toon / matte / matcap / glossy 渲染两两可辨(#533 视觉证据)
8. XDATCAR 轨迹上经真实 CellSelect 走 **1×→2x2x2→1×** 因子循环:状态标签正确、8 复制体 + 晶胞框 + 边界键渲染正确、循环后播放正常
9. image atoms(ghost-images 策略)开关正常
10. 活跃 WebGL context 健康:`isContextLost()=false`、`getError()=0`(两个 lost context 均属已卸载的孤儿画布——launcher 预览等,浏览器正常回收)
11. 全程零非预期 page/console error

### 测量方法说明

本机为 WSL2 headless Chromium(SwiftShader 软件光栅),绝对 fps 无意义;所有结论基于**精确的 GL 调用/字节计数**与同机 A/B。真实 `dump.traj` 在报告机器上,测量用等价合成负载(同 19,968 原子 × 100 帧、47 MB、键数逐帧涨落、~55k half ≥ 真实 ~52k,结论偏保守)。

---

## Merge 前 checklist

- [ ] **Hardware-only performance verification pending**:原版 `dump.traj` @ :3300 真实 GPU,真实 interval Play 回到 **≥20 fps 档**(#534 验收)。correctness / 资源生命周期 / WebGL 健康已在本 PR 内验证完毕,此项仅验证真实硬件绝对吞吐。

## 相关

- Fixes #533;fixes #534(两者均阻塞 #531 的 merge gate)
- 验收排查中发现并另行立案:#536(索引式 xyz/extxyz 加载丢失 Lattice,>2 MB 文件;不同故障域,不入本 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
