### PR TITLE
fix(deploy): avoid Wrangler workspace install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,16 @@ patches/*.patch text eol=lf
 *.sh text eol=lf
 
 tests/fixtures/trajectory/*.extxyz text eol=lf
+
+# Release-rights evidence hashes the shipped bytes. Keep every text file in
+# the two NOTICE_BACKED manifests byte-identical on Windows, macOS, and Linux.
+/THIRD_PARTY_NOTICES.md text eol=lf
+/server/catgo/vendor/pormake/LICENSE text eol=lf
+/server/catgo/vendor/pormake/database/**/*.cgd text eol=lf
+/server/catgo/vendor/pormake/database/**/*.xyz text eol=lf
+/server/catgo/vendor/pormake/database/**/*.txt text eol=lf
+/server/catgo/vendor/pormake/database/**/*.zip -text
+/third_party/licenses/*.txt text eol=lf
+/extensions/rust/src/**/*.rs text eol=lf
+/src/lib/structure/TerminalPanel.svelte text eol=lf
+/src/lib/xrd/*.ts text eol=lf

--- a/.github/workflows/build-vscode-sidecars.yml
+++ b/.github/workflows/build-vscode-sidecars.yml
@@ -53,6 +53,10 @@ jobs:
         shell: bash -el {0}
 
     steps:
+      - name: Preserve release evidence bytes on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -98,12 +98,8 @@ jobs:
             Cache-Control: public, max-age=0, must-revalidate
           EOF
 
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4.90.1'
-          command: deploy --config wrangler.docs.toml
+      - name: Deploy with pinned Wrangler
+        run: pnpm dlx wrangler@4.90.1 deploy --config wrangler.docs.toml
 
   deploy-app:
     name: Deploy app.catgo-ucsd.org
@@ -206,12 +202,8 @@ jobs:
             Cache-Control: public, max-age=0, must-revalidate
           EOF
 
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4.90.1'
-          command: deploy --config wrangler.app.toml
+      - name: Deploy with pinned Wrangler
+        run: pnpm dlx wrangler@4.90.1 deploy --config wrangler.app.toml
 
   deploy-downloads:
     name: Deploy dl.catgo-ucsd.org
@@ -227,9 +219,5 @@ jobs:
         with:
           version: 10.28.2
 
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4.90.1'
-          command: deploy --config wrangler.downloads.toml
+      - name: Deploy with pinned Wrangler
+        run: pnpm dlx wrangler@4.90.1 deploy --config wrangler.downloads.toml

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -5,6 +5,17 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Exact existing release tag to backfill (for example v1.4.6).'
+        type: string
+        required: false
+        default: ''
+      windows_only:
+        description: 'Build only Windows; intended for an exact-tag backfill.'
+        type: boolean
+        required: false
+        default: false
 
 env:
   CARGO_NET_RETRY: "10"
@@ -20,30 +31,14 @@ jobs:
       contents: write
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: windows-latest
-            target: x86_64-pc-windows-msvc
-            backend_target: x86_64-pc-windows-msvc
-            name: Windows
-          - platform: macos-latest
-            target: aarch64-apple-darwin
-            backend_target: aarch64-apple-darwin
-            name: macOS (Apple Silicon)
-          - platform: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            backend_target: x86_64-unknown-linux-gnu
-            name: Linux
-            # Ship .deb + .rpm. AppImage (linuxdeploy) still excluded: it needs
-            # FUSE and hangs 20+ min on GitHub runners. Tauri v2's RPM bundler is
-            # pure-Rust (no rpmbuild), so .rpm builds fine and covers Fedora/RHEL.
-            bundles: deb rpm
+      matrix: ${{ fromJSON(inputs.windows_only && '{"include":[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","backend_target":"x86_64-pc-windows-msvc","name":"Windows"}]}' || '{"include":[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","backend_target":"x86_64-pc-windows-msvc","name":"Windows"},{"platform":"macos-latest","target":"aarch64-apple-darwin","backend_target":"aarch64-apple-darwin","name":"macOS (Apple Silicon)"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","backend_target":"x86_64-unknown-linux-gnu","name":"Linux","bundles":"deb rpm"}]}') }}
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.name }})
 
     env:
       NODE_OPTIONS: --max-old-space-size=6144
+      CATGO_RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
 
     defaults:
       run:
@@ -64,10 +59,14 @@ jobs:
           sudo docker image prune --all --force 2>/dev/null || true
           echo "Disk after:"; df -h /
 
+      - name: Preserve release evidence bytes on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.ref }}
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag != '' && inputs.release_tag || github.ref }}
           fetch-depth: 0
 
       - name: Verify release rights
@@ -75,30 +74,36 @@ jobs:
 
       - name: Verify release version
         env:
-          RELEASE_VERSION_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
-          RELEASE_VERSION_REQUIRE_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
+          RELEASE_VERSION_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
+          RELEASE_VERSION_REQUIRE_TAG: ${{ startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '' }}
         run: node scripts/verify-release-version.mjs
 
       - name: Verify release source
         env:
-          RELEASE_SOURCE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
-          RELEASE_SOURCE_REQUIRE_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
+          RELEASE_SOURCE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
+          RELEASE_SOURCE_REQUIRE_TAG: ${{ startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '' }}
         run: node scripts/verify-release-source.mjs
 
       - name: Verify tag event source identity
-        if: startsWith(github.ref, 'refs/tags/')
+        if: env.CATGO_RELEASE_TAG != ''
+        env:
+          RELEASE_TAG: ${{ env.CATGO_RELEASE_TAG }}
         run: |
           set -euo pipefail
           head_commit=$(git rev-parse HEAD^{commit})
-          tag_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
-          if [ "$head_commit" != "$GITHUB_SHA" ] ||
+          tag_commit=$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "::error::Checkout does not match the requested release tag."
+            exit 1
+          fi
+          if [ "$GITHUB_EVENT_NAME" = "push" ] &&
              [ "$tag_commit" != "$GITHUB_SHA" ]; then
-            echo "::error::Tag moved after this workflow was triggered; refusing release."
+            echo "::error::Tag moved after this workflow was triggered."
             exit 1
           fi
 
       - name: Preflight macOS release signing
-        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/')
+        if: runner.os == 'macOS' && env.CATGO_RELEASE_TAG != ''
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -265,7 +270,7 @@ jobs:
           echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build Tauri app (no release)
-        if: "!startsWith(github.ref, 'refs/tags/')"
+        if: env.CATGO_RELEASE_TAG == ''
         uses: tauri-apps/tauri-action@v0.6
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
@@ -273,7 +278,7 @@ jobs:
           args: --target ${{ matrix.target }}${{ matrix.bundles && format(' --bundles {0}', matrix.bundles) || '' }}
 
       - name: Build and upload Tauri release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: env.CATGO_RELEASE_TAG != ''
         uses: tauri-apps/tauri-action@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -312,8 +317,8 @@ jobs:
           # APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
           # APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'CatGo ${{ github.ref_name }}'
+          tagName: ${{ env.CATGO_RELEASE_TAG }}
+          releaseName: 'CatGo ${{ env.CATGO_RELEASE_TAG }}'
           releaseBody: |
             ## CatGo — AI-driven workbench for computational materials science
 
@@ -364,10 +369,10 @@ jobs:
 
       - name: Verify macOS release signatures
         id: macos_signing
-        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/')
+        if: runner.os == 'macOS' && env.CATGO_RELEASE_TAG != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ env.CATGO_RELEASE_TAG }}
           REPOSITORY: ${{ github.repository }}
           MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
@@ -497,10 +502,10 @@ jobs:
           echo "attestation=$attestation" >> "$GITHUB_OUTPUT"
 
       - name: Upload macOS signing attestation
-        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/')
+        if: runner.os == 'macOS' && env.CATGO_RELEASE_TAG != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ env.CATGO_RELEASE_TAG }}
           REPOSITORY: ${{ github.repository }}
           ATTESTATION_PATH: ${{ steps.macos_signing.outputs.attestation }}
         run: |
@@ -510,18 +515,18 @@ jobs:
             --clobber
 
       - name: Finalize canonical v1.4.6 release body
-        if: startsWith(github.ref, 'refs/tags/') && github.ref_name == 'v1.4.6'
+        if: env.CATGO_RELEASE_TAG == 'v1.4.6'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/ensure-v1.4.6-release-body.sh "$GITHUB_REF_NAME"
+        run: bash scripts/ensure-v1.4.6-release-body.sh "$CATGO_RELEASE_TAG"
 
       - name: Upload canonical legal bundle to release
-        if: runner.os == 'Linux' && startsWith(github.ref, 'refs/tags/')
+        if: runner.os == 'Linux' && env.CATGO_RELEASE_TAG != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           tar czf catgo-legal-bundle.tar.gz -C build/legal-bundle .
           tar tzf catgo-legal-bundle.tar.gz
-          tag="${GITHUB_REF_NAME}"
+          tag="${CATGO_RELEASE_TAG}"
           gh release upload "$tag" catgo-legal-bundle.tar.gz --clobber

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -45,6 +45,13 @@ jobs:
         shell: bash -el {0}
 
     steps:
+      - name: Reject unsafe manual release matrix
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != '' && !inputs.windows_only
+        shell: bash
+        run: |
+          echo "::error::Exact-tag release backfills are Windows-only."
+          exit 1
+
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/scripts/__tests__/deploy-cloudflare-workflow.test.mjs
+++ b/scripts/__tests__/deploy-cloudflare-workflow.test.mjs
@@ -14,6 +14,11 @@ const WASM_PACK_INSTALL =
   'curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh'
 const DOWNLOADS_CONFIG_PATH = resolve(ROOT, 'wrangler.downloads.toml')
 const DEPLOY_CONFIG = loadYaml(DEPLOY_WORKFLOW)
+const WRANGLER_VERSION = '4.90.1'
+
+function wranglerDeployCommand(configFile) {
+  return `pnpm dlx wrangler@${WRANGLER_VERSION} deploy --config ${configFile}`
+}
 
 test('Cloudflare app deployment installs a wasm-pack that supports feature flags', () => {
   assert.doesNotMatch(DEPLOY_WORKFLOW, /jetli\/wasm-pack-action/)
@@ -28,7 +33,7 @@ test('Cloudflare workflow deploys the download Worker', () => {
   assert.match(DEPLOY_WORKFLOW, /name: Deploy dl\.catgo-ucsd\.org/)
   assert.match(
     DEPLOY_WORKFLOW,
-    /command: deploy --config wrangler\.downloads\.toml/,
+    /run: pnpm dlx wrangler@4\.90\.1 deploy --config wrangler\.downloads\.toml/,
   )
 })
 
@@ -38,7 +43,7 @@ test('download deployment provisions pnpm before Wrangler runs', () => {
     (step) => step.uses === 'pnpm/action-setup@v4',
   )
   const wranglerIndex = steps.findIndex(
-    (step) => step.uses === 'cloudflare/wrangler-action@v3',
+    (step) => step.run === wranglerDeployCommand('wrangler.downloads.toml'),
   )
 
   assert.notEqual(pnpmIndex, -1, 'download deployment installs pnpm')
@@ -47,23 +52,24 @@ test('download deployment provisions pnpm before Wrangler runs', () => {
 })
 
 test('every Cloudflare deployment pins the validated Wrangler release', () => {
-  const deployJobs = ['deploy-docs', 'deploy-app', 'deploy-downloads']
-  const wranglerSteps = deployJobs.map((jobName) => {
+  const deployJobs = new Map([
+    ['deploy-docs', 'wrangler.docs.toml'],
+    ['deploy-app', 'wrangler.app.toml'],
+    ['deploy-downloads', 'wrangler.downloads.toml'],
+  ])
+  const wranglerSteps = [...deployJobs].map(([jobName, configFile]) => {
     const steps = DEPLOY_CONFIG.jobs[jobName].steps
     const matches = steps.filter(
-      (step) => step.uses === 'cloudflare/wrangler-action@v3',
+      (step) => step.run === wranglerDeployCommand(configFile),
     )
-    assert.equal(matches.length, 1, `${jobName} has one Wrangler action`)
+    assert.equal(matches.length, 1, `${jobName} has one pinned Wrangler deploy`)
     return [jobName, matches[0]]
   })
 
   assert.equal(wranglerSteps.length, 3)
   for (const [jobName, step] of wranglerSteps) {
-    assert.equal(
-      step.with.wranglerVersion,
-      '4.90.1',
-      `${jobName} pins the validated Wrangler release`,
-    )
+    assert.match(step.run, new RegExp(`wrangler@${WRANGLER_VERSION}`))
+    assert.equal(step.uses, undefined, `${jobName} avoids action self-install`)
   }
 })
 

--- a/scripts/__tests__/macos-signing-run-provenance.test.mjs
+++ b/scripts/__tests__/macos-signing-run-provenance.test.mjs
@@ -11,23 +11,35 @@ import { dirname, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { RELEASE_TRUST_POLICY } from '../release-trust-policy.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const VERIFIER = resolve(ROOT, 'scripts/verify-macos-signing-run.mjs')
 const TRUSTED_WORKFLOW = resolve(ROOT, '.github/workflows/tauri-build.yml')
 const SOURCE_COMMIT = 'a'.repeat(40)
-const RUN_ID = '123456789'
+const V146_SOURCE_COMMIT = '06c02979b9e917011a63dcbfb09aaad7cfb9430d'
+const RUN_ID = '30209332584'
 const MACOS_JOB = 'Build (macOS (Apple Silicon))'
 const REQUIRED_STEPS = [
   'Verify macOS release signatures',
   'Upload macOS signing attestation',
 ]
+const V146_TAURI_WORKFLOW_SHA256 =
+  '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208'
 
-function successfulJob() {
+test('keeps the immutable v1.4.6 Tauri workflow in the trusted allowlist', () => {
+  assert.ok(
+    RELEASE_TRUST_POLICY.tauriReleaseWorkflowSha256s.includes(
+      V146_TAURI_WORKFLOW_SHA256,
+    ),
+  )
+})
+
+function successfulJob(sourceCommit = SOURCE_COMMIT) {
   return {
     id: 987654321,
     run_id: Number(RUN_ID),
-    head_sha: SOURCE_COMMIT,
+    head_sha: sourceCommit,
     name: MACOS_JOB,
     status: 'completed',
     conclusion: 'success',
@@ -42,10 +54,11 @@ function successfulJob() {
 
 function fixture(overrides = {}) {
   const root = mkdtempSync(resolve(tmpdir(), 'catgo-macos-run-'))
+  const sourceCommit = overrides.sourceCommit ?? SOURCE_COMMIT
   const attestation = {
     schemaVersion: 1,
     releaseTag: 'v1.4.6',
-    sourceCommit: SOURCE_COMMIT,
+    sourceCommit,
     githubRunId: RUN_ID,
     signer: 'Developer ID Application: CatGo Project (ABCDEFGHIJ)',
     teamIdentifier: 'ABCDEFGHIJ',
@@ -58,7 +71,7 @@ function fixture(overrides = {}) {
     event: 'push',
     status: 'completed',
     conclusion: 'success',
-    head_sha: SOURCE_COMMIT,
+    head_sha: sourceCommit,
     ...overrides.run,
   }
   const jobs = overrides.jobs ?? {
@@ -71,6 +84,7 @@ function fixture(overrides = {}) {
     run: resolve(root, 'run.json'),
     jobs: resolve(root, 'jobs.json'),
     targetWorkflow: resolve(root, 'tauri-build.yml'),
+    sourceCommit,
   }
   writeFileSync(paths.attestation, `${JSON.stringify(attestation)}\n`)
   writeFileSync(paths.run, `${JSON.stringify(run)}\n`)
@@ -94,12 +108,78 @@ function verify(paths) {
       '--jobs',
       paths.jobs,
       '--source-commit',
-      SOURCE_COMMIT,
+      paths.sourceCommit,
       '--target-workflow',
       paths.targetWorkflow,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   )
+}
+
+function knownV146PartialFailure(overrides = {}) {
+  const windows = {
+    id: 2,
+    run_id: Number(RUN_ID),
+    head_sha: V146_SOURCE_COMMIT,
+    name: 'Build (Windows)',
+    status: 'completed',
+    conclusion: 'failure',
+    steps: [
+      { name: 'Set up job', status: 'completed', conclusion: 'success' },
+      {
+        name: 'Checkout repository',
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        name: 'Verify release rights',
+        status: 'completed',
+        conclusion: 'failure',
+      },
+      {
+        name: 'Build and upload Tauri release',
+        status: 'completed',
+        conclusion: 'skipped',
+      },
+      {
+        name: 'Post Checkout repository',
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        name: 'Complete job',
+        status: 'completed',
+        conclusion: 'success',
+      },
+    ],
+  }
+  const linux = {
+    id: 3,
+    run_id: Number(RUN_ID),
+    head_sha: V146_SOURCE_COMMIT,
+    name: 'Build (Linux)',
+    status: 'completed',
+    conclusion: 'success',
+    steps: [],
+  }
+  const jobs = [
+    successfulJob(V146_SOURCE_COMMIT),
+    overrides.windows ?? windows,
+    overrides.linux ?? linux,
+  ]
+  return {
+    sourceCommit: V146_SOURCE_COMMIT,
+    attestation: {
+      releaseTag: 'v1.4.6',
+      ...(overrides.attestation ?? {}),
+    },
+    run: {
+      event: 'push',
+      conclusion: 'failure',
+      ...(overrides.run ?? {}),
+    },
+    jobs: { total_count: jobs.length, jobs },
+  }
 }
 
 function withFixture(overrides, assertion) {
@@ -121,6 +201,52 @@ test('accepts the exact successful macOS release job from the pinned Tauri workf
   }
 })
 
+test('accepts only the known v1.4.6 Windows rights preflight matrix failure', () => {
+  withFixture(knownV146PartialFailure(), (result) => {
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+  })
+})
+
+test('rejects mutations of the known v1.4.6 partial-failure envelope', async (t) => {
+  const base = knownV146PartialFailure()
+  const windows = base.jobs.jobs[1]
+  const linux = base.jobs.jobs[2]
+  const cases = [
+    knownV146PartialFailure({
+      windows: { ...windows, name: 'Build (Windows forged)' },
+    }),
+    knownV146PartialFailure({
+      windows: {
+        ...windows,
+        steps: windows.steps.map((step) =>
+          step.conclusion === 'failure'
+            ? { ...step, name: 'Build and upload Tauri release' }
+            : step,
+        ),
+      },
+    }),
+    knownV146PartialFailure({
+      linux: { ...linux, conclusion: 'failure' },
+    }),
+    knownV146PartialFailure({
+      attestation: { releaseTag: 'v1.4.7' },
+    }),
+    knownV146PartialFailure({
+      run: { event: 'workflow_dispatch' },
+    }),
+    knownV146PartialFailure({
+      run: { head_sha: 'b'.repeat(40) },
+    }),
+  ]
+  for (const [index, candidate] of cases.entries()) {
+    await t.test(String(index), () => {
+      withFixture(candidate, (result) => {
+        assert.notEqual(result.status, 0)
+      })
+    })
+  }
+})
+
 test('rejects a run id, workflow path, source commit, or result outside the attestation', async (t) => {
   const failures = [
     [{ run: { id: 111111111 } }, /run id.*attestation/i],
@@ -129,7 +255,10 @@ test('rejects a run id, workflow path, source commit, or result outside the atte
       /workflow.*tauri-build\.yml/i,
     ],
     [{ run: { head_sha: 'b'.repeat(40) } }, /head_sha.*source commit/i],
-    [{ run: { conclusion: 'failure' } }, /conclusion.*success/i],
+    [
+      { run: { conclusion: 'failure' } },
+      /success or match the exact v1\.4\.6/i,
+    ],
     [{ run: { event: 'schedule' } }, /push or workflow_dispatch/i],
   ]
   for (const [index, [overrides, message]] of failures.entries()) {

--- a/scripts/__tests__/release-body.test.mjs
+++ b/scripts/__tests__/release-body.test.mjs
@@ -105,5 +105,5 @@ test('Tauri workflow finalizes the canonical body after tauri-action', () => {
   assert.ok(action >= 0)
   assert.ok(finalize > action)
   const block = WORKFLOW.slice(finalize)
-  assert.match(block, /scripts\/ensure-v1\.4\.6-release-body\.sh "\$GITHUB_REF_NAME"/)
+  assert.match(block, /scripts\/ensure-v1\.4\.6-release-body\.sh "\$CATGO_RELEASE_TAG"/)
 })

--- a/scripts/__tests__/release-rights-verifier.test.mjs
+++ b/scripts/__tests__/release-rights-verifier.test.mjs
@@ -168,6 +168,28 @@ test("the repository's notice-backed provenance ledgers are both release-verifia
   assert.match(result.stdout, /VERIFIED: 2 ledgers/i)
 })
 
+test('release-evidence text bytes are pinned to LF on every checkout platform', () => {
+  const attributes = readFileSync(resolve(ROOT, '.gitattributes'), 'utf8')
+  for (const pattern of [
+    '/THIRD_PARTY_NOTICES.md text eol=lf',
+    '/server/catgo/vendor/pormake/LICENSE text eol=lf',
+    '/server/catgo/vendor/pormake/database/**/*.cgd text eol=lf',
+    '/server/catgo/vendor/pormake/database/**/*.xyz text eol=lf',
+    '/server/catgo/vendor/pormake/database/**/*.txt text eol=lf',
+    '/server/catgo/vendor/pormake/database/**/*.zip -text',
+    '/third_party/licenses/*.txt text eol=lf',
+    '/extensions/rust/src/**/*.rs text eol=lf',
+    '/src/lib/structure/TerminalPanel.svelte text eol=lf',
+    '/src/lib/xrd/*.ts text eol=lf',
+  ]) {
+    assert.match(
+      attributes,
+      new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
+      `${pattern} must remain checkout-stable`,
+    )
+  }
+})
+
 test('blocks NOTICE_BACKED when covered bytes no longer match release evidence', () => {
   const root = fixture({})
   writeFixture(root, 'third_party/licenses/component-MIT.txt', 'MIT\n')

--- a/scripts/__tests__/release-rights-workflows.test.mjs
+++ b/scripts/__tests__/release-rights-workflows.test.mjs
@@ -32,7 +32,7 @@ const RELEASE_JOBS = {
 }
 
 const PUBLICATION_SIGNAL =
-  /(?:gh release (?:create|upload)|aws s3 (?:sync|cp)|xcrun altool|vsce publish|ovsx publish)/
+  /(?:gh release (?:create|upload)|aws s3 (?:sync|cp)|xcrun altool|vsce publish|ovsx publish|pnpm dlx wrangler@\S+ deploy)/
 const PUBLICATION_ACTION =
   /(?:actions\/upload-artifact|cloudflare\/wrangler-action|docker\/build-push-action|pypa\/gh-action-pypi-publish|softprops\/action-gh-release|tauri-apps\/tauri-action)/
 

--- a/scripts/__tests__/release-source-workflows.test.mjs
+++ b/scripts/__tests__/release-source-workflows.test.mjs
@@ -170,6 +170,9 @@ test('Windows release publishers disable CRLF conversion before checkout', () =>
 test('desktop workflow can backfill only Windows from an exact release tag', () => {
   const parsed = workflow('tauri-build.yml')
   const dispatch = parsed.on.workflow_dispatch
+  const guard = parsed.jobs.build.steps.find(
+    (step) => step.name === 'Reject unsafe manual release matrix',
+  )
 
   assert.equal(dispatch.inputs.release_tag.type, 'string')
   assert.equal(dispatch.inputs.release_tag.required, false)
@@ -177,6 +180,13 @@ test('desktop workflow can backfill only Windows from an exact release tag', () 
   assert.equal(dispatch.inputs.windows_only.default, false)
   assert.match(String(parsed.jobs.build.strategy.matrix), /inputs\.windows_only/)
   assert.match(String(parsed.jobs.build.strategy.matrix), /windows-latest/)
+  assert.ok(guard)
+  assert.equal(
+    guard.if,
+    "github.event_name == 'workflow_dispatch' && inputs.release_tag != '' && !inputs.windows_only",
+  )
+  assert.match(guard.run, /Windows-only/)
+  assert.match(guard.run, /exit 1/)
 })
 
 test('path-filtered release workflows watch the shared source verifier', () => {

--- a/scripts/__tests__/release-source-workflows.test.mjs
+++ b/scripts/__tests__/release-source-workflows.test.mjs
@@ -19,10 +19,11 @@ const RELEASE_WORKFLOWS = [
     file: 'tauri-build.yml',
     job: 'build',
     checkoutRef:
-      "${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.ref }}",
+      "${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag != '' && inputs.release_tag || github.ref }}",
     tag:
-      "${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}",
-    requireTag: "${{ startsWith(github.ref, 'refs/tags/') }}",
+      "${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}",
+    requireTag:
+      "${{ startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '' }}",
   },
   {
     file: 'android-build.yml',
@@ -142,6 +143,40 @@ test('Android release signing verifies validity and the approved signer identity
     /build `main` and upload the APK to an existing release tag/,
     'comments must not endorse building a different source for a release',
   )
+})
+
+test('Windows release publishers disable CRLF conversion before checkout', () => {
+  for (const [file, job] of [
+    ['tauri-build.yml', 'build'],
+    ['build-vscode-sidecars.yml', 'build'],
+  ]) {
+    const steps = workflow(file).jobs[job].steps
+    const checkoutIndex = steps.findIndex((step) =>
+      String(step.uses ?? '').startsWith('actions/checkout@'),
+    )
+    const checkoutPolicyIndex = steps.findIndex(
+      (step) =>
+        step.if === "runner.os == 'Windows'" &&
+        step.run === 'git config --global core.autocrlf false',
+    )
+
+    assert.ok(
+      checkoutPolicyIndex >= 0 && checkoutPolicyIndex < checkoutIndex,
+      `${file} must preserve release-evidence bytes before Windows checkout`,
+    )
+  }
+})
+
+test('desktop workflow can backfill only Windows from an exact release tag', () => {
+  const parsed = workflow('tauri-build.yml')
+  const dispatch = parsed.on.workflow_dispatch
+
+  assert.equal(dispatch.inputs.release_tag.type, 'string')
+  assert.equal(dispatch.inputs.release_tag.required, false)
+  assert.equal(dispatch.inputs.windows_only.type, 'boolean')
+  assert.equal(dispatch.inputs.windows_only.default, false)
+  assert.match(String(parsed.jobs.build.strategy.matrix), /inputs\.windows_only/)
+  assert.match(String(parsed.jobs.build.strategy.matrix), /windows-latest/)
 })
 
 test('path-filtered release workflows watch the shared source verifier', () => {

--- a/scripts/__tests__/tauri-macos-signing-workflow.test.mjs
+++ b/scripts/__tests__/tauri-macos-signing-workflow.test.mjs
@@ -9,7 +9,7 @@ import { load as loadYaml } from 'js-yaml'
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const WORKFLOW_PATH = resolve(ROOT, '.github/workflows/tauri-build.yml')
 const RELEASE_MACOS_CONDITION =
-  "runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/')"
+  "runner.os == 'macOS' && env.CATGO_RELEASE_TAG != ''"
 const REQUIRED_SIGNING_SECRETS = [
   'TAURI_SIGNING_PRIVATE_KEY',
   'TAURI_SIGNING_PRIVATE_KEY_PASSWORD',
@@ -39,35 +39,36 @@ test('branch dispatch is smoke-only while tag push or dispatch publishes exact s
   const smoke = stepNamed(steps, 'Build Tauri app (no release)')
   const release = stepNamed(steps, 'Build and upload Tauri release')
 
-  assert.equal(current.on.workflow_dispatch?.inputs?.release, undefined)
+  assert.equal(current.on.workflow_dispatch.inputs.release_tag.type, 'string')
+  assert.equal(current.on.workflow_dispatch.inputs.windows_only.type, 'boolean')
   assert.ok(sourceGate)
   assert.equal(
     sourceGate.env.RELEASE_SOURCE_TAG,
-    "${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}",
+    "${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}",
   )
   assert.equal(
     sourceGate.env.RELEASE_SOURCE_REQUIRE_TAG,
-    "${{ startsWith(github.ref, 'refs/tags/') }}",
+    "${{ startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '' }}",
   )
   assert.ok(eventIdentity)
-  assert.equal(eventIdentity.if, "startsWith(github.ref, 'refs/tags/')")
+  assert.equal(eventIdentity.if, "env.CATGO_RELEASE_TAG != ''")
   assert.match(eventIdentity.run, /git rev-parse HEAD\^\{commit\}/)
-  assert.match(eventIdentity.run, /git rev-parse "refs\/tags\/\$GITHUB_REF_NAME\^\{commit\}"/)
+  assert.match(eventIdentity.run, /git rev-parse "refs\/tags\/\$RELEASE_TAG\^\{commit\}"/)
   assert.match(eventIdentity.run, /GITHUB_SHA/)
 
   assert.ok(smoke)
   assert.equal(
     smoke.if,
-    "!startsWith(github.ref, 'refs/tags/')",
+    "env.CATGO_RELEASE_TAG == ''",
   )
   assert.deepEqual(Object.keys(smoke.with).sort(), ['args'])
 
   assert.ok(release)
   assert.equal(
     release.if,
-    "startsWith(github.ref, 'refs/tags/')",
+    "env.CATGO_RELEASE_TAG != ''",
   )
-  assert.equal(release.with.tagName, '${{ github.ref_name }}')
+  assert.equal(release.with.tagName, '${{ env.CATGO_RELEASE_TAG }}')
   assert.equal(release.with.releaseDraft, true)
 })
 

--- a/scripts/__tests__/version-consistency.test.mjs
+++ b/scripts/__tests__/version-consistency.test.mjs
@@ -99,7 +99,7 @@ const WORKFLOW_INVENTORY = {
   },
 }
 const PUBLISHER_SIGNAL =
-  /softprops\/action-gh-release|gh release (?:create|edit|upload)|tauri-apps\/tauri-action|gh-action-pypi-publish|vsce publish|ovsx publish|docker\/build-push-action|cloudflare\/wrangler-action|xcrun altool|aws s3 sync/
+  /softprops\/action-gh-release|gh release (?:create|edit|upload)|tauri-apps\/tauri-action|gh-action-pypi-publish|vsce publish|ovsx publish|docker\/build-push-action|cloudflare\/wrangler-action|pnpm dlx wrangler@\S+ deploy|xcrun altool|aws s3 sync/
 const activeWorkflowSource = (path) =>
   source(path)
     .split('\n')

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -1,8 +1,10 @@
 export const RELEASE_TRUST_POLICY = Object.freeze({
   iosBuildWorkflowSha256:
     '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0',
-  tauriReleaseWorkflowSha256:
-    'c964525893ee143045c357a959cb3d47451152ae4175628d83418bb98983491b',
+  tauriReleaseWorkflowSha256s: Object.freeze([
+    '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',
+    '6dff73ab93babff2d03a2a313330e1bd981c47ab3bcf72687352daa7e7eaf46b',
+  ]),
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',
 })

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -2,7 +2,7 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
   iosBuildWorkflowSha256:
     '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0',
   tauriReleaseWorkflowSha256:
-    '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',
+    'c964525893ee143045c357a959cb3d47451152ae4175628d83418bb98983491b',
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',
 })

--- a/scripts/verify-legal-distributions.mjs
+++ b/scripts/verify-legal-distributions.mjs
@@ -56,7 +56,7 @@ const INTERNAL_ARTIFACT_WORKFLOWS = new Set([
 ])
 
 const DISTRIBUTION_MARKER =
-  /upload-artifact|gh release upload|action-gh-release|tauri-action|gh-action-pypi-publish|vsce publish|ovsx publish|build-push-action|wrangler-action|aws s3 sync/
+  /upload-artifact|gh release upload|action-gh-release|tauri-action|gh-action-pypi-publish|vsce publish|ovsx publish|build-push-action|wrangler-action|pnpm dlx wrangler@\S+ deploy|aws s3 sync/
 
 const read = (path) => readFileSync(resolve(ROOT, path), 'utf8')
 const CITATION_REQUEST =

--- a/scripts/verify-macos-signing-run.mjs
+++ b/scripts/verify-macos-signing-run.mjs
@@ -11,6 +11,12 @@ const RUN_ID_PATTERN = /^[1-9]\d*$/
 const SHA256_PATTERN = /^[0-9a-f]{64}$/
 const TAURI_WORKFLOW_PATH = '.github/workflows/tauri-build.yml'
 const MACOS_JOB_NAME = 'Build (macOS (Apple Silicon))'
+const LINUX_JOB_NAME = 'Build (Linux)'
+const WINDOWS_JOB_NAME = 'Build (Windows)'
+const V146_TAG = 'v1.4.6'
+const V146_SOURCE_COMMIT = '06c02979b9e917011a63dcbfb09aaad7cfb9430d'
+const V146_RUN_ID = '30209332584'
+const V146_WINDOWS_FAILURE_STEP = 'Verify release rights'
 const REQUIRED_STEPS = [
   'Verify macOS release signatures',
   'Upload macOS signing attestation',
@@ -76,13 +82,19 @@ function readJsonFile(path, kind) {
 }
 
 function verifyWorkflowHash(path) {
-  const approved = RELEASE_TRUST_POLICY.tauriReleaseWorkflowSha256
-  if (typeof approved !== 'string' || !SHA256_PATTERN.test(approved)) {
-    throw new Error('Trusted release policy has no valid Tauri workflow SHA-256')
+  const approved = RELEASE_TRUST_POLICY.tauriReleaseWorkflowSha256s
+  if (
+    !Array.isArray(approved) ||
+    approved.length === 0 ||
+    approved.some((digest) => !SHA256_PATTERN.test(digest))
+  ) {
+    throw new Error(
+      'Trusted release policy has no valid Tauri workflow SHA-256 allowlist',
+    )
   }
   const contents = readRegularFile(path, 'Target Tauri workflow', 512 * 1024)
   const actual = createHash('sha256').update(contents).digest('hex')
-  if (actual !== approved) {
+  if (!approved.includes(actual)) {
     throw new Error(
       'Target Tauri workflow SHA-256 does not match the trusted release policy',
     )
@@ -130,6 +142,85 @@ function verifyMacosJob(jobs, runId, sourceCommit) {
   for (const name of REQUIRED_STEPS) verifySuccessfulStep(job, name)
 }
 
+function verifyKnownV146WindowsPreflightFailure({
+  attestation,
+  run,
+  jobs,
+  runId,
+  sourceCommit,
+}) {
+  if (
+    attestation.releaseTag !== V146_TAG ||
+    sourceCommit !== V146_SOURCE_COMMIT ||
+    runId !== V146_RUN_ID ||
+    run.event !== 'push' ||
+    run.status !== 'completed' ||
+    run.conclusion !== 'failure'
+  ) {
+    return false
+  }
+
+  const expectedNames = [MACOS_JOB_NAME, LINUX_JOB_NAME, WINDOWS_JOB_NAME]
+  if (
+    jobs.length !== expectedNames.length ||
+    expectedNames.some(
+      (name) => jobs.filter((job) => job?.name === name).length !== 1,
+    )
+  ) {
+    throw new Error(
+      'Known v1.4.6 partial failure must contain exactly the macOS, Linux, and Windows jobs',
+    )
+  }
+  for (const job of jobs) {
+    if (
+      job.status !== 'completed' ||
+      String(job.run_id) !== runId ||
+      job.head_sha !== sourceCommit
+    ) {
+      throw new Error(
+        'Known v1.4.6 partial-failure job identity does not match the release run',
+      )
+    }
+  }
+
+  verifyMacosJob(jobs, runId, sourceCommit)
+  const linux = jobs.find((job) => job.name === LINUX_JOB_NAME)
+  if (linux.conclusion !== 'success') {
+    throw new Error('Known v1.4.6 Linux release job must complete with success')
+  }
+
+  const windows = jobs.find((job) => job.name === WINDOWS_JOB_NAME)
+  if (windows.conclusion !== 'failure') {
+    throw new Error('Known v1.4.6 Windows release job must be the failed job')
+  }
+  const failedSteps = jobs.flatMap((job) =>
+    (job.steps ?? []).filter((step) => step?.conclusion === 'failure'),
+  )
+  if (
+    failedSteps.length !== 1 ||
+    failedSteps[0].name !== V146_WINDOWS_FAILURE_STEP ||
+    failedSteps[0].status !== 'completed'
+  ) {
+    throw new Error(
+      'Known v1.4.6 run must fail only at the Windows release-rights preflight',
+    )
+  }
+  const failureIndex = windows.steps.findIndex(
+    (step) => step?.name === V146_WINDOWS_FAILURE_STEP,
+  )
+  for (const step of windows.steps.slice(failureIndex + 1)) {
+    const allowedEpilogue =
+      (step.name?.startsWith('Post ') || step.name === 'Complete job') &&
+      step.conclusion === 'success'
+    if (step.conclusion !== 'skipped' && !allowedEpilogue) {
+      throw new Error(
+        'Known v1.4.6 Windows build and upload steps after the preflight must be skipped',
+      )
+    }
+  }
+  return true
+}
+
 function verifyRunProvenance({
   attestationPath,
   runPath,
@@ -168,20 +259,29 @@ function verifyRunProvenance({
       'GitHub Actions run event must be push or workflow_dispatch',
     )
   }
-  if (
-    run.status !== 'completed' ||
-    run.conclusion !== 'success'
-  ) {
-    throw new Error(
-      'GitHub Actions run must be completed with conclusion success',
-    )
+  if (run.status !== 'completed') {
+    throw new Error('GitHub Actions run must be completed')
   }
   if (run.head_sha !== sourceCommit) {
     throw new Error(
       'GitHub Actions run head_sha does not match the source commit',
     )
   }
-  verifyMacosJob(jobs, attestation.githubRunId, sourceCommit)
+  if (run.conclusion === 'success') {
+    verifyMacosJob(jobs, attestation.githubRunId, sourceCommit)
+  } else if (
+    !verifyKnownV146WindowsPreflightFailure({
+      attestation,
+      run,
+      jobs,
+      runId: attestation.githubRunId,
+      sourceCommit,
+    })
+  ) {
+    throw new Error(
+      'GitHub Actions run must complete with success or match the exact v1.4.6 Windows rights-preflight exception',
+    )
+  }
   return { runId: attestation.githubRunId, sourceCommit }
 }
 


### PR DESCRIPTION
## Summary

- deploy all three Cloudflare Workers with pinned Wrangler 4.90.1 via pnpm dlx
- avoid wrangler-action attempting a workspace-root pnpm add
- preserve release-rights evidence bytes on Windows before checkout
- support a Windows-only exact-tag desktop backfill without moving v1.4.6
- pin NOTICE-backed text evidence to LF across platforms
- preserve both the immutable v1.4.6 Tauri workflow trust hash and the reviewed backfill workflow hash
- accept the original failed matrix only through a run-id/tag/commit/job/step-specific v1.4.6 provenance exception

## Root causes

1. wrangler-action inferred pnpm and attempted to add Wrangler at the workspace root; pnpm 10 rejected that with ERR_PNPM_ADDING_TO_ROOT.
2. Windows checkout converted release-evidence files from LF to CRLF; paths and counts stayed correct but both NOTICE-backed manifest hashes changed.
3. The original v1.4.6 Tauri matrix is aggregate-failed even though macOS and Linux succeed; provenance now admits only that exact run when Windows uniquely fails at Verify release rights and all later Windows build/upload steps are skipped.

## Verification

- TDD RED captured Cloudflare, Windows evidence/backfill, immutable trust, and narrow provenance contracts before implementation
- 335/335 Node tests passed
- release-rights verifier passed: 2 ledgers
- legal-distribution verifier passed: 10 contracts and 27 required files
- Wrangler 4.90.1 downloads Worker dry-run passed with the R2 binding
- git diff --check passed
- exact Windows CRLF failure reproduced locally; core.autocrlf=false verified the unchanged v1.4.6 tag successfully