### PR TITLE
fix(release): bind draft finalization to release id

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -84,7 +84,19 @@ jobs:
           set -euo pipefail
           release_json=$(mktemp)
           trap 'rm -f "$release_json"' EXIT
-          gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" > "$release_json"
+          release_id=$(gh release view "$RELEASE_TAG" \
+            --repo "$REPOSITORY" \
+            --json databaseId \
+            --jq '.databaseId')
+          if ! [[ "$release_id" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Could not resolve release database id for $RELEASE_TAG."
+            exit 1
+          fi
+          gh api "repos/$REPOSITORY/releases/$release_id" > "$release_json"
+          if [ "$(jq -r '.tag_name' "$release_json")" != "$RELEASE_TAG" ]; then
+            echo "::error::Release database id is no longer bound to $RELEASE_TAG."
+            exit 1
+          fi
           if [ "$(jq -r '.draft' "$release_json")" != "true" ]; then
             echo "::error::Release $RELEASE_TAG is not a draft."
             exit 1
@@ -552,16 +564,20 @@ jobs:
             release_state=$(mktemp)
             for attempt in $(seq 1 20); do
               if gh api \
-                   "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" \
+                   "repos/$REPOSITORY/releases/$release_id" \
                    > "$release_state"; then
+                if [ "$(jq -r '.tag_name' "$release_state")" != "$RELEASE_TAG" ]; then
+                  echo "::error::Release database id is no longer bound to $RELEASE_TAG."
+                  break
+                fi
                 if [ "$(jq -r '.draft' "$release_state")" = "true" ]; then
                   github_draft_confirmed=true
                   break
                 fi
                 echo "::warning::Restoring $RELEASE_TAG to draft state."
-                gh release edit "$RELEASE_TAG" \
-                  --repo "$REPOSITORY" \
-                  --draft=true || true
+                gh api --method PATCH \
+                  "repos/$REPOSITORY/releases/$release_id" \
+                  -F draft=true > /dev/null || true
               fi
               sleep 3
             done
@@ -590,6 +606,13 @@ jobs:
               sha256sum |
               cut -d ' ' -f 1
           }
+          release_id=$(gh release view "$RELEASE_TAG" \
+            --repo "$REPOSITORY" \
+            --json databaseId \
+            --jq '.databaseId')
+          if ! [[ "$release_id" =~ ^[1-9][0-9]*$ ]]; then
+            fail "Could not resolve release database id for $RELEASE_TAG."
+          fi
           trap rollback ERR
 
           if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
@@ -604,7 +627,9 @@ jobs:
             fail "Release tag moved after validation."
 
           release_json=$(mktemp)
-          gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" > "$release_json"
+          gh api "repos/$REPOSITORY/releases/$release_id" > "$release_json"
+          [ "$(jq -r '.tag_name' "$release_json")" = "$RELEASE_TAG" ] ||
+            fail "Release database id is no longer bound to $RELEASE_TAG."
           [ "$(jq -r '.draft' "$release_json")" = "true" ] ||
             fail "Release is no longer a draft."
           actual_snapshot=$(snapshot < "$release_json")
@@ -613,13 +638,15 @@ jobs:
           verify_cloudflare_promotion ||
             fail "Cloudflare promotion failed critical-section preflight."
 
-          gh release edit "$RELEASE_TAG" \
-            --repo "$REPOSITORY" \
-            --draft=false \
-            --latest
+          gh api --method PATCH \
+            "repos/$REPOSITORY/releases/$release_id" \
+            -F draft=false \
+            -f make_latest=true > /dev/null
 
           post_json=$(mktemp)
-          gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" > "$post_json"
+          gh api "repos/$REPOSITORY/releases/$release_id" > "$post_json"
+          [ "$(jq -r '.tag_name' "$post_json")" = "$RELEASE_TAG" ] ||
+            fail "Published release database id is no longer bound to $RELEASE_TAG."
           post_draft=$(jq -r '.draft' "$post_json")
           [ "$post_draft" = "false" ] ||
             fail "Published release remained a draft."
@@ -787,17 +814,29 @@ jobs:
             # to leave the release in its already-validated draft state.
             github_draft_confirmed=true
           else
+            release_id=$(gh release view "$RELEASE_TAG" \
+              --repo "$REPOSITORY" \
+              --json databaseId \
+              --jq '.databaseId')
+            if ! [[ "$release_id" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::Could not resolve release database id for $RELEASE_TAG."
+              exit 1
+            fi
             for attempt in $(seq 1 20); do
               if gh api \
-                   "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" \
+                   "repos/$REPOSITORY/releases/$release_id" \
                    > "$release_state"; then
+                if [ "$(jq -r '.tag_name' "$release_state")" != "$RELEASE_TAG" ]; then
+                  echo "::error::Release database id is no longer bound to $RELEASE_TAG."
+                  break
+                fi
                 if [ "$(jq -r '.draft' "$release_state")" = "true" ]; then
                   github_draft_confirmed=true
                   break
                 fi
-                gh release edit "$RELEASE_TAG" \
-                  --repo "$REPOSITORY" \
-                  --draft=true || true
+                gh api --method PATCH \
+                  "repos/$REPOSITORY/releases/$release_id" \
+                  -F draft=true > /dev/null || true
               fi
               sleep 3
             done

--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -471,7 +471,19 @@ jobs:
             exit 1
           fi
           release_json=$(mktemp)
-          gh api "repos/$REPOSITORY/releases/tags/$tag" > "$release_json"
+          release_id=$(gh release view "$tag" \
+            --repo "$REPOSITORY" \
+            --json databaseId \
+            --jq '.databaseId')
+          if ! [[ "$release_id" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Could not resolve release database id for $tag."
+            exit 1
+          fi
+          gh api "repos/$REPOSITORY/releases/$release_id" > "$release_json"
+          if [ "$(jq -r '.tag_name' "$release_json")" != "$tag" ]; then
+            echo "::error::Release database id is no longer bound to $tag."
+            exit 1
+          fi
           if [ "$(jq -r '.draft' "$release_json")" != "true" ]; then
             echo "::error::Promotion target must remain a draft release."
             exit 1
@@ -687,7 +699,19 @@ jobs:
             exit 1
           fi
           release_json=$(mktemp)
-          gh api "repos/$REPOSITORY/releases/tags/$tag" > "$release_json"
+          release_id=$(gh release view "$tag" \
+            --repo "$REPOSITORY" \
+            --json databaseId \
+            --jq '.databaseId')
+          if ! [[ "$release_id" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Could not resolve release database id for $tag."
+            exit 1
+          fi
+          gh api "repos/$REPOSITORY/releases/$release_id" > "$release_json"
+          if [ "$(jq -r '.tag_name' "$release_json")" != "$tag" ]; then
+            echo "::error::Release database id is no longer bound to $tag."
+            exit 1
+          fi
           if [ "$(jq -r '.draft' "$release_json")" != "true" ]; then
             echo "::error::Promotion target stopped being a draft."
             exit 1

--- a/scripts/__tests__/r2-release-promotion-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-promotion-workflow.test.mjs
@@ -111,6 +111,16 @@ test('binds draft promotion to the finalizer source and asset snapshot before up
     assert.match(step.run, /EXPECTED_SOURCE_COMMIT/)
     assert.match(step.run, /EXPECTED_ASSET_SNAPSHOT/)
     assert.match(step.run, /git rev-parse "\$tag\^\{commit\}"/)
+    assert.match(
+      step.run,
+      /gh release view "\$tag"[\s\S]*--json databaseId/,
+    )
+    assert.match(
+      step.run,
+      /gh api "repos\/\$REPOSITORY\/releases\/\$release_id"/,
+    )
+    assert.match(step.run, /\.tag_name[\s\S]*\$tag/)
+    assert.doesNotMatch(step.run, /releases\/tags\/\$tag/)
     assert.match(step.run, /\.draft/)
     assert.match(step.run, /asset_snapshot/)
   }

--- a/scripts/__tests__/release-finalize-workflow.test.mjs
+++ b/scripts/__tests__/release-finalize-workflow.test.mjs
@@ -58,6 +58,35 @@ test('executes only trusted default-branch verifiers against a detached target w
   )
 })
 
+test('resolves the draft release database id before REST reads', () => {
+  const current = workflow()
+  const draft = stepNamed(current.jobs.validate, 'Confirm release is a draft')
+  const publish = current.jobs.publish.steps
+    .map((step) => step.run ?? '')
+    .join('\n')
+
+  assert.match(
+    draft.run,
+    /gh release view "\$RELEASE_TAG"[\s\S]*--json databaseId/,
+  )
+  assert.match(
+    draft.run,
+    /gh api "repos\/\$REPOSITORY\/releases\/\$release_id"/,
+  )
+  assert.match(draft.run, /\.tag_name[\s\S]*\$RELEASE_TAG/)
+  assert.doesNotMatch(draft.run, /releases\/tags\/\$RELEASE_TAG/)
+  assert.match(
+    publish,
+    /gh release view "\$RELEASE_TAG"[\s\S]*--json databaseId/,
+  )
+  assert.match(
+    publish,
+    /gh api "repos\/\$REPOSITORY\/releases\/\$release_id"/,
+  )
+  assert.match(publish, /\.tag_name[\s\S]*\$RELEASE_TAG/)
+  assert.doesNotMatch(publish, /releases\/tags\/\$RELEASE_TAG/)
+})
+
 test('proves the TestFlight attestation came from the exact successful iOS workflow run', () => {
   const validate = workflow().jobs.validate
   const attestation = stepNamed(validate, 'Verify TestFlight acceptance')
@@ -235,7 +264,15 @@ test('independently compensates every failed finalization path after validation'
   assert.match(run, /write-out '%\{http_code\}'/)
   assert.match(
     run,
-    /gh api[\s\\]*"repos\/\$REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/,
+    /gh release view "\$RELEASE_TAG"[\s\S]*--json databaseId/,
+  )
+  assert.match(
+    run,
+    /gh api[\s\\]*"repos\/\$REPOSITORY\/releases\/\$release_id"/,
+  )
+  assert.match(
+    run,
+    /gh api --method PATCH[\s\S]*"repos\/\$REPOSITORY\/releases\/\$release_id"[\s\S]*-F draft=true/,
   )
   assert.match(
     run,
@@ -261,11 +298,10 @@ test('preflight, publication, and postflight revalidate Cloudflare in one rollba
   const publishIntent = intent.steps.find((step) => step.id === 'intent')
   assert.match(publishIntent.run, /publish_attempted=true/)
 
-  const mutationSteps = publish.steps.filter((step) =>
-    /gh release edit/.test(step.run ?? ''),
+  const mutation = stepNamed(
+    publish,
+    'Publish with atomic identity recheck and rollback',
   )
-  assert.equal(mutationSteps.length, 1)
-  const mutation = mutationSteps[0]
   assert.equal(
     mutation.name,
     'Publish with atomic identity recheck and rollback',
@@ -274,15 +310,20 @@ test('preflight, publication, and postflight revalidate Cloudflare in one rollba
   assert.match(mutation.run, /trap rollback ERR/)
   assert.match(
     mutation.run,
-    /gh release edit "\$RELEASE_TAG"[\s\S]*--draft=false[\s\S]*--latest/,
+    /gh api --method PATCH[\s\S]*"repos\/\$REPOSITORY\/releases\/\$release_id"[\s\S]*-F draft=false[\s\S]*-f make_latest=true/,
   )
   assert.match(
     mutation.run,
-    /gh release edit "\$RELEASE_TAG"[\s\S]*--draft=true/,
+    /gh api --method PATCH[\s\S]*"repos\/\$REPOSITORY\/releases\/\$release_id"[\s\S]*-F draft=true/,
+  )
+  assert.doesNotMatch(mutation.run, /gh release edit/)
+  assert.match(
+    mutation.run,
+    /gh release view "\$RELEASE_TAG"[\s\S]*--json databaseId/,
   )
   assert.match(
     mutation.run,
-    /gh api "repos\/\$REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/,
+    /gh api "repos\/\$REPOSITORY\/releases\/\$release_id"/,
   )
   assert.doesNotMatch(mutation.run, /if \[ "\$published" = "true" \]/)
   assert.match(
@@ -299,7 +340,7 @@ test('preflight, publication, and postflight revalidate Cloudflare in one rollba
   ) ?? []
   assert.ok(cloudflareChecks.length >= 3)
   const firstCloudflare = mutation.run.indexOf('verify_cloudflare_promotion')
-  const publishIndex = mutation.run.indexOf('--draft=false')
+  const publishIndex = mutation.run.indexOf('-F draft=false')
   const lastCloudflare = mutation.run.lastIndexOf('verify_cloudflare_promotion')
   assert.ok(firstCloudflare >= 0 && firstCloudflare < publishIndex)
   assert.ok(lastCloudflare > publishIndex)

--- a/scripts/__tests__/version-consistency.test.mjs
+++ b/scripts/__tests__/version-consistency.test.mjs
@@ -99,7 +99,7 @@ const WORKFLOW_INVENTORY = {
   },
 }
 const PUBLISHER_SIGNAL =
-  /softprops\/action-gh-release|gh release (?:create|edit|upload)|tauri-apps\/tauri-action|gh-action-pypi-publish|vsce publish|ovsx publish|docker\/build-push-action|cloudflare\/wrangler-action|pnpm dlx wrangler@\S+ deploy|xcrun altool|aws s3 sync/
+  /softprops\/action-gh-release|gh release (?:create|edit|upload)|gh api --method PATCH|tauri-apps\/tauri-action|gh-action-pypi-publish|vsce publish|ovsx publish|docker\/build-push-action|cloudflare\/wrangler-action|pnpm dlx wrangler@\S+ deploy|xcrun altool|aws s3 sync/
 const activeWorkflowSource = (path) =>
   source(path)
     .split('\n')


### PR DESCRIPTION
## Summary
- resolve draft releases through their database ID because the tag REST endpoint hides drafts
- bind every finalizer read, publish, rollback, and compensation mutation to the same release object
- fail closed if the release ID is no longer bound to the requested tag
- apply the same identity checks to both Cloudflare promotion checkpoints

## Root cause
GitHub's REST  endpoint returns 404 for the v1.4.6 draft, so the finalizer and R2 promotion would fail despite complete assets.

## Verification
- RED reproduced in finalizer/R2 workflow tests
- 20/20 targeted workflow tests pass
- 329/329 complete Node script tests pass
- git diff --check passes
- independent security review: PASS