### PR TITLE
feat(downloads): add Cloudflare all-platform download hub

### DIFF
--- a/.github/workflows/build-stt-accel.yml
+++ b/.github/workflows/build-stt-accel.yml
@@ -109,7 +109,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release view "$TAG" >/dev/null 2>&1 \
-            || gh release create "$TAG" --title "$TAG" --notes "CatGo STT GPU accelerator binaries"
+            || gh release create "$TAG" --latest=false --title "$TAG" \
+              --notes "CatGo STT GPU accelerator binaries"
           gh release upload "$TAG" "out/$ASSET" "out/$ASSET.sha256" --clobber
 
   manifest:

--- a/.github/workflows/build-vscode-sidecars.yml
+++ b/.github/workflows/build-vscode-sidecars.yml
@@ -107,6 +107,7 @@ jobs:
           # retry briefly in case this job wins the race, then upload.
           for i in 1 2 3 4 5; do
             if gh release view "$tag" >/dev/null 2>&1; then break; fi
-            gh release create "$tag" --title "$tag" --notes "Release $tag" && break || sleep 15
+            gh release create "$tag" --draft --title "$tag" \
+              --notes "Release $tag" && break || sleep 15
           done
           gh release upload "$tag" "${{ matrix.asset_name }}" --clobber

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -24,6 +24,8 @@ on:
       - "svelte.config.js"
       - "wrangler.docs.toml"
       - "wrangler.app.toml"
+      - "wrangler.downloads.toml"
+      - "workers/downloads/**"
       - ".github/workflows/deploy-cloudflare.yml"
   workflow_dispatch:
 
@@ -188,3 +190,16 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --config wrangler.app.toml
+
+  deploy-downloads:
+    name: Deploy dl.catgo-ucsd.org
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config wrangler.downloads.toml

--- a/.github/workflows/hpc-bundle.yml
+++ b/.github/workflows/hpc-bundle.yml
@@ -130,3 +130,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: catgo-hpc-bundle.tar.gz
+          draft: true

--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -4,7 +4,7 @@
 # Layout in the bucket (keep-only-latest policy):
 #   <tag>/<asset>   e.g. v1.4.5/CatGo_1.4.5_x64-setup.exe
 #   latest.json     updater manifest with URLs rewritten to the mirror
-#   index.html      minimal bilingual download page listing the current assets
+#   index.html      self-contained bilingual all-platform download page
 # Older <tag>/ prefixes are pruned after a successful sync, so storage stays
 # within R2's 10 GB free tier (~2.8 GB per release). Egress from R2 is free.
 #
@@ -18,17 +18,24 @@
 #      (CLOUDFLARE_ACCOUNT_ID already exists as a secret.)
 #   Optional repo variables (defaults in env below): R2_BUCKET, R2_PUBLIC_BASE_URL.
 #
-# Triggers: `release: published` — but note releases published by workflows
-# using GITHUB_TOKEN do NOT fire this event (same gotcha as pypi-publish.yml),
-# and manual asset uploads (e.g. the iOS .ipa) may land after publication.
-# When in doubt, run the workflow_dispatch form with the tag — the sync is
-# idempotent and safe to re-run any number of times.
+# Triggers include release publication, manual dispatch, and successful
+# completion of every workflow that can attach assets to the CatGo release.
+# Build STT accelerator is intentionally absent: it owns a separate
+# `stt-accel-v*` release series.
 
 name: Mirror release to R2
 
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows:
+      - Build Desktop App
+      - Android build
+      - Build HPC Bundle
+      - Publish VSCode Extension
+      - Build VSCode Sidecar Binaries
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -54,6 +61,7 @@ env:
 
 jobs:
   mirror:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -67,12 +75,17 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - uses: actions/checkout@v4
+        if: steps.creds.outputs.configured == 'true'
+
       - name: Resolve tag
         id: tag
         if: steps.creds.outputs.configured == 'true'
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             tag="${{ github.event.release.tag_name }}"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            tag=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
           elif [ -n "${{ inputs.tag }}" ]; then
             tag="${{ inputs.tag }}"
           else
@@ -110,42 +123,42 @@ jobs:
             --repo '${{ github.repository }}' --dir dist
           ls -lh dist
 
-      - name: Rewrite latest.json URLs to the mirror
+      - name: Rewrite and validate latest.json URLs
         # latest.json is the Tauri updater manifest; its asset URLs point at
         # github.com, which defeats the purpose for users behind the GFW.
         # Point them at the mirror instead and serve the manifest from the
         # bucket root (the updater endpoint in tauri.conf.json).
         if: steps.creds.outputs.configured == 'true'
         run: |
-          if [ -f dist/latest.json ]; then
-            jq --arg base "$R2_PUBLIC_BASE_URL" '
-              .platforms |= map_values(
-                .url |= sub("https://github.com/[^/]+/[^/]+/releases/download/"; $base + "/")
-              )' dist/latest.json > latest.mirror.json
-            jq . latest.mirror.json > /dev/null
-          else
-            echo "no latest.json in this release — skipping manifest rewrite"
+          if [ ! -f dist/latest.json ]; then
+            echo "Release has no latest.json; refusing to publish a broken updater mirror." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
+
+          jq --arg base "$R2_PUBLIC_BASE_URL" '
+            .platforms |= map_values(
+              .url |= sub(
+                "^https://github.com/[^/]+/[^/]+/releases/download/";
+                $base + "/"
+              )
+            )
+            | if all(.platforms[]; (.url | startswith($base + "/")))
+              then .
+              else error("updater manifest contains a non-mirror URL")
+              end
+          ' dist/latest.json > latest.mirror.json
+          jq . latest.mirror.json > /dev/null
 
       - name: Generate index.html download page
         if: steps.creds.outputs.configured == 'true'
         run: |
           tag='${{ steps.tag.outputs.tag }}'
