### PR TITLE
fix(desktop): allow window destroy in ACL so the app can close

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-set-title",
     "core:window:allow-create",
     "core:window:allow-close",
+    "core:window:allow-destroy",
     "core:window:allow-set-size",
     "core:window:allow-center",
     "core:window:allow-show",


### PR DESCRIPTION
## Problem

On Windows v1.4.6, clicking X shows **"Unhandled rejection: Command plugin:window|destroy not allowed by ACL"** and the window never closes (running as admin doesn't help). The only way out is killing the process from Task Manager, which can leave the Python backend sidecars running.

## Cause

The unsaved-changes close guard (#498, `desktop/App.svelte` `setup_close_guard`) registers a JS `onCloseRequested` listener. Once such a listener exists, Tauri routes **every** close request through JS, and when JS allows the close the JS API finalizes it by calling `destroy()` — not `close()`. `src-tauri/capabilities/default.json` only granted `core:window:allow-close`, so the `destroy()` call is rejected by the ACL and the window can never be destroyed. This also means the Rust `WindowEvent::Destroyed` teardown (backend/agent/PTY cleanup + `exit(0)`) never runs.

Pre-1.4.6 builds had no close guard, so closes went through the native Rust path and never needed the destroy permission.

## Fix

Grant `core:window:allow-destroy` alongside `core:window:allow-close` in `capabilities/default.json`. One line; applies to all listed windows. Needs a v1.4.7 release to reach users — capabilities are compiled into the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)