### PR TITLE
fix(release): parse current Android signer output

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -230,13 +230,22 @@ jobs:
           fi
           VERIFY_OUTPUT=$("${BT}apksigner" verify --verbose --print-certs "${OUT}")
           printf '%s\n' "$VERIFY_OUTPUT"
-          ACTUAL_SIGNER_SHA256=$(printf '%s\n' "$VERIFY_OUTPUT" | awk -F': ' '/Signer #1 certificate SHA-256 digest:/ {print $2; exit}')
-          ACTUAL_SIGNER_SHA256=$(printf '%s' "$ACTUAL_SIGNER_SHA256" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')
-          EXPECTED_SIGNER_SHA256=$(printf '%s' "$ANDROID_EXPECTED_SIGNER_SHA256" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')
-          if [ -z "$ACTUAL_SIGNER_SHA256" ]; then
-            echo "::error::apksigner did not report the signer certificate SHA-256 digest"
+          mapfile -t SIGNER_SHA256_DIGESTS < <(
+            printf '%s\n' "$VERIFY_OUTPUT" |
+              awk -F': ' '/certificate SHA-256 digest:/ {
+                digest = $NF
+                gsub(/[[:space:]:]/, "", digest)
+                print tolower(digest)
+              }' |
+              sort -u
+          )
+          if [ "${#SIGNER_SHA256_DIGESTS[@]}" -ne 1 ] ||
+             ! [[ "${SIGNER_SHA256_DIGESTS[0]:-}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::apksigner must report exactly one signer certificate SHA-256 digest"
             exit 1
           fi
+          ACTUAL_SIGNER_SHA256="${SIGNER_SHA256_DIGESTS[0]}"
+          EXPECTED_SIGNER_SHA256=$(printf '%s' "$ANDROID_EXPECTED_SIGNER_SHA256" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')
           if [ "$ACTUAL_SIGNER_SHA256" != "$EXPECTED_SIGNER_SHA256" ]; then
             echo "::error::Android signer certificate SHA-256 does not match repository policy"
             exit 1

--- a/scripts/__tests__/release-source-workflows.test.mjs
+++ b/scripts/__tests__/release-source-workflows.test.mjs
@@ -132,6 +132,15 @@ test('Android release signing verifies validity and the approved signer identity
   assert.match(signing.run, /apksigner"\s+verify\s+--verbose\s+--print-certs/)
   assert.match(signing.run, /ANDROID_EXPECTED_SIGNER_SHA256/)
   assert.match(signing.run, /ACTUAL_SIGNER_SHA256/)
+  assert.match(signing.run, /certificate SHA-256 digest:/)
+  assert.match(signing.run, /digest = \$NF/)
+  assert.match(signing.run, /sort -u/)
+  assert.match(signing.run, /SIGNER_SHA256_DIGESTS\[@\]/)
+  assert.doesNotMatch(
+    signing.run,
+    /Signer #1 certificate SHA-256 digest:/,
+    'signer parsing must support current and legacy apksigner labels',
+  )
   assert.match(signing.run, /exit 1/)
   assert.doesNotMatch(
     signing.run,


### PR DESCRIPTION
## Summary
- accept current and legacy apksigner certificate digest labels
- normalize and deduplicate every reported signer certificate SHA-256
- fail closed unless exactly one valid signer remains and matches repository policy

## Root cause
Android build-tools 37 reports V3.0 Signer instead of the legacy Signer #1 label. The signed APK was valid and matched policy, but the label-specific parser returned an empty digest.

## Verification
- failing run 30211818453 proves v2/v3 signatures and the approved digest
- 12/12 targeted release workflow tests pass
- 329/329 complete Node script tests pass
- current and legacy sample output normalize to one approved digest
- independent review: PASS