### PR TITLE
fix(release): grant draft visibility to validators

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -23,7 +23,9 @@ jobs:
     timeout-minutes: 30
     permissions:
       actions: read
-      contents: read
+      # GitHub hides draft releases from tokens without push-equivalent access.
+      # This job remains mutation-free; tests prohibit release write commands.
+      contents: write
     outputs:
       asset_snapshot: ${{ steps.draft.outputs.asset_snapshot }}
       source_commit: ${{ steps.source.outputs.commit }}

--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -83,7 +83,9 @@ concurrency:
 
 permissions:
   actions: read
-  contents: read
+  # GitHub hides draft releases from tokens without push-equivalent access.
+  # This workflow never mutates GitHub releases; tests enforce that boundary.
+  contents: write
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/__tests__/r2-release-promotion-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-promotion-workflow.test.mjs
@@ -32,8 +32,13 @@ test('manual promotion is explicit, serialized, and fails when R2 credentials ar
   assert.equal(current.concurrency['cancel-in-progress'], false)
   assert.deepEqual(current.permissions, {
     actions: 'read',
-    contents: 'read',
+    contents: 'write',
   })
+  assert.doesNotMatch(SOURCE, /gh release (?:create|edit|upload)/)
+  assert.doesNotMatch(
+    SOURCE,
+    /gh api --method (?:POST|PATCH|DELETE)[\s\S]*releases\//,
+  )
 
   const credentials = stepNamed(
     current.jobs.mirror.steps,

--- a/scripts/__tests__/release-finalize-workflow.test.mjs
+++ b/scripts/__tests__/release-finalize-workflow.test.mjs
@@ -365,7 +365,7 @@ test('preflight, publication, and postflight revalidate Cloudflare in one rollba
   assert.match(mutation.run, /post_source_commit/)
 })
 
-test('keeps release write permission out of validation and Cloudflare promotion', () => {
+test('grants draft visibility only where needed and keeps validation mutation-free', () => {
   const current = workflow()
   assert.deepEqual(current.permissions, {
     actions: 'read',
@@ -373,10 +373,18 @@ test('keeps release write permission out of validation and Cloudflare promotion'
   })
   assert.deepEqual(current.jobs.validate.permissions, {
     actions: 'read',
-    contents: 'read',
+    contents: 'write',
   })
   assert.deepEqual(current.jobs['promote-cloudflare'].permissions, {
     actions: 'write',
     contents: 'read',
   })
+  const validationRun = current.jobs.validate.steps
+    .map((step) => step.run ?? '')
+    .join('\n')
+  assert.doesNotMatch(validationRun, /gh release (?:create|edit|upload)/)
+  assert.doesNotMatch(
+    validationRun,
+    /gh api --method (?:POST|PATCH|DELETE)[\s\S]*releases\//,
+  )
 })


### PR DESCRIPTION
## Summary
- grant contents write only to jobs that must read/download a GitHub draft release
- keep the workflow default and Cloudflare dispatch job read-only
- enforce that validation and mirror code contain no GitHub release create/edit/upload or release POST/PATCH/DELETE commands

## Root cause
GitHub hides draft releases from a GITHUB_TOKEN without push-equivalent repository access. Finalizer run 30214089726 used contents read and failed with release not found before any mutation. The same resolver succeeded in the iOS attestation job with contents write.

## Verification
- RED reproduced in permission boundary tests
- 20/20 targeted finalizer/R2 tests pass
- 329/329 complete Node script tests pass
- failure occurred before Cloudflare promotion or publication
- independent security review: PASS