### PR TITLE
chore(release): prepare v1.4.7

### DIFF
--- a/.github/release-notes/v1.4.7.md
+++ b/.github/release-notes/v1.4.7.md
@@ -1,0 +1,48 @@
+## CatGo 1.4.7
+
+CatGo 1.4.7 is a focused reliability release for the desktop app, VS Code
+extension, and multi-platform publishing pipeline.
+
+### Fixed
+
+- **Windows desktop app closes normally again** — the main window can now
+  complete its guarded shutdown, destroy the Tauri window, and clean up bundled
+  backend processes instead of remaining open after the user confirms Exit.
+- **VS Code structure generation no longer depends on WASM directory order** —
+  the extension rejects threaded `ferrox_bg` builds that import shared memory
+  and consistently selects the scalar build supported by its runtime.
+
+### Release maintenance
+
+- Hardened draft-release validation and finalization across desktop, Android,
+  iOS, VS Code sidecars, and the Cloudflare R2 mirror.
+- Normalized Windows updater metadata and preserved signing, provenance, and
+  legal-bundle evidence throughout the release pipeline.
+
+### Downloads
+
+- **Windows** — `.msi` or `-setup.exe`
+- **macOS** — `.dmg` for Apple Silicon
+- **Linux** — `.deb` or `.rpm`
+- **Android** — `CatGo-v*-android-universal.apk`
+- **iOS** — [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
+
+### License and citation
+
+CatGo 1.4.7 distributions use **AGPL-3.0-or-later**.
+
+If CatGo contributes to your work, please include this acknowledgement and the
+preferred citation:
+
+> This work used CatGo (https://catgo-ucsd.org).
+
+Please cite DOI
+[`10.26434/chemrxiv.15002984/v1`](https://doi.org/10.26434/chemrxiv.15002984/v1).
+This request is not an additional condition of the AGPL license. Third-party
+materials retain their own terms.
+
+Historical AGPL grants remain in effect.
+
+See the
+[CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md)
+for the complete release history.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -331,8 +331,8 @@ jobs:
 
             One window for the whole loop: **read almost any code's files → build & edit → run DFT / ML / MD → submit to HPC → analyse → publish.** Ships with the bundled backend server (MLP libraries excluded to keep the download lean).
 
-            ### License change in 1.4.6
-            CatGo 1.4.6 distributions use **AGPL-3.0-or-later**.
+            ### License and citation
+            CatGo 1.4.7 distributions use **AGPL-3.0-or-later**.
 
             If CatGo contributes to your work, please include this acknowledgement and the preferred citation:
 
@@ -362,12 +362,10 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
-            ### New in 1.4.6
-            - **Exact, smooth trajectory playback** — ASE and LAMMPS dump trajectories preserve source coordinates and cells exactly while the prepared-frame GPU path sustains at least 24 unique presented frames per second on the reference trajectory.
-            - **GPU impostor bonds everywhere** — trajectory playback and standalone static structures now share the same seamless GPU bond representation without midpoint boundaries.
-            - **Gaussian frame counting and IRC trajectories** — concatenated jobs no longer over-count frames, and IRC points are reconstructed in the correct order without duplicate transition-state frames.
-            - **China-friendly all-platform download center** — Windows, Apple Silicon macOS, Linux, Android, iOS/TestFlight, HPC, VS Code, and sidecar downloads are available through `dl.catgo-ucsd.org` with resumable transfers.
-            - **Cloudflare-only app acquisition and updates** — normal app downloads, update checks, and signed updater packages no longer depend on GitHub availability.
+            ### New in 1.4.7
+            - **Windows desktop app closes normally again** — guarded shutdown can destroy the Tauri window and clean up bundled backend processes after Exit is confirmed.
+            - **VS Code structure generation consistently loads compatible WASM** — threaded builds that import shared memory are rejected, so the scalar runtime is selected regardless of directory order.
+            - **More reliable multi-platform releases** — draft validation, artifact paths, signatures, provenance, updater metadata, and the Cloudflare R2 mirror are aligned across release jobs.
 
             See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for the full list.
           releaseDraft: true
@@ -526,6 +524,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ensure-v1.4.6-release-body.sh "$CATGO_RELEASE_TAG"
+
+      - name: Finalize canonical release body
+        if: env.CATGO_RELEASE_TAG == 'v1.4.7'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"
 
       - name: Upload canonical legal bundle to release
         if: runner.os == 'Linux' && env.CATGO_RELEASE_TAG != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.7] - 2026-07-28
+
+### Fixed
+
+- **Windows desktop app closes normally again** — the guarded shutdown can destroy the Tauri window and clean up bundled backend processes after the user confirms Exit.
+- **VS Code structure generation consistently loads compatible WASM** — the extension rejects threaded `ferrox_bg` builds that import shared memory and selects the scalar build regardless of directory order.
+- **Multi-platform release finalization** — desktop, Android, iOS, VS Code sidecar, updater, and Cloudflare R2 release jobs now agree on draft visibility, artifact paths, signatures, provenance, and canonical metadata.
+
 ## [1.4.6] - 2026-07-25
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.6
+version: 1.4.7
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/rust-wasm/CITATION.cff
+++ b/extensions/rust-wasm/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.6
+version: 1.4.7
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/CITATION.cff
+++ b/extensions/vscode/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.6
+version: 1.4.7
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures, molecules and MD / optimization trajectories — reads the file formats of VASP, Quantum ESPRESSO, CP2K, ABACUS, ORCA, Gaussian, CASTEP, SIESTA, OpenMX, LAMMPS and ASE: POSCAR/CONTCAR · CIF · XYZ/extXYZ · mol2 · PDB · vasprun.xml · OUTCAR · XDATCAR · .traj · HDF5 · cube/CHGCAR isosurfaces. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, trajectory scrubbing with energy/force overlays, themes that follow VS Code. Right-click → Render, or Ctrl/Cmd+Shift+V.",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/scripts/__tests__/docs-citation-license.test.mjs
+++ b/scripts/__tests__/docs-citation-license.test.mjs
@@ -48,7 +48,7 @@ test('CITATION.cff carries the exact non-binding citation request', () => {
   assert.equal(message, CITATION_REQUEST)
   assert.match(cff, new RegExp(
     `^cff-version: 1\\.2\\.0\\nmessage: ${escapeRegExp(CITATION_REQUEST)}\\n` +
-    'version: 1\\.4\\.6\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
+    'version: 1\\.4\\.7\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
     'license-url: https://github\\.com/Hello-QM/catgo-LRG/blob/main/license$',
     'm',
   ))

--- a/scripts/__tests__/license-policy.test.mjs
+++ b/scripts/__tests__/license-policy.test.mjs
@@ -152,6 +152,7 @@ const licenseClaimInventory = {
   ],
   historicalGrantPreservation: [
     '.github/release-notes/v1.4.6.md',
+    '.github/release-notes/v1.4.7.md',
     '.github/workflows/tauri-build.yml',
   ],
   historicalOnly: [
@@ -290,7 +291,7 @@ test('canonical citation file requests citation without adding an AGPL condition
   assert.equal(existsSync(resolve(ROOT, 'citation.cff')), false)
   const text = read('CITATION.cff')
   assert.match(text, /^cff-version: 1\.2\.0$/m)
-  assert.match(text, /^version: 1\.4\.6$/m)
+  assert.match(text, /^version: 1\.4\.7$/m)
   assert.match(text, /^license: AGPL-3\.0-or-later$/m)
   assert.match(text, /^license-url: https:\/\/github\.com\/Hello-QM\/catgo-LRG\/blob\/main\/license$/m)
   assert.match(text, /CatGo: Bridging CLI Coding Agents/)

--- a/scripts/__tests__/release-body.test.mjs
+++ b/scripts/__tests__/release-body.test.mjs
@@ -14,13 +14,14 @@ import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
-const NOTES = resolve(ROOT, '.github/release-notes/v1.4.6.md')
+const TAG = 'v1.4.7'
+const NOTES = resolve(ROOT, `.github/release-notes/${TAG}.md`)
 const WORKFLOW = readFileSync(
   resolve(ROOT, '.github/workflows/tauri-build.yml'),
   'utf8',
 )
 
-function runEnsure({ existing, createStatus = 0 }) {
+function runEnsure({ existing, createStatus = 0, tag = TAG }) {
   const fixture = mkdtempSync(resolve(tmpdir(), 'catgo-release-body-'))
   const fakeGh = resolve(fixture, 'gh')
   const state = resolve(fixture, 'release-exists')
@@ -45,7 +46,7 @@ exit 0
   chmodSync(fakeGh, 0o755)
   const result = spawnSync(
     'bash',
-    [resolve(ROOT, 'scripts/ensure-v1.4.6-release-body.sh'), 'v1.4.6'],
+    [resolve(ROOT, 'scripts/ensure-release-body.sh'), tag],
     {
       cwd: ROOT,
       encoding: 'utf8',
@@ -63,7 +64,7 @@ exit 0
   return { result, calls }
 }
 
-test('canonical v1.4.6 release body contains every mandatory disclosure', () => {
+test('canonical current release body contains every mandatory disclosure', () => {
   assert.ok(existsSync(NOTES), 'canonical release notes file exists')
   const body = readFileSync(NOTES, 'utf8')
   assert.match(body, /AGPL-3\.0-or-later/)
@@ -78,11 +79,11 @@ test('canonical v1.4.6 release body contains every mandatory disclosure', () => 
 test('existing release is always edited to the canonical body', () => {
   const { result, calls } = runEnsure({ existing: true })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release view v1\.4\.6$/m)
+  assert.match(calls, /^release view v1\.4\.7$/m)
   assert.doesNotMatch(calls, /^release create /m)
   assert.match(
     calls,
-    /^release edit v1\.4\.6 --title CatGo v1\.4\.6 --notes-file \.github\/release-notes\/v1\.4\.6\.md$/m,
+    /^release edit v1\.4\.7 --title CatGo v1\.4\.7 --notes-file \.github\/release-notes\/v1\.4\.7\.md$/m,
   )
 })
 
@@ -92,18 +93,34 @@ test('concurrent draft creation still converges through an explicit edit', () =>
     createStatus: 1,
   })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release create v1\.4\.6 --draft /m)
-  assert.match(calls, /^release view v1\.4\.6$/m)
-  assert.match(calls, /^release edit v1\.4\.6 /m)
+  assert.match(calls, /^release create v1\.4\.7 --draft /m)
+  assert.match(calls, /^release view v1\.4\.7$/m)
+  assert.match(calls, /^release edit v1\.4\.7 /m)
 })
 
 test('Tauri workflow finalizes the canonical body after tauri-action', () => {
   const action = WORKFLOW.indexOf('uses: tauri-apps/tauri-action@v0.6')
-  const finalize = WORKFLOW.indexOf(
-    '- name: Finalize canonical v1.4.6 release body',
-  )
+  const finalize = WORKFLOW.indexOf('- name: Finalize canonical release body')
   assert.ok(action >= 0)
   assert.ok(finalize > action)
   const block = WORKFLOW.slice(finalize)
-  assert.match(block, /scripts\/ensure-v1\.4\.6-release-body\.sh "\$CATGO_RELEASE_TAG"/)
+  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.7'/)
+  assert.match(block, /scripts\/ensure-release-body\.sh "\$CATGO_RELEASE_TAG"/)
+})
+
+test('Tauri workflow retains the v1.4.6 backfill finalizer', () => {
+  assert.match(
+    WORKFLOW,
+    /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.6'[\s\S]*scripts\/ensure-v1\.4\.6-release-body\.sh "\$CATGO_RELEASE_TAG"/,
+  )
+})
+
+test('canonical body finalizer rejects malformed release tags before calling GitHub', () => {
+  const { result, calls } = runEnsure({
+    existing: false,
+    tag: 'latest',
+  })
+  assert.equal(result.status, 2)
+  assert.match(result.stderr, /release tag must match vX\.Y\.Z/)
+  assert.equal(calls, '')
 })

--- a/scripts/__tests__/release-version-verifier.test.mjs
+++ b/scripts/__tests__/release-version-verifier.test.mjs
@@ -53,7 +53,7 @@ function runVerifierWithEnvironment(root, environment) {
   })
 }
 
-function replaceVersion(root, path, from = '1.4.6', to = '1.4.5') {
+function replaceVersion(root, path, from = '1.4.7', to = '1.4.6') {
   const target = resolve(root, path)
   const current = readFileSync(target, 'utf8')
   assert.match(current, new RegExp(from.replaceAll('.', '\\.')), path)
@@ -63,9 +63,9 @@ function replaceVersion(root, path, from = '1.4.6', to = '1.4.5') {
 test('accepts a consistent release tree and its exact v-prefixed tag', () => {
   const root = fixture()
   try {
-    const result = runVerifier(root, '--tag', 'v1.4.6')
+    const result = runVerifier(root, '--tag', 'v1.4.7')
     assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /release version 1\.4\.6 verified/)
+    assert.match(result.stdout, /release version 1\.4\.7 verified/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -78,7 +78,7 @@ test('accepts Windows CRLF checkouts', () => {
       const target = resolve(root, path)
       writeFileSync(target, readFileSync(target, 'utf8').replaceAll('\n', '\r\n'))
     }
-    const result = runVerifier(root, '--tag', 'v1.4.6')
+    const result = runVerifier(root, '--tag', 'v1.4.7')
     assert.equal(result.status, 0, result.stderr)
   } finally {
     rmSync(root, { recursive: true, force: true })
@@ -104,9 +104,9 @@ test('rejects every inconsistent release manifest', async (t) => {
 test('rejects a tag that does not exactly match the manifest version', () => {
   const root = fixture()
   try {
-    const result = runVerifier(root, '--tag', 'v1.4.7')
+    const result = runVerifier(root, '--tag', 'v1.4.6')
     assert.notEqual(result.status, 0)
-    assert.match(result.stderr, /expected v1\.4\.6/)
+    assert.match(result.stderr, /expected v1\.4\.7/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -127,17 +127,17 @@ test('honors the workflow tag and publishing requirement environment', () => {
   const root = fixture()
   try {
     const matching = runVerifierWithEnvironment(root, {
-      RELEASE_VERSION_TAG: 'v1.4.6',
+      RELEASE_VERSION_TAG: 'v1.4.7',
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.equal(matching.status, 0, matching.stderr)
 
     const mismatched = runVerifierWithEnvironment(root, {
-      RELEASE_VERSION_TAG: 'v1.4.7',
+      RELEASE_VERSION_TAG: 'v1.4.6',
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.notEqual(mismatched.status, 0)
-    assert.match(mismatched.stderr, /expected v1\.4\.6/)
+    assert.match(mismatched.stderr, /expected v1\.4\.7/)
 
     const missing = runVerifierWithEnvironment(root, {
       RELEASE_VERSION_TAG: '',

--- a/scripts/__tests__/version-consistency.test.mjs
+++ b/scripts/__tests__/version-consistency.test.mjs
@@ -6,7 +6,7 @@ import test from 'node:test'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const source = (path) => readFileSync(resolve(ROOT, path), 'utf8')
-const APP_VERSION = '1.4.6'
+const APP_VERSION = '1.4.7'
 const WORKFLOW_INVENTORY = {
   'android-build.yml': {
     classification: 'root-versioned-publisher',
@@ -131,7 +131,7 @@ function workflowStep(path, name) {
   return workflow.slice(start, next === -1 ? undefined : next)
 }
 
-test('all CatGo application version surfaces target v1.4.6', () => {
+test('all CatGo application version surfaces target v1.4.7', () => {
   const packageJson = JSON.parse(source('package.json'))
   const tauriConfig = JSON.parse(source('src-tauri/tauri.conf.json'))
   const cargoLockMatch =
@@ -153,7 +153,7 @@ test('all CatGo application version surfaces target v1.4.6', () => {
   )
 })
 
-test('VSIX and citation package metadata target v1.4.6', () => {
+test('VSIX and citation package metadata target v1.4.7', () => {
   const vscodePackage = JSON.parse(source('extensions/vscode/package.json'))
   assert.equal(vscodePackage.version, APP_VERSION)
 
@@ -174,15 +174,13 @@ test('the dependency lock remains a pnpm v9 root-importer lock', () => {
   assert.match(lock, /^importers:\n\n  \.:\n/m)
 })
 
-test('the desktop draft release notes describe v1.4.6', () => {
+test('the desktop draft release notes describe v1.4.7', () => {
   const workflow = source('.github/workflows/tauri-build.yml')
 
-  assert.match(workflow, /### New in 1\.4\.6/)
-  assert.match(workflow, /at least 24 unique presented frames per second/)
-  assert.match(workflow, /GPU impostor bonds/)
-  assert.match(workflow, /Gaussian frame counting and IRC trajectories/)
-  assert.match(workflow, /China-friendly all-platform download center/)
-  assert.match(workflow, /Cloudflare-only app acquisition and updates/)
+  assert.match(workflow, /### New in 1\.4\.7/)
+  assert.match(workflow, /Windows desktop app closes normally again/)
+  assert.match(workflow, /VS Code structure generation consistently loads compatible WASM/)
+  assert.match(workflow, /More reliable multi-platform releases/)
 })
 
 test('VSIX publishing fails on duplicate marketplace versions', () => {

--- a/scripts/ensure-release-body.sh
+++ b/scripts/ensure-release-body.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TAG="${1:?usage: ensure-v1.4.6-release-body.sh v1.4.6}"
-if [ "$TAG" != "v1.4.6" ]; then
-  echo "refusing to apply v1.4.6 release notes to $TAG" >&2
+TAG="${1:?usage: ensure-release-body.sh vX.Y.Z}"
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "release tag must match vX.Y.Z: $TAG" >&2
   exit 2
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(dirname "$SCRIPT_DIR")"
-NOTES=".github/release-notes/v1.4.6.md"
+NOTES=".github/release-notes/${TAG}.md"
 GH_BIN="${CATGO_GH_BIN:-gh}"
 cd "$ROOT"
+
+if [ ! -f "$NOTES" ]; then
+  echo "canonical release notes do not exist: $NOTES" >&2
+  exit 2
+fi
 
 if ! "$GH_BIN" release view "$TAG" >/dev/null 2>&1; then
   # Another matrix or asset workflow may create the draft after our view.

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -10,6 +10,7 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
     '18ede0be37b3bcda404f174ecb407382516f2d3efbb532d09a026f3d9ac9b208',
     '6dff73ab93babff2d03a2a313330e1bd981c47ab3bcf72687352daa7e7eaf46b',
     'ceddcb4f7e0ed52fce1c0e56d53d787770a90936d4cc401bc9d72a6f94f753e7',
+    'abc4a14a9dd54d1255aab9d57819299a5e58b63c3f8ea60cb495295755e50ae1',
   ]),
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',

--- a/scripts/verify-legal-distributions.mjs
+++ b/scripts/verify-legal-distributions.mjs
@@ -323,13 +323,13 @@ function verifyReleaseAssets() {
     'the download mirror must validate assets against legal material from the target tag',
   )
   requireMatch(
-    '.github/release-notes/v1.4.6.md',
+    '.github/release-notes/v1.4.7.md',
     /AGPL-3\.0-or-later[\s\S]*This work used CatGo \(https:\/\/catgo-ucsd\.org\)\.[\s\S]*10\.26434\/chemrxiv\.15002984\/v1[\s\S]*not an additional condition/i,
     'release body must prominently disclose AGPL, the requested acknowledgement, DOI, and its non-binding status',
   )
   requireActiveWorkflowRun(
     '.github/workflows/tauri-build.yml',
-    /ensure-v1\.4\.6-release-body\.sh/,
+    /ensure-release-body\.sh/,
     'the final publishing job must deterministically restore the canonical release body',
   )
 }

--- a/server/CITATION.cff
+++ b/server/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.6
+version: 1.4.7
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catgo"
-version = "1.4.6"
+version = "1.4.7"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
 readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.6"
+version = "1.4.7"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
## Summary

- bump CatGo desktop, server, VS Code extension, Cargo, and citation metadata to `1.4.7`
- add the canonical v1.4.7 release Description covering the Windows shutdown and VS Code scalar WASM fixes
- document release-pipeline reliability work across desktop, Android, iOS, VS Code sidecars, and R2 delivery
- generalize release-body finalization for future versions while retaining the historical v1.4.6 backfill path
- update release trust-policy and distribution consistency checks

## Release Description

The canonical Description is stored in `.github/release-notes/v1.4.7.md` and will be applied by the release finalizer. It includes highlights, download guidance, licensing, acknowledgement, and DOI information.

## Verification

- `pnpm exec vitest run --reporter=dot --maxWorkers=1` — 288 files passed, 1 skipped; 5,146 tests passed, 53 skipped
- `node --test --test-reporter=dot scripts/__tests__/*.test.mjs workers/downloads/index.test.mjs` — passed
- `pnpm check` — 0 errors (304 existing warnings)
- `pnpm legal:verify` — 10 distribution contracts and 27 files validated
- `node scripts/verify-release-rights.mjs` — 2 ledgers verified
- `node scripts/verify-release-version.mjs --root . --tag v1.4.7 --require-tag` — passed
- `pnpm verify:wasm` — passed
- `git diff --cached --check` — passed