### PR TITLE
fix(release): detect draft iOS release

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -385,7 +385,10 @@ jobs:
             echo "::error::Untrusted TestFlight exact-tag backfill context."
             exit 1
           fi
-          draft=$(gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')
+          draft=$(gh release view "$RELEASE_TAG" \
+            --repo "$REPOSITORY" \
+            --json isDraft \
+            --jq '.isDraft')
           if [ "$draft" != "true" ]; then
             echo "::error::Release $RELEASE_TAG must still be a draft."
             exit 1

--- a/scripts/__tests__/ios-testflight-workflow.test.mjs
+++ b/scripts/__tests__/ios-testflight-workflow.test.mjs
@@ -114,7 +114,11 @@ test('binds direct and trusted exact-tag backfill uploads to the release source'
   assert.match(run, /"accepted"/)
   assert.match(run, /RELEASE_SOURCE_COMMIT/)
   assert.match(run, /commits\/\$RELEASE_TAG/)
-  assert.match(run, /gh api[\s\S]*\.draft/)
+  assert.match(
+    run,
+    /gh release view "\$RELEASE_TAG"[\s\S]*--json isDraft[\s\S]*--jq '\.isDraft'/,
+  )
+  assert.doesNotMatch(run, /releases\/tags\/\$RELEASE_TAG/)
   assert.match(run, /gh release upload "\$RELEASE_TAG"[\s\S]*--clobber/)
   assert.doesNotMatch(run, /\$\{\{\s*inputs\.release_tag\s*\}\}/)
 })

--- a/scripts/__tests__/trusted-ios-workflow.test.mjs
+++ b/scripts/__tests__/trusted-ios-workflow.test.mjs
@@ -21,7 +21,7 @@ const IOS_WORKFLOW = resolve(ROOT, '.github/workflows/ios-build.yml')
 const V146_IOS_WORKFLOW_SHA256 =
   '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0'
 const V146_RECOVERY_WORKFLOW_SHA256 =
-  'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156'
+  'c51f8a60b68a86c3fdf672efd47f87c0e2e878d11eda5f424de80151518341c2'
 
 test('keeps the immutable v1.4.6 iOS workflow in the trusted allowlist', () => {
   assert.ok(
@@ -31,7 +31,7 @@ test('keeps the immutable v1.4.6 iOS workflow in the trusted allowlist', () => {
   )
 })
 
-test('keeps the in-flight v1.4.6 recovery workflow trusted', () => {
+test('keeps the current v1.4.6 recovery workflow trusted', () => {
   assert.ok(
     RELEASE_TRUST_POLICY.iosBackfillWorkflowSha256s.includes(
       V146_RECOVERY_WORKFLOW_SHA256,

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -1,12 +1,10 @@
 export const RELEASE_TRUST_POLICY = Object.freeze({
   iosBuildWorkflowSha256s: Object.freeze([
     '52d711337b1a5376d14c22201ce581510e6950d86086ec8cd7f0f5ee5d62d4b0',
-    'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156',
-    '09ece891bdd1cf0efe15485fc4ac7577e4ddb8ea9d3a973613b80a32a7cd421e',
+    'c51f8a60b68a86c3fdf672efd47f87c0e2e878d11eda5f424de80151518341c2',
   ]),
   iosBackfillWorkflowSha256s: Object.freeze([
-    'e84523cf386246dd5d2d8a1c8193b419d684f7e623abd7081b52549a85788156',
-    '09ece891bdd1cf0efe15485fc4ac7577e4ddb8ea9d3a973613b80a32a7cd421e',
+    'c51f8a60b68a86c3fdf672efd47f87c0e2e878d11eda5f424de80151518341c2',
   ]),
   tauriReleaseWorkflowSha256s: Object.freeze([
     '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',


### PR DESCRIPTION
## Summary
- query draft releases through gh release view so v1.4.6 is visible before publication
- bind the exact recovery workflow hash in the release trust policy
- keep the immutable tag workflow hash trusted while removing failed intermediate hashes

## Root cause
The signed iOS build and TestFlight upload succeeded, but the attestation job used the REST tag endpoint, which returns 404 for draft releases.

## Verification
- 347/347 Node tests pass
- release-rights verifier passes for both ledgers
- legal verifier passes 10 contracts / 27 files
- git diff --check passes
- independent review: PASS