### PR TITLE
fix(release): normalize packaged legal checks

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -178,7 +178,11 @@ jobs:
                 echo "::error::$artifact is missing legal/$rel"
                 exit 1
               fi
-            done < <(find build/legal-bundle -type f | sort)
+            done < <(
+              find build/legal-bundle -type f \
+                ! -name '.catgo-legal-bundle-owned' |
+                sort
+            )
           done
 
       - name: Sign the APK (apksigner)

--- a/.github/workflows/build-vscode-sidecars.yml
+++ b/.github/workflows/build-vscode-sidecars.yml
@@ -124,7 +124,8 @@ jobs:
       - name: Verify embedded legal bundle
         run: |
           set -euo pipefail
-          pyi-archive_viewer -l "${{ matrix.asset_name }}" > sidecar-archive.lst
+          pyi-archive_viewer -l "${{ matrix.asset_name }}" |
+            tr '\\' '/' > sidecar-archive.lst
           while IFS= read -r file; do
             rel="${file#build/legal-bundle/}"
             if ! grep -Fq "legal/$rel" sidecar-archive.lst; then

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -271,7 +271,11 @@ jobs:
                 echo "::error::$ipa is missing legal/$rel"
                 exit 1
               fi
-            done < <(find build/legal-bundle -type f | sort)
+            done < <(
+              find build/legal-bundle -type f \
+                ! -name '.catgo-legal-bundle-owned' |
+                sort
+            )
             inspected=$((inspected + 1))
           done < <(find src-tauri/gen/apple/build -type f -name '*.ipa' -print0)
           while IFS= read -r -d '' app; do
@@ -281,7 +285,11 @@ jobs:
                 echo "::error::$app is missing legal/$rel"
                 exit 1
               fi
-            done < <(find build/legal-bundle -type f | sort)
+            done < <(
+              find build/legal-bundle -type f \
+                ! -name '.catgo-legal-bundle-owned' |
+                sort
+            )
             inspected=$((inspected + 1))
           done < <(find src-tauri/gen/apple/build -type d -name '*.app' -print0)
           if [ "$inspected" -eq 0 ]; then

--- a/scripts/__tests__/ios-testflight-workflow.test.mjs
+++ b/scripts/__tests__/ios-testflight-workflow.test.mjs
@@ -9,6 +9,9 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const PATH = resolve(ROOT, '.github/workflows/ios-build.yml')
 const SOURCE = readFileSync(PATH, 'utf8')
 const WORKFLOW = loadYaml(SOURCE)
