### PR TITLE
fix(release): recover iOS and Windows sidecar

### DIFF
--- a/.github/workflows/build-vscode-sidecars.yml
+++ b/.github/workflows/build-vscode-sidecars.yml
@@ -131,7 +131,11 @@ jobs:
               echo "::error::${{ matrix.asset_name }} is missing embedded legal/$rel"
               exit 1
             fi
-          done < <(find build/legal-bundle -type f | sort)
+          done < <(
+            find build/legal-bundle -type f \
+              ! -name '.catgo-legal-bundle-owned' |
+              sort
+          )
 
       - name: Generate SHA-256 checksum
         run: |

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -203,11 +203,23 @@ jobs:
           gh api --paginate --slurp \
             "repos/$REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
             > "$jobs_json"
+          run_head_sha=$(jq -er \
+            '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+            "$run_json")
+          run_source=$(mktemp -d)
+          mkdir -p "$run_source/.github/workflows"
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/$REPOSITORY/contents/.github/workflows/ios-build.yml?ref=$run_head_sha" \
+            > "$run_source/.github/workflows/ios-build.yml"
+          node scripts/verify-trusted-ios-workflow.mjs \
+            --source-root "$run_source"
           node scripts/verify-ios-testflight-run.mjs \
             --attestation "$attestation" \
             --run "$run_json" \
             --jobs "$jobs_json" \
-            --source-commit "$RELEASE_SOURCE_COMMIT"
+            --source-commit "$RELEASE_SOURCE_COMMIT" \
+            --run-workflow "$run_source/.github/workflows/ios-build.yml"
 
   promote-cloudflare:
     name: Promote verified release to Cloudflare

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -28,10 +28,15 @@ on:
         type: boolean
         default: false
       release_tag:
-        description: 'Required for TestFlight; run the workflow from this same tag so GITHUB_SHA matches it (for example, v1.4.6)'
+        description: 'Exact release tag to build and upload (for example, v1.4.6)'
         type: string
         required: false
         default: ''
+      exact_tag_backfill:
+        description: 'Run the trusted main workflow while building the exact release tag source'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   ios:
@@ -73,15 +78,34 @@ jobs:
       - name: Record exact release source
         id: release_source
         env:
+          ALLOW_EXACT_TAG_BACKFILL: ${{ inputs.exact_tag_backfill }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
           REQUIRE_EVENT_SHA: ${{ inputs.upload }}
+          V146_SOURCE_COMMIT: 06c02979b9e917011a63dcbfb09aaad7cfb9430d
+          V146_TAG: v1.4.6
         run: |
           set -euo pipefail
           source_commit=$(git rev-parse HEAD)
-          if [ "$REQUIRE_EVENT_SHA" = "true" ] && [ "$source_commit" != "$GITHUB_SHA" ]; then
-            echo "::error::For a TestFlight upload, dispatch this workflow from the exact release tag so GITHUB_SHA matches the checked-out tag commit."
-            exit 1
+          if [ "$REQUIRE_EVENT_SHA" = "true" ]; then
+            tag_commit=$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")
+            if [ "$source_commit" != "$tag_commit" ]; then
+              echo "::error::Checked-out source is not the requested release tag."
+              exit 1
+            fi
+            if [ "$source_commit" != "$GITHUB_SHA" ] &&
+               { [ "$ALLOW_EXACT_TAG_BACKFILL" != "true" ] ||
+                 [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ] ||
+                 [ "$RELEASE_TAG" != "$V146_TAG" ] ||
+                 [ "$source_commit" != "$V146_SOURCE_COMMIT" ]; }; then
+              echo "::error::TestFlight source differs from GITHUB_SHA outside a trusted default-branch exact-tag backfill."
+              exit 1
+            fi
           fi
           echo "commit=$source_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Stage legal bundle for iOS resources
+        run: node scripts/sync-legal-bundle.mjs
 
       - name: Select Xcode 26 (iOS 26 SDK)
         # App Store Connect now rejects uploads built with the iOS 18.5 SDK —
@@ -323,10 +347,14 @@ jobs:
     permissions:
       contents: write
     env:
+      ALLOW_EXACT_TAG_BACKFILL: ${{ inputs.exact_tag_backfill }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_TAG: ${{ inputs.release_tag }}
       RELEASE_SOURCE_COMMIT: ${{ needs.ios.outputs.source_commit }}
       REPOSITORY: ${{ github.repository }}
+      V146_SOURCE_COMMIT: 06c02979b9e917011a63dcbfb09aaad7cfb9430d
+      V146_TAG: v1.4.6
     steps:
       - name: Confirm matching release is a draft
         run: |
@@ -336,8 +364,17 @@ jobs:
             exit 1
           fi
           if ! [[ "$RELEASE_SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] ||
-             [ "$RELEASE_SOURCE_COMMIT" != "$GITHUB_SHA" ]; then
-            echo "::error::TestFlight source is not the exact GITHUB_SHA."
+             [ "$RELEASE_SOURCE_COMMIT" != \
+               "$(gh api "repos/$REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" ]; then
+            echo "::error::TestFlight source is not the exact release tag commit."
+            exit 1
+          fi
+          if [ "$RELEASE_SOURCE_COMMIT" != "$GITHUB_SHA" ] &&
+             { [ "$ALLOW_EXACT_TAG_BACKFILL" != "true" ] ||
+               [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ] ||
+               [ "$RELEASE_TAG" != "$V146_TAG" ] ||
+               [ "$RELEASE_SOURCE_COMMIT" != "$V146_SOURCE_COMMIT" ]; }; then
+            echo "::error::Untrusted TestFlight exact-tag backfill context."
             exit 1
           fi
           draft=$(gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')
@@ -352,7 +389,7 @@ jobs:
           attestation="catgo-ios-testflight-${RELEASE_TAG}.json"
           jq -n \
             --arg releaseTag "$RELEASE_TAG" \
-            --arg sourceCommit "$GITHUB_SHA" \
+            --arg sourceCommit "$RELEASE_SOURCE_COMMIT" \
             --arg githubRunId "$GITHUB_RUN_ID" \
             '{
               "schemaVersion": 1,

--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -636,11 +636,23 @@ jobs:
           gh api --paginate --slurp \
             "repos/$REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
             > "$jobs_json"
+          run_head_sha=$(jq -er \
+            '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+            "$run_json")
+          run_source=$(mktemp -d)
+          mkdir -p "$run_source/.github/workflows"
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/$REPOSITORY/contents/.github/workflows/ios-build.yml?ref=$run_head_sha" \
+            > "$run_source/.github/workflows/ios-build.yml"
+          node scripts/verify-trusted-ios-workflow.mjs \
+            --source-root "$run_source"
           node scripts/verify-ios-testflight-run.mjs \
             --attestation "$attestation" \
             --run "$run_json" \
             --jobs "$jobs_json" \
-            --source-commit "$source_commit"
+            --source-commit "$source_commit" \
+            --run-workflow "$run_source/.github/workflows/ios-build.yml"
 
       - name: Generate index.html download page
         if: >-

--- a/scripts/__tests__/ios-testflight-run-provenance.test.mjs
+++ b/scripts/__tests__/ios-testflight-run-provenance.test.mjs
@@ -1,5 +1,11 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -8,7 +14,10 @@ import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const VERIFIER = resolve(ROOT, 'scripts/verify-ios-testflight-run.mjs')
-const SOURCE_COMMIT = 'a'.repeat(40)
+const IOS_WORKFLOW = resolve(ROOT, '.github/workflows/ios-build.yml')
+const SOURCE_COMMIT = '06c02979b9e917011a63dcbfb09aaad7cfb9430d'
+const RUN_HEAD_COMMIT = 'b'.repeat(40)
+const RUN_ID = 123456789
 
 function fixture(overrides = {}) {
   const root = mkdtempSync(resolve(tmpdir(), 'catgo-ios-run-'))
@@ -16,26 +25,34 @@ function fixture(overrides = {}) {
     schemaVersion: 1,
     releaseTag: 'v1.4.6',
     sourceCommit: SOURCE_COMMIT,
-    githubRunId: '123456789',
+    githubRunId: String(RUN_ID),
     status: 'accepted',
     ...overrides.attestation,
   }
   const run = {
-    id: 123456789,
+    id: RUN_ID,
     path: '.github/workflows/ios-build.yml',
     event: 'workflow_dispatch',
     status: 'completed',
     conclusion: 'success',
     head_sha: SOURCE_COMMIT,
+    head_branch: 'v1.4.6',
     ...overrides.run,
   }
   const jobs = {
     jobs: [
       {
         name: 'Build iOS app',
+        run_id: RUN_ID,
+        head_sha: overrides.run?.head_sha ?? SOURCE_COMMIT,
         status: 'completed',
         conclusion: 'success',
         steps: [
+          {
+            name: 'Record exact release source',
+            status: 'completed',
+            conclusion: 'success',
+          },
           {
             name: 'Upload to App Store Connect (TestFlight)',
             status: 'completed',
@@ -45,6 +62,8 @@ function fixture(overrides = {}) {
       },
       {
         name: 'Attach TestFlight acceptance attestation',
+        run_id: RUN_ID,
+        head_sha: overrides.run?.head_sha ?? SOURCE_COMMIT,
         status: 'completed',
         conclusion: 'success',
         steps: [
@@ -58,15 +77,24 @@ function fixture(overrides = {}) {
     ],
     ...overrides.jobs,
   }
+  for (const job of jobs.jobs ?? []) {
+    job.run_id ??= RUN_ID
+    job.head_sha ??= run.head_sha
+  }
   const paths = {
     root,
     attestation: resolve(root, 'attestation.json'),
     run: resolve(root, 'run.json'),
     jobs: resolve(root, 'jobs.json'),
+    runWorkflow: resolve(root, 'ios-build.yml'),
   }
   writeFileSync(paths.attestation, `${JSON.stringify(attestation)}\n`)
   writeFileSync(paths.run, `${JSON.stringify(run)}\n`)
   writeFileSync(paths.jobs, `${JSON.stringify(jobs)}\n`)
+  copyFileSync(IOS_WORKFLOW, paths.runWorkflow)
+  if (overrides.runWorkflow) {
+    writeFileSync(paths.runWorkflow, overrides.runWorkflow)
+  }
   return paths
 }
 
@@ -83,6 +111,8 @@ function verify(paths) {
       paths.jobs,
       '--source-commit',
       SOURCE_COMMIT,
+      '--run-workflow',
+      paths.runWorkflow,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   )
@@ -101,6 +131,59 @@ test('accepts a successful ios-build run bound to the attested source commit', (
   withFixture({}, (result) => {
     assert.equal(result.status, 0, result.stderr || result.stdout)
   })
+})
+
+test('accepts a trusted main-workflow run that checks out the exact release source', () => {
+  withFixture(
+    { run: { head_sha: RUN_HEAD_COMMIT, head_branch: 'main' } },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+    },
+  )
+})
+
+test('rejects a main backfill whose executed workflow bytes are not trusted', () => {
+  withFixture(
+    {
+      run: { head_sha: RUN_HEAD_COMMIT, head_branch: 'main' },
+      runWorkflow: '# forged iOS workflow\n',
+    },
+    (result) => {
+      assert.notEqual(result.status, 0)
+      assert.match(result.stderr, /workflow.*trusted|hash/i)
+    },
+  )
+})
+
+test('rejects a split-source backfill outside main', () => {
+  withFixture(
+    { run: { head_sha: RUN_HEAD_COMMIT, head_branch: 'release-helper' } },
+    (result) => {
+      assert.notEqual(result.status, 0)
+      assert.match(result.stderr, /head_sha.*source commit/i)
+    },
+  )
+})
+
+test('rejects iOS proof jobs from another run or head commit', async (t) => {
+  for (const [index, mutation] of [
+    { run_id: 987654321 },
+    { head_sha: 'd'.repeat(40) },
+  ].entries()) {
+    await t.test(String(index), () => {
+      const paths = fixture()
+      try {
+        const jobs = JSON.parse(readFileSync(paths.jobs, 'utf8'))
+        Object.assign(jobs.jobs[0], mutation)
+        writeFileSync(paths.jobs, `${JSON.stringify(jobs)}\n`)
+        const result = verify(paths)
+        assert.notEqual(result.status, 0)
+        assert.match(result.stderr, /mismatched provenance/i)
+      } finally {
+        rmSync(paths.root, { recursive: true, force: true })
+      }
+    })
+  }
 })
 
 test('rejects a run id that does not match the attestation', () => {
@@ -127,15 +210,31 @@ test('rejects a run whose conclusion or source commit is not exact', async (t) =
       assert.match(result.stderr, /conclusion.*success/i)
     })
   })
-  await t.test('wrong source commit', () => {
-    withFixture({ run: { head_sha: 'b'.repeat(40) } }, (result) => {
+  await t.test('wrong attested source commit', () => {
+    withFixture({ attestation: { sourceCommit: 'c'.repeat(40) } }, (result) => {
       assert.notEqual(result.status, 0)
-      assert.match(result.stderr, /head_sha.*source commit/i)
+      assert.match(result.stderr, /attestation source commit/i)
     })
   })
 })
 
 test('rejects missing, skipped, or failed TestFlight proof steps', async (t) => {
+  await t.test('missing exact-source proof', () => {
+    const paths = fixture()
+    try {
+      const jobs = JSON.parse(readFileSync(paths.jobs, 'utf8'))
+      jobs.jobs[0].steps = jobs.jobs[0].steps.filter(
+        (step) => step.name !== 'Record exact release source',
+      )
+      writeFileSync(paths.jobs, `${JSON.stringify(jobs)}\n`)
+      const result = verify(paths)
+      assert.notEqual(result.status, 0)
+      assert.match(result.stderr, /Record exact release source.*success/i)
+    } finally {
+      rmSync(paths.root, { recursive: true, force: true })
+    }
+  })
+
   await t.test('missing TestFlight upload', () => {
     withFixture(
       {
@@ -145,7 +244,13 @@ test('rejects missing, skipped, or failed TestFlight proof steps', async (t) => 
               name: 'Build iOS app',
               status: 'completed',
               conclusion: 'success',
-              steps: [],
+              steps: [
+                {
+                  name: 'Record exact release source',
+                  status: 'completed',
+                  conclusion: 'success',
+                },
+              ],
             },
             {
               name: 'Attach TestFlight acceptance attestation',

--- a/scripts/__tests__/ios-testflight-workflow.test.mjs
+++ b/scripts/__tests__/ios-testflight-workflow.test.mjs
@@ -23,14 +23,49 @@ test('keeps write permission out of the build job and scopes it to attestation u
   )
 })
 
-test('binds the attestation to GITHUB_SHA and uploads it only to the matching draft release', () => {
+test('stages legal resources before every iOS build', () => {
   const buildSteps = WORKFLOW.jobs.ios.steps
+  const legal = buildSteps.findIndex(
+    (step) => step.name === 'Stage legal bundle for iOS resources',
+  )
+  const signedBuild = buildSteps.findIndex(
+    (step) => step.name === 'Build (signed device IPA)',
+  )
+  const simulatorBuild = buildSteps.findIndex(
+    (step) => step.name === 'Build (simulator, unsigned)',
+  )
+  assert.ok(legal >= 0)
+  assert.ok(legal < signedBuild)
+  assert.ok(legal < simulatorBuild)
+  assert.match(buildSteps[legal].run, /scripts\/sync-legal-bundle\.mjs/)
+})
+
+test('binds direct and trusted exact-tag backfill uploads to the release source', () => {
+  const buildSteps = WORKFLOW.jobs.ios.steps
+  assert.equal(
+    WORKFLOW.on.workflow_dispatch.inputs.exact_tag_backfill.type,
+    'boolean',
+  )
+  assert.equal(
+    WORKFLOW.on.workflow_dispatch.inputs.exact_tag_backfill.default,
+    false,
+  )
   const source = buildSteps.find(
     (step) => step.name === 'Record exact release source',
   )
   assert.ok(source)
   assert.match(source.run, /git rev-parse HEAD/)
   assert.match(source.run, /GITHUB_SHA/)
+  assert.match(source.run, /refs\/tags\/\$RELEASE_TAG/)
+  assert.match(source.run, /ALLOW_EXACT_TAG_BACKFILL/)
+  assert.match(source.run, /refs\/heads\/\$DEFAULT_BRANCH/)
+  assert.match(source.run, /V146_TAG/)
+  assert.match(source.run, /V146_SOURCE_COMMIT/)
+  assert.equal(source.env.V146_TAG, 'v1.4.6')
+  assert.equal(
+    source.env.V146_SOURCE_COMMIT,
+    '06c02979b9e917011a63dcbfb09aaad7cfb9430d',
+  )
   assert.match(source.run, /exit 1/)
 
   const testFlightUpload = buildSteps.find(
@@ -49,6 +84,8 @@ test('binds the attestation to GITHUB_SHA and uploads it only to the matching dr
   assert.match(run, /"sourceCommit"/)
   assert.match(run, /GITHUB_RUN_ID/)
   assert.match(run, /"accepted"/)
+  assert.match(run, /RELEASE_SOURCE_COMMIT/)
+  assert.match(run, /commits\/\$RELEASE_TAG/)
   assert.match(run, /gh api[\s\S]*\.draft/)
   assert.match(run, /gh release upload "\$RELEASE_TAG"[\s\S]*--clobber/)
   assert.doesNotMatch(run, /\$\{\{\s*inputs\.release_tag\s*\}\}/)

--- a/scripts/__tests__/r2-release-promotion-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-promotion-workflow.test.mjs
@@ -140,6 +140,18 @@ test('uses trusted default-branch verifiers and verifies the attested iOS workfl
     validate.run,
     /verify-trusted-ios-workflow\.mjs[\s\S]*--source-root "\$target_source"/,
   )
+  assert.match(
+    validate.run,
+    /contents\/\.github\/workflows\/ios-build\.yml\?ref=\$run_head_sha/,
+  )
+  assert.match(
+    validate.run,
+    /verify-trusted-ios-workflow\.mjs[\s\S]*--source-root "\$run_source"/,
+  )
+  assert.match(
+    validate.run,
+    /verify-ios-testflight-run\.mjs[\s\S]*--run-workflow[\s\S]*ios-build\.yml/,
+  )
 })
 
 test('only explicit promotion mutates root and writes index before latest commit marker', () => {

--- a/scripts/__tests__/release-finalize-workflow.test.mjs
+++ b/scripts/__tests__/release-finalize-workflow.test.mjs
@@ -84,6 +84,18 @@ test('proves the TestFlight attestation came from the exact successful iOS workf
     runProof.run,
     /verify-trusted-ios-workflow\.mjs[\s\S]*--source-root "\$TARGET_SOURCE"/,
   )
+  assert.match(
+    runProof.run,
+    /contents\/\.github\/workflows\/ios-build\.yml\?ref=\$run_head_sha/,
+  )
+  assert.match(
+    runProof.run,
+    /verify-trusted-ios-workflow\.mjs[\s\S]*--source-root "\$run_source"/,
+  )
+  assert.match(
+    runProof.run,
+    /verify-ios-testflight-run\.mjs[\s\S]*--run-workflow[\s\S]*ios-build\.yml/,
+  )
 })
 
 test('proves macOS signatures came from the pinned successful Tauri workflow run', () => {

--- a/scripts/__tests__/trusted-ios-workflow.test.mjs
+++ b/scripts/__tests__/trusted-ios-workflow.test.mjs
@@ -3,6 +3,7 @@ import {
   cpSync,
   mkdtempSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -12,10 +13,21 @@ import { dirname, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { RELEASE_TRUST_POLICY } from '../release-trust-policy.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const VERIFIER = resolve(ROOT, 'scripts/verify-trusted-ios-workflow.mjs')
 const IOS_WORKFLOW = resolve(ROOT, '.github/workflows/ios-build.yml')
+const V146_IOS_WORKFLOW_SHA256 =
+  '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0'
+
+test('keeps the immutable v1.4.6 iOS workflow in the trusted allowlist', () => {
+  assert.ok(
+    RELEASE_TRUST_POLICY.iosBuildWorkflowSha256s.includes(
+      V146_IOS_WORKFLOW_SHA256,
+    ),
+  )
+})
 
 function verify(sourceRoot) {
   return spawnSync(
@@ -60,4 +72,3 @@ test('rejects changed or symlinked iOS workflow source', async (t) => {
     }
   })
 })
-

--- a/scripts/__tests__/vscode-sidecar-release.test.mjs
+++ b/scripts/__tests__/vscode-sidecar-release.test.mjs
@@ -42,6 +42,16 @@ test('sidecar publishing uploads strict SHA-256 metadata beside every binary', (
   assert.match(uploadStep, /"\$\{\{\s*matrix\.asset_name\s*\}\}\.sha256"/)
 })
 
+test('sidecar archive verification excludes the sync ownership sentinel', () => {
+  const step = workflowStep('Verify embedded legal bundle')
+  assert.match(step, /find build\/legal-bundle -type f/)
+  assert.match(
+    step,
+    /! -name ['"]\.catgo-legal-bundle-owned['"]/,
+    'the ownership sentinel is not a redistributed legal document',
+  )
+})
+
 test('pnpm is canonical and no nested npm lock can silently drift', () => {
   const rootPackage = JSON.parse(source('package.json'))
   assert.match(rootPackage.packageManager, /^pnpm@/)

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -1,6 +1,10 @@
 export const RELEASE_TRUST_POLICY = Object.freeze({
-  iosBuildWorkflowSha256:
+  iosBuildWorkflowSha256s: Object.freeze([
     '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0',
+    'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156',
+  ]),
+  iosBackfillWorkflowSha256:
+    'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156',
   tauriReleaseWorkflowSha256s: Object.freeze([
     '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',
     '6dff73ab93babff2d03a2a313330e1bd981c47ab3bcf72687352daa7e7eaf46b',

--- a/scripts/verify-ios-testflight-run.mjs
+++ b/scripts/verify-ios-testflight-run.mjs
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto'
 import { lstatSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import { RELEASE_TRUST_POLICY } from './release-trust-policy.mjs'
+
 const SOURCE_COMMIT_PATTERN = /^[0-9a-f]{40}$/
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
 const IOS_WORKFLOW_PATH = '.github/workflows/ios-build.yml'
+const V146_TAG = 'v1.4.6'
+const V146_SOURCE_COMMIT = '06c02979b9e917011a63dcbfb09aaad7cfb9430d'
+const V146_BACKFILL_BRANCH = 'main'
 const REQUIRED_PROOF = [
+  {
+    job: 'Build iOS app',
+    step: 'Record exact release source',
+  },
   {
     job: 'Build iOS app',
     step: 'Upload to App Store Connect (TestFlight)',
@@ -22,17 +33,30 @@ function parseArguments(argv) {
     const key = argv[index]
     const value = argv[index + 1]
     if (
-      !['--attestation', '--run', '--jobs', '--source-commit'].includes(key) ||
+      ![
+        '--attestation',
+        '--run',
+        '--jobs',
+        '--source-commit',
+        '--run-workflow',
+      ].includes(key) ||
       !value
     ) {
       throw new Error(
         'Usage: verify-ios-testflight-run.mjs --attestation <json> ' +
-          '--run <json> --jobs <json> --source-commit <40-hex-sha>',
+          '--run <json> --jobs <json> --source-commit <40-hex-sha> ' +
+          '--run-workflow <ios-build.yml>',
       )
     }
     values.set(key, value)
   }
-  for (const key of ['--attestation', '--run', '--jobs', '--source-commit']) {
+  for (const key of [
+    '--attestation',
+    '--run',
+    '--jobs',
+    '--source-commit',
+    '--run-workflow',
+  ]) {
     if (!values.has(key)) throw new Error(`Missing required argument: ${key}`)
   }
   const sourceCommit = values.get('--source-commit')
@@ -44,6 +68,7 @@ function parseArguments(argv) {
     runPath: resolve(values.get('--run')),
     jobsPath: resolve(values.get('--jobs')),
     sourceCommit,
+    runWorkflowPath: resolve(values.get('--run-workflow')),
   }
 }
 
@@ -59,7 +84,29 @@ function readJsonFile(path, kind) {
   }
 }
 
-function exactSuccessfulStep(jobs, expected) {
+function trustedRunWorkflowHash(path) {
+  const metadata = lstatSync(path)
+  if (
+    metadata.isSymbolicLink() ||
+    !metadata.isFile() ||
+    metadata.size > 512 * 1024
+  ) {
+    throw new Error('Executed iOS workflow must be a small regular file')
+  }
+  const actual = createHash('sha256').update(readFileSync(path)).digest('hex')
+  const approved = RELEASE_TRUST_POLICY.iosBuildWorkflowSha256s
+  if (
+    !Array.isArray(approved) ||
+    approved.length === 0 ||
+    approved.some((digest) => !SHA256_PATTERN.test(digest)) ||
+    !approved.includes(actual)
+  ) {
+    throw new Error('Executed iOS workflow hash is not trusted')
+  }
+  return actual
+}
+
+function exactSuccessfulStep(jobs, expected, run) {
   const matchingJobs = jobs.filter((job) => job?.name === expected.job)
   if (
     matchingJobs.length !== 1 ||
@@ -67,6 +114,12 @@ function exactSuccessfulStep(jobs, expected) {
     matchingJobs[0].conclusion !== 'success'
   ) {
     throw new Error(`Required iOS job ${expected.job} must complete successfully`)
+  }
+  if (
+    String(matchingJobs[0].run_id) !== String(run.id) ||
+    matchingJobs[0].head_sha !== run.head_sha
+  ) {
+    throw new Error(`Required iOS job ${expected.job} has mismatched provenance`)
   }
   const matchingSteps = (matchingJobs[0].steps ?? []).filter(
     (step) => step?.name === expected.step,
@@ -85,7 +138,9 @@ function verifyRunProvenance({
   runPath,
   jobsPath,
   sourceCommit,
+  runWorkflowPath,
 }) {
+  const runWorkflowHash = trustedRunWorkflowHash(runWorkflowPath)
   const attestation = readJsonFile(attestationPath, 'TestFlight attestation')
   const run = readJsonFile(runPath, 'GitHub Actions run')
   const jobsDocument = readJsonFile(jobsPath, 'GitHub Actions jobs')
@@ -114,15 +169,24 @@ function verifyRunProvenance({
       'GitHub Actions run must be a completed workflow_dispatch with conclusion success',
     )
   }
-  if (run.head_sha !== sourceCommit) {
-    throw new Error(
-      `GitHub Actions run head_sha does not match source commit ${sourceCommit}`,
-    )
-  }
   if (attestation.sourceCommit !== sourceCommit) {
     throw new Error('TestFlight attestation source commit does not match release source')
   }
-  for (const expected of REQUIRED_PROOF) exactSuccessfulStep(jobs, expected)
+  if (run.head_sha !== sourceCommit) {
+    if (
+      attestation.releaseTag !== V146_TAG ||
+      sourceCommit !== V146_SOURCE_COMMIT ||
+      run.head_branch !== V146_BACKFILL_BRANCH ||
+      runWorkflowHash !== RELEASE_TRUST_POLICY.iosBackfillWorkflowSha256
+    ) {
+      throw new Error(
+        `GitHub Actions run head_sha does not match source commit ${sourceCommit}`,
+      )
+    }
+  }
+  for (const expected of REQUIRED_PROOF) {
+    exactSuccessfulStep(jobs, expected, run)
+  }
   return { runId: attestation.githubRunId, sourceCommit }
 }
 

--- a/scripts/verify-trusted-ios-workflow.mjs
+++ b/scripts/verify-trusted-ios-workflow.mjs
@@ -35,13 +35,19 @@ function main(sourceRoot) {
   const actual = createHash('sha256')
     .update(readFileSync(workflowPath))
     .digest('hex')
-  const approved = RELEASE_TRUST_POLICY.iosBuildWorkflowSha256
-  if (typeof approved !== 'string' || !/^[0-9a-f]{64}$/.test(approved)) {
-    throw new Error('Trusted release policy has no approved iOS workflow hash')
-  }
-  if (actual !== approved) {
+  const approved = RELEASE_TRUST_POLICY.iosBuildWorkflowSha256s
+  if (
+    !Array.isArray(approved) ||
+    approved.length === 0 ||
+    approved.some((digest) => !/^[0-9a-f]{64}$/.test(digest))
+  ) {
     throw new Error(
-      `Target iOS workflow hash ${actual} does not match trusted hash ${approved}`,
+      'Trusted release policy has no approved iOS workflow hash allowlist',
+    )
+  }
+  if (!approved.includes(actual)) {
+    throw new Error(
+      `Target iOS workflow hash ${actual} is not in the trusted allowlist`,
     )
   }
   process.stdout.write(`[ios-workflow] verified ${actual}\n`)


### PR DESCRIPTION
## Summary

- stage the canonical legal bundle before iOS simulator or signed builds
- allow only the immutable v1.4.6 source to be rebuilt by the trusted main iOS workflow
- bind TestFlight provenance to the exact run-head workflow bytes fetched from GitHub
- preserve the immutable v1.4.6 iOS workflow hash alongside the reviewed recovery workflow
- exclude only the internal legal-sync ownership sentinel from sidecar archive document checks

## Root causes

- iOS Tauri bundling failed before compilation because src-tauri/resources/legal did not exist.
- Windows PyInstaller correctly omitted the hidden .catgo-legal-bundle-owned sync sentinel, but the post-build verifier treated it as a user-facing legal document.

## Security boundaries

The split-source TestFlight recovery is limited to v1.4.6, source commit 06c02979b9e917011a63dcbfb09aaad7cfb9430d, main, and the exact reviewed workflow hash. Finalizer and R2 independently fetch the workflow at the run head SHA, verify its allowlisted hash, and bind both proof jobs to that run id/head SHA.

## Verification

- TDD RED reproduced missing iOS legal staging, untrusted split provenance, and sidecar sentinel mismatch
- 345/345 Node tests passed
- release-rights verifier passed: 2 ledgers
- legal-distribution verifier passed: 10 contracts and 27 files
- git diff --check passed
- independent security review: PASS, no Critical/Important