### PR TITLE
fix(downloads): return correct status for complete R2 reads

### DIFF
--- a/workers/downloads/index.mjs
+++ b/workers/downloads/index.mjs
@@ -191,8 +191,13 @@ function parseRangeHeader(value, size) {
 function responseRange(object) {
   if (
     !object.range
+    || !Number.isSafeInteger(object.size)
     || !Number.isSafeInteger(object.range.offset)
     || !Number.isSafeInteger(object.range.length)
+    || object.size < 0
+    || object.range.offset < 0
+    || object.range.length <= 0
+    || object.range.length > object.size - object.range.offset
   ) {
     return null
   }
@@ -326,6 +331,17 @@ async function serveGet(request, bucket, key) {
 
   const partial = options.range !== undefined
   const range = partial ? responseRange(object) : null
+  if (partial && range === null) {
+    try {
+      await object.body.cancel()
+    } catch {
+      // The response is already rejected; cancellation is best effort.
+    }
+    return textResponse(
+      '下载范围元数据无效 / Invalid download range metadata',
+      502,
+    )
+  }
   return new Response(object.body, {
     status: partial ? 206 : 200,
     headers: buildHeaders(object, key, range),

--- a/workers/downloads/index.mjs
+++ b/workers/downloads/index.mjs
@@ -188,20 +188,6 @@ function parseRangeHeader(value, size) {
   }
 }
 
-function responseRange(object) {
-  if (
-    !object.range
-    || !Number.isSafeInteger(object.range.offset)
-    || !Number.isSafeInteger(object.range.length)
-  ) {
-    return null
-  }
-  return {
-    offset: object.range.offset,
-    length: object.range.length,
-  }
-}
-
 function extensionForKey(key) {
   const filename = key.split('/').at(-1) ?? key
   const dot = filename.lastIndexOf('.')
@@ -324,7 +310,7 @@ async function serveGet(request, bucket, key) {
     })
   }
 
-  const range = responseRange(object)
+  const range = options.range ?? null
   return new Response(object.body, {
     status: range ? 206 : 200,
     headers: buildHeaders(object, key, range),

--- a/workers/downloads/index.mjs
+++ b/workers/downloads/index.mjs
@@ -188,6 +188,20 @@ function parseRangeHeader(value, size) {
   }
 }
 
+function responseRange(object) {
+  if (
+    !object.range
+    || !Number.isSafeInteger(object.range.offset)
+    || !Number.isSafeInteger(object.range.length)
+  ) {
+    return null
+  }
+  return {
+    offset: object.range.offset,
+    length: object.range.length,
+  }
+}
+
 function extensionForKey(key) {
   const filename = key.split('/').at(-1) ?? key
   const dot = filename.lastIndexOf('.')
@@ -310,9 +324,10 @@ async function serveGet(request, bucket, key) {
     })
   }
 
-  const range = options.range ?? null
+  const partial = options.range !== undefined
+  const range = partial ? responseRange(object) : null
   return new Response(object.body, {
-    status: range ? 206 : 200,
+    status: partial ? 206 : 200,
     headers: buildHeaders(object, key, range),
   })
 }

--- a/workers/downloads/index.test.mjs
+++ b/workers/downloads/index.test.mjs
@@ -134,6 +134,22 @@ test('forwards byte ranges to R2 and emits resumable response metadata', async (
   )
 })
 
+test('returns a complete GET response when R2 reports a full-object range', async () => {
+  const bucket = createBucket({
+    getResult: createObject({
+      body: new ReadableStream(),
+      size: 100,
+      range: { offset: 0, length: 100 },
+    }),
+  })
+
+  const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe')
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get('content-range'), null)
+  assert.equal(response.headers.get('content-length'), '100')
+})
+
 test('returns an empty 304 when an R2 conditional GET has no body', async () => {
   const bucket = createBucket({
     getResult: createObject({ body: undefined, key: 'latest.json' }),

--- a/workers/downloads/index.test.mjs
+++ b/workers/downloads/index.test.mjs
@@ -134,6 +134,25 @@ test('forwards byte ranges to R2 and emits resumable response metadata', async (
   )
 })
 
+test('uses R2 returned range metadata when the object shrinks after HEAD', async () => {
+  const bucket = createBucket({
+    headResult: createObject({ size: 100 }),
+    getResult: createObject({
+      body: new ReadableStream(),
+      size: 95,
+      range: { offset: 90, length: 5 },
+    }),
+  })
+
+  const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+    headers: { Range: 'bytes=90-' },
+  })
+
+  assert.equal(response.status, 206)
+  assert.equal(response.headers.get('content-range'), 'bytes 90-94/95')
+  assert.equal(response.headers.get('content-length'), '5')
+})
+
 test('returns a complete GET response when R2 reports a full-object range', async () => {
   const bucket = createBucket({
     getResult: createObject({

--- a/workers/downloads/index.test.mjs
+++ b/workers/downloads/index.test.mjs
@@ -153,6 +153,33 @@ test('uses R2 returned range metadata when the object shrinks after HEAD', async
   assert.equal(response.headers.get('content-length'), '5')
 })
 
+test('rejects partial bodies with missing or invalid R2 range metadata', async () => {
+  for (const range of [undefined, { offset: 90, length: 0 }]) {
+    let cancellations = 0
+    const body = new ReadableStream({
+      cancel() {
+        cancellations += 1
+      },
+    })
+    const bucket = createBucket({
+      headResult: createObject({ size: 100 }),
+      getResult: createObject({ body, size: 95, range }),
+    })
+
+    const response = await fetchDownload(bucket, '/v1.4.6/CatGo.exe', {
+      headers: { Range: 'bytes=90-' },
+    })
+
+    assert.deepEqual(bucket.getCalls[0].options.range, {
+      offset: 90,
+      length: 10,
+    })
+    assert.equal(response.status, 502)
+    assert.equal(response.headers.get('content-range'), null)
+    assert.equal(cancellations, 1)
+  }
+})
+
 test('returns a complete GET response when R2 reports a full-object range', async () => {
   const bucket = createBucket({
     getResult: createObject({


### PR DESCRIPTION
## Summary
- return 200 for ordinary GETs even when R2 reports a full-object range
- keep 206 tied to a validated Range actually sent to R2
- build partial headers from the GET response metadata and reject malformed upstream partial metadata with 502

## Root cause
R2 may populate `R2Object.range` with `{offset: 0, length: size}` for a complete read. The Worker treated any populated object range as proof that the client requested a partial response, so `/` and `/latest.json` returned 206 without a Range request.

## TDD and verification
- RED→GREEN: full-object R2 range without client Range returns 200
- RED→GREEN: HEAD→GET shrink uses returned range metadata
- RED→GREEN: missing/invalid partial metadata cancels the body and returns 502
- Worker 17/17
- full Node/Worker 55/55
- Downloads Wrangler dry-run
- two review rounds; final review clean