+const ANDROID_WORKFLOW = loadYaml(
+  readFileSync(resolve(ROOT, '.github/workflows/android-build.yml'), 'utf8'),
+)
 
 test('keeps write permission out of the build job and scopes it to attestation upload', () => {
   const build = WORKFLOW.jobs.ios
@@ -38,6 +41,31 @@ test('stages legal resources before every iOS build', () => {
   assert.ok(legal < signedBuild)
   assert.ok(legal < simulatorBuild)
   assert.match(buildSteps[legal].run, /scripts\/sync-legal-bundle\.mjs/)
+})
+
+test('mobile archive checks exclude only the legal-sync ownership sentinel', () => {
+  const cases = [
+    [
+      WORKFLOW.jobs.ios.steps.find(
+        (step) => step.name === 'Verify legal bundle in iOS artifacts',
+      ),
+      2,
+    ],
+    [
+      ANDROID_WORKFLOW.jobs.android.steps.find(
+        (step) => step.name === 'Verify legal bundle in APK/AAB',
+      ),
+      1,
+    ],
+  ]
+  for (const [step, expectedCount] of cases) {
+    assert.ok(step)
+    assert.equal(
+      [...step.run.matchAll(/! -name ['"]\.catgo-legal-bundle-owned['"]/g)]
+        .length,
+      expectedCount,
+    )
+  }
 })
 
 test('binds direct and trusted exact-tag backfill uploads to the release source', () => {

--- a/scripts/__tests__/trusted-ios-workflow.test.mjs
+++ b/scripts/__tests__/trusted-ios-workflow.test.mjs
@@ -20,11 +20,21 @@ const VERIFIER = resolve(ROOT, 'scripts/verify-trusted-ios-workflow.mjs')
 const IOS_WORKFLOW = resolve(ROOT, '.github/workflows/ios-build.yml')
 const V146_IOS_WORKFLOW_SHA256 =
   '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0'
+const V146_RECOVERY_WORKFLOW_SHA256 =
+  'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156'
 
 test('keeps the immutable v1.4.6 iOS workflow in the trusted allowlist', () => {
   assert.ok(
     RELEASE_TRUST_POLICY.iosBuildWorkflowSha256s.includes(
       V146_IOS_WORKFLOW_SHA256,
+    ),
+  )
+})
+
+test('keeps the in-flight v1.4.6 recovery workflow trusted', () => {
+  assert.ok(
+    RELEASE_TRUST_POLICY.iosBackfillWorkflowSha256s.includes(
+      V146_RECOVERY_WORKFLOW_SHA256,
     ),
   )
 })

--- a/scripts/__tests__/vscode-sidecar-release.test.mjs
+++ b/scripts/__tests__/vscode-sidecar-release.test.mjs
@@ -47,6 +47,11 @@ test('sidecar archive verification excludes the sync ownership sentinel', () => 
   assert.match(step, /find build\/legal-bundle -type f/)
   assert.match(
     step,
+    /pyi-archive_viewer[\s\S]*\|\s*tr ['"]\\\\['"] ['"]\/['"]/,
+    'Windows archive paths must be normalized before exact legal checks',
+  )
+  assert.match(
+    step,
     /! -name ['"]\.catgo-legal-bundle-owned['"]/,
     'the ownership sentinel is not a redistributed legal document',
   )

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -2,9 +2,12 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
   iosBuildWorkflowSha256s: Object.freeze([
     '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0',
     'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156',
+    '09ece891bdd1cf0efe15485fc4ac7577e4ddb8ea9d3a973613b80a32a7cd421e',
   ]),
-  iosBackfillWorkflowSha256:
+  iosBackfillWorkflowSha256s: Object.freeze([
     'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156',
+    '09ece891bdd1cf0efe15485fc4ac7577e4ddb8ea9d3a973613b80a32a7cd421e',
+  ]),
   tauriReleaseWorkflowSha256s: Object.freeze([
     '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',
     '6dff73ab93babff2d03a2a313330e1bd981c47ab3bcf72687352daa7e7eaf46b',

--- a/scripts/verify-ios-testflight-run.mjs
+++ b/scripts/verify-ios-testflight-run.mjs
@@ -173,11 +173,15 @@ function verifyRunProvenance({
     throw new Error('TestFlight attestation source commit does not match release source')
   }
   if (run.head_sha !== sourceCommit) {
+    const approvedBackfills =
+      RELEASE_TRUST_POLICY.iosBackfillWorkflowSha256s
     if (
       attestation.releaseTag !== V146_TAG ||
       sourceCommit !== V146_SOURCE_COMMIT ||
       run.head_branch !== V146_BACKFILL_BRANCH ||
-      runWorkflowHash !== RELEASE_TRUST_POLICY.iosBackfillWorkflowSha256
+      !Array.isArray(approvedBackfills) ||
+      approvedBackfills.some((digest) => !SHA256_PATTERN.test(digest)) ||
+      !approvedBackfills.includes(runWorkflowHash)
     ) {
       throw new Error(
         `GitHub Actions run head_sha does not match source commit ${sourceCommit}`,


### PR DESCRIPTION
## Summary

- exclude only the internal legal-sync ownership sentinel from Android and iOS archive document checks
- normalize PyInstaller archive path separators before Windows sidecar legal verification
- retain the in-flight v1.4.6 iOS recovery workflow hash while trusting the hardened successor

## Root causes

- mobile packagers and Windows PyInstaller may omit the hidden ownership sentinel because it is build state, not a redistributed legal document
- Windows PyInstaller archive listings use backslashes, while the verifier searched only normalized legal/... paths

## Verification

- TDD RED captured both mobile sentinel and Windows archive separator contracts
- 347/347 Node tests passed
- release-rights and legal-distribution verifiers passed
- git diff --check passed
- independent mobile review PASS; all actual legal sources and ACKNOWLEDGEMENT remain mandatory