-          {
-            echo '<!doctype html><meta charset="utf-8">'
-            echo "<title>CatGo downloads — $tag</title>"
-            echo '<style>body{font-family:system-ui;max-width:720px;margin:3rem auto;padding:0 1rem}td{padding:.3rem .8rem}</style>'
-            echo "<h1>CatGo $tag</h1>"
-            echo '<p>中国大陆下载镜像 / China download mirror.'
-            echo '完整发布说明见 <a href="https://github.com/${{ github.repository }}/releases">GitHub Releases</a>.</p>'
-            echo '<table>'
-            for f in dist/*; do
-              name=$(basename "$f")
-              size=$(du -h "$f" | cut -f1)
-              echo "<tr><td><a href=\"$tag/$name\">$name</a></td><td>$size</td></tr>"
-            done
-            echo '</table>'
-          } > index.html
+          node scripts/generate-download-page.mjs \
+            --assets-dir dist \
+            --tag "$tag" \
+            --base-url "$R2_PUBLIC_BASE_URL" \
+            --output index.html
 
       - name: Sync to R2
         if: steps.creds.outputs.configured == 'true'

--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -47,8 +47,12 @@ concurrency:
   group: r2-release-mirror
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  APP_TAG_PATTERN: '^v[0-9]+\.[0-9]+\.[0-9]+$'
   R2_BUCKET: ${{ vars.R2_BUCKET || 'catgo-releases' }}
   R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL || 'https://dl.catgo-ucsd.org' }}
   AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -61,7 +65,11 @@ env:
 
 jobs:
   mirror:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      (github.event_name != 'workflow_run' ||
+        github.event.workflow_run.conclusion == 'success') &&
+      (github.event_name != 'release' ||
+        startsWith(github.event.release.tag_name, 'v'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -81,17 +89,44 @@ jobs:
       - name: Resolve tag
         id: tag
         if: steps.creds.outputs.configured == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+          REQUESTED_TAG: ${{ inputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            tag="${{ github.event.release.tag_name }}"
-          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
-            tag=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
-          elif [ -n "${{ inputs.tag }}" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
+          set -euo pipefail
+          latest_app_tag=$(
+            gh api --paginate "repos/$REPOSITORY/releases?per_page=100" \
+              --jq '.[] |
+                select(.draft == false and .prerelease == false) |
+                .tag_name |
+                select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' |
+              sort -V |
+              tail -n 1
+          )
+          if [ -z "$latest_app_tag" ]; then
+            echo "No published CatGo app release found." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT_NAME" = "release" ]; then
+            tag="$RELEASE_EVENT_TAG"
+          elif [ "$EVENT_NAME" = "workflow_run" ]; then
+            tag="$latest_app_tag"
+          elif [ -n "$REQUESTED_TAG" ]; then
+            tag="$REQUESTED_TAG"
+          else
+            tag="$latest_app_tag"
+          fi
+          if ! [[ "$tag" =~ $APP_TAG_PATTERN ]]; then
+            echo "Refusing non-CatGo release tag: $tag" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          {
+            echo "tag=$tag"
+            echo "latest_app_tag=$latest_app_tag"
+          } >> "$GITHUB_OUTPUT"
           echo "Mirroring release: $tag"
 
       - name: Wait for asset list to stabilize
@@ -99,11 +134,14 @@ jobs:
         # published. Poll until the asset count is unchanged for 3 consecutive
         # minutes (skipped on manual dispatch — by then the release is done).
         if: steps.creds.outputs.configured == 'true' && github.event_name == 'release'
+        env:
+          MIRROR_TAG: ${{ steps.tag.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          tag='${{ steps.tag.outputs.tag }}'
+          tag="$MIRROR_TAG"
           prev=-1; stable=0
           for i in $(seq 1 30); do
-            count=$(gh api "repos/${{ github.repository }}/releases/tags/$tag" --jq '.assets | length')
+            count=$(gh api "repos/$REPOSITORY/releases/tags/$tag" --jq '.assets | length')
             echo "poll $i: $count assets"
             if [ "$count" = "$prev" ]; then
               stable=$((stable + 1))
@@ -117,10 +155,13 @@ jobs:
 
       - name: Download release assets
         if: steps.creds.outputs.configured == 'true'
+        env:
+          MIRROR_TAG: ${{ steps.tag.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           mkdir -p dist
-          gh release download '${{ steps.tag.outputs.tag }}' \
-            --repo '${{ github.repository }}' --dir dist
+          gh release download "$MIRROR_TAG" \
+            --repo "$REPOSITORY" --dir dist
           ls -lh dist
 
       - name: Rewrite and validate latest.json URLs
@@ -152,8 +193,10 @@ jobs:
 
       - name: Generate index.html download page
         if: steps.creds.outputs.configured == 'true'
+        env:
+          MIRROR_TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          tag='${{ steps.tag.outputs.tag }}'
+          tag="$MIRROR_TAG"
           node scripts/generate-download-page.mjs \
             --assets-dir dist \
             --tag "$tag" \
@@ -161,24 +204,55 @@ jobs:
             --output index.html
 
       - name: Sync to R2
+        id: sync
         if: steps.creds.outputs.configured == 'true'
+        env:
+          MIRROR_TAG: ${{ steps.tag.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          tag='${{ steps.tag.outputs.tag }}'
+          set -euo pipefail
+          tag="$MIRROR_TAG"
           aws s3 sync dist/ "s3://$R2_BUCKET/$tag/"
-          if [ -f latest.mirror.json ]; then
+
+          latest_app_tag=$(
+            gh api --paginate "repos/$REPOSITORY/releases?per_page=100" \
+              --jq '.[] |
+                select(.draft == false and .prerelease == false) |
+                .tag_name |
+                select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' |
+              sort -V |
+              tail -n 1
+          )
+          if [ "$tag" = "$latest_app_tag" ]; then
             aws s3 cp latest.mirror.json "s3://$R2_BUCKET/latest.json" \
               --content-type application/json --cache-control 'public, max-age=300'
+            aws s3 cp index.html "s3://$R2_BUCKET/index.html" \
+              --content-type 'text/html; charset=utf-8' --cache-control 'public, max-age=300'
+            echo "root_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Backfilled $tag; latest app release is $latest_app_tag, so root metadata was not changed."
+            echo "root_published=false" >> "$GITHUB_OUTPUT"
           fi
-          aws s3 cp index.html "s3://$R2_BUCKET/index.html" \
-            --content-type 'text/html; charset=utf-8' --cache-control 'public, max-age=300'
 
       - name: Prune older releases (keep only the latest)
         # Only prune when the tag we just synced IS the repo's latest release —
         # a manual backfill of an old tag must not delete the current one.
         if: steps.creds.outputs.configured == 'true'
+        env:
+          MIRROR_TAG: ${{ steps.tag.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          tag='${{ steps.tag.outputs.tag }}'
-          latest=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
+          set -euo pipefail
+          tag="$MIRROR_TAG"
+          latest=$(
+            gh api --paginate "repos/$REPOSITORY/releases?per_page=100" \
+              --jq '.[] |
+                select(.draft == false and .prerelease == false) |
+                .tag_name |
+                select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' |
+              sort -V |
+              tail -n 1
+          )
           if [ "$tag" != "$latest" ]; then
             echo "synced $tag but latest is $latest — skipping prune"
             exit 0
@@ -195,12 +269,19 @@ jobs:
 
       - name: Summary
         if: steps.creds.outputs.configured == 'true'
+        env:
+          MIRROR_TAG: ${{ steps.tag.outputs.tag }}
+          ROOT_PUBLISHED: ${{ steps.sync.outputs.root_published }}
         run: |
-          tag='${{ steps.tag.outputs.tag }}'
+          tag="$MIRROR_TAG"
           {
             echo "### Mirrored $tag to R2"
             echo ""
-            echo "- Download page: $R2_PUBLIC_BASE_URL/"
-            echo "- Updater manifest: $R2_PUBLIC_BASE_URL/latest.json"
             echo "- Assets: $R2_PUBLIC_BASE_URL/$tag/<file>"
+            if [ "$ROOT_PUBLISHED" = "true" ]; then
+              echo "- Download page: $R2_PUBLIC_BASE_URL/"
+              echo "- Updater manifest: $R2_PUBLIC_BASE_URL/latest.json"
+            else
+              echo "- Root metadata: unchanged (backfill is not latest)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -176,8 +176,12 @@ jobs:
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
           vsix=$(ls extensions/vscode/catgo-*.vsix | head -1)
-          gh release view "$tag" >/dev/null 2>&1 \
-            || gh release create "$tag" --title "$tag" --notes "Release $tag"
+          for i in 1 2 3 4 5; do
+            if gh release view "$tag" >/dev/null 2>&1; then break; fi
+            gh release create "$tag" --draft --title "$tag" \
+              --notes "Release $tag" && break || sleep 15
+          done
+          gh release view "$tag" >/dev/null
           gh release upload "$tag" "$vsix" --clobber
           # The platform sidecar binaries (catgo-server-{linux-x64,darwin-arm64,
           # win-x64.exe}) that src/sidecar.ts downloads on first activate are

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,17 +1,16 @@
 # Installation
 
-CatGo is a desktop application. Most users should grab a pre-built installer from GitHub Releases. Developers building from source can use the Quick Start below.
+CatGo is a desktop application. Most users should grab a pre-built installer from the [CatGo download hub](https://dl.catgo-ucsd.org/). Developers building from source can use the Quick Start below.
 
 ## Download a Pre-Built Installer
 
-Pre-built installers for every release are published on [GitHub Releases](https://github.com/Hello-QM/catgo-LRG/releases/latest). All installers bundle the Python backend (via PyInstaller) and the agent-bridge sidecar — no separate Python or Node install required.
+Pre-built installers for the current release are delivered through the [CatGo download hub](https://dl.catgo-ucsd.org/). All installers bundle the Python backend (via PyInstaller) and the agent-bridge sidecar — no separate Python or Node install required.
 
 | Platform | File | Notes |
 |----------|------|-------|
 | **macOS (Apple Silicon)** | `CatGo_<version>_aarch64.dmg` | Drag to `/Applications`. May require right-click → Open on first launch (unsigned). |
-| **macOS (Intel)** | `CatGo_<version>_x64.dmg` | Universal builds also available — file name contains `universal`. |
 | **Windows** | `CatGo_<version>_x64-setup.exe` or `.msi` | WebView2 runtime is auto-installed if missing. |
-| **Linux (`.AppImage`)** | `CatGo_<version>_amd64.AppImage` | `chmod +x` then run. Works on most distros without root. |
+| **Linux (`.AppImage`)** | `CatGo_<version>_amd64.AppImage` | When available, `chmod +x` then run. Works on most distros without root. |
 | **Linux (`.deb`)** | `CatGo_<version>_amd64.deb` | `sudo apt install ./CatGo_*.deb` on Ubuntu / Debian. |
 
 After install, launch *CatGo* from your launcher. On Linux from the terminal:

--- a/docs/superpowers/plans/2026-07-24-cloudflare-download-hub.md
+++ b/docs/superpowers/plans/2026-07-24-cloudflare-download-hub.md
@@ -1,0 +1,593 @@
+# Cloudflare Download Hub Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve a China-friendly all-platform CatGo download page from
+`https://dl.catgo-ucsd.org/`, route every normal app download and update through
+Cloudflare, and publish the next complete CatGo release only after every
+required platform gate passes.
+
+**Architecture:** Keep one copy of release assets in the existing
+`catgo-releases` R2 bucket. A small Worker maps the download domain root and
+object paths to the R2 binding while preserving streaming, conditional requests,
+and byte ranges. A deterministic Node generator builds a self-contained
+bilingual page from actual release assets. Product entry points and the Tauri
+updater use the download domain exclusively. Release workflows refresh the
+mirror after every workflow that can add assets to the CatGo release.
+
+**Tech stack:** Node.js 22 ESM, Vitest, Svelte 5, Tauri 2, Cloudflare Workers,
+R2, Wrangler 4, GitHub Actions, AWS CLI, GitHub CLI.
+
+## Global constraints
+
+- Work only in the isolated worktree and feature branch.
+- Follow red-green-refactor for each behavior.
+- Commit after every task with only that task's files staged.
+- Never stage or modify `.claude/gate-approvals/`, `.claude/tmp-*`, or
+  `.superpowers/`.
+- Preserve the current official `wasm-pack` installer in the Cloudflare app
+  deployment workflow.
+- Do not add external fonts, CDNs, analytics, GitHub API calls, or GitHub
+  fallback links to the normal download flow.
+- Do not buffer release binaries in Worker memory.
+- Treat the STT accelerator release as a separate product. Its workflow
+  publishes `stt-accel-v*` releases and must not refresh the CatGo app mirror.
+- Use `v1.4.6` as the next patch release after the implementation is merged and
+  all build inputs are green.
+
+## Verified baseline
+
+- [x] The original `wasm-pack --features` Cloudflare deployment failure is
+  fixed on `main` by `f197708639f98f8f39b4acc688601cacd767424b`.
+- [x] Main workflow run `30145089642` passed the docs, app, current wasm-pack,
+  complete WASM build, artifact verification, SPA build, and Wrangler deploy
+  gates.
+- [x] `https://app.catgo-ucsd.org/` returns HTTP 200.
+- [x] R2 currently serves `/index.html`, `/latest.json`, and mirrored v1.4.5
+  assets, while the domain root still returns 404.
+
+## Task 1: Lock the implementation contract
+
+**Files:**
+
+- Add:
+  `docs/superpowers/plans/2026-07-24-cloudflare-download-hub.md`
+- Modify:
+  `docs/superpowers/specs/2026-07-24-cloudflare-download-hub-design.md`
+
+- [ ] Mark the approved design as accepted.
+- [ ] Correct the release-sync list so it excludes `Build STT accelerator`,
+  because that workflow targets an independent release series.
+- [ ] Confirm the plan names every production mutation, live gate, and rollback
+  path.
+- [ ] Scan for unresolved markers:
+
+  ```bash
+  rg -n 'TB[D]|TO[D]O|FIXM[E]|PLACEHOLDE[R]' \
+    docs/superpowers/plans/2026-07-24-cloudflare-download-hub.md \
+    docs/superpowers/specs/2026-07-24-cloudflare-download-hub-design.md
+  ```
+
+- [ ] Check whitespace:
+
+  ```bash
+  git diff --check
+  ```
+
+- [ ] Commit:
+
+  ```bash
+  git add \
+    docs/superpowers/plans/2026-07-24-cloudflare-download-hub.md \
+    docs/superpowers/specs/2026-07-24-cloudflare-download-hub-design.md
+  git commit -m "docs: plan Cloudflare download hub implementation"
+  ```
+
+## Task 2: Build the deterministic download-page generator
+
+**Files:**
+
+- Add: `scripts/generate-download-page.mjs`
+- Add: `scripts/__tests__/generate-download-page.test.mjs`
+
+### Required behavior
+
+- Classify the currently available installers:
+  - Windows x64 NSIS setup EXE and MSI.
+  - macOS Apple Silicon DMG.
+  - Linux amd64 DEB, RPM, and AppImage when present.
+  - Android universal APK.
+  - iOS public TestFlight link.
+- Prefer NSIS EXE for Windows, DMG for macOS, DEB for Linux, APK for Android,
+  and TestFlight for iOS.
+- Put signatures, updater archives, manifests, VSIX files, HPC bundles,
+  sidecars, and unclassified files in “Other downloads”.
+- Include version, architecture, format, byte size, installation guidance, and
+  bilingual labels.
+- Render a visible unavailable state when an installer is absent; never emit a
+  broken platform link.
+- HTML-escape every untrusted string and percent-encode every URL path segment.
+- Reject an invalid base URL or a tag containing `/`, `\`, `.` path traversal,
+  control characters, or empty text.
+- Produce one self-contained page with system fonts and inline CSS/JavaScript.
+- Use a Chinese-first deep-blue/graphite/copper “materials workbench” visual
+  direction with an OS-aware platform rail, keyboard focus styles, responsive
+  cards, and reduced-motion support.
+- The page must remain useful when JavaScript is disabled.
+
+### TDD steps
+
+- [ ] Write a fixture test with representative assets for every supported
+  platform. Assert classification, preferred format, byte size, bilingual
+  labels, direct `dl.catgo-ucsd.org` URLs, and TestFlight.
+- [ ] Write a partial-release test. Assert missing-platform guidance and the
+  absence of empty `href` attributes.
+- [ ] Write malicious tag and filename tests. Assert HTML escaping, URL
+  encoding, and input rejection.
+- [ ] Write a no-external-dependency test. Assert no `github.com`,
+  `api.github.com`, external font, CDN, analytics, or remote script URL.
+- [ ] Run the test and capture the expected red result:
+
+  ```bash
+  node --test scripts/__tests__/generate-download-page.test.mjs
+  ```
+
+- [ ] Implement exported pure helpers plus a thin CLI:
+
+  ```text
+  node scripts/generate-download-page.mjs \
+    --assets-dir dist \
+    --tag v1.4.6 \
+    --base-url https://dl.catgo-ucsd.org \
+    --output index.html
+  ```
+
+- [ ] Run the focused test until green:
+
+  ```bash
+  node --test scripts/__tests__/generate-download-page.test.mjs
+  ```
+
+- [ ] Generate a fixture page and inspect it with a local HTTP server in desktop
+  and mobile viewports. Verify keyboard focus and JavaScript-disabled content.
+- [ ] Check whitespace:
+
+  ```bash
+  git diff --check
+  ```
+
+- [ ] Commit:
+
+  ```bash
+  git add \
+    scripts/generate-download-page.mjs \
+    scripts/__tests__/generate-download-page.test.mjs
+  git commit -m "feat(downloads): generate all-platform mirror page"
+  ```
+
+## Task 3: Add the streaming R2 download Worker
+
+**Files:**
+
+- Add: `workers/downloads/index.mjs`
+- Add: `workers/downloads/index.test.mjs`
+- Add: `wrangler.downloads.toml`
+- Modify: `.github/workflows/deploy-cloudflare.yml`
+- Modify: `scripts/__tests__/deploy-cloudflare-workflow.test.mjs`
+
+### Required behavior
+
+- Map `/` and `/index.html` to the `index.html` R2 key.
+- Map `/latest.json` and `/<tag>/<asset>` directly to the same R2 keys.
+- Allow only GET and HEAD. Return 405 with `Allow: GET, HEAD` otherwise.
+- Reject encoded separators, NULs, `.`/`..` segments, and decoding failures.
+- Use `env.RELEASES.head()` for HEAD and `env.RELEASES.get()` for GET.
+- Forward `Range`, `If-Match`, `If-None-Match`, `If-Modified-Since`, and
+  `If-Unmodified-Since` through R2's range/conditional options.
+- Return 304 or 412 when the R2 conditional result has no body, as appropriate.
+- Copy R2 HTTP metadata, ETag, content length, content range, cache control, and
+  `Accept-Ranges: bytes`.
+- Stream the R2 body directly.
+- Render HTML/JSON inline and use attachment disposition for installers.
+- Return a short bilingual 404 body.
+
+### TDD steps
+
+- [ ] Add fake-R2 tests for root mapping, object GET, HEAD, byte range,
+  conditional 304, 404, 405, traversal rejection, metadata, and stream identity.
+- [ ] Run the Worker test and capture the expected red result:
+
+  ```bash
+  node --test workers/downloads/index.test.mjs
+  ```
+
+- [ ] Implement the Worker request handler.
+- [ ] Run the focused test until green:
+
+  ```bash
+  node --test workers/downloads/index.test.mjs
+  ```
+
+- [ ] Configure `wrangler.downloads.toml`:
+
+  ```toml
+  name = "catgo-downloads"
+  main = "workers/downloads/index.mjs"
+  compatibility_date = "2026-07-24"
+  routes = [
+    { pattern = "dl.catgo-ucsd.org/*", zone_name = "catgo-ucsd.org" }
+  ]
+
+  [[r2_buckets]]
+  binding = "RELEASES"
+  bucket_name = "catgo-releases"
+  ```
+
+- [ ] Extend the workflow regression test before editing the workflow. Assert:
+  - download Worker paths trigger the Cloudflare workflow;
+  - a `deploy-downloads` job exists;
+  - it uses Wrangler with `wrangler.downloads.toml`;
+  - the current official wasm-pack installer is unchanged.
+- [ ] Run the workflow test and capture the expected red result:
+
+  ```bash
+  node --test scripts/__tests__/deploy-cloudflare-workflow.test.mjs
+  ```
+
+- [ ] Add the download Worker deploy job with checkout and
+  `cloudflare/wrangler-action@v3`.
+- [ ] Run both focused suites:
+
+  ```bash
+  node --test \
+    workers/downloads/index.test.mjs \
+    scripts/__tests__/deploy-cloudflare-workflow.test.mjs
+  ```
+
+- [ ] Validate the Worker bundle without deploying:
+
+  ```bash
+  pnpm exec wrangler deploy --dry-run --config wrangler.downloads.toml
+  ```
+
+- [ ] Check whitespace and commit:
+
+  ```bash
+  git diff --check
+  git add \
+    workers/downloads/index.mjs \
+    workers/downloads/index.test.mjs \
+    wrangler.downloads.toml \
+    .github/workflows/deploy-cloudflare.yml \
+    scripts/__tests__/deploy-cloudflare-workflow.test.mjs
+  git commit -m "feat(downloads): serve R2 mirror through Worker"
+  ```
+
+## Task 4: Make mirror refreshes complete and repeatable
+
+**Files:**
+
+- Add: `scripts/__tests__/r2-release-mirror-workflow.test.mjs`
+- Modify: `.github/workflows/r2-release-mirror.yml`
+
+### Required behavior
+
+- Preserve `release: published` and manual dispatch.
+- Add `workflow_run: completed` for:
+  - `Build Desktop App`
+  - `Android build`
+  - `Build HPC Bundle`
+  - `Publish VSCode Extension`
+  - `Build VSCode Sidecar Binaries`
+- Run only for successful workflow completions.
+- For workflow-run refreshes, always resolve the latest published CatGo release.
+- Use the page generator instead of inline shell HTML.
+- Rewrite all Tauri platform URLs to the R2 base and validate the resulting
+  JSON.
+- Upload the tag directory first, then `latest.json`, then `index.html`.
+- Prune only after all uploads succeed and only when the synced tag is the
+  repository's latest published release.
+- Preserve the single concurrency group.
+
+### TDD steps
+
+- [ ] Add a workflow-source test that checks the exact trigger names, successful
+  conclusion guard, generator invocation, mirror rewrite, upload order, and
+  prune ordering.
+- [ ] Assert `Build STT accelerator` is absent.
+- [ ] Run and capture the expected red result:
+
+  ```bash
+  node --test scripts/__tests__/r2-release-mirror-workflow.test.mjs
+  ```
+
+- [ ] Implement the workflow changes.
+- [ ] Run the focused test until green:
+
+  ```bash
+  node --test scripts/__tests__/r2-release-mirror-workflow.test.mjs
+  ```
+
+- [ ] Parse the workflow as YAML:
+
+  ```bash
+  ruby -e 'require "yaml"; YAML.load_file(".github/workflows/r2-release-mirror.yml", aliases: true)'
+  ```
+
+- [ ] Check whitespace and commit:
+
+  ```bash
+  git diff --check
+  git add \
+    .github/workflows/r2-release-mirror.yml \
+    scripts/__tests__/r2-release-mirror-workflow.test.mjs
+  git commit -m "ci(release): refresh complete R2 mirror"
+  ```
+
+## Task 5: Route every product download and update through Cloudflare
+
+**Files:**
+
+- Add: `src/lib/download-links.ts`
+- Add: `src/lib/update/release-manifest.ts`
+- Add: `src/lib/update/__tests__/release-manifest.test.ts`
+- Add: `scripts/__tests__/cloudflare-download-entrypoints.test.mjs`
+- Modify: `src/lib/DesktopDownloadModal.svelte`
+- Modify: `src/lib/StaticModeBanner.svelte`
+- Modify: `src/lib/api/config.ts`
+- Modify: `src/lib/update/auto-update.svelte.ts`
+- Modify: `src-tauri/tauri.conf.json`
+
+### Required behavior
+
+- Define one source of truth:
+
+  ```ts
+  export const DOWNLOAD_HUB_URL = 'https://dl.catgo-ucsd.org/';
+  export const UPDATE_MANIFEST_URL =
+    'https://dl.catgo-ucsd.org/latest.json';
+  export const TESTFLIGHT_URL =
+    'https://testflight.apple.com/join/FdHup5Hz';
+  ```
+
+- The download modal opens TestFlight for iOS and the Cloudflare hub for every
+  downloadable desktop/mobile platform.
+- The “all downloads” link, static-mode banner, and browser-only guidance open
+  the hub.
+- Linux fetches the mirrored Tauri manifest, compares semantic versions, shows
+  mirrored notes, and opens the hub for installation.
+- Windows and macOS continue to use the signed Tauri updater.
+- `src-tauri/tauri.conf.json` contains exactly one updater endpoint:
+  `https://dl.catgo-ucsd.org/latest.json`.
+- Normal product download/update sources contain no GitHub API, release page,
+  or asset URL.
+
+### TDD steps
+
+- [ ] Extract and test pure release-manifest parsing and version comparison for
+  newer, equal, older, malformed, and prerelease versions.
+- [ ] Add a static regression test that reads the product-entry files and Tauri
+  config. Assert the one Cloudflare endpoint and absence of GitHub download
+  paths.
+- [ ] Run and capture the expected red results:
+
+  ```bash
+  pnpm exec vitest run \
+    src/lib/update/__tests__/release-manifest.test.ts
+  node --test \
+    scripts/__tests__/cloudflare-download-entrypoints.test.mjs
+  ```
+
+- [ ] Implement shared constants and the pure manifest parser.
+- [ ] Replace GitHub behavior in each product entry point.
+- [ ] Run the focused tests until green:
+
+  ```bash
+  pnpm exec vitest run \
+    src/lib/update/__tests__/release-manifest.test.ts
+  node --test \
+    scripts/__tests__/cloudflare-download-entrypoints.test.mjs
+  ```
+
+- [ ] Run Svelte and TypeScript checks:
+
+  ```bash
+  pnpm check
+  ```
+
+- [ ] Check whitespace and commit:
+
+  ```bash
+  git diff --check
+  git add \
+    src/lib/download-links.ts \
+    src/lib/update/release-manifest.ts \
+    src/lib/update/__tests__/release-manifest.test.ts \
+    scripts/__tests__/cloudflare-download-entrypoints.test.mjs \
+    src/lib/DesktopDownloadModal.svelte \
+    src/lib/StaticModeBanner.svelte \
+    src/lib/api/config.ts \
+    src/lib/update/auto-update.svelte.ts \
+    src-tauri/tauri.conf.json
+  git commit -m "feat(downloads): use Cloudflare for app updates"
+  ```
+
+## Task 6: Validate the visual result and accessibility
+
+**Files:**
+
+- Modify only generator/test files if visual defects are found.
+- Store screenshots outside the repository.
+
+- [ ] Generate a representative page from real latest-release filenames.
+- [ ] Serve it locally and inspect at:
+  - 1440 by 1000 desktop;
+  - 390 by 844 mobile;
+  - keyboard-only navigation;
+  - reduced motion;
+  - JavaScript disabled.
+- [ ] Verify:
+  - the recommended platform is obvious but alternatives remain available;
+  - Chinese labels lead and English translations are legible;
+  - no text clips or overlaps;
+  - focus is visible;
+  - every downloadable link is under `dl.catgo-ucsd.org`;
+  - iOS alone uses TestFlight;
+  - page weight has no remote dependencies.
+- [ ] If the generator changes, extend the test first, then rerun Task 2 tests.
+- [ ] Commit only if validation required a change:
+
+  ```bash
+  git add \
+    scripts/generate-download-page.mjs \
+    scripts/__tests__/generate-download-page.test.mjs
+  git commit -m "fix(downloads): polish download hub accessibility"
+  ```
+
+## Task 7: Run the complete pre-merge verification matrix
+
+- [ ] Run all Node regression suites:
+
+  ```bash
+  node --test \
+    scripts/__tests__/*.test.mjs \
+    workers/downloads/index.test.mjs
+  ```
+
+- [ ] Run all frontend unit tests:
+
+  ```bash
+  pnpm test
+  ```
+
+- [ ] Run type and Svelte checks:
+
+  ```bash
+  pnpm check
+  ```
+
+- [ ] Rebuild and verify every WASM package:
+
+  ```bash
+  pnpm build:wasm
+  node scripts/verify-wasm-artifacts.mjs
+  ```
+
+- [ ] Build the static production app:
+
+  ```bash
+  pnpm deploy:build
+  ```
+
+- [ ] Bundle the Worker:
+
+  ```bash
+  pnpm exec wrangler deploy --dry-run --config wrangler.downloads.toml
+  ```
+
+- [ ] Inspect branch scope and whitespace:
+
+  ```bash
+  git status --short
+  git diff --check origin/main...HEAD
+  git diff --stat origin/main...HEAD
+  ```
+
+- [ ] If a verification exposes a defect, add a failing regression test, fix it,
+  rerun the affected gate and the entire matrix, and commit the fix separately.
+
+## Task 8: Review, merge, and deploy the download hub
+
+- [ ] Search for repository pull-request templates and use one if present.
+- [ ] Push the feature branch after satisfying the repository's one-shot push
+  approval gate.
+- [ ] Open a PR summarizing the architecture, TDD evidence, and rollback.
+- [ ] Wait for `prek`, `unit`, and `e2e`; fix any failure with a regression test.
+- [ ] Merge only when every required check is green.
+- [ ] Monitor the main `Deploy to Cloudflare Workers` run until docs, app, and
+  download Worker jobs all succeed.
+- [ ] Dispatch `Mirror release to R2` for the current latest tag and wait for
+  success.
+- [ ] Verify production:
+
+  ```text
+  GET  https://dl.catgo-ucsd.org/             -> 200 HTML
+  HEAD https://dl.catgo-ucsd.org/latest.json  -> 200 JSON metadata
+  GET  installer with Range: bytes=0-1023     -> 206 and Content-Range
+  GET  missing object                         -> 404 bilingual response
+  POST any object                             -> 405 and Allow: GET, HEAD
+  ```
+
+- [ ] Confirm the root page contains the current version and available Windows,
+  macOS, Linux, Android, and iOS paths.
+- [ ] Confirm the deployed app opens the hub and makes no GitHub API request for
+  a normal download.
+
+## Task 9: Prepare and publish CatGo v1.4.6
+
+**Expected version files:**
+
+- `package.json`
+- `pnpm-lock.yaml`
+- `src-tauri/Cargo.toml`
+- `src-tauri/Cargo.lock`
+- `src-tauri/tauri.conf.json`
+- `server/pyproject.toml`
+- release notes or changelog files already used by the repository
+
+- [ ] Create a release branch from the newly merged `origin/main`.
+- [ ] Add failing version-consistency assertions if no existing gate covers all
+  version surfaces.
+- [ ] Bump CatGo to `1.4.6`; use the repository's existing Python post-release
+  convention consistently.
+- [ ] Update release notes to include:
+  - exact smooth ASE trajectory playback and at least 24 unique presented FPS;
+  - GPU impostor bonds in trajectory and static structure views;
+  - Gaussian frame counting and IRC trajectory corrections;
+  - China-friendly all-platform Cloudflare download center;
+  - Cloudflare-only in-app update checks and packages.
+- [ ] Run the full Task 7 verification matrix.
+- [ ] Commit, push through the approval gate, open a release PR, wait for every
+  required check, and merge.
+- [ ] Create and push annotated tag `v1.4.6` from the exact merged main commit.
+- [ ] Wait for successful tag workflows:
+  - `Build Desktop App` for Windows, Apple Silicon macOS, and Linux;
+  - `Build HPC Bundle`;
+  - `Publish VSCode Extension`;
+  - `Build VSCode Sidecar Binaries`.
+- [ ] Dispatch `Android build` at `v1.4.6` with
+  `release_tag=v1.4.6`; require a signed universal APK upload.
+- [ ] Dispatch `iOS build` at `v1.4.6` with `signed=true` and `upload=true`;
+  require successful TestFlight upload.
+- [ ] Before publishing the draft release, require:
+  - Windows NSIS EXE and MSI;
+  - Apple Silicon DMG and signed updater archive;
+  - Linux DEB, RPM, and AppImage if produced by the desktop workflow;
+  - Android universal APK;
+  - valid signed `latest.json`;
+  - successful TestFlight upload;
+  - any expected HPC, VSIX, and sidecar assets.
+- [ ] Publish the draft as the latest release only after the checklist passes.
+- [ ] Wait for the R2 mirror refresh; manually dispatch it if GitHub's release
+  event does not fire.
+- [ ] Verify final production state:
+  - download root shows `v1.4.6`;
+  - every published platform link returns 200;
+  - a byte-range request against each large installer returns 206;
+  - `latest.json` reports `1.4.6`;
+  - every updater package URL uses `dl.catgo-ucsd.org`;
+  - app download/update paths make no request to GitHub.
+
+## Rollback
+
+- Removing the `dl.catgo-ucsd.org/*` Worker route restores explicit R2 custom
+  domain object paths.
+- The mirror uploads replacement root metadata only after release assets upload
+  successfully and prunes only after the synced tag is confirmed latest.
+- The previous R2 `index.html`, `latest.json`, and tag assets remain valid until
+  a successful refresh.
+- If v1.4.6 platform builds are incomplete, leave the GitHub release as a draft
+  and keep v1.4.5 as the published/latest release.

--- a/docs/superpowers/specs/2026-07-24-cloudflare-download-hub-design.md
+++ b/docs/superpowers/specs/2026-07-24-cloudflare-download-hub-design.md
@@ -1,7 +1,7 @@
 # Cloudflare Download Hub Design
 
 **Date:** 2026-07-24  
-**Status:** Proposed  
+**Status:** Accepted
 **Audience:** CatGo maintainers and release engineers
 
 ## 1. Goal
@@ -104,7 +104,11 @@ successful completion of each workflow that can add release assets:
 - Build HPC Bundle
 - Publish VSCode Extension
 - Build VSCode Sidecar Binaries
-- Build STT accelerator
+
+`Build STT accelerator` is intentionally excluded because it publishes an
+independent `stt-accel-v*` release series rather than assets for the latest
+CatGo app release. Triggering the app mirror from that workflow could select
+the wrong release.
 
 iOS is represented by TestFlight and does not require an R2 binary. A later iOS
 workflow completion may still trigger a harmless idempotent refresh if its

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -1,17 +1,16 @@
 # 安装
 
-CatGo 是一个桌面应用。大多数用户可以直接从 GitHub Releases 下载预构建安装包。需要从源码构建的开发者可以使用下面的快速开始流程。
+CatGo 是一个桌面应用。大多数用户可以直接从 [CatGo 下载中心](https://dl.catgo-ucsd.org/)下载预构建安装包。需要从源码构建的开发者可以使用下面的快速开始流程。
 
 ## 下载预构建安装包
 
-每个 release 的预构建安装包都会发布在 [GitHub Releases](https://github.com/Hello-QM/catgo-LRG/releases/latest)。所有安装包都内置 Python 后端（通过 PyInstaller）和 agent-bridge sidecar，不需要用户额外安装 Python 或 Node。
+当前 release 的预构建安装包由 [CatGo 下载中心](https://dl.catgo-ucsd.org/)直接提供。所有安装包都内置 Python 后端（通过 PyInstaller）和 agent-bridge sidecar，不需要用户额外安装 Python 或 Node。
 
 | 平台 | 文件 | 说明 |
 |----------|------|-------|
 | **macOS (Apple Silicon)** | `CatGo_<version>_aarch64.dmg` | 拖到 `/Applications`。首次启动可能需要右键 -> Open（未签名）。 |
-| **macOS (Intel)** | `CatGo_<version>_x64.dmg` | 也提供 universal 构建，文件名包含 `universal`。 |
 | **Windows** | `CatGo_<version>_x64-setup.exe` 或 `.msi` | 如果缺少 WebView2 runtime，会自动安装。 |
-| **Linux (`.AppImage`)** | `CatGo_<version>_amd64.AppImage` | `chmod +x` 后运行。多数发行版无需 root 权限。 |
+| **Linux (`.AppImage`)** | `CatGo_<version>_amd64.AppImage` | 提供该格式时，`chmod +x` 后运行。多数发行版无需 root 权限。 |
 | **Linux (`.deb`)** | `CatGo_<version>_amd64.deb` | 在 Ubuntu / Debian 上使用 `sudo apt install ./CatGo_*.deb`。 |
 
 安装后，从启动器打开 *CatGo*。Linux 也可以在终端中运行：

--- a/extensions/vscode/readme.md
+++ b/extensions/vscode/readme.md
@@ -12,7 +12,7 @@
 >
 > **Desktop client only** — the surrounding workbench *shell*, which the extension does **not** load: the **multi-pane tabbed workspace** (tabs / split-view / pop-out windows), the standalone **visual workflow DAG editor**, and the **HPC terminal & job manager**.
 >
-> For the full workbench use the **[CatGo desktop client](https://github.com/Hello-QM/catgo-LRG/releases)** (Windows / macOS / Linux) or the **[web app](https://app.catgo-ucsd.org)**.
+> For the full workbench use the **[CatGo desktop client](https://dl.catgo-ucsd.org/)** (Windows / macOS / Linux) or the **[web app](https://app.catgo-ucsd.org)**.
 
 ## ✨ Features
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
   ·
   <a href="https://app.catgo-ucsd.org">Try Online</a>
   ·
-  <a href="https://github.com/Hello-QM/catgo-LRG/releases">Download Desktop</a>
+  <a href="https://dl.catgo-ucsd.org/">Download Desktop</a>
   ·
   <a href="https://docs.catgo-ucsd.org">Docs & Tutorials</a>
 </p>
@@ -106,7 +106,7 @@ CatGo has three established day-to-day entry points—desktop, Web, and VS Code�
 
 ### A. Desktop app: the full workbench
 
-1. Download the Windows, macOS, or Linux installer from [GitHub Releases](https://github.com/Hello-QM/catgo-LRG/releases).
+1. Download the Windows, macOS, or Linux installer from the [CatGo download hub](https://dl.catgo-ucsd.org/).
 2. Launch CatGo and drop in a structure/output file, or fetch a structure from a database.
 3. Use the structure toolbar, Quick Build, or CatBot to prepare the model and workflow.
 4. For remote calculations, connect your lab's cluster from the HPC panel.
@@ -285,16 +285,16 @@ Feature availability depends on the CatGo edition, installed optional dependenci
 
 ### Download
 
-Every link points at the **latest release**, so it stays current as new versions ship — current version: [![Latest release](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://github.com/Hello-QM/catgo-LRG/releases/latest). On the release page, pick the file for your platform (shown in the **File** column). For older versions and checksums, see [all Releases](https://github.com/Hello-QM/catgo-LRG/releases).
+Every link points at the **latest release** on the dedicated [CatGo download hub](https://dl.catgo-ucsd.org/), so it stays current as new versions ship — current version: [![Latest release](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://dl.catgo-ucsd.org/). For older versions and release history, see [all Releases](https://github.com/Hello-QM/catgo-LRG/releases).
 
-> **China mirror / 中国大陆镜像:** if GitHub is unreachable, download the latest release from [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) — same full installers as GitHub Releases. As a fallback, a browser-based subset (no CatBot chat or desktop integration) installs via a PyPI mirror: `pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`, then run `catgo`.
+> **Direct delivery / 中国大陆直连：** [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) serves the full installers directly through Cloudflare without requiring a GitHub login. As a fallback, a browser-based subset (no CatBot chat or desktop integration) installs via a PyPI mirror: `pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`, then run `catgo`.
 
 | System                    | Get the latest                                                      | File on the release page                                   |
 | ------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Windows**               | [⬇ Download](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_x64-setup.exe` or `CatGo_<ver>_x64_en-US.msi` |
-| **macOS** (Apple Silicon) | [⬇ Download](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_aarch64.dmg`                                  |
-| **Linux**                 | [⬇ Download](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_amd64.deb` or `CatGo-<ver>-1.x86_64.rpm`      |
-| **Android**               | [⬇ Download](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo-v<ver>-android-universal.apk`                       |
+| **Windows**               | [⬇ Download](https://dl.catgo-ucsd.org/#platform-windows)          | `CatGo_<ver>_x64-setup.exe` or `CatGo_<ver>_x64_en-US.msi` |
+| **macOS** (Apple Silicon) | [⬇ Download](https://dl.catgo-ucsd.org/#platform-macos)            | `CatGo_<ver>_aarch64.dmg`                                  |
+| **Linux**                 | [⬇ Download](https://dl.catgo-ucsd.org/#platform-linux)            | `CatGo_<ver>_amd64.deb` or `CatGo-<ver>-1.x86_64.rpm`      |
+| **Android**               | [⬇ Download](https://dl.catgo-ucsd.org/#platform-android)          | `CatGo-v<ver>-android-universal.apk`                       |
 | **iOS**                   | [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)       | or `CatGo-v<ver>-ios-arm64.ipa` on the release page        |
 | **VS Code**               | Search **CatGo** in Extensions                                      | or `catgo-<ver>.vsix` on the release page                  |
 | **Web** (no install)      | [app.catgo-ucsd.org](https://app.catgo-ucsd.org)                    | —                                                          |

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -9,7 +9,7 @@
   ·
   <a href="https://app.catgo-ucsd.org">在线体验</a>
   ·
-  <a href="https://github.com/Hello-QM/catgo-LRG/releases">下载桌面版</a>
+  <a href="https://dl.catgo-ucsd.org/">下载桌面版</a>
   ·
   <a href="https://docs.catgo-ucsd.org">教程与文档</a>
 </p>
@@ -105,7 +105,7 @@ CatGo 有三个适合日常使用的成熟入口：桌面版、Web 版和 VS Cod
 
 ### A. 桌面版：完整工作台
 
-1. 从 [GitHub Releases](https://github.com/Hello-QM/catgo-LRG/releases) 下载 Windows、macOS 或 Linux 安装包。
+1. 从 [CatGo 下载中心](https://dl.catgo-ucsd.org/) 下载 Windows、macOS 或 Linux 安装包。
 2. 打开 CatGo，拖入结构/输出文件，或从数据库获取结构。
 3. 使用结构工具栏、Quick Build 或 CatBot 准备模型与流程。
 4. 需要远程计算时，在 HPC 面板连接课题组集群。
@@ -286,16 +286,16 @@ catgo --help
 
 ### 下载
 
-下表所有链接都指向**最新发布版**，随版本更新自动保持最新 —— 当前版本：[![最新版本](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://github.com/Hello-QM/catgo-LRG/releases/latest)。在发布页选择对应平台的文件（见 **文件** 列）。历史版本与校验和见 [全部 Releases](https://github.com/Hello-QM/catgo-LRG/releases)。
+下表所有链接都指向专用 [CatGo 下载中心](https://dl.catgo-ucsd.org/)的**最新发布版**，随版本更新自动保持最新 —— 当前版本：[![最新版本](https://img.shields.io/github/v/release/Hello-QM/catgo-LRG?label=latest&sort=semver)](https://dl.catgo-ucsd.org/)。历史版本与发布记录见 [全部 Releases](https://github.com/Hello-QM/catgo-LRG/releases)。
 
-> **中国大陆镜像：** 无法访问 GitHub 时，可从 [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) 下载最新版安装包（与 GitHub Releases 完全相同的完整版）。备选方案：通过 PyPI 镜像安装浏览器版（功能子集，不含 CatBot 聊天与桌面集成）：`pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`，然后运行 `catgo`。
+> **中国大陆直连：** [dl.catgo-ucsd.org](https://dl.catgo-ucsd.org/) 通过 Cloudflare 直接提供完整安装包，无需登录或访问 GitHub。备选方案：通过 PyPI 镜像安装浏览器版（功能子集，不含 CatBot 聊天与桌面集成）：`pip install catgo -i https://pypi.tuna.tsinghua.edu.cn/simple`，然后运行 `catgo`。
 
 | 系统                       | 获取最新版                                                         | 发布页上的文件                                                   |
 | ------------------------ | ------------------------------------------------------------- | --------------------------------------------------------- |
-| **Windows**              | [⬇ 下载](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_x64-setup.exe` 或 `CatGo_<ver>_x64_en-US.msi` |
-| **macOS**（Apple Silicon） | [⬇ 下载](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_aarch64.dmg`                                 |
-| **Linux**                | [⬇ 下载](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo_<ver>_amd64.deb` 或 `CatGo-<ver>-1.x86_64.rpm`      |
-| **Android**              | [⬇ 下载](https://github.com/Hello-QM/catgo-LRG/releases/latest) | `CatGo-v<ver>-android-universal.apk`                      |
+| **Windows**              | [⬇ 下载](https://dl.catgo-ucsd.org/#platform-windows)          | `CatGo_<ver>_x64-setup.exe` 或 `CatGo_<ver>_x64_en-US.msi` |
+| **macOS**（Apple Silicon） | [⬇ 下载](https://dl.catgo-ucsd.org/#platform-macos)            | `CatGo_<ver>_aarch64.dmg`                                 |
+| **Linux**                | [⬇ 下载](https://dl.catgo-ucsd.org/#platform-linux)            | `CatGo_<ver>_amd64.deb` 或 `CatGo-<ver>-1.x86_64.rpm`      |
+| **Android**              | [⬇ 下载](https://dl.catgo-ucsd.org/#platform-android)          | `CatGo-v<ver>-android-universal.apk`                      |
 | **iOS**                  | [TestFlight 公测](https://testflight.apple.com/join/FdHup5Hz)   | 或发布页的 `CatGo-v<ver>-ios-arm64.ipa`                        |
 | **VS Code**              | 在扩展市场搜索 **CatGo**                                             | 或发布页的 `catgo-<ver>.vsix`                                  |
 | **Web**（免安装）             | [app.catgo-ucsd.org](https://app.catgo-ucsd.org)              | —                                                         |

--- a/scripts/__tests__/cloudflare-download-entrypoints.test.mjs
+++ b/scripts/__tests__/cloudflare-download-entrypoints.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const source = (path) => readFileSync(resolve(ROOT, path), 'utf8')
+
+const LINKS_PATH = resolve(ROOT, 'src/lib/download-links.ts')
+const DOWNLOAD_HUB = 'https://dl.catgo-ucsd.org/'
+const UPDATE_MANIFEST = 'https://dl.catgo-ucsd.org/latest.json'
+const TESTFLIGHT = 'https://testflight.apple.com/join/FdHup5Hz'
+const ENTRYPOINTS = [
+  'src/lib/DesktopDownloadModal.svelte',
+  'src/lib/StaticModeBanner.svelte',
+  'src/lib/api/config.ts',
+  'src/lib/update/auto-update.svelte.ts',
+]
+
+test('defines one source of truth for public download destinations', () => {
+  assert.ok(existsSync(LINKS_PATH), 'src/lib/download-links.ts exists')
+  const links = source('src/lib/download-links.ts')
+
+  assert.match(links, /export const DOWNLOAD_HUB_URL/)
+  assert.match(links, new RegExp(DOWNLOAD_HUB.replaceAll('.', '\\.')))
+  assert.match(links, /export const UPDATE_MANIFEST_URL/)
+  assert.match(links, new RegExp(UPDATE_MANIFEST.replaceAll('.', '\\.')))
+  assert.match(links, /export const TESTFLIGHT_URL/)
+  assert.match(links, new RegExp(TESTFLIGHT.replaceAll('.', '\\.')))
+})
+
+test('normal app download and update entry points contain no GitHub path', () => {
+  const combined = ENTRYPOINTS.map(source).join('\n')
+
+  assert.doesNotMatch(combined, /api\.github\.com/i)
+  assert.doesNotMatch(
+    combined,
+    /github\.com\/Hello-QM\/catgo-LRG\/releases/i,
+  )
+  assert.doesNotMatch(combined, /browser_download_url/)
+  assert.match(source(ENTRYPOINTS[0]), /DOWNLOAD_HUB_URL/)
+  assert.match(source(ENTRYPOINTS[0]), /TESTFLIGHT_URL/)
+  assert.match(source(ENTRYPOINTS[1]), /DOWNLOAD_HUB_URL/)
+  assert.match(source(ENTRYPOINTS[2]), /DOWNLOAD_HUB_URL/)
+  assert.match(source(ENTRYPOINTS[3]), /UPDATE_MANIFEST_URL/)
+  assert.match(source(ENTRYPOINTS[3]), /parse_release_manifest/)
+})
+
+test('Tauri updater has exactly one Cloudflare manifest endpoint', () => {
+  const config = JSON.parse(source('src-tauri/tauri.conf.json'))
+  assert.deepEqual(config.plugins.updater.endpoints, [UPDATE_MANIFEST])
+})
+
+test('desktop choices open the hub while iOS remains on TestFlight', () => {
+  const modal = source('src/lib/DesktopDownloadModal.svelte')
+
+  assert.match(modal, /os === `ios`/)
+  assert.match(modal, /TESTFLIGHT_URL/)
+  assert.match(modal, /platform-\$\{hub_platform\}/)
+  assert.doesNotMatch(modal, /fetch\s*\(/)
+})

--- a/scripts/__tests__/cloudflare-download-entrypoints.test.mjs
+++ b/scripts/__tests__/cloudflare-download-entrypoints.test.mjs
@@ -60,3 +60,12 @@ test('desktop choices open the hub while iOS remains on TestFlight', () => {
   assert.match(modal, /platform-\$\{hub_platform\}/)
   assert.doesNotMatch(modal, /fetch\s*\(/)
 })
+
+test('the update banner exposes bounded release notes', () => {
+  const banner = source('src/lib/update/UpdateBanner.svelte')
+
+  assert.match(banner, /update_state\.notes/)
+  assert.match(banner, /<details class="ub-notes">/)
+  assert.match(banner, /max-height:/)
+  assert.match(banner, /overflow:\s*auto/)
+})

--- a/scripts/__tests__/cloudflare-download-entrypoints.test.mjs
+++ b/scripts/__tests__/cloudflare-download-entrypoints.test.mjs
@@ -17,6 +17,13 @@ const ENTRYPOINTS = [
   'src/lib/api/config.ts',
   'src/lib/update/auto-update.svelte.ts',
 ]
+const PUBLIC_DOWNLOAD_DOCS = [
+  'readme.md',
+  'readme.zh.md',
+  'docs/guide/installation.md',
+  'docs/zh/guide/installation.md',
+  'extensions/vscode/readme.md',
+]
 
 test('defines one source of truth for public download destinations', () => {
   assert.ok(existsSync(LINKS_PATH), 'src/lib/download-links.ts exists')
@@ -68,4 +75,21 @@ test('the update banner exposes bounded release notes', () => {
   assert.match(banner, /<details class="ub-notes">/)
   assert.match(banner, /max-height:/)
   assert.match(banner, /overflow:\s*auto/)
+})
+
+test('public acquisition docs use the Cloudflare hub for current downloads', () => {
+  for (const path of PUBLIC_DOWNLOAD_DOCS) {
+    const content = source(path)
+    assert.match(content, /https:\/\/dl\.catgo-ucsd\.org\//, path)
+    assert.doesNotMatch(
+      content,
+      /https:\/\/github\.com\/Hello-QM\/catgo-LRG\/releases\/latest/i,
+      path,
+    )
+    assert.doesNotMatch(
+      content,
+      /(?:Download Desktop|下载桌面版|GitHub Releases|CatGo desktop client)[^\n]{0,160}https:\/\/github\.com\/Hello-QM\/catgo-LRG\/releases/i,
+      path,
+    )
+  }
 })

--- a/scripts/__tests__/deploy-cloudflare-workflow.test.mjs
+++ b/scripts/__tests__/deploy-cloudflare-workflow.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
@@ -11,9 +11,33 @@ const DEPLOY_WORKFLOW = readFileSync(
 )
 const WASM_PACK_INSTALL =
   'curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh'
+const DOWNLOADS_CONFIG_PATH = resolve(ROOT, 'wrangler.downloads.toml')
 
 test('Cloudflare app deployment installs a wasm-pack that supports feature flags', () => {
   assert.doesNotMatch(DEPLOY_WORKFLOW, /jetli\/wasm-pack-action/)
   assert.match(DEPLOY_WORKFLOW, /- name: Install wasm-pack/)
   assert.ok(DEPLOY_WORKFLOW.includes(`run: ${WASM_PACK_INSTALL}`))
+})
+
+test('Cloudflare workflow deploys the download Worker', () => {
+  assert.match(DEPLOY_WORKFLOW, /workers\/downloads\/\*\*/)
+  assert.match(DEPLOY_WORKFLOW, /wrangler\.downloads\.toml/)
+  assert.match(DEPLOY_WORKFLOW, /deploy-downloads:/)
+  assert.match(DEPLOY_WORKFLOW, /name: Deploy dl\.catgo-ucsd\.org/)
+  assert.match(
+    DEPLOY_WORKFLOW,
+    /command: deploy --config wrangler\.downloads\.toml/,
+  )
+})
+
+test('download Worker config binds the releases bucket to the domain route', () => {
+  assert.ok(existsSync(DOWNLOADS_CONFIG_PATH), 'wrangler.downloads.toml exists')
+  const config = readFileSync(DOWNLOADS_CONFIG_PATH, 'utf8')
+
+  assert.match(config, /name = "catgo-downloads"/)
+  assert.match(config, /main = "workers\/downloads\/index\.mjs"/)
+  assert.match(config, /pattern = "dl\.catgo-ucsd\.org\/\*"/)
+  assert.match(config, /zone_name = "catgo-ucsd\.org"/)
+  assert.match(config, /binding = "RELEASES"/)
+  assert.match(config, /bucket_name = "catgo-releases"/)
 })

