### PR TITLE
fix(ci): provision pnpm for download deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -198,6 +198,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/__tests__/deploy-cloudflare-workflow.test.mjs
+++ b/scripts/__tests__/deploy-cloudflare-workflow.test.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
+import { load as loadYaml } from 'js-yaml'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const DEPLOY_WORKFLOW = readFileSync(
@@ -12,6 +13,7 @@ const DEPLOY_WORKFLOW = readFileSync(
 const WASM_PACK_INSTALL =
   'curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh'
 const DOWNLOADS_CONFIG_PATH = resolve(ROOT, 'wrangler.downloads.toml')
+const DEPLOY_CONFIG = loadYaml(DEPLOY_WORKFLOW)
 
 test('Cloudflare app deployment installs a wasm-pack that supports feature flags', () => {
   assert.doesNotMatch(DEPLOY_WORKFLOW, /jetli\/wasm-pack-action/)
@@ -28,6 +30,20 @@ test('Cloudflare workflow deploys the download Worker', () => {
     DEPLOY_WORKFLOW,
     /command: deploy --config wrangler\.downloads\.toml/,
   )
+})
+
+test('download deployment provisions pnpm before Wrangler runs', () => {
+  const steps = DEPLOY_CONFIG.jobs['deploy-downloads'].steps
+  const pnpmIndex = steps.findIndex(
+    (step) => step.uses === 'pnpm/action-setup@v4',
+  )
+  const wranglerIndex = steps.findIndex(
+    (step) => step.uses === 'cloudflare/wrangler-action@v3',
+  )
+
+  assert.notEqual(pnpmIndex, -1, 'download deployment installs pnpm')
+  assert.notEqual(wranglerIndex, -1, 'download deployment invokes Wrangler')
+  assert.ok(pnpmIndex < wranglerIndex, 'pnpm is available before Wrangler starts')
 })
 
 test('download Worker config binds the releases bucket to the domain route', () => {


### PR DESCRIPTION
Fixes the failed dl.catgo-ucsd.org deployment by provisioning pnpm before cloudflare/wrangler-action runs. Adds a parsed-workflow regression test that fails if pnpm is absent or ordered after Wrangler. Verification: targeted workflow test, complete Node/Worker release suite (50/50), and git diff --check.