### PR TITLE
fix(trajectory): indexed XYZ/extxyz loading keeps the lattice for files >2 MB

### DIFF
--- a/src/lib/trajectory/parsers/common.ts
+++ b/src/lib/trajectory/parsers/common.ts
@@ -54,9 +54,7 @@ export const create_structure = (
   // Pre-compute fractional coords for all atoms so the wrap-decision pass
   // can do a near-neighbor check in raw Cartesian without re-deriving abc.
   const initial_abcs: Vec3[] = positions.map((pos) =>
-    inv_matrix
-      ? math.mat3x3_vec3_multiply(inv_matrix, pos as Vec3)
-      : [0, 0, 0] as Vec3
+    inv_matrix ? math.mat3x3_vec3_multiply(inv_matrix, pos as Vec3) : [0, 0, 0] as Vec3
   )
   // Threshold for the heuristic-wrap near-neighbor check. Conservative
   // covalent bond max (Å). Larger than typical bond lengths; smaller than
@@ -156,6 +154,25 @@ export const create_structure = (
       },
     }
     : { sites }
+}
+
+/**
+ * Extract the extended-XYZ `Lattice="ax ay az bx by bz cx cy cz"` field from a
+ * frame comment line (row-major, 9 floats). Returns undefined when absent or
+ * malformed. Shared by the eager XYZ parser and the indexed frame loader so
+ * the two paths can never disagree on lattice handling (#536: the indexed
+ * loader used to drop the lattice entirely for >2 MB files).
+ */
+export const parse_xyz_lattice = (comment: string): Matrix3x3 | undefined => {
+  const lattice_match = comment.match(/Lattice\s*=\s*"([^"]+)"/i)
+  if (!lattice_match) return undefined
+  const values = lattice_match[1].split(/\s+/).map(Number)
+  if (values.length !== 9) return undefined
+  return [
+    [values[0], values[1], values[2]],
+    [values[3], values[4], values[5]],
+    [values[6], values[7], values[8]],
+  ]
 }
 
 export const create_trajectory_frame = (

--- a/src/lib/trajectory/parsers/frame-loader.ts
+++ b/src/lib/trajectory/parsers/frame-loader.ts
@@ -14,6 +14,7 @@ import {
   create_trajectory_frame,
   MAX_METADATA_SIZE,
   MAX_SAFE_STRING_LENGTH,
+  parse_xyz_lattice,
   read_ndarray_from_view,
 } from './common'
 
@@ -312,11 +313,18 @@ export class TrajFrameReader implements FrameLoader {
     }
 
     const metadata = this.parse_xyz_metadata(comment, frame_number)
+    // Per-frame lattice from the extxyz comment (#536): the indexed path must
+    // agree with the eager parser (parsers/xyz.ts), which attaches the lattice
+    // and pbc [true, true, true] whenever a Lattice field is present. Dropping
+    // it here silently degraded >2 MB extxyz files to non-periodic (no cell
+    // box, non-periodic bonds, supercell controls gone). Variable-cell
+    // trajectories work naturally — each frame parses its own comment.
+    const lattice_matrix = parse_xyz_lattice(comment)
     return create_trajectory_frame(
       positions,
       elements,
-      undefined,
-      undefined,
+      lattice_matrix,
+      lattice_matrix ? [true, true, true] : undefined,
       frame_number,
       metadata.properties,
     )

--- a/src/lib/trajectory/parsers/xyz.ts
+++ b/src/lib/trajectory/parsers/xyz.ts
@@ -1,9 +1,8 @@
 // Multi-frame XYZ / extended XYZ trajectory parser
 import type { ElementSymbol } from '$lib'
-import type { Matrix3x3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { TrajectoryFrame, TrajectoryType } from '../index'
-import { create_trajectory_frame } from './common'
+import { create_trajectory_frame, parse_xyz_lattice } from './common'
 
 export const parse_xyz_trajectory = (content: string): TrajectoryType => {
   const lines = content.trim().split(/\r?\n/)
@@ -56,19 +55,10 @@ export const parse_xyz_trajectory = (content: string): TrajectoryType => {
       metadata.source_file = source_file_match[1]
     }
 
-    // Extract lattice matrix
-    const lattice_match = comment.match(/Lattice\s*=\s*"([^"]+)"/i)
-    let lattice_matrix: Matrix3x3 | undefined
-    if (lattice_match) {
-      const values = lattice_match[1].split(/\s+/).map(Number)
-      if (values.length === 9) {
-        lattice_matrix = [[values[0], values[1], values[2]], [
-          values[3],
-          values[4],
-          values[5],
-        ], [values[6], values[7], values[8]]]
-        metadata.volume = math.calc_lattice_params(lattice_matrix).volume
-      }
+    // Extract lattice matrix (shared with the indexed frame loader, #536).
+    const lattice_matrix = parse_xyz_lattice(comment)
+    if (lattice_matrix) {
+      metadata.volume = math.calc_lattice_params(lattice_matrix).volume
     }
 
     // Parse the Properties spec to find column offsets for any extension
@@ -130,7 +120,9 @@ export const parse_xyz_trajectory = (content: string): TrajectoryType => {
       // Exclude fully-fixed atoms (move_mask=false) from the reported max/RMS so the
       // force curve tracks the free atoms actually being relaxed, not a large
       // constraint reaction on a frozen atom.
-      const free = magnitudes.filter((_, i) => move_mask.length === 0 || move_mask[i] !== false)
+      const free = magnitudes.filter((_, i) =>
+        move_mask.length === 0 || move_mask[i] !== false
+      )
       const mags = free.length > 0 ? free : magnitudes
       metadata.force_max = Math.max(...mags)
       // Calculate RMS (root mean square) of force magnitudes

--- a/tests/vitest/trajectory/indexed-xyz-lattice.test.ts
+++ b/tests/vitest/trajectory/indexed-xyz-lattice.test.ts
@@ -1,0 +1,95 @@
+// #536 — the indexed/lazy XYZ loader must preserve the extxyz Lattice.
+//
+// parse_trajectory_async routes text trajectories > 2 MB through the unified
+// indexed loader (TrajFrameReader.load_xyz_frame), which used to pass
+// `undefined` lattice/pbc to create_trajectory_frame even though every frame
+// comment carried a valid `Lattice="..."` field. The SAME file below the
+// threshold (eager parsers/xyz.ts path) kept its lattice — so behavior
+// silently diverged on file size: no cell box, non-periodic bonds, and the
+// supercell controls vanished for any extxyz over 2 MB.
+import type { Matrix3x3 } from '$lib/math'
+import { parse_trajectory_async, TrajFrameReader } from '$lib/trajectory/parse'
+import { parse_trajectory_data } from '$lib/trajectory/parse'
+import { describe, expect, it } from 'vitest'
+
+type LatticeStructure = { lattice?: { matrix: Matrix3x3; pbc: boolean[] } }
+
+/** Synthetic extxyz: per-frame Lattice (variable-cell when grow_cell). */
+function make_extxyz(
+  num_frames: number,
+  atoms_per_frame: number,
+  { with_lattice = true, grow_cell = false } = {},
+): string {
+  const frames: string[] = []
+  for (let ii = 0; ii < num_frames; ii++) {
+    const aa = 10 + (grow_cell ? ii : 0)
+    const lattice = with_lattice
+      ? `Lattice="${aa}.0 0.0 0.0 0.0 ${aa}.0 0.0 0.0 0.0 ${aa}.0" `
+      : ``
+    const lines = [
+      `${atoms_per_frame}`,
+      `${lattice}Properties=species:S:1:pos:R:3 pbc="T T T" step=${ii}`,
+    ]
+    for (let jj = 0; jj < atoms_per_frame; jj++) {
+      lines.push(`Cu ${(jj % 10) * 0.9} ${Math.floor(jj / 10) * 0.9} ${ii * 0.01}`)
+    }
+    frames.push(lines.join(`\n`))
+  }
+  return frames.join(`\n`) + `\n`
+}
+
+const lattice_of = (structure: unknown) => (structure as LatticeStructure).lattice
+
+describe(`indexed XYZ loading preserves the extxyz lattice (#536)`, () => {
+  it(`forced-indexing path attaches lattice + pbc exactly like the eager path`, async () => {
+    const data = make_extxyz(6, 4)
+    const indexed = await parse_trajectory_async(data, `traj.extxyz`, undefined, {
+      use_indexing: true,
+    })
+    expect(indexed.is_indexed).toBe(true)
+    expect(indexed.frames.length).toBeGreaterThan(0)
+
+    const eager = await parse_trajectory_data(data, `traj.extxyz`)
+    const idx_lattice = lattice_of(indexed.frames[0].structure)
+    const eager_lattice = lattice_of(eager.frames[0].structure)
+    expect(idx_lattice).toBeDefined()
+    expect(idx_lattice!.matrix).toEqual([[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    expect(idx_lattice!.pbc).toEqual([true, true, true])
+    // Parity with the eager parser — the two paths must never disagree.
+    expect(idx_lattice!.matrix).toEqual(eager_lattice!.matrix)
+    expect(idx_lattice!.pbc).toEqual(eager_lattice!.pbc)
+  })
+
+  it(`on-demand frame loads carry each frame's OWN lattice (variable-cell)`, async () => {
+    const data = make_extxyz(8, 3, { grow_cell: true })
+    const loader = new TrajFrameReader(`varcell.extxyz`)
+    const frame_0 = await loader.load_frame(data, 0)
+    const frame_5 = await loader.load_frame(data, 5)
+    expect(lattice_of(frame_0!.structure)!.matrix[0][0]).toBe(10)
+    expect(lattice_of(frame_5!.structure)!.matrix[0][0]).toBe(15)
+  })
+
+  it(`molecular xyz (no Lattice field) stays lattice-free on the indexed path`, async () => {
+    const data = make_extxyz(4, 3, { with_lattice: false })
+    const result = await parse_trajectory_async(data, `mol.xyz`, undefined, {
+      use_indexing: true,
+    })
+    expect(result.is_indexed).toBe(true)
+    expect(lattice_of(result.frames[0].structure)).toBeUndefined()
+  })
+
+  it(`>2 MB extxyz auto-routes to the indexed loader AND keeps its lattice`, async () => {
+    // Big enough to cross TEXT_INDEX_THRESHOLD (2 MB) so parse_trajectory_async
+    // takes the indexed path on its own — the exact user-facing regression.
+    const data = make_extxyz(27, 5000)
+    expect(data.length).toBeGreaterThan(2 * 1024 * 1024)
+
+    const result = await parse_trajectory_async(data, `big-md.extxyz`)
+    expect(result.is_indexed).toBe(true)
+    expect(result.total_frames).toBe(27)
+    const lattice = lattice_of(result.frames[0].structure)
+    expect(lattice).toBeDefined()
+    expect(lattice!.matrix).toEqual([[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    expect(lattice!.pbc).toEqual([true, true, true])
+  })
+})


### PR DESCRIPTION
## 中文摘要

修复 #536:**>2 MB 的 .xyz/.extxyz 轨迹在索引式(lazy)加载路径上静默丢失晶格**。单提交 `27e6c786`,基于 `main`。

**故障域链条(修复前):**

```text
>2 MB XYZ/extxyz
        ↓
parse_trajectory_async: TEXT_INDEX_THRESHOLD = 2 MB → indexed/lazy loading
        ↓
frame-loader.ts load_xyz_frame()
        ↓
create_trajectory_frame(..., undefined, undefined, ...)  ← 晶格/pbc 硬传 undefined
        ↓
Lattice 丢失 → periodic bonds / cell box / supercell UI 一并退化
```

同一文件 <2 MB 走急切路径(`parsers/xyz.ts`)一切正常——行为以文件大小为分界,用户无法理解。

**修复(三处,+40/−22):**

1. `parsers/common.ts`:抽出共享 helper `parse_xyz_lattice(comment)`(`Lattice="9 值行主序"` → `Matrix3x3`,缺失/畸形返回 undefined)。
2. `parsers/frame-loader.ts`:`load_xyz_frame` 逐帧解析注释行晶格,连同 `pbc [true, true, true]` 传入 `create_trajectory_frame`——与急切路径约定完全一致;变胞轨迹天然正确(每帧解析自己的注释行)。
3. `parsers/xyz.ts`:急切路径换用同一 helper(volume 元数据计算留在调用点)——**单一事实源,两条路径此后不可能再分叉**。

**回归测试(新文件 `indexed-xyz-lattice.test.ts`,4 用例):**

- 强制索引路径的 lattice + pbc 与急切路径**逐值对齐**(parity 断言);
- 按需帧加载携带**各帧自己的**晶格(变胞:frame 0 → a=10,frame 5 → a=15);
- 分子 xyz(无 Lattice 字段)在索引路径上保持无晶格(不误加);
- **>2 MB extxyz 自动路由进索引加载器且晶格保留**——issue 验收要求的用户侧回归用例(2.66 MB 合成数据,断言真实越过 `TEXT_INDEX_THRESHOLD`)。

**验证:** trajectory 套件 433 pass / 1 skipped;`pnpm check` 0 errors;全量 vitest 4584 pass,仅有的 2 个红项为既知基线项(`cube/periodic-cube-lattice` worker 超时 = 已知环境豁免;`rdf` = 负载 flake,单独跑通过)——与 #537 中的裁决一致,与本改动无关。

**范围说明:** 按 #537 评审结论,本 PR 与 #533/#534(GPU/packet 渲染路径)分属不同故障域,独立成 PR。索引路径同样丢失 forces/move_mask 列的问题在排查中被观察到,但不属于 #536 的晶格范围,未纳入本 PR(如需要可另行立案)。

Fixes #536

---

## English summary

Fixes #536: text trajectories above the 2 MB `TEXT_INDEX_THRESHOLD` route through the indexed loader, whose `load_xyz_frame` passed `undefined` lattice/pbc to `create_trajectory_frame` even though every extxyz frame comment carries a valid `Lattice="..."` field — so >2 MB files silently lost their cell (no cell box, non-periodic bonds, supercell controls gone) while the SAME file under 2 MB behaved correctly.

Fix: shared `parse_xyz_lattice` helper in `parsers/common.ts`, used by BOTH the indexed loader (now attaching per-frame lattice + `pbc [true,true,true]`, matching the eager convention; variable-cell works naturally) and the eager parser (deduped onto the helper — single source of truth). Four regression tests including the issue's acceptance case: a genuinely >2 MB extxyz that auto-routes through the indexed loader and keeps its lattice, plus eager/indexed parity, per-frame variable-cell lattices on on-demand loads, and a molecular-xyz guard.

trajectory suite 433 pass / 1 skipped; `pnpm check` 0 errors; full vitest 4584 pass with only the two known baseline items (cube worker timeout = known environment exemption; rdf = load flake, passes isolated) — same adjudication as #537. Known adjacent gap (indexed path also drops forces/move_mask columns) intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
