### PR TITLE
fix(vscode): select scalar ferrox WASM

### DIFF
--- a/extensions/vscode/src/__tests__/ferrox-assets.test.ts
+++ b/extensions/vscode/src/__tests__/ferrox-assets.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest'
+import { select_scalar_ferrox_wasm } from '../ferrox-assets'
+
+describe(`select_scalar_ferrox_wasm`, () => {
+  test(`selects scalar when threaded artifact is listed first`, () => {
+    const scalar = {
+      filename: `ferrox_bg-scalar.wasm`,
+      buffer: Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0]),
+    }
+    const threaded = {
+      filename: `ferrox_bg-threaded.wasm`,
+      buffer: Uint8Array.from([
+        0, 97, 115, 109, 1, 0, 0, 0,
+        2, 11, 1, 1, 109, 3, 109, 101, 109, 2, 3, 1, 1,
+      ]),
+    }
+
+    expect(select_scalar_ferrox_wasm([threaded, scalar])).toBe(scalar)
+  })
+
+  test(`skips invalid artifacts`, () => {
+    const on_invalid = vi.fn()
+    const invalid = {
+      filename: `ferrox_bg-invalid.wasm`,
+      buffer: Uint8Array.from([0]),
+    }
+    const scalar = {
+      filename: `ferrox_bg-scalar.wasm`,
+      buffer: Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0]),
+    }
+
+    expect(select_scalar_ferrox_wasm([invalid, scalar], on_invalid)).toBe(scalar)
+    expect(on_invalid).toHaveBeenCalledWith(invalid, expect.any(Error))
+  })
+})

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -18,6 +18,7 @@ import { stream_file_to_buffer } from './node-io'
 import { search_optimade_structures_backend, type OptimadeSearchOptions } from './optimade-backend'
 import { search_pubchem_compounds_backend } from './pubchem-backend'
 import { CatgoDocument } from './catgo-document'
+import { select_scalar_ferrox_wasm } from './ferrox-assets'
 
 // CatgoDocument is a VS-Code-free core (its own module so unit tests can import
 // it without pulling the full extension/webview graph); re-exported here so it
@@ -373,13 +374,22 @@ export const create_html = (
         .readdirSync(assets_dir)
         .filter((f) => f.startsWith(`ferrox_bg-`) && f.endsWith(`.wasm`))
       console.log(`[CatGO] Found WASM files: ${ferrox_files.join(`, `)}`)
-      if (ferrox_files.length > 0) {
-        const wasm_path = path.join(assets_dir, ferrox_files[0])
-        const wasm_buffer = fs.readFileSync(wasm_path)
-        data_with_wasm.wasm_binary = wasm_buffer.toString(`base64`)
-        console.log(`[CatGO] Successfully loaded ferrox WASM binary (${wasm_buffer.length} bytes → ${data_with_wasm.wasm_binary.length} base64 chars)`)
+      const scalar_ferrox = select_scalar_ferrox_wasm(
+        ferrox_files.map((filename) => ({
+          filename,
+          buffer: fs.readFileSync(path.join(assets_dir, filename)),
+        })),
+        ({ filename }, error) => {
+          console.warn(`[CatGO] Ignoring invalid ferrox WASM ${filename}:`, error)
+        },
+      )
+      if (scalar_ferrox) {
+        data_with_wasm.wasm_binary = scalar_ferrox.buffer.toString(`base64`)
+        console.log(
+          `[CatGO] Successfully loaded scalar ferrox WASM ${scalar_ferrox.filename} (${scalar_ferrox.buffer.length} bytes → ${data_with_wasm.wasm_binary.length} base64 chars)`,
+        )
       } else {
-        console.warn(`[CatGO] No ferrox WASM files found in ${assets_dir}`)
+        console.warn(`[CatGO] No scalar ferrox WASM found in ${assets_dir}`)
       }
 
       // Load moyo WASM

--- a/extensions/vscode/src/ferrox-assets.ts
+++ b/extensions/vscode/src/ferrox-assets.ts
@@ -1,0 +1,24 @@
+export interface FerroxWasmCandidate {
+  filename: string
+  buffer: Uint8Array
+}
+
+// The webview uses scalar wasm-bindgen glue. Threaded builds import memory,
+// so passing one to that glue fails before slab generation starts.
+export function select_scalar_ferrox_wasm<T extends FerroxWasmCandidate>(
+  candidates: readonly T[],
+  on_invalid?: (candidate: T, error: unknown) => void,
+): T | undefined {
+  for (const candidate of candidates) {
+    try {
+      const module = new WebAssembly.Module(
+        candidate.buffer as unknown as BufferSource,
+      )
+      const is_threaded = WebAssembly.Module.imports(module)
+        .some((entry) => entry.kind === `memory`)
+      if (!is_threaded) return candidate
+    } catch (error) {
+      on_invalid?.(candidate, error)
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Inspect every bundled `ferrox_bg-*.wasm` candidate and select the scalar build deterministically.
- Reject threaded artifacts by checking for a WebAssembly memory import before injecting the binary into the webview.
- Add regression coverage for threaded-first directory order and invalid artifacts.

## Root cause

CatGo v1.4.6 ships both threaded and scalar ferrox WASM artifacts. The VS Code extension used `ferrox_files[0]`, and the packaged directory order placed the threaded build first. Passing that binary to the scalar wasm-bindgen glue fails with:

```text
LinkError: WebAssembly.instantiate(): Import #0 "./ferrox_bg.js" "memory": memory import must be a WebAssembly.Memory object
```

The webview then fell back to fetching the bundled URL, producing the user-visible `HTTP status code is not ok` slab-generation error.

## Impact

VS Code slab generation now initializes the bundled scalar ferrox WASM regardless of filesystem enumeration order.

## Validation

- Targeted Vitest: `src/__tests__/ferrox-assets.test.ts` — 2 tests passed.
- Fresh Marketplace v1.4.6 package reproduced the old threaded-selection failure.
- Patched selector chose `ferrox_bg-Dcn6B0VW.wasm`; base64 transport preserved SHA256 `050ccb3bc1050366e8dd76a5f45ba3a327183bc1d57cacab57221c310f0519b3`.
- FCC Cu(001): 4 bulk atoms → 3 slab atoms, `pbc=[true,true,false]`.
- FCC Cu(111) p(3×3)×5: 45 atoms, 9 atoms per layer, surface-normal c vector.
