### PR TITLE
fix(release): read raw sidecar archive paths

### DIFF
--- a/.github/workflows/build-vscode-sidecars.yml
+++ b/.github/workflows/build-vscode-sidecars.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Verify embedded legal bundle
         run: |
           set -euo pipefail
-          pyi-archive_viewer -l "${{ matrix.asset_name }}" |
+          pyi-archive_viewer -b -l "${{ matrix.asset_name }}" |
             tr '\\' '/' > sidecar-archive.lst
           while IFS= read -r file; do
             rel="${file#build/legal-bundle/}"

--- a/scripts/__tests__/vscode-sidecar-release.test.mjs
+++ b/scripts/__tests__/vscode-sidecar-release.test.mjs
@@ -47,7 +47,7 @@ test('sidecar archive verification excludes the sync ownership sentinel', () => 
   assert.match(step, /find build\/legal-bundle -type f/)
   assert.match(
     step,
-    /pyi-archive_viewer[\s\S]*\|\s*tr ['"]\\\\['"] ['"]\/['"]/,
+    /pyi-archive_viewer -b -l[\s\S]*\|\s*tr ['"]\\\\['"] ['"]\/['"]/,
     'Windows archive paths must be normalized before exact legal checks',
   )
   assert.match(


### PR DESCRIPTION
## Summary

- use PyInstaller archive viewer brief mode before normalizing Windows path separators
- retain exact verification of every redistributed legal document

## Root cause

Non-brief archive output uses repr-style escaped names. On Windows, a single path separator appears as two literal backslashes; replacing each one produced legal//... and still failed exact checks. Brief mode emits the raw single separator, which normalizes to legal/... correctly.

## Verification

- TDD RED requires -b -l before separator normalization
- 347/347 Node tests passed
- release-rights and legal-distribution verifiers passed
- git diff --check passed
- independent PyInstaller source review confirmed the repr vs brief behavior