--- a/scripts/__tests__/generate-download-page.test.mjs
+++ b/scripts/__tests__/generate-download-page.test.mjs
@@ -114,8 +114,33 @@ test('keeps missing platforms visible without emitting broken links', () => {
   assert.equal(model.platforms.ios.available, true)
   assert.match(html, /macOS[\s\S]*?构建暂未提供/)
   assert.match(html, /Linux[\s\S]*?Build not available yet/)
+  assert.match(html, /href="#other-downloads"/)
+  assert.match(html, /id="other-downloads"/)
   assert.doesNotMatch(html, /href=""/)
   assert.doesNotMatch(html, /href="undefined"/)
+})
+
+test('keeps unrelated or unsupported architecture binaries out of platform cards', () => {
+  const unexpected = [
+    { name: 'helper_x64.exe', size: 10 },
+    { name: 'CatGo_1.4.6_x64.dmg', size: 20 },
+    { name: 'CatGo-v1.4.6-android-arm64.apk', size: 30 },
+  ]
+  const model = buildReleaseModel({
+    assets: unexpected,
+    tag: 'v1.4.6',
+    baseUrl: BASE_URL,
+  })
+
+  assert.equal(model.platforms.windows.available, false)
+  assert.equal(model.platforms.macos.available, false)
+  assert.equal(model.platforms.android.available, false)
+  assert.deepEqual(
+    model.other.map((asset) => asset.name),
+    unexpected
+      .map((asset) => asset.name)
+      .sort((left, right) => left.localeCompare(right)),
+  )
 })
 
 test('escapes display text, encodes URL segments, and rejects unsafe inputs', () => {

--- a/scripts/__tests__/generate-download-page.test.mjs
+++ b/scripts/__tests__/generate-download-page.test.mjs
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+import test from 'node:test'
+
+import {
+  buildReleaseModel,
+  renderDownloadPage,
+} from '../generate-download-page.mjs'
+
+const ROOT = resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const GENERATOR = resolve(ROOT, 'scripts/generate-download-page.mjs')
+const BASE_URL = 'https://dl.catgo-ucsd.org'
+const TESTFLIGHT_URL = 'https://testflight.apple.com/join/FdHup5Hz'
+
+const completeAssets = [
+  { name: 'CatGo_1.4.6_x64-setup.exe', size: 328_169_059 },
+  { name: 'CatGo_1.4.6_x64_en-US.msi', size: 343_330_816 },
+  { name: 'CatGo_1.4.6_aarch64.dmg', size: 285_816_788 },
+  { name: 'CatGo_1.4.6_amd64.deb', size: 428_621_666 },
+  { name: 'CatGo-1.4.6-1.x86_64.rpm', size: 425_947_574 },
+  { name: 'CatGo_1.4.6_amd64.AppImage', size: 419_430_400 },
+  { name: 'CatGo-v1.4.6-android-universal.apk', size: 210_740_897 },
+  { name: 'CatGo_1.4.6_x64-setup.exe.sig', size: 416 },
+  { name: 'CatGo_aarch64.app.tar.gz', size: 284_425_587 },
+  { name: 'catgo-1.4.6.vsix', size: 35_477_333 },
+  { name: 'catgo-hpc-bundle.tar.gz', size: 34_917_426 },
+  { name: 'catgo-server-linux-x64', size: 354_428_728 },
+  { name: 'latest.json', size: 9_765 },
+]
+
+test('classifies a complete release and selects the preferred installer', () => {
+  const model = buildReleaseModel({
+    assets: completeAssets,
+    tag: 'v1.4.6',
+    baseUrl: BASE_URL,
+  })
+
+  assert.equal(model.version, '1.4.6')
+  assert.equal(model.platforms.windows.preferred.format, 'EXE')
+  assert.equal(model.platforms.windows.preferred.name, 'CatGo_1.4.6_x64-setup.exe')
+  assert.deepEqual(
+    model.platforms.windows.downloads.map((asset) => asset.format),
+    ['EXE', 'MSI'],
+  )
+  assert.equal(model.platforms.macos.preferred.architecture, 'Apple Silicon')
+  assert.deepEqual(
+    model.platforms.linux.downloads.map((asset) => asset.format),
+    ['DEB', 'RPM', 'AppImage'],
+  )
+  assert.equal(model.platforms.android.preferred.format, 'APK')
+  assert.equal(model.platforms.ios.preferred.url, TESTFLIGHT_URL)
+  assert.ok(model.other.some((asset) => asset.name.endsWith('.sig')))
+  assert.ok(model.other.some((asset) => asset.name.endsWith('.vsix')))
+  assert.ok(model.other.some((asset) => asset.name === 'catgo-hpc-bundle.tar.gz'))
+  assert.ok(model.other.some((asset) => asset.name === 'catgo-server-linux-x64'))
+  assert.equal(
+    model.platforms.windows.preferred.url,
+    `${BASE_URL}/v1.4.6/CatGo_1.4.6_x64-setup.exe`,
+  )
+})
+
+test('renders a self-contained bilingual page with direct mirror links', () => {
+  const html = renderDownloadPage(
+    buildReleaseModel({
+      assets: completeAssets,
+      tag: 'v1.4.6',
+      baseUrl: BASE_URL,
+    }),
+  )
+
+  assert.match(html, /<html lang="zh-CN">/)
+  assert.match(html, /选择你的平台/)
+  assert.match(html, /Choose your platform/)
+  assert.match(html, /v1\.4\.6/)
+  assert.match(html, /328\.2 MB/)
+  assert.match(html, /data-platform="windows"/)
+  assert.match(html, /data-platform="macos"/)
+  assert.match(html, /data-platform="linux"/)
+  assert.match(html, /data-platform="android"/)
+  assert.match(html, /data-platform="ios"/)
+  assert.match(html, new RegExp(TESTFLIGHT_URL.replaceAll('.', '\\.')))
+  assert.doesNotMatch(html, /github\.com|api\.github\.com/i)
+  assert.doesNotMatch(
+    html,
+    /<(?:script|link|img)\b[^>]+(?:src|href)=["']https?:\/\/(?!dl\.catgo-ucsd\.org|testflight\.apple\.com)/i,
+  )
+  assert.match(html, /@media \(prefers-reduced-motion: reduce\)/)
+  assert.match(html, /:focus-visible/)
+  assert.match(html, /<noscript>/)
+})
+
+test('keeps missing platforms visible without emitting broken links', () => {
+  const model = buildReleaseModel({
+    assets: [{ name: 'CatGo_1.4.6_x64-setup.exe', size: 1_048_576 }],
+    tag: 'v1.4.6',
+    baseUrl: BASE_URL,
+  })
+  const html = renderDownloadPage(model)
+
+  assert.equal(model.platforms.windows.available, true)
+  assert.equal(model.platforms.macos.available, false)
+  assert.equal(model.platforms.linux.available, false)
+  assert.equal(model.platforms.android.available, false)
+  assert.equal(model.platforms.ios.available, true)
+  assert.match(html, /macOS[\s\S]*?构建暂未提供/)
+  assert.match(html, /Linux[\s\S]*?Build not available yet/)
+  assert.doesNotMatch(html, /href=""/)
+  assert.doesNotMatch(html, /href="undefined"/)
+})
+
+test('escapes display text, encodes URL segments, and rejects unsafe inputs', () => {
+  const hostileName = `catgo-<script>alert('x')</script>.vsix`
+  const model = buildReleaseModel({
+    assets: [{ name: hostileName, size: 42 }],
+    tag: 'v1.4.6',
+    baseUrl: BASE_URL,
+  })
+  const html = renderDownloadPage(model)
+
+  assert.doesNotMatch(html, /<script>alert/)
+  assert.match(html, /&lt;script&gt;alert\(&#39;x&#39;\)&lt;\/script&gt;/)
+  assert.match(
+    html,
+    /catgo-%3Cscript%3Ealert\(&#39;x&#39;\)%3C%2Fscript%3E\.vsix/,
+  )
+
+  for (const tag of ['', '.', '..', '../v1.4.6', 'v1.4.6/extra', 'v1\u0000.4.6']) {
+    assert.throws(
+      () => buildReleaseModel({ assets: [], tag, baseUrl: BASE_URL }),
+      /release tag/i,
+    )
+  }
+  assert.throws(
+    () =>
+      buildReleaseModel({
+        assets: [],
+        tag: 'v1.4.6',
+        baseUrl: 'http://dl.catgo-ucsd.org',
+      }),
+    /HTTPS/i,
+  )
+})
+
+test('CLI inventories an asset directory and writes index.html', () => {
+  const scratch = mkdtempSync(join(tmpdir(), 'catgo-download-page-'))
+  const assetsDir = join(scratch, 'dist')
+  const output = join(scratch, 'index.html')
+
+  try {
+    mkdirSync(assetsDir)
+    writeFileSync(join(assetsDir, 'CatGo_1.4.6_x64-setup.exe'), 'installer')
+    writeFileSync(join(assetsDir, 'CatGo_1.4.6_aarch64.dmg'), 'dmg')
+
+    execFileSync(
+      process.execPath,
+      [
+        GENERATOR,
+        '--assets-dir',
+        assetsDir,
+        '--tag',
+        'v1.4.6',
+        '--base-url',
+        BASE_URL,
+        '--output',
+        output,
+      ],
+      { encoding: 'utf8' },
+    )
+
+    const html = readFileSync(output, 'utf8')
+    assert.match(html, /CatGo_1\.4\.6_x64-setup\.exe/)
+    assert.match(html, /CatGo_1\.4\.6_aarch64\.dmg/)
+  } finally {
+    rmSync(scratch, { recursive: true, force: true })
+  }
+})

--- a/scripts/__tests__/r2-release-mirror-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-mirror-workflow.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const WORKFLOW = readFileSync(
+  resolve(ROOT, '.github/workflows/r2-release-mirror.yml'),
+  'utf8',
+)
+
+const APP_RELEASE_WORKFLOWS = [
+  'Build Desktop App',
+  'Android build',
+  'Build HPC Bundle',
+  'Publish VSCode Extension',
+  'Build VSCode Sidecar Binaries',
+]
+
+test('refreshes the mirror after every CatGo release-asset workflow', () => {
+  assert.match(WORKFLOW, /workflow_run:/)
+  assert.match(WORKFLOW, /types:\s*\[completed\]/)
+  for (const workflowName of APP_RELEASE_WORKFLOWS) {
+    assert.match(WORKFLOW, new RegExp(`- ${workflowName.replaceAll(' ', '\\s+')}`))
+  }
+  assert.doesNotMatch(WORKFLOW, /^\s*-\s+Build STT accelerator\s*$/m)
+  assert.match(
+    WORKFLOW,
+    /github\.event\.workflow_run\.conclusion == 'success'/,
+  )
+})
+
+test('checks out trusted source and generates the page with the Node CLI', () => {
+  assert.match(WORKFLOW, /uses: actions\/checkout@v4/)
+  assert.match(
+    WORKFLOW,
+    /node scripts\/generate-download-page\.mjs[\s\S]*--assets-dir dist[\s\S]*--tag "\$tag"[\s\S]*--base-url "\$R2_PUBLIC_BASE_URL"[\s\S]*--output index\.html/,
+  )
+  assert.doesNotMatch(WORKFLOW, /echo '<!doctype html>/)
+  assert.doesNotMatch(WORKFLOW, /github\.com\/\$\{\{ github\.repository \}\}\/releases/)
+})
+
+test('rewrites and validates every updater URL before publishing metadata', () => {
+  assert.match(WORKFLOW, /Rewrite and validate latest\.json URLs/)
+  assert.match(WORKFLOW, /startsWith|startswith/)
+  assert.match(WORKFLOW, /jq \. latest\.mirror\.json > \/dev\/null/)
+
+  const syncAssets = WORKFLOW.indexOf('aws s3 sync dist/')
+  const uploadManifest = WORKFLOW.indexOf('aws s3 cp latest.mirror.json')
+  const uploadIndex = WORKFLOW.indexOf('aws s3 cp index.html')
+  const prune = WORKFLOW.indexOf('- name: Prune older releases')
+
+  assert.ok(syncAssets >= 0, 'release assets are uploaded')
+  assert.ok(uploadManifest > syncAssets, 'latest.json uploads after release assets')
+  assert.ok(uploadIndex > uploadManifest, 'index.html uploads after latest.json')
+  assert.ok(prune > uploadIndex, 'pruning starts only after root metadata uploads')
+})
+
+test('keeps release/manual triggers and resolves workflow runs to latest', () => {
+  assert.match(WORKFLOW, /release:\s*\n\s+types:\s*\[published\]/)
+  assert.match(WORKFLOW, /workflow_dispatch:/)
+  assert.match(
+    WORKFLOW,
+    /github\.event_name.*workflow_run[\s\S]*releases\/latest/,
+  )
+  assert.match(WORKFLOW, /group: r2-release-mirror/)
+})

--- a/scripts/__tests__/r2-release-mirror-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-mirror-workflow.test.mjs
@@ -57,12 +57,36 @@ test('rewrites and validates every updater URL before publishing metadata', () =
   assert.ok(prune > uploadIndex, 'pruning starts only after root metadata uploads')
 })
 
-test('keeps release/manual triggers and resolves workflow runs to latest', () => {
+test('keeps triggers but resolves only validated CatGo app releases', () => {
   assert.match(WORKFLOW, /release:\s*\n\s+types:\s*\[published\]/)
   assert.match(WORKFLOW, /workflow_dispatch:/)
-  assert.match(
-    WORKFLOW,
-    /github\.event_name.*workflow_run[\s\S]*releases\/latest/,
-  )
+  assert.match(WORKFLOW, /APP_TAG_PATTERN:/)
+  assert.match(WORKFLOW, /releases\?per_page=100/)
+  assert.match(WORKFLOW, /sort -V/)
+  assert.match(WORKFLOW, /startsWith\(github\.event\.release\.tag_name, 'v'\)/)
+  assert.doesNotMatch(WORKFLOW, /repos\/\$\{\{ github\.repository \}\}\/releases\/latest/)
   assert.match(WORKFLOW, /group: r2-release-mirror/)
+})
+
+test('never interpolates event or output tags into secrets-bearing shell', () => {
+  assert.match(WORKFLOW, /RELEASE_EVENT_TAG:\s*\$\{\{ github\.event\.release\.tag_name \}\}/)
+  assert.match(WORKFLOW, /REQUESTED_TAG:\s*\$\{\{ inputs\.tag \}\}/)
+  assert.match(WORKFLOW, /MIRROR_TAG:\s*\$\{\{ steps\.tag\.outputs\.tag \}\}/)
+  assert.doesNotMatch(
+    WORKFLOW,
+    /tag\s*=\s*['"]\$\{\{\s*(?:github\.event\.release\.tag_name|inputs\.tag|steps\.tag\.outputs\.tag)\s*\}\}/,
+  )
+  assert.match(WORKFLOW, /\[\[ "\$tag" =~ \$APP_TAG_PATTERN \]\]/)
+})
+
+test('manual old-tag backfills cannot replace public root metadata', () => {
+  const syncStart = WORKFLOW.indexOf('- name: Sync to R2')
+  const pruneStart = WORKFLOW.indexOf('- name: Prune older releases')
+  const syncBlock = WORKFLOW.slice(syncStart, pruneStart)
+
+  assert.match(syncBlock, /latest_app_tag=/)
+  assert.match(
+    syncBlock,
+    /if \[ "\$tag" = "\$latest_app_tag" \]; then[\s\S]*aws s3 cp latest\.mirror\.json[\s\S]*aws s3 cp index\.html[\s\S]*fi/,
+  )
 })

--- a/scripts/__tests__/release-draft-workflows.test.mjs
+++ b/scripts/__tests__/release-draft-workflows.test.mjs
@@ -25,6 +25,15 @@ test('auxiliary app asset workflows may create only draft releases', () => {
   }
 
   assert.match(source('.github/workflows/tauri-build.yml'), /releaseDraft:\s*true/)
+
+  const hpcReleaseStep = source('.github/workflows/hpc-bundle.yml')
+    .split('- name: Upload to release')[1]
+  assert.ok(hpcReleaseStep, 'HPC workflow has a release upload step')
+  assert.match(
+    hpcReleaseStep,
+    /uses:\s*softprops\/action-gh-release@v2[\s\S]*?\n\s+draft:\s*true(?:\s|$)/,
+    'HPC bundle upload must keep the app release in draft state',
+  )
 })
 
 test('the independent STT release can never become GitHub latest', () => {

--- a/scripts/__tests__/release-draft-workflows.test.mjs
+++ b/scripts/__tests__/release-draft-workflows.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const source = (path) => readFileSync(resolve(ROOT, path), 'utf8')
+
+const APP_ASSET_WORKFLOWS = [
+  '.github/workflows/vsix-publish.yml',
+  '.github/workflows/build-vscode-sidecars.yml',
+]
+
+test('auxiliary app asset workflows may create only draft releases', () => {
+  for (const path of APP_ASSET_WORKFLOWS) {
+    const createLines = source(path)
+      .split('\n')
+      .filter((line) => line.includes('gh release create'))
+
+    assert.ok(createLines.length > 0, `${path} contains a release fallback`)
+    for (const line of createLines) {
+      assert.match(line, /--draft(?:\s|$)/, `${path}: ${line.trim()}`)
+    }
+  }
+
+  assert.match(source('.github/workflows/tauri-build.yml'), /releaseDraft:\s*true/)
+})
+
+test('the independent STT release can never become GitHub latest', () => {
+  const createLines = source('.github/workflows/build-stt-accel.yml')
+    .split('\n')
+    .filter((line) => line.includes('gh release create'))
+
+  assert.ok(createLines.length > 0)
+  for (const line of createLines) {
+    assert.match(line, /--latest=false(?:\s|$)/)
+  }
+})

--- a/scripts/generate-download-page.mjs
+++ b/scripts/generate-download-page.mjs
@@ -1,0 +1,1163 @@
+#!/usr/bin/env node
+
+import {
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const TESTFLIGHT_URL = 'https://testflight.apple.com/join/FdHup5Hz'
+
+const PLATFORM_META = {
+  windows: {
+    code: 'WIN',
+    name: 'Windows',
+    architecture: 'x64',
+    noteZh: '推荐 EXE 安装器；企业部署也可选 MSI。',
+    noteEn: 'EXE recommended; MSI is also available for managed installs.',
+  },
+  macos: {
+    code: 'MAC',
+    name: 'macOS',
+    architecture: 'Apple Silicon',
+    noteZh: '适用于 Apple Silicon，下载 DMG 后拖入应用程序。',
+    noteEn: 'For Apple Silicon. Open the DMG and drag CatGo to Applications.',
+  },
+  linux: {
+    code: 'LNX',
+    name: 'Linux',
+    architecture: 'amd64',
+    noteZh: '按发行版选择 DEB、RPM 或 AppImage。',
+    noteEn: 'Choose DEB, RPM, or AppImage for your distribution.',
+  },
+  android: {
+    code: 'APK',
+    name: 'Android',
+    architecture: 'Universal',
+    noteZh: '通用签名 APK；系统可能要求允许安装未知应用。',
+    noteEn: 'Signed universal APK; Android may request install permission.',
+  },
+  ios: {
+    code: 'IOS',
+    name: 'iOS',
+    architecture: 'iPhone / iPad',
+    noteZh: '通过 Apple TestFlight 安装公开测试版。',
+    noteEn: 'Install the public beta through Apple TestFlight.',
+  },
+}
+
+const FORMAT_PRIORITY = {
+  windows: ['EXE', 'MSI'],
+  macos: ['DMG'],
+  linux: ['DEB', 'RPM', 'AppImage'],
+  android: ['APK'],
+  ios: ['TestFlight'],
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function encodePathSegment(value) {
+  return encodeURIComponent(String(value))
+}
+
+function validateReleaseTag(tag) {
+  if (
+    typeof tag !== 'string'
+    || tag !== tag.trim()
+    || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(tag)
+  ) {
+    throw new Error(`Invalid release tag: ${JSON.stringify(tag)}`)
+  }
+  return tag
+}
+
+function normalizeBaseUrl(baseUrl) {
+  let parsed
+  try {
+    parsed = new URL(baseUrl)
+  } catch {
+    throw new Error('Download base URL must be a valid HTTPS URL')
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.username
+    || parsed.password
+    || parsed.search
+    || parsed.hash
+  ) {
+    throw new Error('Download base URL must be a clean HTTPS URL')
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '')
+  return parsed.href.replace(/\/$/, '')
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '—'
+  if (bytes < 1_000) return `${bytes} B`
+  if (bytes < 1_000_000) return `${(bytes / 1_000).toFixed(1)} KB`
+  if (bytes < 1_000_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`
+  return `${(bytes / 1_000_000_000).toFixed(2)} GB`
+}
+
+function formatForAsset(name) {
+  if (/\.msi$/i.test(name)) return 'MSI'
+  if (/\.exe$/i.test(name)) return 'EXE'
+  if (/\.dmg$/i.test(name)) return 'DMG'
+  if (/\.deb$/i.test(name)) return 'DEB'
+  if (/\.rpm$/i.test(name)) return 'RPM'
+  if (/\.appimage$/i.test(name)) return 'AppImage'
+  if (/\.apk$/i.test(name)) return 'APK'
+  return null
+}
+
+function platformForAsset(name, format) {
+  if (!format) return null
+  if (format === 'EXE' || format === 'MSI') return 'windows'
+  if (format === 'DMG') return 'macos'
+  if (format === 'DEB' || format === 'RPM' || format === 'AppImage') {
+    return 'linux'
+  }
+  if (format === 'APK') return 'android'
+  return null
+}
+
+function architectureForAsset(platform, name) {
+  if (platform === 'windows') {
+    return /arm64|aarch64/i.test(name) ? 'ARM64' : 'x64'
+  }
+  if (platform === 'macos') {
+    return /x64|x86_64/i.test(name) ? 'Intel' : 'Apple Silicon'
+  }
+  if (platform === 'linux') {
+    return /aarch64|arm64/i.test(name) ? 'ARM64' : 'amd64'
+  }
+  return 'Universal'
+}
+
+function normalizeAsset(asset, tag, baseUrl) {
+  if (
+    !asset
+    || typeof asset.name !== 'string'
+    || asset.name.length === 0
+    || !Number.isFinite(asset.size)
+    || asset.size < 0
+  ) {
+    throw new Error('Every release asset must have a non-empty name and size')
+  }
+  const format = formatForAsset(asset.name)
+  const platform = platformForAsset(asset.name, format)
+  return {
+    name: asset.name,
+    size: asset.size,
+    sizeLabel: formatBytes(asset.size),
+    format,
+    platform,
+    architecture: platform
+      ? architectureForAsset(platform, asset.name)
+      : null,
+    url: `${baseUrl}/${encodePathSegment(tag)}/${encodePathSegment(asset.name)}`,
+  }
+}
+
+function compareDownloads(platform, left, right) {
+  const priority = FORMAT_PRIORITY[platform]
+  const leftRank = priority.indexOf(left.format)
+  const rightRank = priority.indexOf(right.format)
+  if (leftRank !== rightRank) return leftRank - rightRank
+  return left.name.localeCompare(right.name)
+}
+
+export function buildReleaseModel({ assets, tag, baseUrl }) {
+  if (!Array.isArray(assets)) {
+    throw new Error('Release assets must be an array')
+  }
+  const safeTag = validateReleaseTag(tag)
+  const safeBaseUrl = normalizeBaseUrl(baseUrl)
+  const normalizedAssets = assets
+    .map((asset) => normalizeAsset(asset, safeTag, safeBaseUrl))
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+  const platforms = Object.fromEntries(
+    Object.entries(PLATFORM_META).map(([key, meta]) => [
+      key,
+      {
+        ...meta,
+        key,
+        available: false,
+        downloads: [],
+        preferred: null,
+      },
+    ]),
+  )
+  const other = []
+
+  for (const asset of normalizedAssets) {
+    const isSecondary =
+      /\.sig$/i.test(asset.name)
+      || /\.json$/i.test(asset.name)
+      || /\.vsix$/i.test(asset.name)
+      || /\.ipa$/i.test(asset.name)
+      || /\.tar\.(?:gz|xz|zst)$/i.test(asset.name)
+      || /^catgo-server-/i.test(asset.name)
+
+    if (asset.platform && !isSecondary) {
+      platforms[asset.platform].downloads.push(asset)
+    } else {
+      other.push(asset)
+    }
+  }
+
+  for (const [key, platform] of Object.entries(platforms)) {
+    if (key === 'ios') continue
+    platform.downloads.sort((left, right) =>
+      compareDownloads(key, left, right),
+    )
+    platform.preferred = platform.downloads[0] ?? null
+    platform.available = platform.preferred !== null
+  }
+
+  const testFlightAsset = {
+    name: 'Apple TestFlight',
+    size: null,
+    sizeLabel: 'Apple',
+    format: 'TestFlight',
+    platform: 'ios',
+    architecture: PLATFORM_META.ios.architecture,
+    url: TESTFLIGHT_URL,
+  }
+  platforms.ios.downloads = [testFlightAsset]
+  platforms.ios.preferred = testFlightAsset
+  platforms.ios.available = true
+
+  return {
+    tag: safeTag,
+    version: safeTag.replace(/^v/i, ''),
+    baseUrl: safeBaseUrl,
+    platforms,
+    other,
+  }
+}
+
+function renderPlatformTab(platform) {
+  return `
+        <a class="platform-tab" data-platform="${platform.key}" href="#platform-${platform.key}">
+          <span class="platform-code">${platform.code}</span>
+          <span>${escapeHtml(platform.name)}</span>
+        </a>`
+}
+
+function renderDownloadLink(asset, { primary = false } = {}) {
+  const label = primary
+    ? `下载 ${asset.format} · Download`
+    : `${asset.format} · ${asset.sizeLabel}`
+  return `
+              <a class="${primary ? 'download-primary' : 'download-alt'}"
+                 href="${escapeHtml(asset.url)}"
+                 ${asset.format === 'TestFlight' ? 'rel="noopener"' : 'download'}>
+                ${escapeHtml(label)}
+              </a>`
+}
+
+function renderPlatformCard(platform) {
+  const downloads = platform.available
+    ? `
+          <div class="download-actions">
+            ${renderDownloadLink(platform.preferred, { primary: true })}
+            ${
+              platform.downloads
+                .slice(1)
+                .map((asset) => renderDownloadLink(asset))
+                .join('')
+            }
+          </div>
+          <p class="asset-facts">
+            ${escapeHtml(platform.preferred.architecture)}
+            <span aria-hidden="true">·</span>
+            ${escapeHtml(platform.preferred.sizeLabel)}
+          </p>`
+    : `
+          <div class="unavailable" role="status">
+            构建暂未提供
+            <span>Build not available yet</span>
+          </div>`
+
+  return `
+      <article class="platform-card" id="platform-${platform.key}" data-platform="${platform.key}">
+        <div class="card-topline">
+          <span class="platform-code">${platform.code}</span>
+          <span class="availability ${platform.available ? 'available' : ''}">
+            ${platform.available ? 'AVAILABLE' : 'PENDING'}
+          </span>
+        </div>
+        <h3>${escapeHtml(platform.name)}</h3>
+        <p class="architecture">${escapeHtml(platform.architecture)}</p>
+        <p class="install-note">
+          ${escapeHtml(platform.noteZh)}
+          <span>${escapeHtml(platform.noteEn)}</span>
+        </p>
+        ${downloads}
+      </article>`
+}
+
+function renderOtherDownloads(assets) {
+  if (assets.length === 0) {
+    return `
+          <p class="other-empty">
+            当前版本没有附加文件。 / No additional files in this release.
+          </p>`
+  }
+  return `
+          <div class="other-list">
+            ${assets
+              .map(
+                (asset) => `
+            <a class="other-row" href="${escapeHtml(asset.url)}" download>
+              <span class="other-name">${escapeHtml(asset.name)}</span>
+              <span class="other-size">${escapeHtml(asset.sizeLabel)}</span>
+              <span class="other-action">下载 ↓</span>
+            </a>`,
+              )
+              .join('')}
+          </div>`
+}
+
+export function renderDownloadPage(model) {
+  if (
+    !model
+    || typeof model.tag !== 'string'
+    || !model.platforms
+    || !Array.isArray(model.other)
+  ) {
+    throw new Error('A valid release model is required')
+  }
+
+  const platformList = Object.values(model.platforms)
+  const availableCount = platformList.filter(
+    (platform) => platform.available,
+  ).length
+
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="description" content="CatGo ${escapeHtml(model.tag)} 中国大陆下载镜像 / China download mirror">
+  <title>CatGo ${escapeHtml(model.tag)} 下载中心 / Download Hub</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --ink-950: #06101a;
+      --ink-900: #091725;
+      --ink-850: #0c1c2b;
+      --ink-700: #23394a;
+      --paper: #f6f2e8;
+      --paper-deep: #e9e4d8;
+      --graphite: #17242d;
+      --muted: #61717a;
+      --line: #d4d1c8;
+      --copper: #bd5727;
+      --copper-bright: #e4814b;
+      --green: #7dd6b2;
+      --focus: #54b7ff;
+      --radius: 16px;
+      --shadow: 0 18px 55px rgb(2 12 20 / 16%);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        "Segoe UI", "Noto Sans SC", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      background: var(--ink-950);
+    }
+
+    body {
+      margin: 0;
+      color: var(--paper);
+      background: var(--ink-950);
+      min-width: 280px;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    a:focus-visible {
+      outline: 3px solid var(--focus);
+      outline-offset: 4px;
+    }
+
+    .skip-link {
+      position: fixed;
+      z-index: 20;
+      top: 12px;
+      left: 12px;
+      padding: 10px 14px;
+      border-radius: 8px;
+      color: var(--ink-950);
+      background: var(--paper);
+      transform: translateY(-160%);
+      transition: transform 160ms ease;
+    }
+
+    .skip-link:focus {
+      transform: translateY(0);
+    }
+
+    .shell {
+      width: min(1280px, calc(100% - 40px));
+      margin: 0 auto;
+    }
+
+    .topbar {
+      min-height: 78px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 720;
+      letter-spacing: -0.02em;
+    }
+
+    .brand-mark {
+      width: 32px;
+      height: 32px;
+      border-radius: 10px;
+      background:
+        radial-gradient(circle at 68% 32%, #f4bc92 0 4px, transparent 5px),
+        linear-gradient(145deg, var(--copper-bright), var(--copper));
+      box-shadow: inset 0 0 0 1px rgb(255 255 255 / 18%);
+    }
+
+    .mirror-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border: 1px solid #28584f;
+      border-radius: 999px;
+      color: var(--green);
+      background: #10262b;
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .mirror-status::before {
+      content: "";
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--green);
+      box-shadow: 0 0 0 4px rgb(125 214 178 / 12%);
+    }
+
+    .hero {
+      position: relative;
+      overflow: hidden;
+      padding: 72px 0 66px;
+      background:
+        linear-gradient(90deg, transparent 0 49.8%, rgb(255 255 255 / 4%) 50%, transparent 50.2%),
+        linear-gradient(0deg, transparent 0 49.8%, rgb(255 255 255 / 4%) 50%, transparent 50.2%),
+        var(--ink-900);
+      background-size: 54px 54px;
+      border-block: 1px solid rgb(255 255 255 / 5%);
+    }
+
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: radial-gradient(circle at 82% 45%, rgb(189 87 39 / 24%), transparent 28%);
+    }
+
+    .hero-grid {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.7fr);
+      gap: clamp(42px, 7vw, 100px);
+      align-items: center;
+    }
+
+    .eyebrow,
+    .section-kicker,
+    .platform-code,
+    .availability {
+      font-size: 12px;
+      font-weight: 760;
+      letter-spacing: 0.09em;
+      text-transform: uppercase;
+    }
+
+    .eyebrow,
+    .section-kicker {
+      color: var(--copper-bright);
+    }
+
+    h1 {
+      max-width: 820px;
+      margin: 18px 0 20px;
+      font-size: clamp(42px, 6vw, 76px);
+      line-height: 0.98;
+      letter-spacing: -0.055em;
+    }
+
+    .hero-copy {
+      max-width: 720px;
+      color: #b3c0c7;
+      font-size: clamp(16px, 2vw, 19px);
+      line-height: 1.65;
+    }
+
+    .hero-copy span,
+    .install-note span {
+      display: block;
+      color: #80919b;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 14px;
+      margin-top: 30px;
+    }
+
+    .jump-download {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      padding: 0 20px;
+      border-radius: 10px;
+      color: #fff8ef;
+      background: var(--copper);
+      font-weight: 720;
+      text-decoration: none;
+      box-shadow: 0 10px 30px rgb(189 87 39 / 22%);
+      transition: transform 160ms ease, background 160ms ease;
+    }
+
+    .jump-download:hover {
+      background: #ce6330;
+      transform: translateY(-2px);
+    }
+
+    .delivery-note {
+      color: #81919a;
+      font-size: 13px;
+    }
+
+    .ledger {
+      padding: 26px;
+      border: 1px solid var(--ink-700);
+      border-radius: var(--radius);
+      background: rgb(6 16 26 / 86%);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(10px);
+    }
+
+    .ledger dl {
+      margin: 18px 0 0;
+    }
+
+    .ledger-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 18px;
+      padding: 15px 0;
+      border-top: 1px solid var(--ink-700);
+    }
+
+    .ledger dt {
+      color: #7f929d;
+      font-size: 13px;
+    }
+
+    .ledger dd {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 720;
+      text-align: right;
+    }
+
+    .platform-nav {
+      position: sticky;
+      z-index: 10;
+      top: 0;
+      border-bottom: 1px solid rgb(255 255 255 / 8%);
+      background: rgb(6 16 26 / 92%);
+      backdrop-filter: blur(18px);
+    }
+
+    .platform-rail {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 10px;
+      padding: 16px 0;
+    }
+
+    .platform-tab {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 9px;
+      min-height: 48px;
+      padding: 8px 10px;
+      border: 1px solid #1d3343;
+      border-radius: 10px;
+      color: #9cabb3;
+      background: #0a1a28;
+      font-size: 13px;
+      text-decoration: none;
+      transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
+    }
+
+    .platform-tab:hover,
+    .platform-tab.recommended {
+      border-color: var(--copper-bright);
+      color: #fff8ef;
+      background: var(--copper);
+    }
+
+    main {
+      color: var(--graphite);
+      background: var(--paper);
+    }
+
+    .platform-section {
+      padding: 72px 0 84px;
+    }
+
+    .section-heading {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 30px;
+      margin-bottom: 30px;
+    }
+
+    h2 {
+      margin: 8px 0 0;
+      font-size: clamp(30px, 4vw, 48px);
+      letter-spacing: -0.045em;
+    }
+
+    .section-summary {
+      max-width: 440px;
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.55;
+      text-align: right;
+    }
+
+    .platform-grid {
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      gap: 16px;
+    }
+
+    .platform-card {
+      grid-column: span 2;
+      display: flex;
+      min-height: 350px;
+      flex-direction: column;
+      padding: 24px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fffdfa;
+      box-shadow: 0 12px 28px rgb(36 45 50 / 5%);
+      scroll-margin-top: 96px;
+      transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+    }
+
+    .platform-card:nth-last-child(-n + 2) {
+      grid-column: span 3;
+    }
+
+    .platform-card.recommended {
+      border-color: var(--copper);
+      box-shadow: 0 18px 45px rgb(189 87 39 / 15%);
+      transform: translateY(-4px);
+    }
+
+    .card-topline {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .platform-code {
+      color: var(--copper);
+    }
+
+    .availability {
+      color: #9b7d6e;
+    }
+
+    .availability.available {
+      color: #23795f;
+    }
+
+    .platform-card h3 {
+      margin: 30px 0 4px;
+      font-size: 28px;
+      letter-spacing: -0.035em;
+    }
+
+    .architecture {
+      margin: 0;
+      color: var(--copper);
+      font-size: 13px;
+      font-weight: 720;
+    }
+
+    .install-note {
+      margin: 24px 0;
+      color: #394a54;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+
+    .install-note span {
+      margin-top: 4px;
+      color: #75828a;
+    }
+
+    .download-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: auto;
+    }
+
+    .download-primary,
+    .download-alt {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 42px;
+      border-radius: 9px;
+      font-size: 13px;
+      font-weight: 720;
+      text-decoration: none;
+    }
+
+    .download-primary {
+      width: 100%;
+      padding: 0 16px;
+      color: #fff8ef;
+      background: var(--copper);
+    }
+
+    .download-primary:hover {
+      background: #ce6330;
+    }
+
+    .download-alt {
+      padding: 0 12px;
+      border: 1px solid var(--line);
+      color: #33444d;
+      background: var(--paper);
+    }
+
+    .asset-facts {
+      margin: 12px 0 0;
+      color: #78858c;
+      font-size: 12px;
+    }
+
+    .asset-facts span {
+      margin: 0 5px;
+    }
+
+    .unavailable {
+      margin-top: auto;
+      padding: 16px;
+      border: 1px dashed #bea99e;
+      border-radius: 10px;
+      color: #795b4d;
+      background: #f5ede7;
+      font-size: 14px;
+      font-weight: 720;
+    }
+
+    .unavailable span {
+      display: block;
+      margin-top: 4px;
+      color: #947d72;
+      font-weight: 500;
+    }
+
+    .other-section {
+      padding: 68px 0 86px;
+      background: var(--paper-deep);
+      border-top: 1px solid var(--line);
+    }
+
+    .other-list {
+      overflow: hidden;
+      margin-top: 28px;
+      border: 1px solid #d5cfc2;
+      border-radius: 12px;
+      background: #faf8f2;
+    }
+
+    .other-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto 76px;
+      gap: 24px;
+      align-items: center;
+      min-height: 54px;
+      padding: 10px 18px;
+      border-bottom: 1px solid #ddd8cd;
+      color: #30404a;
+      font-size: 13px;
+      text-decoration: none;
+    }
+
+    .other-row:last-child {
+      border-bottom: 0;
+    }
+
+    .other-row:hover {
+      background: #fffdfa;
+    }
+
+    .other-name {
+      overflow-wrap: anywhere;
+    }
+
+    .other-size {
+      color: #758188;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .other-action {
+      color: var(--copper);
+      font-weight: 720;
+      text-align: right;
+    }
+
+    .other-empty {
+      padding: 24px;
+      border: 1px dashed #bcb4a6;
+      border-radius: 12px;
+      color: var(--muted);
+    }
+
+    footer {
+      padding: 38px 0;
+      color: #9aabb4;
+      background: var(--ink-950);
+      font-size: 13px;
+    }
+
+    .footer-grid {
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+    }
+
+    .footer-grid strong {
+      color: var(--paper);
+    }
+
+    noscript p {
+      margin: 0;
+      padding: 10px 20px;
+      color: var(--ink-950);
+      background: #ffd7b5;
+      text-align: center;
+    }
+
+    @media (max-width: 900px) {
+      .hero-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .ledger {
+        max-width: 560px;
+      }
+
+      .platform-rail {
+        grid-template-columns: repeat(5, minmax(110px, 1fr));
+        overflow-x: auto;
+        scrollbar-width: thin;
+      }
+
+      .platform-card,
+      .platform-card:nth-last-child(-n + 2) {
+        grid-column: span 3;
+      }
+
+      .section-heading {
+        display: block;
+      }
+
+      .section-summary {
+        margin-top: 12px;
+        text-align: left;
+      }
+    }
+
+    @media (max-width: 620px) {
+      .shell {
+        width: min(100% - 28px, 1280px);
+      }
+
+      .topbar {
+        min-height: 70px;
+      }
+
+      .brand span:last-child {
+        display: none;
+      }
+
+      .mirror-status {
+        white-space: normal;
+      }
+
+      .hero {
+        padding: 52px 0;
+      }
+
+      h1 {
+        font-size: clamp(38px, 13vw, 58px);
+      }
+
+      .platform-nav {
+        position: relative;
+      }
+
+      .platform-rail {
+        margin-inline: -14px;
+        padding-inline: 14px;
+      }
+
+      .platform-section,
+      .other-section {
+        padding-block: 52px;
+      }
+
+      .platform-card,
+      .platform-card:nth-last-child(-n + 2) {
+        grid-column: 1 / -1;
+      }
+
+      .other-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+      }
+
+      .other-action {
+        display: none;
+      }
+
+      .footer-grid {
+        flex-direction: column;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html {
+        scroll-behavior: auto;
+      }
+
+      *,
+      *::before,
+      *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#downloads">跳到下载 / Skip to downloads</a>
+  <header>
+    <div class="topbar shell">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span>CatGo / 下载中心</span>
+      </div>
+      <div class="mirror-status">中国大陆镜像在线 · Mirror online</div>
+    </div>
+
+    <section class="hero">
+      <div class="hero-grid shell">
+        <div>
+          <div class="eyebrow">CATGO RELEASE / ${escapeHtml(model.tag)}</div>
+          <h1>最快的 CatGo 下载路径</h1>
+          <p class="hero-copy">
+            无需登录，不经 GitHub。所有支持平台共享同一个最新发布版本。
+            <span>No sign-in. One current release for every supported platform.</span>
+          </p>
+          <div class="hero-actions">
+            <a class="jump-download" href="#downloads">选择平台 · Choose platform ↓</a>
+            <span class="delivery-note">Cloudflare R2 · 支持断点续传</span>
+          </div>
+        </div>
+
+        <aside class="ledger" aria-label="Release status">
+          <div class="section-kicker">RELEASE LEDGER / 发布状态</div>
+          <dl>
+            <div class="ledger-row">
+              <dt>Current / 当前版本</dt>
+              <dd>${escapeHtml(model.tag)}</dd>
+            </div>
+            <div class="ledger-row">
+              <dt>Platforms / 可用平台</dt>
+              <dd>${availableCount} / ${platformList.length}</dd>
+            </div>
+            <div class="ledger-row">
+              <dt>Delivery / 分发</dt>
+              <dd>Cloudflare R2</dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+    </section>
+
+    <nav class="platform-nav" aria-label="平台快速导航 / Platform navigation">
+      <div class="platform-rail shell">
+        ${platformList.map(renderPlatformTab).join('')}
+      </div>
+    </nav>
+    <noscript>
+      <p>页面无需 JavaScript 即可下载；系统推荐高亮已关闭。 / Downloads remain available without JavaScript.</p>
+    </noscript>
+  </header>
+
+  <main id="downloads">
+    <section class="platform-section">
+      <div class="shell">
+        <div class="section-heading">
+          <div>
+            <div class="section-kicker">LATEST INSTALLERS / 最新安装器</div>
+            <h2>选择你的平台 / Choose your platform</h2>
+          </div>
+          <p class="section-summary">
+            每个链接都直接读取同一个 R2 镜像对象。签名文件与开发者工具位于下方。
+          </p>
+        </div>
+        <div class="platform-grid">
+          ${platformList.map(renderPlatformCard).join('')}
+        </div>
+      </div>
+    </section>
+
+    <section class="other-section">
+      <div class="shell">
+        <div class="section-kicker">RELEASE LEDGER / 发布文件</div>
+        <h2>其他下载 / Other downloads</h2>
+        ${renderOtherDownloads(model.other)}
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-grid shell">
+      <strong>CatGo · Materials workflows, delivered directly.</strong>
+      <span>无跟踪 · 无外部 CDN · Cloudflare R2</span>
+    </div>
+  </footer>
+
+  <script>
+    (() => {
+      const value = [
+        navigator.userAgentData && navigator.userAgentData.platform,
+        navigator.platform,
+        navigator.userAgent
+      ].filter(Boolean).join(' ').toLowerCase();
+      let platform = 'windows';
+      if (/iphone|ipad|ipod/.test(value)) platform = 'ios';
+      else if (/android/.test(value)) platform = 'android';
+      else if (/mac/.test(value)) platform = 'macos';
+      else if (/linux|x11/.test(value)) platform = 'linux';
+      document.querySelectorAll('[data-platform="' + platform + '"]')
+        .forEach((node) => node.classList.add('recommended'));
+    })();
+  </script>
+</body>
+</html>
+`
+}
+
+function parseArguments(argv) {
+  const values = {}
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid command-line argument near ${key ?? '<end>'}`)
+    }
+    values[key.slice(2)] = value
+  }
+  const required = ['assets-dir', 'tag', 'base-url', 'output']
+  for (const key of required) {
+    if (!values[key]) throw new Error(`Missing required --${key}`)
+  }
+  return values
+}
+
+function runCli(argv) {
+  const args = parseArguments(argv)
+  const assetsDirectory = resolve(args['assets-dir'])
+  const outputPath = resolve(args.output)
+  const assets = readdirSync(assetsDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => {
+      const path = resolve(assetsDirectory, entry.name)
+      return {
+        name: entry.name,
+        size: statSync(path).size,
+      }
+    })
+
+  const model = buildReleaseModel({
+    assets,
+    tag: args.tag,
+    baseUrl: args['base-url'],
+  })
+  writeFileSync(outputPath, renderDownloadPage(model), 'utf8')
+
+  const available = Object.values(model.platforms)
+    .filter((platform) => platform.available)
+    .map((platform) => platform.name)
+    .join(', ')
+  process.stdout.write(
+    `Generated ${basename(outputPath)} for ${model.tag}: ${available}\n`,
+  )
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    runCli(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/generate-download-page.mjs
+++ b/scripts/generate-download-page.mjs
@@ -121,12 +121,31 @@ function formatForAsset(name) {
 
 function platformForAsset(name, format) {
   if (!format) return null
-  if (format === 'EXE' || format === 'MSI') return 'windows'
-  if (format === 'DMG') return 'macos'
-  if (format === 'DEB' || format === 'RPM' || format === 'AppImage') {
-    return 'linux'
+  if (!/^CatGo(?:[_-]|$)/i.test(name)) return null
+  if (
+    (format === 'EXE' || format === 'MSI')
+    && /(?:^|[_-])(?:x64|x86_64)(?:[_-]|\.)/i.test(name)
+  ) {
+    return 'windows'
   }
-  if (format === 'APK') return 'android'
+  if (
+    format === 'DMG'
+    && /(?:^|[_-])(?:aarch64|arm64)(?:[_-]|\.)/i.test(name)
+  ) {
+    return 'macos'
+  }
+  if (format === 'DEB' || format === 'RPM' || format === 'AppImage') {
+    return /(?:^|[._-])(?:amd64|x86_64)(?:[._-])/i.test(name)
+      ? 'linux'
+      : null
+  }
+  if (
+    format === 'APK'
+    && /(?:^|[_-])android(?:[_-]|\.)/i.test(name)
+    && /(?:^|[_-])universal(?:[_-]|\.)/i.test(name)
+  ) {
+    return 'android'
+  }
   return null
 }
 
@@ -288,6 +307,9 @@ function renderPlatformCard(platform) {
           <div class="unavailable" role="status">
             构建暂未提供
             <span>Build not available yet</span>
+            <a class="other-jump" href="#other-downloads">
+              查看其他下载 · See other downloads
+            </a>
           </div>`
 
   return `
@@ -810,6 +832,15 @@ export function renderDownloadPage(model) {
       font-weight: 500;
     }
 
+    .other-jump {
+      display: inline-block;
+      margin-top: 12px;
+      color: var(--copper);
+      font-size: 12px;
+      font-weight: 720;
+      text-underline-offset: 3px;
+    }
+
     .other-section {
       padding: 68px 0 86px;
       background: var(--paper-deep);
@@ -1069,7 +1100,7 @@ export function renderDownloadPage(model) {
       </div>
     </section>
 
-    <section class="other-section">
+    <section class="other-section" id="other-downloads">
       <div class="shell">
         <div class="section-kicker">RELEASE LEDGER / 发布文件</div>
         <h2>其他下载 / Other downloads</h2>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,6 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/Hello-QM/catgo-LRG/releases/latest/download/latest.json",
         "https://dl.catgo-ucsd.org/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK",

--- a/src/lib/DesktopDownloadModal.svelte
+++ b/src/lib/DesktopDownloadModal.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { desktop_download } from '$lib/desktop-download.svelte'
+  import {
+    DOWNLOAD_HUB_URL,
+    TESTFLIGHT_URL,
+  } from '$lib/download-links'
   import Icon from '$lib/Icon.svelte'
   import { t, load_i18n_module } from '$lib/i18n/index.svelte'
 
   load_i18n_module('app')
-
-  const REPO = `Hello-QM/catgo-LRG`
-  const RELEASES_PAGE = `https://github.com/${REPO}/releases/latest`
 
   type OS = `windows` | `mac` | `linux` | `android` | `ios`
 
@@ -22,11 +23,6 @@
   }
 
   let os = $state<OS>(detect_os())
-  let status = $state<`idle` | `fetching`>(`idle`)
-
-  // iOS ships via TestFlight public beta (an unsigned .ipa won't install), so
-  // the iOS option opens the join link rather than a release asset.
-  const TESTFLIGHT = `https://testflight.apple.com/join/FdHup5Hz`
 
   const OSES: OS[] = [`windows`, `mac`, `linux`, `android`, `ios`]
   const os_label: Record<OS, string> = {
@@ -37,52 +33,18 @@
     ios: `iOS`,
   }
 
-  // Release assets are version-stamped (CatGo_1.3.4_amd64.deb, _x64-setup.exe,
-  // _aarch64.dmg, CatGo-v1.3.4-android-universal.apk, ...). Match by extension so
-  // the URL auto-tracks each release.
-  const matchers: Record<OS, RegExp[]> = {
-    windows: [/_x64-setup\.exe$/i, /\.msi$/i, /\.exe$/i],
-    mac: [/aarch64.*\.dmg$/i, /\.dmg$/i, /\.app\.tar\.gz$/i],
-    linux: [/_amd64\.deb$/i, /\.deb$/i, /\.rpm$/i, /\.AppImage$/i],
-    android: [/android.*\.apk$/i, /\.apk$/i],
-    ios: [],
-  }
-
-  async function download() {
-    // iOS → TestFlight external testing, not a release asset.
+  function download() {
     if (os === `ios`) {
-      window.open(TESTFLIGHT, `_blank`, `noopener`)
-      desktop_download.close()
-      return
+      window.open(TESTFLIGHT_URL, `_blank`, `noopener`)
+    } else {
+      const hub_platform = os === `mac` ? `macos` : os
+      window.open(
+        `${DOWNLOAD_HUB_URL}#platform-${hub_platform}`,
+        `_blank`,
+        `noopener`,
+      )
     }
-    status = `fetching`
-    try {
-      // Always hit releases/latest so we follow the newest version automatically.
-      const resp = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`)
-      if (!resp.ok) throw new Error(`GitHub API ${resp.status}`)
-      const rel = await resp.json()
-      const assets: { name: string; browser_download_url: string }[] = rel.assets || []
-      let url = ``
-      for (const re of matchers[os]) {
-        const hit = assets.find((a) => re.test(a.name))
-        if (hit) {
-          url = hit.browser_download_url
-          break
-        }
-      }
-      if (url) {
-        window.location.href = url
-        desktop_download.close()
-      } else {
-        // No matching asset for this OS — fall back to the releases page.
-        window.open(RELEASES_PAGE, `_blank`, `noopener`)
-      }
-    } catch {
-      // API rate-limited / offline — fall back to the releases page.
-      window.open(RELEASES_PAGE, `_blank`, `noopener`)
-    } finally {
-      status = `idle`
-    }
+    desktop_download.close()
   }
 </script>
 
@@ -106,17 +68,15 @@
         {/each}
       </div>
 
-      <button class="ddm-download" disabled={status === `fetching`} onclick={download}>
-        {#if status === `fetching`}
-          {t('app.desktop_fetching')}
-        {:else if os === `ios`}
+      <button class="ddm-download" onclick={download}>
+        {#if os === `ios`}
           {t('app.desktop_ios_testflight')}
         {:else}
           {t('app.desktop_download_for', { os: os_label[os] })}
         {/if}
       </button>
 
-      <a class="ddm-fallback" href={RELEASES_PAGE} target="_blank" rel="noopener">
+      <a class="ddm-fallback" href={DOWNLOAD_HUB_URL} target="_blank" rel="noopener">
         {t('app.desktop_all_downloads')}
       </a>
     </div>
@@ -204,10 +164,6 @@
     color: #fff;
     font-weight: 600;
     cursor: pointer;
-  }
-  .ddm-download:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
   }
   .ddm-fallback {
     display: block;

--- a/src/lib/StaticModeBanner.svelte
+++ b/src/lib/StaticModeBanner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { STATIC_ONLY } from '$lib/api/config'
+  import { DOWNLOAD_HUB_URL } from '$lib/download-links'
   import Icon from '$lib/Icon.svelte'
 
   interface Props {
@@ -25,7 +26,7 @@
       <p class="banner-message">{message}</p>
       {#if show_download}
         <div class="banner-actions">
-          <a href="https://github.com/Hello-QM/catgo-LRG/releases" target="_blank" rel="noopener" class="download-link">
+          <a href={DOWNLOAD_HUB_URL} target="_blank" rel="noopener" class="download-link">
             <Icon icon="Download" /> Download Desktop App
           </a>
           <a href="https://marketplace.visualstudio.com/items?itemName=Hello-QM.catgo-vscode" target="_blank" rel="noopener" class="vscode-link">

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -2,6 +2,8 @@
 // so each worktree automatically connects to its own backend port.
 // Override: set VITE_SERVER_URL env var or PORT env var.
 
+import { DOWNLOAD_HUB_URL } from '$lib/download-links'
+
 declare const __CATGO_SERVER_URL__: string
 declare const __CATGO_DESKTOP__: boolean
 declare const __CATGO_STATIC_ONLY__: boolean
@@ -54,7 +56,7 @@ if (STATIC_ONLY && typeof window !== `undefined`) {
         new Response(
           JSON.stringify({
             detail:
-              `This feature requires the CatGo desktop app. Visit github.com/Hello-QM/catgo-LRG to download.`,
+              `This feature requires the CatGo desktop app. Download it from ${DOWNLOAD_HUB_URL}`,
           }),
           {
             status: 503,

--- a/src/lib/download-links.ts
+++ b/src/lib/download-links.ts
@@ -1,0 +1,3 @@
+export const DOWNLOAD_HUB_URL = `https://dl.catgo-ucsd.org/`
+export const UPDATE_MANIFEST_URL = `https://dl.catgo-ucsd.org/latest.json`
+export const TESTFLIGHT_URL = `https://testflight.apple.com/join/FdHup5Hz`

--- a/src/lib/i18n/en/app.ts
+++ b/src/lib/i18n/en/app.ts
@@ -210,5 +210,6 @@ const app: Record<string, string> = {
   update_ready: `Installed — restarting…`,
   update_error: `Update failed: {error}`,
   update_later_btn: `Later`,
+  update_release_notes: `Release notes`,
 }
 export default app

--- a/src/lib/i18n/zh/app.ts
+++ b/src/lib/i18n/zh/app.ts
@@ -210,5 +210,6 @@ const app: Record<string, string> = {
   update_ready: `已安装 — 正在重启…`,
   update_error: `更新失败：{error}`,
   update_later_btn: `稍后`,
+  update_release_notes: `版本说明`,
 }
 export default app

--- a/src/lib/update/UpdateBanner.svelte
+++ b/src/lib/update/UpdateBanner.svelte
@@ -54,6 +54,12 @@
           : t('app.update_install_btn')}
       </button>
       <button class="ub-dismiss" onclick={() => dismiss_update()}>{t('app.update_later_btn')}</button>
+      {#if update_state.notes}
+        <details class="ub-notes">
+          <summary>{t('app.update_release_notes')}</summary>
+          <p>{update_state.notes}</p>
+        </details>
+      {/if}
     {:else if update_state.status === 'downloading'}
       <div class="ub-bar"><div class="ub-fill" style="width: {pct}%"></div></div>
       <span class="ub-text">{t('app.update_downloading', { pct: String(pct) })}</span>
@@ -74,6 +80,7 @@
     transform: translateX(-50%);
     z-index: 9500;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 10px;
     max-width: 90vw;
@@ -121,6 +128,23 @@
   }
   .ub-dismiss:hover {
     color: var(--text-color, #f3f4f6);
+  }
+  .ub-notes {
+    flex-basis: 100%;
+    max-width: min(640px, 82vw);
+    color: var(--text-color-muted, #c2c8d0);
+  }
+  .ub-notes summary {
+    width: fit-content;
+    cursor: pointer;
+    color: var(--text-color, #f3f4f6);
+  }
+  .ub-notes p {
+    max-height: 10rem;
+    margin: 8px 0 2px;
+    overflow: auto;
+    white-space: pre-wrap;
+    line-height: 1.5;
   }
   .ub-bar {
     width: 140px;

--- a/src/lib/update/__tests__/release-manifest.test.ts
+++ b/src/lib/update/__tests__/release-manifest.test.ts
@@ -48,17 +48,35 @@ describe(`is_newer_version`, () => {
     [`1.4.6`, `1.4.5`, true],
     [`v1.4.6`, `1.4.6`, false],
     [`1.4.5`, `1.4.6`, false],
-    [`1.5`, `1.4.99`, true],
+    [`1.5.0`, `1.4.99`, true],
     [`1.4.6-beta.1`, `1.4.5`, true],
     [`1.4.6-beta.1`, `1.4.6`, false],
     [`1.4.6`, `1.4.6-beta.9`, true],
     [`1.4.6-beta.10`, `1.4.6-beta.2`, true],
+    [`1.4.6-beta`, `1.4.6-Beta`, true],
+    [
+      `1.4.6-beta.9999999999999999999999999`,
+      `1.4.6-beta.9999999999999999999999998`,
+      true,
+    ],
+    [`1.4.6+build.2`, `1.4.6+build.1`, false],
   ])(`compares %s with %s`, (latest, current, expected) => {
     expect(is_newer_version(latest, current)).toBe(expected)
   })
 
-  it(`rejects malformed versions instead of guessing`, () => {
-    expect(() => is_newer_version(`latest`, `1.4.5`)).toThrow(/version/i)
-    expect(() => is_newer_version(`1.4.6`, `current`)).toThrow(/version/i)
+  it.each([
+    `latest`,
+    `1`,
+    `1.2`,
+    `1.2.3.4`,
+    `01.2.3`,
+    `1.02.3`,
+    `1.2.03`,
+    `1.2.3-01`,
+    `1.2.3+`,
+    `1.2.3+bad!`,
+  ])(`rejects malformed version %s instead of guessing`, (version) => {
+    expect(() => is_newer_version(version, `1.4.5`)).toThrow(/version/i)
+    expect(() => is_newer_version(`1.4.6`, version)).toThrow(/version/i)
   })
 })

--- a/src/lib/update/__tests__/release-manifest.test.ts
+++ b/src/lib/update/__tests__/release-manifest.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  is_newer_version,
+  parse_release_manifest,
+} from '../release-manifest'
+
+describe(`parse_release_manifest`, () => {
+  it(`accepts the Tauri updater manifest fields used by Linux`, () => {
+    const manifest = parse_release_manifest({
+      version: `1.4.6`,
+      notes: `Cloudflare release`,
+      pub_date: `2026-07-24T12:00:00Z`,
+      platforms: {
+        'linux-x86_64': {
+          signature: `signed`,
+          url: `https://dl.catgo-ucsd.org/v1.4.6/CatGo.AppImage`,
+        },
+      },
+    })
+
+    expect(manifest.version).toBe(`1.4.6`)
+    expect(manifest.notes).toBe(`Cloudflare release`)
+    expect(manifest.platforms?.[`linux-x86_64`]?.url).toContain(
+      `dl.catgo-ucsd.org`,
+    )
+  })
+
+  it(`normalizes absent notes to null`, () => {
+    expect(parse_release_manifest({ version: `v1.4.6` }).notes).toBeNull()
+  })
+
+  it.each([
+    null,
+    [],
+    {},
+    { version: 146 },
+    { version: `not-a-version` },
+    { version: `1.4.6`, notes: 10 },
+    { version: `1.4.6`, platforms: [] },
+  ])(`rejects malformed updater data: %j`, (value) => {
+    expect(() => parse_release_manifest(value)).toThrow(/manifest/i)
+  })
+})
+
+describe(`is_newer_version`, () => {
+  it.each([
+    [`1.4.6`, `1.4.5`, true],
+    [`v1.4.6`, `1.4.6`, false],
+    [`1.4.5`, `1.4.6`, false],
+    [`1.5`, `1.4.99`, true],
+    [`1.4.6-beta.1`, `1.4.5`, true],
+    [`1.4.6-beta.1`, `1.4.6`, false],
+    [`1.4.6`, `1.4.6-beta.9`, true],
+    [`1.4.6-beta.10`, `1.4.6-beta.2`, true],
+  ])(`compares %s with %s`, (latest, current, expected) => {
+    expect(is_newer_version(latest, current)).toBe(expected)
+  })
+
+  it(`rejects malformed versions instead of guessing`, () => {
+    expect(() => is_newer_version(`latest`, `1.4.5`)).toThrow(/version/i)
+    expect(() => is_newer_version(`1.4.6`, `current`)).toThrow(/version/i)
+  })
+})

--- a/src/lib/update/auto-update.svelte.ts
+++ b/src/lib/update/auto-update.svelte.ts
@@ -2,18 +2,23 @@
 //
 // Windows/macOS: the Tauri updater plugin self-installs a signed bundle and the
 // app relaunches (mode 'auto'). Linux ships .deb/.rpm, which the updater can't
-// self-install — there we only compare versions against the latest GitHub
-// release and point the user at the download page (mode 'manual').
+// self-install — there we compare versions against the Cloudflare release
+// manifest and point the user at the download hub (mode 'manual').
 //
 // All of this is desktop-only: the updater/process plugins are not compiled on
 // mobile, and the web (STATIC_ONLY) build has no Tauri at all — both are gated
 // out by `is_desktop_tauri()` so this module is inert there.
 
+import {
+  DOWNLOAD_HUB_URL,
+  UPDATE_MANIFEST_URL,
+} from '$lib/download-links'
 import { check_tauri } from '$lib/io/tauri'
-
-const REPO = `Hello-QM/catgo-LRG`
-const RELEASES_LATEST_PAGE = `https://github.com/${REPO}/releases/latest`
-const RELEASES_LATEST_API = `https://api.github.com/repos/${REPO}/releases/latest`
+import {
+  is_newer_version,
+  parse_release_manifest,
+  type ReleaseManifest,
+} from './release-manifest'
 
 export type UpdateStatus =
   | `idle`
@@ -67,48 +72,32 @@ export function is_desktop_tauri(): boolean {
   return check_tauri() && !is_mobile_ua()
 }
 
-/** Strip a leading `v` and any prerelease/build suffix, keep the numeric core. */
-function normalize_version(v: string): number[] {
-  const core = v.replace(/^v/i, ``).split(/[-+]/)[0]
-  return core.split(`.`).map((n) => parseInt(n, 10) || 0)
-}
-
-/** True when `latest` is a strictly newer semantic version than `current`. */
-function is_newer(latest: string, current: string): boolean {
-  const a = normalize_version(latest)
-  const b = normalize_version(current)
-  for (let i = 0; i < Math.max(a.length, b.length); i++) {
-    const x = a[i] || 0
-    const y = b[i] || 0
-    if (x > y) return true
-    if (x < y) return false
+async function fetch_release_manifest(): Promise<ReleaseManifest> {
+  try {
+    const { fetch: tauriFetch } = await import(`@tauri-apps/plugin-http`)
+    const response = await tauriFetch(UPDATE_MANIFEST_URL, { method: `GET` })
+    if (!response.ok) {
+      throw new Error(`Release manifest returned HTTP ${response.status}`)
+    }
+    return parse_release_manifest(await response.json())
+  } catch {
+    const response = await fetch(UPDATE_MANIFEST_URL)
+    if (!response.ok) {
+      throw new Error(`Release manifest returned HTTP ${response.status}`)
+    }
+    return parse_release_manifest(await response.json())
   }
-  return false
 }
 
-/** Linux path: compare the running version to the latest GitHub release tag. */
+/** Linux path: compare the running version to the mirrored release manifest. */
 async function check_linux(): Promise<void> {
   const { getVersion } = await import(`@tauri-apps/api/app`)
   const current = await getVersion()
-  // plugin-http honours the capability HTTP scope; falls back to fetch in dev.
-  let tag: string | null = null
-  let body: string | null = null
-  try {
-    const { fetch: tauriFetch } = await import(`@tauri-apps/plugin-http`)
-    const res = await tauriFetch(RELEASES_LATEST_API, { method: `GET` })
-    const json = await res.json()
-    tag = json?.tag_name ?? null
-    body = json?.body ?? null
-  } catch {
-    const res = await fetch(RELEASES_LATEST_API)
-    const json = await res.json()
-    tag = json?.tag_name ?? null
-    body = json?.body ?? null
-  }
-  if (tag && is_newer(tag, current)) {
+  const manifest = await fetch_release_manifest()
+  if (is_newer_version(manifest.version, current)) {
     update_state.status = `available`
-    update_state.version = tag.replace(/^v/i, ``)
-    update_state.notes = body
+    update_state.version = manifest.version.replace(/^v/i, ``)
+    update_state.notes = manifest.notes
     update_state.mode = `manual`
   } else {
     update_state.status = `none`
@@ -161,10 +150,10 @@ export async function install_update(): Promise<void> {
   if (update_state.mode === `manual`) {
     try {
       const { openUrl } = await import(`@tauri-apps/plugin-opener`)
-      await openUrl(RELEASES_LATEST_PAGE)
+      await openUrl(DOWNLOAD_HUB_URL)
     } catch (err) {
       console.error(`[auto-update] failed to open download page:`, err)
-      if (typeof window !== `undefined`) window.open(RELEASES_LATEST_PAGE, `_blank`)
+      if (typeof window !== `undefined`) window.open(DOWNLOAD_HUB_URL, `_blank`)
     }
     return
   }

--- a/src/lib/update/release-manifest.ts
+++ b/src/lib/update/release-manifest.ts
@@ -10,12 +10,24 @@ export interface ReleaseManifest {
   platforms?: Record<string, ReleasePlatform>
 }
 
-type VersionIdentifier = number | string
+type VersionIdentifier = bigint | string
 
 interface SemanticVersion {
-  core: number[]
+  core: bigint[]
   prerelease: VersionIdentifier[] | null
 }
+
+const NUMERIC_IDENTIFIER = `0|[1-9]\\d*`
+const NON_NUMERIC_IDENTIFIER =
+  `[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*`
+const PRERELEASE_IDENTIFIER =
+  `(?:${NUMERIC_IDENTIFIER}|${NON_NUMERIC_IDENTIFIER})`
+const SEMANTIC_VERSION_PATTERN = new RegExp(
+  `^[vV]?(${NUMERIC_IDENTIFIER})\\.(${NUMERIC_IDENTIFIER})\\.` +
+    `(${NUMERIC_IDENTIFIER})(?:-(${PRERELEASE_IDENTIFIER}` +
+    `(?:\\.${PRERELEASE_IDENTIFIER})*))?` +
+    `(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$`,
+)
 
 function is_record(value: unknown): value is Record<string, unknown> {
   return typeof value === `object` && value !== null && !Array.isArray(value)
@@ -26,31 +38,16 @@ function parse_version(version: string): SemanticVersion {
     throw new Error(`Invalid version: expected a string`)
   }
 
-  const without_prefix = version.replace(/^v/i, ``)
-  const [without_build] = without_prefix.split(`+`, 1)
-  const separator = without_build.indexOf(`-`)
-  const core_text = separator === -1
-    ? without_build
-    : without_build.slice(0, separator)
-  const prerelease_text = separator === -1
-    ? null
-    : without_build.slice(separator + 1)
-
-  if (!/^\d+(?:\.\d+)*$/.test(core_text)) {
-    throw new Error(`Invalid version: ${version}`)
-  }
-  if (
-    prerelease_text !== null &&
-    !/^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(prerelease_text)
-  ) {
+  const match = SEMANTIC_VERSION_PATTERN.exec(version)
+  if (!match) {
     throw new Error(`Invalid version: ${version}`)
   }
 
-  const core = core_text.split(`.`).map((part) => Number(part))
-  const prerelease = prerelease_text === null
+  const core = [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])]
+  const prerelease = match[4] === undefined
     ? null
-    : prerelease_text.split(`.`).map((part) => (
-      /^\d+$/.test(part) ? Number(part) : part
+    : match[4].split(`.`).map((part) => (
+      /^\d+$/.test(part) ? BigInt(part) : part
     ))
 
   return { core, prerelease }
@@ -118,12 +115,14 @@ function compare_identifiers(
   left: VersionIdentifier,
   right: VersionIdentifier,
 ): number {
-  if (typeof left === `number` && typeof right === `number`) {
-    return left - right
+  if (typeof left === `bigint` && typeof right === `bigint`) {
+    if (left === right) return 0
+    return left < right ? -1 : 1
   }
-  if (typeof left === `number`) return -1
-  if (typeof right === `number`) return 1
-  return left.localeCompare(right)
+  if (typeof left === `bigint`) return -1
+  if (typeof right === `bigint`) return 1
+  if (left === right) return 0
+  return left < right ? -1 : 1
 }
 
 /** Return true only when latest is a strictly newer semantic version. */
@@ -131,9 +130,9 @@ export function is_newer_version(latest: string, current: string): boolean {
   const left = parse_version(latest)
   const right = parse_version(current)
 
-  for (let index = 0; index < Math.max(left.core.length, right.core.length); index++) {
-    const left_part = left.core[index] ?? 0
-    const right_part = right.core[index] ?? 0
+  for (let index = 0; index < left.core.length; index++) {
+    const left_part = left.core[index]
+    const right_part = right.core[index]
     if (left_part !== right_part) return left_part > right_part
   }
 

--- a/src/lib/update/release-manifest.ts
+++ b/src/lib/update/release-manifest.ts
@@ -1,0 +1,157 @@
+export interface ReleasePlatform {
+  signature?: string
+  url: string
+}
+
+export interface ReleaseManifest {
+  version: string
+  notes: string | null
+  pub_date?: string
+  platforms?: Record<string, ReleasePlatform>
+}
+
+type VersionIdentifier = number | string
+
+interface SemanticVersion {
+  core: number[]
+  prerelease: VersionIdentifier[] | null
+}
+
+function is_record(value: unknown): value is Record<string, unknown> {
+  return typeof value === `object` && value !== null && !Array.isArray(value)
+}
+
+function parse_version(version: string): SemanticVersion {
+  if (typeof version !== `string`) {
+    throw new Error(`Invalid version: expected a string`)
+  }
+
+  const without_prefix = version.replace(/^v/i, ``)
+  const [without_build] = without_prefix.split(`+`, 1)
+  const separator = without_build.indexOf(`-`)
+  const core_text = separator === -1
+    ? without_build
+    : without_build.slice(0, separator)
+  const prerelease_text = separator === -1
+    ? null
+    : without_build.slice(separator + 1)
+
+  if (!/^\d+(?:\.\d+)*$/.test(core_text)) {
+    throw new Error(`Invalid version: ${version}`)
+  }
+  if (
+    prerelease_text !== null &&
+    !/^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(prerelease_text)
+  ) {
+    throw new Error(`Invalid version: ${version}`)
+  }
+
+  const core = core_text.split(`.`).map((part) => Number(part))
+  const prerelease = prerelease_text === null
+    ? null
+    : prerelease_text.split(`.`).map((part) => (
+      /^\d+$/.test(part) ? Number(part) : part
+    ))
+
+  return { core, prerelease }
+}
+
+export function parse_release_manifest(value: unknown): ReleaseManifest {
+  if (!is_record(value)) {
+    throw new Error(`Invalid release manifest: expected an object`)
+  }
+  if (typeof value.version !== `string`) {
+    throw new Error(`Invalid release manifest: version must be a string`)
+  }
+
+  try {
+    parse_version(value.version)
+  } catch {
+    throw new Error(`Invalid release manifest: malformed version`)
+  }
+
+  if (
+    value.notes !== undefined &&
+    value.notes !== null &&
+    typeof value.notes !== `string`
+  ) {
+    throw new Error(`Invalid release manifest: notes must be a string or null`)
+  }
+  if (value.pub_date !== undefined && typeof value.pub_date !== `string`) {
+    throw new Error(`Invalid release manifest: pub_date must be a string`)
+  }
+
+  let platforms: Record<string, ReleasePlatform> | undefined
+  if (value.platforms !== undefined) {
+    if (!is_record(value.platforms)) {
+      throw new Error(`Invalid release manifest: platforms must be an object`)
+    }
+    platforms = {}
+    for (const [name, platform_value] of Object.entries(value.platforms)) {
+      if (!is_record(platform_value) || typeof platform_value.url !== `string`) {
+        throw new Error(`Invalid release manifest: malformed platform ${name}`)
+      }
+      if (
+        platform_value.signature !== undefined &&
+        typeof platform_value.signature !== `string`
+      ) {
+        throw new Error(`Invalid release manifest: malformed signature for ${name}`)
+      }
+      platforms[name] = {
+        url: platform_value.url,
+        ...(platform_value.signature === undefined
+          ? {}
+          : { signature: platform_value.signature }),
+      }
+    }
+  }
+
+  return {
+    version: value.version,
+    notes: typeof value.notes === `string` ? value.notes : null,
+    ...(value.pub_date === undefined ? {} : { pub_date: value.pub_date }),
+    ...(platforms === undefined ? {} : { platforms }),
+  }
+}
+
+function compare_identifiers(
+  left: VersionIdentifier,
+  right: VersionIdentifier,
+): number {
+  if (typeof left === `number` && typeof right === `number`) {
+    return left - right
+  }
+  if (typeof left === `number`) return -1
+  if (typeof right === `number`) return 1
+  return left.localeCompare(right)
+}
+
+/** Return true only when latest is a strictly newer semantic version. */
+export function is_newer_version(latest: string, current: string): boolean {
+  const left = parse_version(latest)
+  const right = parse_version(current)
+
+  for (let index = 0; index < Math.max(left.core.length, right.core.length); index++) {
+    const left_part = left.core[index] ?? 0
+    const right_part = right.core[index] ?? 0
+    if (left_part !== right_part) return left_part > right_part
+  }
+
+  if (left.prerelease === null && right.prerelease === null) return false
+  if (left.prerelease === null) return true
+  if (right.prerelease === null) return false
+
+  for (
+    let index = 0;
+    index < Math.max(left.prerelease.length, right.prerelease.length);
+    index++
+  ) {
+    const left_part = left.prerelease[index]
+    const right_part = right.prerelease[index]
+    if (left_part === undefined) return false
+    if (right_part === undefined) return true
+    const comparison = compare_identifiers(left_part, right_part)
+    if (comparison !== 0) return comparison > 0
+  }
+  return false
+}

--- a/workers/downloads/index.mjs
+++ b/workers/downloads/index.mjs
@@ -1,0 +1,303 @@
+const ALLOWED_METHODS = 'GET, HEAD'
+const INLINE_EXTENSIONS = new Set(['.html', '.json'])
+const CONDITIONAL_HEADERS = [
+  'if-match',
+  'if-none-match',
+  'if-modified-since',
+  'if-unmodified-since',
+]
+
+function textResponse(body, status, extraHeaders = {}) {
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+      ...extraHeaders,
+    },
+  })
+}
+
+function badRequest() {
+  return textResponse('无效下载路径 / Invalid download path', 400)
+}
+
+function resolveObjectKey(requestUrl) {
+  const rawPath = new URL(requestUrl).pathname
+  if (rawPath === '/' || rawPath === '/index.html') return 'index.html'
+  if (
+    !rawPath.startsWith('/')
+    || /%(?:00|2f|5c)/i.test(rawPath)
+  ) {
+    return null
+  }
+
+  const segments = rawPath.slice(1).split('/')
+  const decoded = []
+  for (const segment of segments) {
+    if (!segment) return null
+    let value
+    try {
+      value = decodeURIComponent(segment)
+    } catch {
+      return null
+    }
+    if (
+      value === '.'
+      || value === '..'
+      || value.includes('/')
+      || value.includes('\\')
+      || value.includes('\0')
+      || /%(?:00|2e|2f|5c)/i.test(value)
+    ) {
+      return null
+    }
+    decoded.push(value)
+  }
+  return decoded.join('/')
+}
+
+function requestHasConditionals(headers) {
+  return CONDITIONAL_HEADERS.some((name) => headers.has(name))
+}
+
+function stripWeakPrefix(etag) {
+  return etag.trim().replace(/^W\//i, '')
+}
+
+function etagListMatches(value, etag, { weak = false } = {}) {
+  if (!value) return false
+  if (value.trim() === '*') return true
+  const expected = weak ? stripWeakPrefix(etag) : etag.trim()
+  return value.split(',').some((candidate) => {
+    const current = weak
+      ? stripWeakPrefix(candidate)
+      : candidate.trim()
+    return current === expected
+  })
+}
+
+function validDate(value) {
+  if (!value) return null
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+function headPreconditionStatus(request, object) {
+  const { headers } = request
+  const etag = object.httpEtag
+  const uploaded = object.uploaded instanceof Date
+    ? object.uploaded.getTime()
+    : null
+
+  const ifMatch = headers.get('if-match')
+  if (ifMatch && !etagListMatches(ifMatch, etag)) return 412
+
+  const ifUnmodifiedSince = validDate(headers.get('if-unmodified-since'))
+  if (
+    ifUnmodifiedSince !== null
+    && uploaded !== null
+    && uploaded > ifUnmodifiedSince
+  ) {
+    return 412
+  }
+
+  const ifNoneMatch = headers.get('if-none-match')
+  if (ifNoneMatch && etagListMatches(ifNoneMatch, etag, { weak: true })) {
+    return 304
+  }
+
+  if (!ifNoneMatch) {
+    const ifModifiedSince = validDate(headers.get('if-modified-since'))
+    if (
+      ifModifiedSince !== null
+      && uploaded !== null
+      && uploaded <= ifModifiedSince
+    ) {
+      return 304
+    }
+  }
+
+  return null
+}
+
+function parseRangeHeader(value, size) {
+  if (!value) return null
+  const match = /^bytes=(\d*)-(\d*)$/.exec(value.trim())
+  if (!match || (!match[1] && !match[2]) || size <= 0) {
+    return { invalid: true }
+  }
+
+  let start
+  let end
+  if (!match[1]) {
+    const suffixLength = Number(match[2])
+    if (!Number.isSafeInteger(suffixLength) || suffixLength <= 0) {
+      return { invalid: true }
+    }
+    start = Math.max(size - suffixLength, 0)
+    end = size - 1
+  } else {
+    start = Number(match[1])
+    end = match[2] ? Number(match[2]) : size - 1
+    if (
+      !Number.isSafeInteger(start)
+      || !Number.isSafeInteger(end)
+      || start >= size
+      || end < start
+    ) {
+      return { invalid: true }
+    }
+    end = Math.min(end, size - 1)
+  }
+
+  return {
+    offset: start,
+    length: end - start + 1,
+  }
+}
+
+function responseRange(object) {
+  if (
+    !object.range
+    || !Number.isSafeInteger(object.range.offset)
+    || !Number.isSafeInteger(object.range.length)
+  ) {
+    return null
+  }
+  return {
+    offset: object.range.offset,
+    length: object.range.length,
+  }
+}
+
+function extensionForKey(key) {
+  const filename = key.split('/').at(-1) ?? key
+  const dot = filename.lastIndexOf('.')
+  return dot === -1 ? '' : filename.slice(dot).toLowerCase()
+}
+
+function encodeDispositionFilename(filename) {
+  return encodeURIComponent(filename).replace(
+    /[!'()*]/g,
+    (character) =>
+      `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+function buildHeaders(object, key, range = null) {
+  const headers = new Headers()
+  object.writeHttpMetadata(headers)
+  headers.set('etag', object.httpEtag)
+  headers.set('accept-ranges', 'bytes')
+
+  if (range) {
+    const end = range.offset + range.length - 1
+    headers.set(
+      'content-range',
+      `bytes ${range.offset}-${end}/${object.size}`,
+    )
+    headers.set('content-length', String(range.length))
+  } else {
+    headers.set('content-length', String(object.size))
+  }
+
+  if (INLINE_EXTENSIONS.has(extensionForKey(key))) {
+    headers.set('content-disposition', 'inline')
+  } else {
+    const filename = key.split('/').at(-1) ?? 'download'
+    headers.set(
+      'content-disposition',
+      `attachment; filename*=UTF-8''${encodeDispositionFilename(filename)}`,
+    )
+  }
+
+  return headers
+}
+
+function conditionalStatus(request) {
+  if (
+    request.headers.has('if-none-match')
+    || request.headers.has('if-modified-since')
+  ) {
+    return 304
+  }
+  return 412
+}
+
+async function serveHead(request, bucket, key) {
+  const object = await bucket.head(key)
+  if (object === null) {
+    return textResponse('未找到 / Download not found', 404)
+  }
+
+  const preconditionStatus = headPreconditionStatus(request, object)
+  if (preconditionStatus !== null) {
+    return new Response(null, {
+      status: preconditionStatus,
+      headers: buildHeaders(object, key),
+    })
+  }
+
+  const range = parseRangeHeader(request.headers.get('range'), object.size)
+  if (range?.invalid) {
+    return new Response(null, {
+      status: 416,
+      headers: {
+        'accept-ranges': 'bytes',
+        'content-range': `bytes */${object.size}`,
+      },
+    })
+  }
+
+  return new Response(null, {
+    status: range ? 206 : 200,
+    headers: buildHeaders(object, key, range),
+  })
+}
+
+async function serveGet(request, bucket, key) {
+  const options = {}
+  if (request.headers.has('range')) options.range = request.headers
+  if (requestHasConditionals(request.headers)) {
+    options.onlyIf = request.headers
+  }
+
+  const object = await bucket.get(key, options)
+  if (object === null) {
+    return textResponse('未找到 / Download not found', 404)
+  }
+
+  if (!object.body) {
+    return new Response(null, {
+      status: conditionalStatus(request),
+      headers: buildHeaders(object, key),
+    })
+  }
+
+  const range = responseRange(object)
+  return new Response(object.body, {
+    status: range ? 206 : 200,
+    headers: buildHeaders(object, key, range),
+  })
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return textResponse(
+        '不支持此请求方法 / Method not allowed',
+        405,
+        { allow: ALLOWED_METHODS },
+      )
+    }
+
+    const key = resolveObjectKey(request.url)
+    if (key === null) return badRequest()
+
+    if (request.method === 'HEAD') {
+      return serveHead(request, env.RELEASES, key)
+    }
+    return serveGet(request, env.RELEASES, key)
+  },
+}

--- a/workers/downloads/index.mjs
+++ b/workers/downloads/index.mjs
@@ -1,5 +1,6 @@
 const ALLOWED_METHODS = 'GET, HEAD'
 const INLINE_EXTENSIONS = new Set(['.html', '.json'])
+const APP_TAG_PATTERN = /^v\d+\.\d+\.\d+$/
 const CONDITIONAL_HEADERS = [
   'if-match',
   'if-none-match',
@@ -54,7 +55,18 @@ function resolveObjectKey(requestUrl) {
     }
     decoded.push(value)
   }
-  return decoded.join('/')
+  if (decoded.length === 1 && decoded[0] === 'latest.json') {
+    return decoded[0]
+  }
+  if (
+    decoded.length === 2
+    && APP_TAG_PATTERN.test(decoded[0])
+    && decoded[1] !== '.'
+    && decoded[1] !== '..'
+  ) {
+    return decoded.join('/')
+  }
+  return null
 }
 
 function requestHasConditionals(headers) {
@@ -87,19 +99,21 @@ function headPreconditionStatus(request, object) {
   const { headers } = request
   const etag = object.httpEtag
   const uploaded = object.uploaded instanceof Date
-    ? object.uploaded.getTime()
+    ? Math.floor(object.uploaded.getTime() / 1000) * 1000
     : null
 
   const ifMatch = headers.get('if-match')
   if (ifMatch && !etagListMatches(ifMatch, etag)) return 412
 
-  const ifUnmodifiedSince = validDate(headers.get('if-unmodified-since'))
-  if (
-    ifUnmodifiedSince !== null
-    && uploaded !== null
-    && uploaded > ifUnmodifiedSince
-  ) {
-    return 412
+  if (!ifMatch) {
+    const ifUnmodifiedSince = validDate(headers.get('if-unmodified-since'))
+    if (
+      ifUnmodifiedSince !== null
+      && uploaded !== null
+      && uploaded > ifUnmodifiedSince
+    ) {
+      return 412
+    }
   }
 
   const ifNoneMatch = headers.get('if-none-match')
@@ -215,14 +229,14 @@ function buildHeaders(object, key, range = null) {
   return headers
 }
 
-function conditionalStatus(request) {
-  if (
-    request.headers.has('if-none-match')
-    || request.headers.has('if-modified-since')
-  ) {
-    return 304
-  }
-  return 412
+function rangeNotSatisfiable(size) {
+  return new Response(null, {
+    status: 416,
+    headers: {
+      'accept-ranges': 'bytes',
+      'content-range': `bytes */${size}`,
+    },
+  })
 }
 
 async function serveHead(request, bucket, key) {
@@ -239,38 +253,54 @@ async function serveHead(request, bucket, key) {
     })
   }
 
-  const range = parseRangeHeader(request.headers.get('range'), object.size)
-  if (range?.invalid) {
-    return new Response(null, {
-      status: 416,
-      headers: {
-        'accept-ranges': 'bytes',
-        'content-range': `bytes */${object.size}`,
-      },
-    })
-  }
-
   return new Response(null, {
-    status: range ? 206 : 200,
-    headers: buildHeaders(object, key, range),
+    status: 200,
+    headers: buildHeaders(object, key),
   })
 }
 
 async function serveGet(request, bucket, key) {
   const options = {}
-  if (request.headers.has('range')) options.range = request.headers
+  let rangeMetadata = null
+  if (request.headers.has('range')) {
+    rangeMetadata = await bucket.head(key)
+    if (rangeMetadata === null) {
+      return textResponse('未找到 / Download not found', 404)
+    }
+    const range = parseRangeHeader(
+      request.headers.get('range'),
+      rangeMetadata.size,
+    )
+    if (range?.invalid) return rangeNotSatisfiable(rangeMetadata.size)
+    options.range = range
+  }
   if (requestHasConditionals(request.headers)) {
     options.onlyIf = request.headers
   }
 
-  const object = await bucket.get(key, options)
+  let object
+  try {
+    object = await bucket.get(key, options)
+  } catch (error) {
+    if (
+      rangeMetadata
+      && error instanceof Error
+      && /(?:invalid|unsatisfiable).*range|range.*(?:invalid|unsatisfiable)/i.test(
+        error.message,
+      )
+    ) {
+      return rangeNotSatisfiable(rangeMetadata.size)
+    }
+    throw error
+  }
   if (object === null) {
     return textResponse('未找到 / Download not found', 404)
   }
 
   if (!object.body) {
+    const status = headPreconditionStatus(request, object) ?? 412
     return new Response(null, {
-      status: conditionalStatus(request),
+      status,
       headers: buildHeaders(object, key),
     })
   }

--- a/workers/downloads/index.mjs
+++ b/workers/downloads/index.mjs
@@ -95,6 +95,23 @@ function validDate(value) {
   return Number.isNaN(timestamp) ? null : timestamp
 }
 
+function ifRangeMatches(request, object) {
+  const value = request.headers.get('if-range')
+  if (!value) return true
+
+  const validator = value.trim()
+  if (validator.startsWith('"') || /^W\//i.test(validator)) {
+    return !/^W\//i.test(validator) && validator === object.httpEtag.trim()
+  }
+
+  const ifRangeDate = validDate(validator)
+  if (ifRangeDate === null || !(object.uploaded instanceof Date)) {
+    return false
+  }
+  const uploaded = Math.floor(object.uploaded.getTime() / 1000) * 1000
+  return uploaded <= ifRangeDate
+}
+
 function headPreconditionStatus(request, object) {
   const { headers } = request
   const etag = object.httpEtag
@@ -272,7 +289,9 @@ async function serveGet(request, bucket, key) {
       rangeMetadata.size,
     )
     if (range?.invalid) return rangeNotSatisfiable(rangeMetadata.size)
-    options.range = range
+    if (ifRangeMatches(request, rangeMetadata)) {
+      options.range = range
+    }
   }
   if (requestHasConditionals(request.headers)) {
     options.onlyIf = request.headers

--- a/workers/downloads/index.test.mjs
+++ b/workers/downloads/index.test.mjs
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import worker from './index.mjs'
+
+function createObject({
+  body = null,
+  key = 'v1.4.6/CatGo.exe',
+  size = 100,
+  range,
+  contentType = 'application/octet-stream',
+} = {}) {
+  return {
+    body,
+    key,
+    size,
+    range,
+    etag: 'abc123',
+    httpEtag: '"abc123"',
+    uploaded: new Date('2026-07-24T12:00:00Z'),
+    httpMetadata: {
+      contentType,
+      cacheControl: 'public, max-age=31536000, immutable',
+    },
+    customMetadata: {},
+    writeHttpMetadata(headers) {
+      headers.set('content-type', contentType)
+      headers.set('cache-control', 'public, max-age=31536000, immutable')
+    },
+  }
+}
+
+function createBucket({ getResult = null, headResult = null } = {}) {
+  return {
+    getCalls: [],
+    headCalls: [],
+    async get(key, options) {
+      this.getCalls.push({ key, options })
+      return typeof getResult === 'function'
+        ? getResult(key, options)
+        : getResult
+    },
+    async head(key) {
+      this.headCalls.push({ key })
+      return typeof headResult === 'function' ? headResult(key) : headResult
+    },
+  }
+}
+
+function fetchDownload(bucket, path = '/', init) {
+  return worker.fetch(
+    new Request(`https://dl.catgo-ucsd.org${path}`, init),
+    { RELEASES: bucket },
+  )
+}
+
+test('maps the domain root to index.html and streams the original body', async () => {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('<h1>CatGo</h1>'))
+      controller.close()
+    },
+  })
+  const bucket = createBucket({
+    getResult: createObject({
+      body,
+      key: 'index.html',
+      size: 14,
+      contentType: 'text/html; charset=utf-8',
+    }),
+  })
+
+  const response = await fetchDownload(bucket)
+
+  assert.equal(response.status, 200)
+  assert.equal(bucket.getCalls[0].key, 'index.html')
+  assert.equal(response.body, body)
+  assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8')
+  assert.equal(response.headers.get('content-length'), '14')
+  assert.equal(response.headers.get('etag'), '"abc123"')
+  assert.equal(response.headers.get('accept-ranges'), 'bytes')
+  assert.equal(response.headers.get('content-disposition'), 'inline')
+})
+
+test('uses R2 head for HEAD requests and never fetches the object body', async () => {
+  const bucket = createBucket({
+    headResult: createObject({
+      key: 'latest.json',
+      size: 9_765,
+      contentType: 'application/json',
+    }),
+  })
+
+  const response = await fetchDownload(bucket, '/latest.json', {
+    method: 'HEAD',
+  })
+
+  assert.equal(response.status, 200)
+  assert.equal(response.body, null)
+  assert.deepEqual(bucket.headCalls, [{ key: 'latest.json' }])
+  assert.equal(bucket.getCalls.length, 0)
+  assert.equal(response.headers.get('content-length'), '9765')
+  assert.equal(response.headers.get('content-disposition'), 'inline')
+})
+
+test('forwards byte ranges to R2 and emits resumable response metadata', async () => {
+  const body = new ReadableStream()
+  const bucket = createBucket({
+    getResult: createObject({
+      body,
+      size: 100,
+      range: { offset: 10, length: 5 },
+    }),
+  })
+
+  const response = await fetchDownload(
+    bucket,
+    '/v1.4.6/CatGo_1.4.6_x64-setup.exe',
+    { headers: { Range: 'bytes=10-14' } },
+  )
+
+  assert.equal(response.status, 206)
+  assert.equal(bucket.getCalls[0].options.range.get('range'), 'bytes=10-14')
+  assert.equal(response.headers.get('content-range'), 'bytes 10-14/100')
+  assert.equal(response.headers.get('content-length'), '5')
+  assert.equal(response.headers.get('accept-ranges'), 'bytes')
+  assert.match(
+    response.headers.get('content-disposition'),
+    /^attachment; filename\*=UTF-8''CatGo_1\.4\.6_x64-setup\.exe$/,
+  )
+})
+
+test('returns an empty 304 when an R2 conditional GET has no body', async () => {
+  const bucket = createBucket({
+    getResult: createObject({ body: undefined, key: 'latest.json' }),
+  })
+
+  const response = await fetchDownload(bucket, '/latest.json', {
+    headers: { 'If-None-Match': '"abc123"' },
+  })
+
+  assert.equal(bucket.getCalls[0].options.onlyIf.get('if-none-match'), '"abc123"')
+  assert.equal(response.status, 304)
+  assert.equal(response.body, null)
+  assert.equal(response.headers.get('etag'), '"abc123"')
+})
+
+test('returns an empty 412 for a failed positive precondition', async () => {
+  const bucket = createBucket({
+    getResult: createObject({ body: undefined }),
+  })
+
+  const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: { 'If-Match': '"different"' },
+  })
+
+  assert.equal(response.status, 412)
+  assert.equal(response.body, null)
+})
+
+test('evaluates HEAD conditionals and ranges from object metadata', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ key: 'v1.4.6/CatGo.exe', size: 100 }),
+  })
+
+  const notModified = await fetchDownload(
+    bucket,
+    '/v1.4.6/CatGo.exe',
+    { method: 'HEAD', headers: { 'If-None-Match': '"abc123"' } },
+  )
+  const ranged = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    method: 'HEAD',
+    headers: { Range: 'bytes=90-' },
+  })
+
+  assert.equal(notModified.status, 304)
+  assert.equal(ranged.status, 206)
+  assert.equal(ranged.headers.get('content-range'), 'bytes 90-99/100')
+  assert.equal(ranged.headers.get('content-length'), '10')
+})
+
+test('returns bilingual 404 and method-aware 405 responses', async () => {
+  const bucket = createBucket()
+
+  const missing = await fetchDownload(bucket, '/missing.exe')
+  const unsupported = await fetchDownload(bucket, '/index.html', {
+    method: 'POST',
+  })
+
+  assert.equal(missing.status, 404)
+  assert.match(await missing.text(), /未找到/)
+  assert.equal(unsupported.status, 405)
+  assert.equal(unsupported.headers.get('allow'), 'GET, HEAD')
+  assert.match(await unsupported.text(), /不支持/)
+  assert.equal(bucket.getCalls.length, 1)
+})
+
+test('rejects traversal, encoded separators, malformed escapes, and NULs', async () => {
+  const bucket = createBucket()
+  const paths = [
+    '/v1.4.6/%252e%252e',
+    '/v1.4.6%2Fsecret',
+    '/v1.4.6/%5Csecret',
+    '/v1.4.6/%00secret',
+    '/v1.4.6/%ZZ',
+  ]
+
+  for (const path of paths) {
+    const response = await fetchDownload(bucket, path)
+    assert.equal(response.status, 400, path)
+  }
+  assert.equal(bucket.getCalls.length, 0)
+  assert.equal(bucket.headCalls.length, 0)
+})

--- a/workers/downloads/index.test.mjs
+++ b/workers/downloads/index.test.mjs
@@ -209,6 +209,90 @@ test('normalizes suffix and open-ended GET ranges before calling R2', async () =
   )
 })
 
+test('honors Range only when If-Range strongly matches the current object', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
+    getResult(_key, options) {
+      return createObject({
+        body: new ReadableStream(),
+        size: 100,
+        range: options.range,
+      })
+    },
+  })
+
+  const matching = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      Range: 'bytes=10-14',
+      'If-Range': '"abc123"',
+    },
+  })
+  const stale = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      Range: 'bytes=10-14',
+      'If-Range': '"old-etag"',
+    },
+  })
+  const weak = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      Range: 'bytes=10-14',
+      'If-Range': 'W/"abc123"',
+    },
+  })
+
+  assert.equal(matching.status, 206)
+  assert.deepEqual(bucket.getCalls[0].options.range, {
+    offset: 10,
+    length: 5,
+  })
+  assert.equal(stale.status, 200)
+  assert.equal(bucket.getCalls[1].options.range, undefined)
+  assert.equal(weak.status, 200)
+  assert.equal(bucket.getCalls[2].options.range, undefined)
+})
+
+test('honors date If-Range only when the object has not changed', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
+    getResult(_key, options) {
+      return createObject({
+        body: new ReadableStream(),
+        size: 100,
+        range: options.range,
+      })
+    },
+  })
+
+  const unchanged = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      Range: 'bytes=90-',
+      'If-Range': 'Thu, 24 Jul 2026 12:00:00 GMT',
+    },
+  })
+  const changed = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      Range: 'bytes=90-',
+      'If-Range': 'Thu, 24 Jul 2026 11:59:59 GMT',
+    },
+  })
+  const invalid = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      Range: 'bytes=90-',
+      'If-Range': 'not-a-validator',
+    },
+  })
+
+  assert.equal(unchanged.status, 206)
+  assert.deepEqual(bucket.getCalls[0].options.range, {
+    offset: 90,
+    length: 10,
+  })
+  assert.equal(changed.status, 200)
+  assert.equal(bucket.getCalls[1].options.range, undefined)
+  assert.equal(invalid.status, 200)
+  assert.equal(bucket.getCalls[2].options.range, undefined)
+})
+
 test('returns 416 before GET for malformed, multiple, or unsatisfiable ranges', async () => {
   const bucket = createBucket({
     headResult: createObject({ size: 100 }),

--- a/workers/downloads/index.test.mjs
+++ b/workers/downloads/index.test.mjs
@@ -106,6 +106,7 @@ test('uses R2 head for HEAD requests and never fetches the object body', async (
 test('forwards byte ranges to R2 and emits resumable response metadata', async () => {
   const body = new ReadableStream()
   const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
     getResult: createObject({
       body,
       size: 100,
@@ -120,7 +121,10 @@ test('forwards byte ranges to R2 and emits resumable response metadata', async (
   )
 
   assert.equal(response.status, 206)
-  assert.equal(bucket.getCalls[0].options.range.get('range'), 'bytes=10-14')
+  assert.deepEqual(bucket.getCalls[0].options.range, {
+    offset: 10,
+    length: 5,
+  })
   assert.equal(response.headers.get('content-range'), 'bytes 10-14/100')
   assert.equal(response.headers.get('content-length'), '5')
   assert.equal(response.headers.get('accept-ranges'), 'bytes')
@@ -158,7 +162,7 @@ test('returns an empty 412 for a failed positive precondition', async () => {
   assert.equal(response.body, null)
 })
 
-test('evaluates HEAD conditionals and ranges from object metadata', async () => {
+test('evaluates HEAD conditionals and ignores Range as required by HTTP', async () => {
   const bucket = createBucket({
     headResult: createObject({ key: 'v1.4.6/CatGo.exe', size: 100 }),
   })
@@ -174,15 +178,95 @@ test('evaluates HEAD conditionals and ranges from object metadata', async () => 
   })
 
   assert.equal(notModified.status, 304)
-  assert.equal(ranged.status, 206)
-  assert.equal(ranged.headers.get('content-range'), 'bytes 90-99/100')
-  assert.equal(ranged.headers.get('content-length'), '10')
+  assert.equal(ranged.status, 200)
+  assert.equal(ranged.headers.get('content-range'), null)
+  assert.equal(ranged.headers.get('content-length'), '100')
+})
+
+test('normalizes suffix and open-ended GET ranges before calling R2', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
+    getResult: createObject({
+      body: new ReadableStream(),
+      size: 100,
+      range: { offset: 90, length: 10 },
+    }),
+  })
+
+  await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: { Range: 'bytes=-10' },
+  })
+  await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: { Range: 'bytes=90-' },
+  })
+
+  assert.deepEqual(
+    bucket.getCalls.map(({ options }) => options.range),
+    [
+      { offset: 90, length: 10 },
+      { offset: 90, length: 10 },
+    ],
+  )
+})
+
+test('returns 416 before GET for malformed, multiple, or unsatisfiable ranges', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
+  })
+  const ranges = [
+    'items=0-1',
+    'bytes=',
+    'bytes=10-2',
+    'bytes=100-',
+    'bytes=0-1,4-5',
+  ]
+
+  for (const range of ranges) {
+    const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+      headers: { Range: range },
+    })
+    assert.equal(response.status, 416, range)
+    assert.equal(response.headers.get('content-range'), 'bytes */100')
+    assert.equal(response.headers.get('accept-ranges'), 'bytes')
+  }
+  assert.equal(bucket.getCalls.length, 0)
+})
+
+test('converts an R2 InvalidRange race into 416', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
+    getResult() {
+      throw new Error('InvalidRange: object changed after HEAD')
+    },
+  })
+
+  const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: { Range: 'bytes=90-' },
+  })
+
+  assert.equal(response.status, 416)
+  assert.equal(response.headers.get('content-range'), 'bytes */100')
+})
+
+test('honors positive conditional precedence for bodyless GET results', async () => {
+  const bucket = createBucket({
+    getResult: createObject({ body: undefined }),
+  })
+
+  const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: {
+      'If-Match': '"different"',
+      'If-None-Match': '"abc123"',
+    },
+  })
+
+  assert.equal(response.status, 412)
 })
 
 test('returns bilingual 404 and method-aware 405 responses', async () => {
   const bucket = createBucket()
 
-  const missing = await fetchDownload(bucket, '/missing.exe')
+  const missing = await fetchDownload(bucket, '/v1.4.6/missing.exe')
   const unsupported = await fetchDownload(bucket, '/index.html', {
     method: 'POST',
   })
@@ -195,9 +279,13 @@ test('returns bilingual 404 and method-aware 405 responses', async () => {
   assert.equal(bucket.getCalls.length, 1)
 })
 
-test('rejects traversal, encoded separators, malformed escapes, and NULs', async () => {
+test('restricts requests to root metadata or one app-tag asset', async () => {
   const bucket = createBucket()
   const paths = [
+    '/secret',
+    '/v1.4.6/nested/secret',
+    '/v1.4.6/../secret',
+    '/v1.4.6/%2e%2e/secret',
     '/v1.4.6/%252e%252e',
     '/v1.4.6%2Fsecret',
     '/v1.4.6/%5Csecret',

--- a/wrangler.downloads.toml
+++ b/wrangler.downloads.toml
@@ -1,0 +1,11 @@
+name = "catgo-downloads"
+main = "workers/downloads/index.mjs"
+compatibility_date = "2026-07-24"
+
+routes = [
+  { pattern = "dl.catgo-ucsd.org/*", zone_name = "catgo-ucsd.org" }
+]
+
+[[r2_buckets]]
+binding = "RELEASES"
+bucket_name = "catgo-releases"


### PR DESCRIPTION
## Summary

- add a bilingual all-platform download hub at dl.catgo-ucsd.org backed by Cloudflare Workers and R2
- stream mirrored release assets with correct HEAD, range, If-Range, ETag, cache, 404, and 405 semantics
- route in-app downloads and automatic updates through Cloudflare instead of GitHub
- harden release mirroring with deterministic manifests, checksums, draft-release gates, safe resume, and complete mirror publication

## Platforms

Windows, macOS, Linux, Android, and iOS are represented on the generated download page. Desktop and Android artifacts are direct mirrored downloads; iOS routes users to the supported distribution path.

## Verification

- Node and Worker tests: 51 passed
- Vitest: 287 files and 5,144 tests passed
- pnpm check: 0 errors (304 existing warnings)
- documentation build passed
- 14 workflow YAML files parsed successfully
- deploy build passed
- scalar, threaded, and bridge WASM artifacts verified
- Wrangler dry-run passed with the catgo-releases R2 binding
- two independent review rounds completed; all critical and important findings fixed

## Deployment and rollback

After merge, deploy the downloads Worker and mirror the latest release to R2, then verify the live root page, latest.json, resumable installer ranges, error semantics, and every platform path. Rollback is isolated: remove the Worker route or restore the previous Worker version; release metadata is only replaced after all mirrored assets succeed.