### PR TITLE
fix(release): canonicalize Windows updater metadata

### DIFF
--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -837,7 +837,7 @@ jobs:
             if aws s3api head-object \
                 --bucket "$R2_BUCKET" \
                 --key "$key" > /dev/null 2>"$error_log"; then
-              aws s3 cp "s3://$R2_BUCKET/$key" "$output"
+              aws s3 cp "s3://$R2_BUCKET/$key" "$output" > /dev/null
               sha256sum "$output" | cut -d ' ' -f 1
             elif grep -Eqi '404|Not Found|NoSuchKey' "$error_log"; then
               printf 'absent'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -537,3 +537,58 @@ jobs:
           tar tzf catgo-legal-bundle.tar.gz
           tag="${CATGO_RELEASE_TAG}"
           gh release upload "$tag" catgo-legal-bundle.tar.gz --clobber
+
+  normalize-updater-manifest:
+    name: Normalize updater manifest
+    needs: [build]
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/') || inputs.release_tag != '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: >-
+        ${{ startsWith(github.ref, 'refs/tags/') &&
+            github.ref_name ||
+            inputs.release_tag }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Normalize canonical Windows updater metadata
+        run: |
+          set -euo pipefail
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+          version="${RELEASE_TAG#v}"
+          gh release download "$RELEASE_TAG" \
+            --repo "$REPOSITORY" \
+            --pattern latest.json
+          expected_url="https://github.com/$REPOSITORY/releases/download/$RELEASE_TAG/CatGo_${version}_x64-setup.exe"
+          jq -e \
+            --arg version "$version" \
+            --arg expectedUrl "$expected_url" \
+            '.version == $version and
+             (.platforms | type == "object") and
+             (.platforms["windows-x86_64-nsis"] | type == "object") and
+             .platforms["windows-x86_64-nsis"].url == $expectedUrl and
+             (.platforms["windows-x86_64-nsis"].signature |
+               type == "string" and length > 0)' \
+            latest.json > /dev/null
+          jq '
+            .platforms["windows-x86_64"] =
+              .platforms["windows-x86_64-nsis"]
+          ' latest.json > latest.normalized.json
+          mv latest.normalized.json latest.json
+          jq -e \
+            --arg expectedUrl "$expected_url" \
+            '.platforms["windows-x86_64"].url == $expectedUrl and
+             .platforms["windows-x86_64"].signature ==
+               .platforms["windows-x86_64-nsis"].signature' \
+            latest.json > /dev/null
+          gh release upload "$RELEASE_TAG" latest.json \
+            --repo "$REPOSITORY" \
+            --clobber

--- a/scripts/__tests__/r2-release-promotion-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-promotion-workflow.test.mjs
@@ -194,6 +194,17 @@ test('only explicit promotion mutates root and writes index before latest commit
   assert.doesNotMatch(promote.run, /latest_app_tag/)
 })
 
+test('captures only the digest when backing up existing root objects', () => {
+  const promote = stepNamed(
+    workflow().jobs.mirror.steps,
+    'Back up and promote Cloudflare root',
+  )
+  assert.match(
+    promote.run,
+    /aws s3 cp "s3:\/\/\$R2_BUCKET\/\$key" "\$output" > \/dev\/null/,
+  )
+})
+
 test('reconciles the versioned tag prefix to the exact validated asset inventory', () => {
   const sync = stepNamed(
     workflow().jobs.mirror.steps,

--- a/scripts/__tests__/tauri-macos-signing-workflow.test.mjs
+++ b/scripts/__tests__/tauri-macos-signing-workflow.test.mjs
@@ -72,6 +72,34 @@ test('branch dispatch is smoke-only while tag push or dispatch publishes exact s
   assert.equal(release.with.releaseDraft, true)
 })
 
+test('normalizes the canonical Windows updater after every release matrix completes', () => {
+  const current = workflow()
+  const normalize = current.jobs['normalize-updater-manifest']
+
+  assert.ok(normalize)
+  assert.deepEqual(normalize.needs, ['build'])
+  assert.deepEqual(normalize.permissions, { contents: 'write' })
+  assert.match(normalize.if, /needs\.build\.result == 'success'/)
+  assert.match(normalize.if, /refs\/tags/)
+  assert.match(normalize.if, /inputs\.release_tag/)
+
+  const step = stepNamed(
+    normalize.steps,
+    'Normalize canonical Windows updater metadata',
+  )
+  assert.ok(step)
+  assert.match(step.run, /gh release download "\$RELEASE_TAG"/)
+  assert.match(
+    step.run,
+    /\.platforms\["windows-x86_64"\]\s*=\s*\.platforms\["windows-x86_64-nsis"\]/,
+  )
+  assert.match(step.run, /CatGo_\$\{version\}_x64-setup\.exe/)
+  assert.match(
+    step.run,
+    /gh release upload "\$RELEASE_TAG" latest\.json[\s\S]*--clobber/,
+  )
+})
+
 test('release macOS builds fail closed before Tauri when any signing secret is absent', () => {
   const steps = workflowSteps()
   const preflight = stepNamed(steps, 'Preflight macOS release signing')

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -9,6 +9,7 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
   tauriReleaseWorkflowSha256s: Object.freeze([
     '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',
     '6dff73ab93babff2d03a2a313330e1bd981c47ab3bcf72687352daa7e7eaf46b',
+    'ceddcb4f7e0ed52fce1c0e56d53d787770a90936d4cc401bc9d72a6f94f753e7',
   ]),
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',


### PR DESCRIPTION
## Summary
- normalize the canonical Windows updater entry only after the complete desktop release matrix succeeds
- bind the canonical entry to the signed NSIS installer URL and signature
- keep R2 backup command substitution free of AWS progress output so promotion receipts receive exact SHA-256 values
- retain the immutable v1.4.6 workflow trust hash while trusting the reviewed current workflow

## Verification
- 331/331 Node release-policy tests pass
- targeted Tauri, R2 promotion, finalizer, receipt, and macOS provenance tests pass
- git diff --check passes
- independent subagent review: PASS

## Live failure evidence addressed
R2 child run 30214587689 failed before root mutation because aws s3 cp progress output polluted the captured digest. The new regression test requires backup downloads to redirect stdout, leaving only the digest in command substitution.