### PR TITLE
fix(release): reconcile R2 versioned assets

### DIFF
--- a/.github/workflows/r2-release-mirror.yml
+++ b/.github/workflows/r2-release-mirror.yml
@@ -746,6 +746,10 @@ jobs:
           set -euo pipefail
           tag="$MIRROR_TAG"
           aws s3 sync dist/ "s3://$R2_BUCKET/$tag/" --delete
+          # R2 can race a same-key upload and --delete operation within one
+          # concurrent sync. Reconcile once without deletion so every source
+          # object is guaranteed to be the final operation for its key.
+          aws s3 sync dist/ "s3://$R2_BUCKET/$tag/"
 
       - name: Back up and promote Cloudflare root
         id: promote
@@ -951,6 +955,45 @@ jobs:
           assets_dir=$(mktemp -d)
           trap 'rm -rf "$assets_dir"; rm -f "$receipt" "$manifest" "$index_page"' EXIT
           verified=false
+          probe_required_assets() {
+            RECEIPT_PATH=$1 node --input-type=module <<'NODE'
+          import { readFileSync } from 'node:fs'
+
+          const receipt = JSON.parse(
+            readFileSync(process.env.RECEIPT_PATH, 'utf8'),
+          )
+          const base = process.env.R2_PUBLIC_BASE_URL.replace(/\/+$/, '')
+          const tag = process.env.MIRROR_TAG
+          const promotionId = process.env.PROMOTION_ID
+          for (const asset of receipt.requiredAssets) {
+            if (
+              typeof asset.name !== 'string' ||
+              !/^[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(asset.name) ||
+              !Number.isSafeInteger(asset.size) ||
+              asset.size < 0
+            ) {
+              throw new Error('Invalid required asset metadata')
+            }
+            const url =
+              `${base}/${encodeURIComponent(tag)}/` +
+              `${encodeURIComponent(asset.name)}` +
+              `?promotion=${encodeURIComponent(promotionId)}`
+            const response = await fetch(url, {
+              method: 'HEAD',
+              headers: { 'Cache-Control': 'no-cache' },
+            })
+            const contentLength = Number(
+              response.headers.get('content-length'),
+            )
+            if (response.status !== 200 || contentLength !== asset.size) {
+              throw new Error(
+                `Required asset is unavailable or has the wrong size: ` +
+                `${asset.name} (${response.status}, ${contentLength})`,
+              )
+            }
+          }
+          NODE
+          }
           for attempt in $(seq 1 60); do
             if curl --fail --silent --show-error \
                 --header 'Cache-Control: no-cache' \
@@ -975,6 +1018,7 @@ jobs:
                  '.schemaVersion == 2 and
                   (.requiredAssets | type == "array")' \
                  "$receipt" > /dev/null &&
+               probe_required_assets "$receipt" &&
                grep -Fq "$MIRROR_TAG" "$index_page" &&
                rm -rf "$assets_dir" &&
                mkdir "$assets_dir"; then

--- a/scripts/__tests__/r2-release-promotion-workflow.test.mjs
+++ b/scripts/__tests__/r2-release-promotion-workflow.test.mjs
@@ -210,9 +210,12 @@ test('reconciles the versioned tag prefix to the exact validated asset inventory
     workflow().jobs.mirror.steps,
     'Sync versioned release to R2',
   )
-  assert.match(
-    sync.run,
-    /aws s3 sync dist\/ "s3:\/\/\$R2_BUCKET\/\$tag\/" --delete/,
+  assert.deepEqual(
+    sync.run.match(/^aws s3 sync .+$/gm),
+    [
+      'aws s3 sync dist/ "s3://$R2_BUCKET/$tag/" --delete',
+      'aws s3 sync dist/ "s3://$R2_BUCKET/$tag/"',
+    ],
   )
 })
 
@@ -228,6 +231,14 @@ test('verifies public root metadata only after the latest.json commit marker', (
   assert.match(verify.run, /\.requiredAssets\[\]\.name/)
   assert.match(verify.run, /curl[\s\S]*--output "\$asset_path"/)
   assert.match(verify.run, /--assets-dir "\$assets_dir"/)
+  const headProbe = verify.run.indexOf("method: 'HEAD'")
+  const fullDownload = verify.run.indexOf('--output "$asset_path"')
+  assert.ok(headProbe >= 0, 'required assets must be size-probed first')
+  assert.ok(
+    headProbe < fullDownload,
+    'HEAD availability checks must precede multi-gigabyte downloads',
+  )
+  assert.match(verify.run, /headers\.get\('content-length'\)/)
   assert.doesNotMatch(verify.run, /(?:--head|-I)[\s\S]*http_code/)
 })
 


### PR DESCRIPTION
## Summary
- run a second non-deleting R2 sync so same-key upload/delete races cannot leave required files missing
- HEAD-probe every required public asset and exact Content-Length before the 2.41 GB byte-for-byte verification pass
- preserve the full receipt/hash verification gate after availability checks

## Live evidence
Run 30214826974 logged upload of CatGo_1.4.6_amd64.deb followed by deletion of the same key in one aws s3 sync --delete operation. The DEB became the only 404 while all other required assets matched exact sizes.

## Verification
- RED regression reproduced both missing reconciliation and missing fail-fast probe
- targeted R2/finalizer tests: 21/21 pass
- complete Node release-policy suite: 331/331 pass
- git diff --check passes