### PR TITLE
fix(database): restore MP, OPTIMADE, and PubChem search

### DIFF
--- a/extensions/vscode/pnpm-lock.yaml
+++ b/extensions/vscode/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 importers:
+
   .:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
@@ -16,6 +17,12 @@ importers:
       '@types/vscode':
         specifier: ^1.96.0
         version: 1.108.1
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      happy-dom:
+        specifier: ^20.3.7
+        version: 20.11.1
       svelte:
         specifier: ^5.38.7
         version: 5.48.0
@@ -27,478 +34,369 @@ importers:
         version: 7.3.1(@types/node@24.10.9)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.10.9)
+        version: 3.2.4(@types/node@24.10.9)(happy-dom@20.11.1)
+      ws:
+        specifier: ^8.19.0
+        version: 8.21.1
 
 packages:
+
   '@esbuild/aix-ppc64@0.27.2':
-    resolution: {
-      integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
-    resolution: {
-      integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.27.2':
-    resolution: {
-      integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
-    resolution: {
-      integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
-    resolution: {
-      integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
-    resolution: {
-      integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.27.2':
-    resolution: {
-      integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
-    resolution: {
-      integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.27.2':
-    resolution: {
-      integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
-    resolution: {
-      integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.27.2':
-    resolution: {
-      integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
-    resolution: {
-      integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.2':
-    resolution: {
-      integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
-    resolution: {
-      integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
-    resolution: {
-      integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.27.2':
-    resolution: {
-      integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.27.2':
-    resolution: {
-      integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.2':
-    resolution: {
-      integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
-    resolution: {
-      integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
-    resolution: {
-      integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-    }
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/remapping@2.3.5':
-    resolution: {
-      integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-    }
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
-    resolution: {
-      integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-    }
-    engines: { node: '>=6.0.0' }
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {
-      integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-    }
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.31':
-    resolution: {
-      integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-    }
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@rollup/rollup-android-arm-eabi@4.56.0':
-    resolution: {
-      integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==,
-    }
+    resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.56.0':
-    resolution: {
-      integrity: sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==,
-    }
+    resolution: {integrity: sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==}
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.56.0':
-    resolution: {
-      integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==,
-    }
+    resolution: {integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==}
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.56.0':
-    resolution: {
-      integrity: sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==,
-    }
+    resolution: {integrity: sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==}
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.56.0':
-    resolution: {
-      integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==,
-    }
+    resolution: {integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==}
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.56.0':
-    resolution: {
-      integrity: sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==,
-    }
+    resolution: {integrity: sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==}
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
-    resolution: {
-      integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==,
-    }
+    resolution: {integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.56.0':
-    resolution: {
-      integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==,
-    }
+    resolution: {integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==,
-    }
+    resolution: {integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.56.0':
-    resolution: {
-      integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==,
-    }
+    resolution: {integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==,
-    }
+    resolution: {integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.56.0':
-    resolution: {
-      integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==,
-    }
+    resolution: {integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==,
-    }
+    resolution: {integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.56.0':
-    resolution: {
-      integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==,
-    }
+    resolution: {integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==,
-    }
+    resolution: {integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.56.0':
-    resolution: {
-      integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==,
-    }
+    resolution: {integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==,
-    }
+    resolution: {integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==,
-    }
+    resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.56.0':
-    resolution: {
-      integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==,
-    }
+    resolution: {integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.56.0':
-    resolution: {
-      integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==,
-    }
+    resolution: {integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==}
     cpu: [x64]
     os: [openbsd]
 
   '@rollup/rollup-openharmony-arm64@4.56.0':
-    resolution: {
-      integrity: sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==,
-    }
+    resolution: {integrity: sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==}
     cpu: [arm64]
     os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.56.0':
-    resolution: {
-      integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==,
-    }
+    resolution: {integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==}
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.56.0':
-    resolution: {
-      integrity: sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==,
-    }
+    resolution: {integrity: sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==}
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.56.0':
-    resolution: {
-      integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==,
-    }
+    resolution: {integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==}
     cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.56.0':
-    resolution: {
-      integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==,
-    }
+    resolution: {integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==}
     cpu: [x64]
     os: [win32]
 
   '@sveltejs/acorn-typescript@1.0.8':
-    resolution: {
-      integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==,
-    }
+    resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
     peerDependencies:
       acorn: ^8.9.0
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
-    resolution: {
-      integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==,
-    }
-    engines: { node: ^20.19 || ^22.12 || >=24 }
+    resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
       svelte: ^5.0.0
       vite: ^6.3.0 || ^7.0.0
 
   '@sveltejs/vite-plugin-svelte@6.2.4':
-    resolution: {
-      integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==,
-    }
-    engines: { node: ^20.19 || ^22.12 || >=24 }
+    resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
       svelte: ^5.0.0
       vite: ^6.3.0 || ^7.0.0
 
   '@types/chai@5.2.3':
-    resolution: {
-      integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-    }
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/deep-eql@4.0.2':
-    resolution: {
-      integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-    }
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
-    resolution: {
-      integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
-    }
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@24.10.9':
-    resolution: {
-      integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==,
-    }
+    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
   '@types/vscode@1.108.1':
-    resolution: {
-      integrity: sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==,
-    }
+    resolution: {integrity: sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@3.2.4':
-    resolution: {
-      integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
-    }
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
   '@vitest/mocker@3.2.4':
-    resolution: {
-      integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==,
-    }
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -509,84 +407,60 @@ packages:
         optional: true
 
   '@vitest/pretty-format@3.2.4':
-    resolution: {
-      integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
-    }
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/runner@3.2.4':
-    resolution: {
-      integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==,
-    }
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/snapshot@3.2.4':
-    resolution: {
-      integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==,
-    }
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/spy@3.2.4':
-    resolution: {
-      integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
-    }
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
   '@vitest/utils@3.2.4':
-    resolution: {
-      integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
-    }
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   acorn@8.15.0:
-    resolution: {
-      integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
-    }
-    engines: { node: '>=0.4.0' }
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
     hasBin: true
 
   aria-query@5.3.2:
-    resolution: {
-      integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==,
-    }
-    engines: { node: '>= 0.4' }
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
-    resolution: {
-      integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-    }
-    engines: { node: '>=12' }
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   axobject-query@4.1.0:
-    resolution: {
-      integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==,
-    }
-    engines: { node: '>= 0.4' }
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   cac@6.7.14:
-    resolution: {
-      integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-    }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   chai@5.3.3:
-    resolution: {
-      integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   check-error@2.1.3:
-    resolution: {
-      integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
-    }
-    engines: { node: '>= 16' }
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   clsx@2.1.1:
-    resolution: {
-      integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
-    }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   debug@4.4.3:
-    resolution: {
-      integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-    }
-    engines: { node: '>=6.0' }
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -594,60 +468,44 @@ packages:
         optional: true
 
   deep-eql@5.0.2:
-    resolution: {
-      integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-    }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deepmerge@4.3.1:
-    resolution: {
-      integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
-    }
-    engines: { node: '>=0.10.0' }
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   devalue@5.6.2:
-    resolution: {
-      integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==,
-    }
+    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
-    resolution: {
-      integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
-    }
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.27.2:
-    resolution: {
-      integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esm-env@1.2.2:
-    resolution: {
-      integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==,
-    }
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   esrap@2.2.2:
-    resolution: {
-      integrity: sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==,
-    }
+    resolution: {integrity: sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==}
 
   estree-walker@3.0.3:
-    resolution: {
-      integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-    }
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   expect-type@1.3.0:
-    resolution: {
-      integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
-    }
-    engines: { node: '>=12.0.0' }
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
-    resolution: {
-      integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-    }
-    engines: { node: '>=12.0.0' }
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -655,179 +513,121 @@ packages:
         optional: true
 
   fsevents@2.3.3:
-    resolution: {
-      integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-    }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  happy-dom@20.11.1:
+    resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
+    engines: {node: '>=20.0.0'}
+
   is-reference@3.0.3:
-    resolution: {
-      integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==,
-    }
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   js-tokens@9.0.1:
-    resolution: {
-      integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
-    }
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   locate-character@3.0.0:
-    resolution: {
-      integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==,
-    }
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   loupe@3.2.1:
-    resolution: {
-      integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-    }
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
-    resolution: {
-      integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-    }
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   ms@2.1.3:
-    resolution: {
-      integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-    }
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
-    resolution: {
-      integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-    }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   obug@2.1.1:
-    resolution: {
-      integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
-    }
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   pathe@2.0.3:
-    resolution: {
-      integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-    }
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
-    resolution: {
-      integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-    }
-    engines: { node: '>= 14.16' }
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
-    resolution: {
-      integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-    }
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.3:
-    resolution: {
-      integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
-    }
-    engines: { node: '>=12' }
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   postcss@8.5.6:
-    resolution: {
-      integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
-    }
-    engines: { node: ^10 || ^12 || >=14 }
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   rollup@4.56.0:
-    resolution: {
-      integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==,
-    }
-    engines: { node: '>=18.0.0', npm: '>=8.0.0' }
+    resolution: {integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   siginfo@2.0.0:
-    resolution: {
-      integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
-    }
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   source-map-js@1.2.1:
-    resolution: {
-      integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-    }
-    engines: { node: '>=0.10.0' }
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   stackback@0.0.2:
-    resolution: {
-      integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-    }
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
-    resolution: {
-      integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
-    }
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-literal@3.1.0:
-    resolution: {
-      integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==,
-    }
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   svelte@5.48.0:
-    resolution: {
-      integrity: sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==,
-    }
-    engines: { node: '>=18' }
+    resolution: {integrity: sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
-    resolution: {
-      integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
-    }
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
-    resolution: {
-      integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
-    }
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.15:
-    resolution: {
-      integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
-    }
-    engines: { node: '>=12.0.0' }
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
-    resolution: {
-      integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
-    }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
-    resolution: {
-      integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
-    }
-    engines: { node: '>=14.0.0' }
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
-    resolution: {
-      integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
-    }
-    engines: { node: '>=14.0.0' }
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
-    resolution: {
-      integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
-    }
-    engines: { node: '>=14.17' }
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   undici-types@7.16.0:
-    resolution: {
-      integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
-    }
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   vite-node@3.2.4:
-    resolution: {
-      integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
-    }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@7.3.1:
-    resolution: {
-      integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==,
-    }
-    engines: { node: ^20.19.0 || >=22.12.0 }
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
@@ -866,9 +666,7 @@ packages:
         optional: true
 
   vitefu@1.1.1:
-    resolution: {
-      integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==,
-    }
+    resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
     peerDependenciesMeta:
@@ -876,10 +674,8 @@ packages:
         optional: true
 
   vitest@3.2.4:
-    resolution: {
-      integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==,
-    }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -905,19 +701,32 @@ packages:
       jsdom:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   why-is-node-running@2.3.0:
-    resolution: {
-      integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
-    }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   zimmerframe@1.1.4:
-    resolution: {
-      integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==,
-    }
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
+
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -1126,6 +935,12 @@ snapshots:
 
   '@types/vscode@1.108.1': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.10.9
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1176,6 +991,10 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.10.9
+
   cac@6.7.14: {}
 
   chai@5.3.3:
@@ -1199,6 +1018,8 @@ snapshots:
   deepmerge@4.3.1: {}
 
   devalue@5.6.2: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1249,6 +1070,19 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  happy-dom@20.11.1:
+    dependencies:
+      '@types/node': 24.10.9
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   is-reference@3.0.3:
     dependencies:
@@ -1401,7 +1235,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.10.9)
 
-  vitest@3.2.4(@types/node@24.10.9):
+  vitest@3.2.4(@types/node@24.10.9)(happy-dom@20.11.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -1428,6 +1262,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.9
+      happy-dom: 20.11.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -1442,9 +1277,13 @@ snapshots:
       - tsx
       - yaml
 
+  whatwg-mimetype@3.0.0: {}
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.1: {}
 
   zimmerframe@1.1.4: {}

--- a/extensions/vscode/src/optimade-backend.ts
+++ b/extensions/vscode/src/optimade-backend.ts
@@ -64,6 +64,8 @@ export interface OptimadeSearchOptions {
   nsites_max?: number
   limit?: number
   offset?: number
+  response_fields?: string
+  sort?: string
 }
 
 export interface OptimadeSearchResult {
@@ -76,6 +78,7 @@ export interface OptimadeSearchResult {
 let cached_providers: OptimadeProvider[] | null = null
 let providers_cache_time = 0
 const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+const resolved_urls_cache = new Map<string, string>()
 
 /**
  * Fetch list of OPTIMADE providers from central registry
@@ -105,6 +108,7 @@ async function fetch_providers(): Promise<OptimadeProvider[]> {
     const BROKEN_PROVIDER_IDS = new Set([
       `aflow`, `cod`, `cmr`, `exmpl`, `matcloud`, `mpds`,
       `mpod`, `nmd`, `odbx`, `oqmd`, `jarvis`, `tcod`,
+      `mcloud`, `omdb`, `twodmatpedia`,
     ])
     providers = providers.filter(p => !BROKEN_PROVIDER_IDS.has(p.id))
 
@@ -115,6 +119,73 @@ async function fetch_providers(): Promise<OptimadeProvider[]> {
     console.warn(`[OPTIMADE] Failed to fetch providers:`, error)
     return cached_providers || []
   }
+}
+
+/**
+ * Registry entries often point at an index meta-database rather than a
+ * structures API. Resolve its child URL, caching successes only so a transient
+ * registry/index failure can recover on the next request.
+ */
+async function resolve_provider_url(base_url: string): Promise<string> {
+  const cached = resolved_urls_cache.get(base_url)
+  if (cached) return cached
+
+  const normalized_base = base_url.replace(/\/$/, ``)
+  for (const endpoint of [`/links`, `/v1/links`]) {
+    try {
+      const response = await fetch(`${normalized_base}${endpoint}`, {
+        headers: {
+          'Accept': `application/vnd.api+json`,
+          'User-Agent': `CatGO/1.0`,
+        },
+      })
+      if (!response.ok) continue
+      const payload = await response.json() as {
+        data?: Array<{
+          type?: string
+          attributes?: { link_type?: string; base_url?: string }
+        }>
+      }
+      const child = payload.data?.find((link) =>
+        link.type === `links`
+        && link.attributes?.link_type === `child`
+        && link.attributes.base_url
+      )?.attributes?.base_url
+      if (child) {
+        resolved_urls_cache.set(base_url, child)
+        return child
+      }
+    } catch {
+      // Try the alternate links endpoint, then fall back without caching.
+    }
+  }
+  return base_url
+}
+
+async function fetch_structures_response(
+  base_url: string,
+  params: URLSearchParams,
+): Promise<{ response: Response; url: string }> {
+  const normalized_base = base_url.replace(/\/$/, ``)
+  let last_response: Response | null = null
+  let last_url = ``
+  for (const endpoint of [
+    `${normalized_base}/v1/structures`,
+    `${normalized_base}/structures`,
+  ]) {
+    const url = `${endpoint}?${params}`
+    const response = await fetch(url, {
+      headers: {
+        'Accept': `application/vnd.api+json`,
+        'User-Agent': `CatGO/1.0`,
+      },
+    })
+    if (response.ok) return { response, url }
+    last_response = response
+    last_url = url
+  }
+  if (!last_response) throw new Error(`No OPTIMADE structures endpoint for ${base_url}`)
+  return { response: last_response, url: last_url }
 }
 
 /**
@@ -223,28 +294,29 @@ export async function search_optimade_structures_backend(
       throw new Error(`Unknown provider: ${provider}`)
     }
 
-    // Special case: Materials Project has a real OPTIMADE API at optimade.materialsproject.org
-    // The providers registry returns a proxy URL that doesn't work for API calls
+    // Materials Project's registry entry is an index meta-database. Its known
+    // direct endpoint is safe to use; all other providers (including MPDD)
+    // must resolve their own child URL instead of being mistaken for MP.
     let base_url = provider_obj.attributes.base_url
-    if (provider === `mp` || provider === `mpdd`) {
+    if (provider === `mp`) {
       base_url = `https://optimade.materialsproject.org`
       console.log(`[OPTIMADE] Using real Materials Project API: ${base_url}`)
+    } else {
+      base_url = await resolve_provider_url(base_url)
     }
 
     // Build query URL
-    const filter_param = filter ? `&filter=${encodeURIComponent(filter)}` : ``
-    const url = `${base_url}/v1/structures?page_limit=${limit}&page_offset=${offset}${filter_param}`
+    const params = new URLSearchParams({
+      page_limit: String(limit),
+      page_offset: String(offset),
+    })
+    if (filter) params.set(`filter`, filter)
+    if (options.response_fields) params.set(`response_fields`, options.response_fields)
+    if (options.sort) params.set(`sort`, options.sort)
 
+    const { response, url } = await fetch_structures_response(base_url, params)
     console.log(`[OPTIMADE] Search URL: ${url}`)
     if (filter) console.log(`[OPTIMADE] Filter: ${filter}`)
-
-    // Fetch from provider
-    const response = await fetch(url, {
-      headers: {
-        'Accept': `application/vnd.api+json`,
-        'User-Agent': `CatGO/1.0`,
-      },
-    })
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`)
@@ -252,16 +324,24 @@ export async function search_optimade_structures_backend(
 
     const data = await response.json() as {
       data?: OptimadeStructure[]
-      meta?: { data_returned?: number; data_available?: number }
+      meta?: {
+        data_returned?: number
+        data_available?: number
+        more_data_available?: boolean
+      }
     }
 
     const structures = data.data || []
-    const total_count = data.meta?.data_returned ?? data.meta?.data_available
+    const total_count = data.meta?.data_available ?? data.meta?.data_returned
+    const has_more = data.meta?.more_data_available
+      ?? (total_count === undefined
+        ? structures.length === limit
+        : offset + structures.length < total_count)
 
     return {
       structures,
       total_count,
-      has_more: structures.length === limit,
+      has_more,
     }
   } catch (error) {
     console.error(`[OPTIMADE] Search failed:`, error)
@@ -282,15 +362,14 @@ export async function fetch_suggested_structures_backend(
 
     if (!provider_obj) return []
 
-    const base_url = provider_obj.attributes.base_url
-    const url = `${base_url}/v1/structures?page_limit=${limit}&page_offset=0`
-
-    const response = await fetch(url, {
-      headers: {
-        'Accept': `application/vnd.api+json`,
-        'User-Agent': `CatGO/1.0`,
-      },
+    const base_url = provider === `mp`
+      ? `https://optimade.materialsproject.org`
+      : await resolve_provider_url(provider_obj.attributes.base_url)
+    const params = new URLSearchParams({
+      page_limit: String(limit),
+      page_offset: `0`,
     })
+    const { response } = await fetch_structures_response(base_url, params)
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)

--- a/extensions/vscode/vite.config.mjs
+++ b/extensions/vscode/vite.config.mjs
@@ -10,6 +10,10 @@ import { mock_vscode } from './tests/vscode-mock'
 const __dirname = fileURLToPath(new URL(`.`, import.meta.url))
 
 export default defineConfig(({ mode }) => ({
+  // VS Code serves this bundle from a vscode-webview:// URI. Absolute
+  // `/assets/...` URLs resolve against the webview origin and return empty
+  // responses; relative URLs stay beside dist/webview.js.
+  base: `./`,
   // wasm-bindgen-rayon's threaded glue imports child worker chunks. Vite's
   // default IIFE worker output cannot code-split, so emit module workers.
   worker: {

--- a/server/catgo/routers/materials_project.py
+++ b/server/catgo/routers/materials_project.py
@@ -20,7 +20,9 @@ class MPSearchRequest(BaseModel):
     elements: Optional[list[str]] = None
     formula: Optional[str] = None
     material_ids: Optional[list[str]] = None  # Search by specific material IDs
+    num_elements: Optional[int] = None
     limit: int = 20
+    offset: int = 0
 
 
 @router.get("/validate-key")
@@ -108,6 +110,13 @@ async def search_structures(
     if request.formula:
         params["formula"] = request.formula
 
+    if request.num_elements is not None:
+        params["nelements_min"] = str(request.num_elements)
+        params["nelements_max"] = str(request.num_elements)
+
+    if request.offset > 0:
+        params["_skip"] = str(request.offset)
+
     print(f"[MP DEBUG] Search params: {params}")
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
@@ -169,14 +178,17 @@ async def get_structure(
             "vbm",
             "ordering",
             "has_props",
+            "structure",
         ]),
+        "material_ids": material_id,
+        "_limit": "1",
     }
 
     print(f"[MP DEBUG] Fetching structure: {material_id}")
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         try:
-            url = f"{MP_API_BASE}/materials/summary/{material_id}"
+            url = f"{MP_API_BASE}/materials/summary/"
             print(f"[MP DEBUG] URL: {url}")
             response = await client.get(
                 url,

--- a/server/catgo/routers/optimade.py
+++ b/server/catgo/routers/optimade.py
@@ -22,6 +22,10 @@ HTTP_TIMEOUT = 30.0
 BROKEN_PROVIDER_IDS = {
     "aflow", "cod", "cmr", "exmpl", "matcloud", "mpds",
     "mpod", "nmd", "odbx", "oqmd", "jarvis", "tcod",
+    # Registry entries currently resolve to endpoints that cannot serve
+    # structures: Materials Cloud main returns 404, OMDB times out, and
+    # 2DMatpedia's advertised TLS endpoint fails the handshake.
+    "mcloud", "omdb", "twodmatpedia",
 }
 
 # Fallback providers when main provider list is unavailable
@@ -37,53 +41,33 @@ FALLBACK_PROVIDERS = [
         },
     },
     {
-        "id": "mc3d",
+        "id": "mpdd",
         "type": "links",
         "attributes": {
-            "name": "MC3D",
-            "description": "Materials Cloud 3D crystals database",
-            "base_url": "https://aiida.materialscloud.org/mc3d/optimade",
-            "homepage": "https://materialscloud.org",
+            "name": "Material-Property-Descriptor Database",
+            "description": "MPDD crystal structures",
+            "base_url": "http://mpddoptimade.phaseslab.org",
+            "homepage": "https://www.phaseslab.com/mpdd",
         },
     },
     {
-        "id": "alexandria",
+        "id": "matterverse",
         "type": "links",
         "attributes": {
-            "name": "Alexandria",
-            "description": "Alexandria database",
-            "base_url": "https://alexandria.icams.rub.de/optimade",
-            "homepage": "https://alexandria.icams.rub.de",
+            "name": "Matterverse",
+            "description": "Machine-learning material predictions",
+            "base_url": "https://optimade.matterverse.ai",
+            "homepage": "https://matterverse.ai",
         },
     },
     {
-        "id": "mcloud",
+        "id": "atomgpt",
         "type": "links",
         "attributes": {
-            "name": "Materials Cloud",
-            "description": "Materials Cloud main database",
-            "base_url": "https://www.materialscloud.org/optimade/main",
-            "homepage": "https://www.materialscloud.org",
-        },
-    },
-    {
-        "id": "omdb",
-        "type": "links",
-        "attributes": {
-            "name": "Open Materials Database",
-            "description": "Open Materials Database",
-            "base_url": "https://optimade.openmaterialsdb.se",
-            "homepage": "https://openmaterialsdb.se",
-        },
-    },
-    {
-        "id": "twodmatpedia",
-        "type": "links",
-        "attributes": {
-            "name": "2DMatpedia",
-            "description": "2D Materials database",
-            "base_url": "https://optimade.2dmatpedia.org",
-            "homepage": "https://www.2dmatpedia.org",
+            "name": "AtomGPT JARVIS-DFT",
+            "description": "JARVIS-DFT structures served by AtomGPT",
+            "base_url": "https://atomgpt.org/optimade/v1",
+            "homepage": "https://atomgpt.org",
         },
     },
 ]
@@ -150,8 +134,9 @@ async def resolve_provider_url(base_url: str) -> str:
         except Exception:
             continue
 
-    # Fallback to original URL
-    _resolved_urls_cache[base_url] = base_url
+    # Do not cache a failed resolution. A transient index outage must recover
+    # on the next search instead of pinning the unresolved meta-database URL
+    # until the sidecar process restarts.
     return base_url
 
 
@@ -184,8 +169,8 @@ async def get_providers():
         _providers_cache = providers
         return {"data": providers}
     except Exception as e:
-        # Return fallback providers on error
-        _providers_cache = FALLBACK_PROVIDERS
+        # Return fallback providers for this request, but do not cache them.
+        # The provider registry may have suffered only a transient outage.
         return {"data": FALLBACK_PROVIDERS, "warning": str(e)}
 
 

--- a/server/tests/test_materials_project_router.py
+++ b/server/tests/test_materials_project_router.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from catgo.routers import materials_project
+
+
+class _FakeResponse:
+    status_code = 200
+    text = '{"data":[]}'
+
+    def json(self):
+        return {"data": [], "meta": {"total_doc": 0}}
+
+    def raise_for_status(self):
+        return None
+
+
+class _FakeAsyncClient:
+    requests: list[dict] = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, url, *, params, headers):
+        self.requests.append({"url": url, "params": params, "headers": headers})
+        return _FakeResponse()
+
+
+@pytest.fixture(autouse=True)
+def _mock_httpx(monkeypatch):
+    _FakeAsyncClient.requests = []
+    monkeypatch.setattr(materials_project.httpx, "AsyncClient", _FakeAsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_search_forwards_exact_element_count_and_offset():
+    request = materials_project.MPSearchRequest(
+        elements=["Ti", "O"],
+        num_elements=2,
+        limit=20,
+        offset=20,
+    )
+
+    await materials_project.search_structures(request, x_api_key="test-key")
+
+    params = _FakeAsyncClient.requests[0]["params"]
+    assert params["elements"] == "Ti,O"
+    assert params["nelements_min"] == "2"
+    assert params["nelements_max"] == "2"
+    assert params["_skip"] == "20"
+
+
+@pytest.mark.asyncio
+async def test_single_structure_request_includes_geometry_field():
+    await materials_project.get_structure("mp-2657", x_api_key="test-key")
+
+    request = _FakeAsyncClient.requests[0]
+    assert request["url"].endswith("/materials/summary/")
+    assert request["params"]["material_ids"] == "mp-2657"
+    assert request["params"]["_limit"] == "1"
+    fields = request["params"]["_fields"].split(",")
+    assert "structure" in fields

--- a/server/tests/test_optimade_provider_recovery.py
+++ b/server/tests/test_optimade_provider_recovery.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from catgo.routers import optimade
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_caches():
+    optimade._providers_cache = None
+    optimade._resolved_urls_cache.clear()
+    yield
+    optimade._providers_cache = None
+    optimade._resolved_urls_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_registry_failure_does_not_cache_fallback_forever(monkeypatch):
+    calls = 0
+
+    async def fake_fetch_json(url: str):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary registry outage")
+        return {
+            "data": [{
+                "id": "healthy",
+                "attributes": {
+                    "name": "Healthy",
+                    "description": "working provider",
+                    "base_url": "https://healthy.example",
+                },
+            }],
+        }
+
+    monkeypatch.setattr(optimade, "fetch_json", fake_fetch_json)
+
+    first = await optimade.get_providers()
+    second = await optimade.get_providers()
+
+    assert first["data"] == optimade.FALLBACK_PROVIDERS
+    assert [entry["id"] for entry in second["data"]] == ["healthy"]
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_transient_child_resolution_failure_is_retried(monkeypatch):
+    calls = 0
+
+    async def fake_fetch_json(url: str):
+        nonlocal calls
+        calls += 1
+        if calls <= 2:
+            raise RuntimeError("temporary index outage")
+        return {
+            "data": [{
+                "id": "child",
+                "type": "links",
+                "attributes": {
+                    "link_type": "child",
+                    "base_url": "https://child.example",
+                },
+            }],
+        }
+
+    monkeypatch.setattr(optimade, "fetch_json", fake_fetch_json)
+
+    first = await optimade.resolve_provider_url("https://index.example")
+    second = await optimade.resolve_provider_url("https://index.example")
+
+    assert first == "https://index.example"
+    assert second == "https://child.example"
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_provider_registry_filters_confirmed_dead_endpoints(monkeypatch):
+    async def fake_fetch_json(url: str):
+        return {
+            "data": [
+                {
+                    "id": provider_id,
+                    "attributes": {
+                        "name": provider_id,
+                        "base_url": f"https://{provider_id}.example",
+                    },
+                }
+                for provider_id in (
+                    "healthy",
+                    "mcloud",
+                    "omdb",
+                    "twodmatpedia",
+                )
+            ],
+        }
+
+    monkeypatch.setattr(optimade, "fetch_json", fake_fetch_json)
+
+    response = await optimade.get_providers()
+
+    assert [entry["id"] for entry in response["data"]] == ["healthy"]

--- a/src/lib/api/__tests__/materials-project.test.ts
+++ b/src/lib/api/__tests__/materials-project.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as materials_project from '../materials-project'
 import { search_mp_structures, set_mp_api_key, validate_mp_api_key } from '../materials-project'
 
 // Controllable isMobile + native-fetch mocks (same pattern as provider-routing tests).
@@ -51,6 +52,72 @@ describe(`materials-project mobile gating`, () => {
     expect(url).toContain(`elements=Fe%2CO`)
   })
 
+  it(`requests structure geometry when loading one MP material`, async () => {
+    mobile_flag.value = true
+    set_mp_api_key(`test-key`)
+    tauri_fetch_mock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              material_id: `mp-2657`,
+              formula_pretty: `TiO2`,
+              nsites: 6,
+              nelements: 2,
+              structure: {
+                lattice: {
+                  matrix: [[4.59, 0, 0], [0, 4.59, 0], [0, 0, 2.96]],
+                  pbc: [true, true, true],
+                  a: 4.59,
+                  b: 4.59,
+                  c: 2.96,
+                  alpha: 90,
+                  beta: 90,
+                  gamma: 90,
+                  volume: 62.36,
+                },
+                sites: [],
+                charge: 0,
+                properties: {},
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const result = await materials_project.get_mp_structure_summary(`mp-2657`)
+
+    expect(result?.material_id).toBe(`mp-2657`)
+    const url = new URL(String(tauri_fetch_mock.mock.calls[0]?.[0] ?? ``))
+    expect(url.pathname).toBe(`/materials/summary/`)
+    expect(url.searchParams.get(`material_ids`)).toBe(`mp-2657`)
+    expect(url.searchParams.get(`_limit`)).toBe(`1`)
+    const fields = url.searchParams.get(`_fields`)?.split(`,`) ?? []
+    expect(fields).toContain(`structure`)
+  })
+
+  it(`uses MP REST nelements bounds for an exact element set on mobile`, async () => {
+    mobile_flag.value = true
+    set_mp_api_key(`test-key`)
+    tauri_fetch_mock.mockResolvedValue(
+      new Response(JSON.stringify({ data: [], meta: { total_doc: 0 } }), { status: 200 }),
+    )
+
+    await materials_project.search_mp_structures_page({
+      elements: [`Ti`, `O`],
+      num_elements: 2,
+      limit: 20,
+      offset: 0,
+    })
+
+    const url = new URL(String(tauri_fetch_mock.mock.calls[0]?.[0] ?? ``))
+    expect(url.searchParams.get(`nelements_min`)).toBe(`2`)
+    expect(url.searchParams.get(`nelements_max`)).toBe(`2`)
+    expect(url.searchParams.has(`num_elements`)).toBe(false)
+  })
+
   it(`desktop (non-mobile, non-static) still uses the backend proxy`, async () => {
     const fetch_mock = vi.fn().mockResolvedValue(
       new Response(`{"valid":true}`, { status: 200 }),
@@ -61,5 +128,200 @@ describe(`materials-project mobile gating`, () => {
     const url = String(fetch_mock.mock.calls[0]?.[0] ?? ``)
     expect(url).toContain(`/mp/validate-key`)
     expect(tauri_fetch_mock).not.toHaveBeenCalled()
+  })
+
+  it(`searches an exact element set on the requested MP result page`, async () => {
+    set_mp_api_key(`test-key`)
+    const fetch_mock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ material_id: `mp-2657`, formula_pretty: `TiO2`, nsites: 6, nelements: 2 }],
+          meta: { total_doc: 37 },
+        }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal(`fetch`, fetch_mock)
+
+    const search_page = (
+      materials_project as typeof materials_project & {
+        search_mp_structures_page: (options: {
+          elements: string[]
+          num_elements: number
+          limit: number
+          offset: number
+        }) => Promise<{
+          structures: Array<{ material_id: string }>
+          total_count?: number
+          has_more: boolean
+        }>
+      }
+    ).search_mp_structures_page
+
+    const result = await search_page({
+      elements: [`Ti`, `O`],
+      num_elements: 2,
+      limit: 20,
+      offset: 20,
+    })
+
+    const request = fetch_mock.mock.calls[0]
+    expect(String(request?.[0] ?? ``)).toContain(`/mp/search`)
+    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+      elements: [`Ti`, `O`],
+      formula: null,
+      material_ids: null,
+      num_elements: 2,
+      limit: 20,
+      offset: 20,
+    })
+    expect(result.structures.map((entry) => entry.material_id)).toEqual([`mp-2657`])
+    expect(result.total_count).toBe(37)
+    expect(result.has_more).toBe(true)
+  })
+
+  it(`maps an MP summary into the structure-card contract`, () => {
+    const to_optimade = (
+      materials_project as typeof materials_project & {
+        mp_summary_to_optimade_structure: (
+          summary: materials_project.MPSummaryData,
+        ) => {
+          id: string
+          type: string
+          attributes: Record<string, unknown>
+        }
+      }
+    ).mp_summary_to_optimade_structure
+
+    const mapped = to_optimade({
+      material_id: `mp-2657`,
+      formula_pretty: `TiO2`,
+      nsites: 6,
+      nelements: 2,
+      symmetry: { crystal_system: `Tetragonal`, symbol: `P4₂/mnm`, number: 136 },
+      energy_above_hull: 0,
+      formation_energy_per_atom: -3.45,
+      band_gap: 1.8,
+      is_stable: true,
+      is_metal: false,
+      ordering: `NM`,
+      has_props: { dos: true, bandstructure: true },
+    })
+
+    expect(mapped.id).toBe(`mp-2657`)
+    expect(mapped.type).toBe(`structures`)
+    expect(mapped.attributes).toMatchObject({
+      chemical_formula_descriptive: `TiO2`,
+      chemical_formula_reduced: `TiO2`,
+      nsites: 6,
+      nelements: 2,
+      _mp_crystal_system: `Tetragonal`,
+      _mp_spacegroup_symbol: `P4₂/mnm`,
+      _mp_spacegroup_number: 136,
+      _mp_energy_above_hull: 0,
+      _mp_formation_energy_per_atom: -3.45,
+      _mp_band_gap: 1.8,
+      _mp_is_stable: true,
+      _mp_is_metal: false,
+      _mp_ordering: `NM`,
+      _mp_has_props: { dos: true, bandstructure: true },
+    })
+  })
+
+  it(`maps MP structure geometry so import does not call OPTIMADE`, () => {
+    const mapped = materials_project.mp_summary_to_optimade_structure({
+      material_id: `mp-2657`,
+      formula_pretty: `TiO2`,
+      nsites: 2,
+      nelements: 2,
+      structure: {
+        lattice: {
+          matrix: [[4.59, 0, 0], [0, 4.59, 0], [0, 0, 2.96]],
+          pbc: [true, true, true],
+          a: 4.59,
+          b: 4.59,
+          c: 2.96,
+          alpha: 90,
+          beta: 90,
+          gamma: 90,
+          volume: 62.36,
+        },
+        sites: [
+          {
+            species: [{ element: `Ti`, occu: 1 }],
+            abc: [0, 0, 0],
+            xyz: [0, 0, 0],
+            label: `Ti`,
+            properties: {},
+          },
+          {
+            species: [{ element: `O`, occu: 1 }],
+            abc: [0.5, 0.5, 0.5],
+            xyz: [2.295, 2.295, 1.48],
+            label: `O`,
+            properties: {},
+          },
+        ],
+        charge: 0,
+        properties: {},
+      },
+    })
+
+    expect(mapped.attributes).toMatchObject({
+      dimension_types: [1, 1, 1],
+      nperiodic_dimensions: 3,
+      lattice_vectors: [[4.59, 0, 0], [0, 4.59, 0], [0, 0, 2.96]],
+      cartesian_site_positions: [[0, 0, 0], [2.295, 2.295, 1.48]],
+      species_at_sites: [`Ti`, `O`],
+    })
+  })
+
+  it(`returns MP REST search results in the shared database-search shape`, async () => {
+    set_mp_api_key(`test-key`)
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                material_id: `mp-2657`,
+                formula_pretty: `TiO2`,
+                nsites: 6,
+                nelements: 2,
+                energy_above_hull: 0,
+              },
+            ],
+            meta: { total_doc: 1 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+
+    const search_as_optimade = (
+      materials_project as typeof materials_project & {
+        search_mp_structures_as_optimade: (
+          options: materials_project.MPSearchOptions,
+        ) => Promise<{
+          structures: Array<{ id: string; attributes: Record<string, unknown> }>
+          total_count?: number
+          has_more: boolean
+        }>
+      }
+    ).search_mp_structures_as_optimade
+
+    const result = await search_as_optimade({ formula: `TiO2`, limit: 20, offset: 0 })
+
+    expect(result.structures).toHaveLength(1)
+    expect(result.structures[0]).toMatchObject({
+      id: `mp-2657`,
+      attributes: {
+        chemical_formula_descriptive: `TiO2`,
+        _mp_energy_above_hull: 0,
+      },
+    })
+    expect(result.total_count).toBe(1)
+    expect(result.has_more).toBe(false)
   })
 })

--- a/src/lib/api/__tests__/optimade.test.ts
+++ b/src/lib/api/__tests__/optimade.test.ts
@@ -76,6 +76,291 @@ describe(`optimade search static-mode relay substitution`, () => {
   })
 })
 
+describe(`Materials Project primary REST search`, () => {
+  afterEach(async () => {
+    const { set_mp_api_key } = await import(`../materials-project`)
+    set_mp_api_key(``)
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it(`uses the MP summary API instead of OPTIMADE when an API key is configured`, async () => {
+    vi.resetModules()
+    const { set_mp_api_key } = await import(`../materials-project`)
+    set_mp_api_key(`test-key`)
+
+    const fetch_spy = vi.spyOn(globalThis, `fetch`).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes(`/mp/search`)) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                material_id: `mp-2657`,
+                formula_pretty: `TiO2`,
+                nsites: 6,
+                nelements: 2,
+              },
+            ],
+            meta: { total_doc: 1 },
+          }),
+          { status: 200 },
+        )
+      }
+      return new Response(
+        JSON.stringify({ data: [], meta: { data_returned: 0, data_available: 0 } }),
+        { status: 200 },
+      )
+    })
+
+    const { search_optimade_structures } = await import(`../optimade`)
+    const result = await search_optimade_structures(
+      `mp`,
+      [{
+        id: `mp`,
+        type: `links`,
+        attributes: {
+          name: `Materials Project`,
+          base_url: `https://optimade.materialsproject.org`,
+        },
+      }],
+      { formula: `TiO2`, limit: 20, offset: 0 },
+    )
+
+    expect(result.structures.map((entry) => entry.id)).toEqual([`mp-2657`])
+    expect(fetch_spy).toHaveBeenCalledTimes(1)
+    expect(String(fetch_spy.mock.calls[0]?.[0] ?? ``)).toContain(`/mp/search`)
+  })
+
+  it(`loads MP geometry from the summary API instead of OPTIMADE`, async () => {
+    vi.resetModules()
+    const { set_mp_api_key } = await import(`../materials-project`)
+    set_mp_api_key(`test-key`)
+
+    const fetch_spy = vi.spyOn(globalThis, `fetch`).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes(`/mp/structure/mp-2657`)) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              material_id: `mp-2657`,
+              formula_pretty: `TiO2`,
+              nsites: 2,
+              nelements: 2,
+              structure: {
+                lattice: {
+                  matrix: [[4.59, 0, 0], [0, 4.59, 0], [0, 0, 2.96]],
+                  pbc: [true, true, true],
+                  a: 4.59,
+                  b: 4.59,
+                  c: 2.96,
+                  alpha: 90,
+                  beta: 90,
+                  gamma: 90,
+                  volume: 62.36,
+                },
+                sites: [
+                  {
+                    species: [{ element: `Ti`, occu: 1 }],
+                    abc: [0, 0, 0],
+                    xyz: [0, 0, 0],
+                    label: `Ti`,
+                    properties: {},
+                  },
+                  {
+                    species: [{ element: `O`, occu: 1 }],
+                    abc: [0.5, 0.5, 0.5],
+                    xyz: [2.295, 2.295, 1.48],
+                    label: `O`,
+                    properties: {},
+                  },
+                ],
+                charge: 0,
+                properties: {},
+              },
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      return new Response(JSON.stringify({ data: null }), { status: 200 })
+    })
+
+    const { fetch_optimade_structure } = await import(`../optimade`)
+    const result = await fetch_optimade_structure(
+      `mp-2657`,
+      `mp`,
+      [{
+        id: `mp`,
+        type: `links`,
+        attributes: {
+          name: `Materials Project`,
+          base_url: `https://optimade.materialsproject.org`,
+        },
+      }],
+    )
+
+    expect(result).toMatchObject({
+      id: `mp-2657`,
+      attributes: {
+        lattice_vectors: [[4.59, 0, 0], [0, 4.59, 0], [0, 0, 2.96]],
+        species_at_sites: [`Ti`, `O`],
+      },
+    })
+    expect(fetch_spy).toHaveBeenCalledTimes(1)
+    expect(String(fetch_spy.mock.calls[0]?.[0] ?? ``)).toContain(`/mp/structure/mp-2657`)
+  })
+})
+
+describe(`OPTIMADE pagination metadata`, () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it(`uses data_available for the total and offset-aware has_more`, async () => {
+    delete (globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__
+    vi.resetModules()
+    vi.spyOn(globalThis, `fetch`).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{
+            id: `alex-21`,
+            type: `structures`,
+            attributes: { chemical_formula_reduced: `TiO2` },
+          }],
+          meta: { data_returned: 1, data_available: 57 },
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const { search_optimade_structures } = await import(`../optimade`)
+    const result = await search_optimade_structures(
+      `alexandria`,
+      [{
+        id: `alexandria`,
+        type: `links`,
+        attributes: {
+          name: `Alexandria`,
+          base_url: `https://alexandria.icams.rub.de/pbe`,
+        },
+      }],
+      { limit: 20, offset: 20 },
+    )
+
+    expect(result.total_count).toBe(57)
+    expect(result.has_more).toBe(true)
+  })
+})
+
+describe(`VS Code structure routing`, () => {
+  afterEach(async () => {
+    const { set_mp_api_key } = await import(`../materials-project`)
+    set_mp_api_key(``)
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it(`routes MPDD structure fetches through the backend instead of the MP endpoint`, async () => {
+    vi.resetModules()
+    const { set_mp_api_key } = await import(`../materials-project`)
+    set_mp_api_key(``)
+    const posted: Array<Record<string, unknown>> = []
+
+    const { fetch_optimade_structure, set_vscode_api } = await import(`../optimade`)
+    set_vscode_api({
+      postMessage(message) {
+        const msg = message as Record<string, unknown>
+        posted.push(msg)
+        queueMicrotask(() => {
+          window.dispatchEvent(new MessageEvent(`message`, {
+            data: {
+              command: `optimade_fetch_response`,
+              request_id: msg.request_id,
+              data: {
+                data: {
+                  id: `mpdd-1`,
+                  type: `structures`,
+                  attributes: {},
+                },
+              },
+            },
+          }))
+        })
+      },
+    })
+
+    const result = await fetch_optimade_structure(
+      `mpdd-1`,
+      `mpdd`,
+      [{
+        id: `mpdd`,
+        type: `links`,
+        attributes: {
+          name: `MPDD`,
+          base_url: `https://providers.optimade.org/index-metadbs/mpdd`,
+        },
+      }],
+    )
+
+    expect(result?.id).toBe(`mpdd-1`)
+    const requested_url = String(posted[0]?.url)
+    expect(requested_url).toContain(`/optimade/structure/mpdd/mpdd-1`)
+    expect(requested_url).not.toContain(`optimade.materialsproject.org`)
+  })
+
+  it(`routes MPDD suggestions through the extension search backend`, async () => {
+    vi.resetModules()
+    const posted: Array<Record<string, unknown>> = []
+    const { fetch_suggested_structures, set_vscode_api } = await import(`../optimade`)
+    set_vscode_api({
+      postMessage(message) {
+        const msg = message as Record<string, unknown>
+        posted.push(msg)
+        queueMicrotask(() => {
+          window.dispatchEvent(new MessageEvent(`message`, {
+            data: {
+              command: `optimade_search_response`,
+              request_id: msg.request_id,
+              data: {
+                structures: [{
+                  id: `mpdd-1`,
+                  type: `structures`,
+                  attributes: {},
+                }],
+                total_count: 1,
+                has_more: false,
+              },
+            },
+          }))
+        })
+      },
+    })
+
+    const result = await fetch_suggested_structures(
+      `mpdd`,
+      [{
+        id: `mpdd`,
+        type: `links`,
+        attributes: {
+          name: `MPDD`,
+          base_url: `https://providers.optimade.org/index-metadbs/mpdd`,
+        },
+      }],
+      12,
+    )
+
+    expect(result.map((entry) => entry.id)).toEqual([`mpdd-1`])
+    expect(posted[0]).toMatchObject({
+      command: `optimade_search`,
+      provider: `mpdd`,
+      options: { limit: 12, offset: 0 },
+    })
+  })
+})
+
 // MP moved thermo data into a nested `_mp_stability` dict (keyed by thermo
 // type); the flat `_mp_formation_energy_per_atom` / `_mp_energy_above_hull`
 // fields now return null. Details extraction and stability sorting must read

--- a/src/lib/api/__tests__/pubchem.test.ts
+++ b/src/lib/api/__tests__/pubchem.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe(`PubChem search routing`, () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it(`keeps different page sizes in separate cache entries`, async () => {
+    delete (globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__
+    vi.resetModules()
+    const fetch_spy = vi.spyOn(globalThis, `fetch`).mockImplementation(async (input) => {
+      const url = new URL(String(input))
+      const count = Number(url.searchParams.get(`max_results`))
+      return new Response(
+        JSON.stringify({
+          compounds: Array.from({ length: count }, (_, index) => ({
+            cid: index + 1,
+            formula: `C${index + 1}`,
+          })),
+          total_count: 100,
+          has_more: true,
+        }),
+        { status: 200 },
+      )
+    })
+
+    const { search_pubchem_compounds } = await import(`../pubchem`)
+    const small = await search_pubchem_compounds(`carbon`, undefined, 5, 0)
+    const large = await search_pubchem_compounds(`carbon`, undefined, 20, 0)
+
+    expect(small.compounds).toHaveLength(5)
+    expect(large.compounds).toHaveLength(20)
+    expect(fetch_spy).toHaveBeenCalledTimes(2)
+  })
+
+  it(`paginates direct formula searches through a PubChem list key`, async () => {
+    ;(globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__ = true
+    vi.resetModules()
+    const fetch_spy = vi.spyOn(globalThis, `fetch`).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes(`/fastformula/C6H12O6/cids/JSON`)) {
+        return new Response(
+          JSON.stringify({
+            IdentifierList: { ListKey: `formula-key`, Size: 25 },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url.includes(`/compound/listkey/formula-key/property/`)) {
+        return new Response(
+          JSON.stringify({
+            PropertyTable: {
+              Properties: Array.from({ length: 5 }, (_, index) => ({
+                CID: 21 + index,
+                MolecularFormula: `C6H12O6`,
+                MolecularWeight: 180.16,
+              })),
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      return new Response(`unexpected URL: ${url}`, { status: 500 })
+    })
+
+    const { search_pubchem_compounds } = await import(`../pubchem`)
+    const result = await search_pubchem_compounds(`C6H12O6`, undefined, 5, 20)
+
+    expect(result.compounds.map((entry) => entry.cid)).toEqual([21, 22, 23, 24, 25])
+    expect(result.total_count).toBe(25)
+    expect(result.has_more).toBe(false)
+    expect(fetch_spy).toHaveBeenCalledTimes(2)
+    const page_url = String(fetch_spy.mock.calls[1]?.[0] ?? ``)
+    expect(page_url).toContain(`listkey_start=20`)
+    expect(page_url).toContain(`listkey_count=5`)
+  })
+
+  it(`uses fast substructure rather than a name lookup for direct element search`, async () => {
+    ;(globalThis as Record<string, unknown>).__CATGO_STATIC_ONLY__ = true
+    vi.resetModules()
+    const fetch_spy = vi.spyOn(globalThis, `fetch`).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes(`/fastsubstructure/smiles/%5BFe%5D/cids/JSON`)) {
+        return new Response(
+          JSON.stringify({
+            IdentifierList: { ListKey: `iron-key`, Size: 2 },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url.includes(`/compound/listkey/iron-key/property/`)) {
+        return new Response(
+          JSON.stringify({
+            PropertyTable: {
+              Properties: [
+                { CID: 1, MolecularFormula: `Fe2O3`, MolecularWeight: 159.69 },
+                { CID: 2, MolecularFormula: `FeS`, MolecularWeight: 87.91 },
+              ],
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      return new Response(`unexpected URL: ${url}`, { status: 500 })
+    })
+
+    const { search_pubchem_compounds } = await import(`../pubchem`)
+    const result = await search_pubchem_compounds(undefined, [`Fe`, `O`], 20, 0)
+
+    expect(result.compounds.map((entry) => entry.cid)).toEqual([1])
+    expect(result.total_count).toBe(1)
+    expect(result.has_more).toBe(false)
+    expect(String(fetch_spy.mock.calls[0]?.[0] ?? ``)).toContain(
+      `/fastsubstructure/smiles/%5BFe%5D/cids/JSON`,
+    )
+  })
+})

--- a/src/lib/api/materials-project.ts
+++ b/src/lib/api/materials-project.ts
@@ -7,6 +7,7 @@
 import { API_BASE as _DEFAULT_API, STATIC_ONLY } from './config'
 import { isMobile } from '$lib/api/transport'
 import { relay_fetch } from '$lib/chat/provider-routing'
+import type { OptimadeSearchResult, OptimadeStructure } from './optimade'
 
 // Mobile has no Python backend regardless of STATIC_ONLY (local dev builds run
 // with STATIC_ONLY=false), so it must take the direct-API branch — same rule
@@ -135,6 +136,37 @@ async function fetch_json_smart(url: string, api_key: string): Promise<unknown> 
   return await response.json()
 }
 
+export interface MPStructureData {
+  lattice: {
+    matrix: number[][]
+    pbc?: boolean[]
+    a?: number
+    b?: number
+    c?: number
+    alpha?: number
+    beta?: number
+    gamma?: number
+    volume?: number
+    [key: string]: unknown
+  }
+  sites: Array<{
+    species: Array<{
+      element: string
+      occu: number
+      oxidation_state?: number
+      [key: string]: unknown
+    }>
+    abc: number[]
+    xyz: number[]
+    label: string
+    properties: Record<string, unknown>
+    [key: string]: unknown
+  }>
+  charge?: number
+  properties?: Record<string, unknown>
+  [key: string]: unknown
+}
+
 export interface MPSummaryData {
   material_id: string
   formula_pretty: string
@@ -154,50 +186,131 @@ export interface MPSummaryData {
   cbm?: number
   vbm?: number
   ordering?: string
+  structure?: MPStructureData
   // Availability map MP returns at `has_props`: { dos: bool, bandstructure: bool, ... }.
   // We only read .dos / .bandstructure for the preview — the full payloads are huge
   // and would defeat the point of "preview before import".
   has_props?: Record<string, boolean>
 }
 
+export interface MPSearchOptions {
+  elements?: string[]
+  formula?: string
+  material_ids?: string[]
+  num_elements?: number
+  limit?: number
+  offset?: number
+}
+
+export interface MPSearchPage {
+  structures: MPSummaryData[]
+  total_count?: number
+  has_more: boolean
+}
+
 /**
- * Search Materials Project for structures with full computed properties
+ * Adapt an MP summary document to the result-card shape shared with OPTIMADE.
  */
-export async function search_mp_structures(
-  elements?: string[],
-  formula?: string,
-  limit: number = 20,
-  material_ids?: string[],
-): Promise<MPSummaryData[]> {
+export function mp_summary_to_optimade_structure(
+  summary: MPSummaryData,
+): OptimadeStructure {
+  const mp_structure = summary.structure
+  const pbc = mp_structure?.lattice.pbc ?? [true, true, true]
+  const species_at_sites = mp_structure?.sites.map(
+    (site) => site.species[0]?.element ?? site.label,
+  )
+
+  return {
+    id: summary.material_id,
+    type: `structures`,
+    attributes: {
+      chemical_formula_descriptive: summary.formula_pretty,
+      chemical_formula_reduced: summary.formula_pretty,
+      nsites: summary.nsites,
+      nelements: summary.nelements,
+      dimension_types: mp_structure
+        ? pbc.map((periodic) => periodic ? 1 : 0)
+        : undefined,
+      nperiodic_dimensions: mp_structure
+        ? pbc.filter(Boolean).length
+        : undefined,
+      lattice_vectors: mp_structure?.lattice.matrix,
+      cartesian_site_positions: mp_structure?.sites.map((site) => site.xyz),
+      species_at_sites,
+      _mp_crystal_system: summary.symmetry?.crystal_system,
+      _mp_spacegroup_symbol: summary.symmetry?.symbol,
+      _mp_spacegroup_number: summary.symmetry?.number,
+      _mp_energy_above_hull: summary.energy_above_hull,
+      _mp_formation_energy_per_atom: summary.formation_energy_per_atom,
+      _mp_band_gap: summary.band_gap,
+      _mp_is_stable: summary.is_stable,
+      _mp_is_metal: summary.is_metal,
+      _mp_efermi: summary.efermi,
+      _mp_cbm: summary.cbm,
+      _mp_vbm: summary.vbm,
+      _mp_ordering: summary.ordering,
+      _mp_has_props: summary.has_props,
+    },
+  }
+}
+
+const MP_SUMMARY_FIELDS = [
+  `material_id`,
+  `formula_pretty`,
+  `nsites`,
+  `nelements`,
+  `symmetry`,
+  `energy_above_hull`,
+  `formation_energy_per_atom`,
+  `band_gap`,
+  `is_stable`,
+  `is_metal`,
+  `efermi`,
+  `cbm`,
+  `vbm`,
+  `ordering`,
+  `has_props`,
+].join(`,`)
+
+/**
+ * Search one page of Materials Project summary documents.
+ */
+export async function search_mp_structures_page(
+  options: MPSearchOptions = {},
+): Promise<MPSearchPage> {
   const api_key = get_mp_api_key()
   if (!api_key) {
     throw new Error(`Materials Project API key not configured`)
   }
 
-  let url: string
-  let data: { data?: MPSummaryData[] }
+  const limit = options.limit ?? 20
+  const offset = options.offset ?? 0
+  let data: {
+    data?: MPSummaryData[]
+    meta?: { total_doc?: number }
+  }
 
   if (vscode_api || direct_api()) {
-    // Direct Materials Project API call (relay-routed in the web build)
     const params = new URLSearchParams({
-      _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal,efermi,cbm,vbm,ordering,has_props`,
+      _fields: MP_SUMMARY_FIELDS,
       _limit: String(limit),
     })
 
-    if (material_ids) {
-      params.set(`material_ids`, material_ids.join(`,`))
-    } else if (elements) {
-      params.set(`elements`, elements.join(`,`))
+    if (offset > 0) params.set(`_skip`, String(offset))
+    if (options.material_ids) {
+      params.set(`material_ids`, options.material_ids.join(`,`))
+    } else if (options.elements) {
+      params.set(`elements`, options.elements.join(`,`))
+    }
+    if (options.formula) params.set(`formula`, options.formula)
+    if (options.num_elements !== undefined) {
+      params.set(`nelements_min`, String(options.num_elements))
+      params.set(`nelements_max`, String(options.num_elements))
     }
 
-    if (formula) {
-      params.set(`formula`, formula)
-    }
-
-    url = `https://api.materialsproject.org/materials/summary/?${params}`
+    const url = `https://api.materialsproject.org/materials/summary/?${params}`
     data = await fetch_json_smart(url, api_key) as typeof data
   } else {
-    // Backend proxy
     const response = await fetch(`${API_BASE}/mp/search`, {
       method: `POST`,
       headers: {
@@ -205,10 +318,12 @@ export async function search_mp_structures(
         'X-API-KEY': api_key,
       },
       body: JSON.stringify({
-        elements: elements || null,
-        formula: formula || null,
-        material_ids: material_ids || null,
+        elements: options.elements || null,
+        formula: options.formula || null,
+        material_ids: options.material_ids || null,
+        num_elements: options.num_elements ?? null,
         limit,
+        offset,
       }),
     })
 
@@ -222,7 +337,47 @@ export async function search_mp_structures(
     data = await response.json()
   }
 
-  return data.data || []
+  const structures = data.data || []
+  const total_count = data.meta?.total_doc
+  return {
+    structures,
+    total_count,
+    has_more: total_count === undefined
+      ? structures.length === limit
+      : offset + structures.length < total_count,
+  }
+}
+
+/**
+ * Search MP's primary REST API while preserving the modal's shared result shape.
+ */
+export async function search_mp_structures_as_optimade(
+  options: MPSearchOptions = {},
+): Promise<OptimadeSearchResult> {
+  const page = await search_mp_structures_page(options)
+  return {
+    structures: page.structures.map(mp_summary_to_optimade_structure),
+    total_count: page.total_count,
+    has_more: page.has_more,
+  }
+}
+
+/**
+ * Search Materials Project for structures with full computed properties
+ */
+export async function search_mp_structures(
+  elements?: string[],
+  formula?: string,
+  limit: number = 20,
+  material_ids?: string[],
+): Promise<MPSummaryData[]> {
+  const page = await search_mp_structures_page({
+    elements,
+    formula,
+    limit,
+    material_ids,
+  })
+  return page.structures
 }
 
 /**
@@ -236,14 +391,16 @@ export async function get_mp_structure_summary(material_id: string): Promise<MPS
 
   try {
     let url: string
-    let data: { data?: MPSummaryData }
+    let data: { data?: MPSummaryData | MPSummaryData[] }
 
     if (vscode_api || direct_api()) {
       // Direct API call (relay-routed in the web build)
       const params = new URLSearchParams({
-        _fields: `material_id,formula_pretty,nsites,nelements,symmetry,energy_above_hull,formation_energy_per_atom,band_gap,is_stable,is_metal,efermi,cbm,vbm,ordering,has_props`,
+        _fields: `${MP_SUMMARY_FIELDS},structure`,
+        material_ids: material_id,
+        _limit: `1`,
       })
-      url = `https://api.materialsproject.org/materials/summary/${material_id}?${params}`
+      url = `https://api.materialsproject.org/materials/summary/?${params}`
       data = await fetch_json_smart(url, api_key) as typeof data
     } else {
       // Backend proxy
@@ -256,7 +413,8 @@ export async function get_mp_structure_summary(material_id: string): Promise<MPS
       data = await response.json()
     }
 
-    return data.data || null
+    if (Array.isArray(data.data)) return data.data[0] ?? null
+    return data.data ?? null
   } catch (err) {
     console.error(`[MP API] Error fetching ${material_id}:`, err)
     return null

--- a/src/lib/api/optimade.ts
+++ b/src/lib/api/optimade.ts
@@ -5,6 +5,12 @@ declare const __CATGO_STATIC_ONLY__: boolean
 import { API_BASE as _DEFAULT_API } from './config'
 import { relay_fetch } from '$lib/chat/provider-routing'
 import { isMobile } from '$lib/api/transport'
+import {
+  get_mp_structure_summary,
+  has_mp_api_key,
+  mp_summary_to_optimade_structure,
+  search_mp_structures_as_optimade,
+} from './materials-project'
 
 // API base URL - same as compute.ts
 let API_BASE = _DEFAULT_API
@@ -288,6 +294,13 @@ export async function fetch_optimade_structure(
   provider: string,
   providers: OptimadeProvider[],
 ): Promise<OptimadeStructure | null> {
+  if (provider === `mp` && has_mp_api_key()) {
+    const summary = await get_mp_structure_summary(structure_id)
+    if (summary?.structure) {
+      return mp_summary_to_optimade_structure(summary)
+    }
+  }
+
   const encoded_id = encode_structure_id(structure_id)
 
   // Request the same provider-specific extras the list-search asks for —
@@ -299,21 +312,24 @@ export async function fetch_optimade_structure(
 
   const is_static = (typeof __CATGO_STATIC_ONLY__ !== `undefined` && __CATGO_STATIC_ONLY__) || isMobile()
   let url: string
-  if (vscode_api || is_static) {
-    // Direct API call: need to resolve provider base URL and construct endpoint
+  if (is_static) {
+    // Direct API call: static/mobile builds have no Python OPTIMADE router.
     const provider_obj = providers.find(p => p.id === provider)
     if (!provider_obj) {
       throw new Error(`Unknown provider: ${provider}`)
     }
     let base_url = provider_obj.attributes.base_url
     // Special case: Materials Project has a real OPTIMADE API at optimade.materialsproject.org
-    if (provider === `mp` || provider === `mpdd`) {
+    if (provider === `mp`) {
       base_url = `https://optimade.materialsproject.org`
     }
     url = `${base_url}/v1/structures/${encoded_id}`
     if (response_fields) url += `?response_fields=${encodeURIComponent(response_fields)}`
   } else {
-    // Backend proxy
+    // Desktop and VS Code both have the Python router, which resolves registry
+    // index meta-databases (MPDD, Matterverse, etc.) to their real child API.
+    // In VS Code fetch_json_smart sends this localhost request via the extension
+    // host, avoiding both webview CSP and duplicated provider routing logic.
     url = `${API_BASE}/optimade/structure/${provider}/${encoded_id}`
     if (response_fields) url += `?response_fields=${encodeURIComponent(response_fields)}`
   }
@@ -358,13 +374,19 @@ export async function fetch_suggested_structures(
     let data: { data?: OptimadeStructure[] }
 
     const is_static = (typeof __CATGO_STATIC_ONLY__ !== `undefined` && __CATGO_STATIC_ONLY__) || isMobile()
-    if (vscode_api || is_static) {
-      // Direct API call
+    if (vscode_api) {
+      const result = await post_to_extension_optimade_search(provider, {
+        limit,
+        offset: 0,
+      })
+      data = { data: result.structures }
+    } else if (is_static) {
+      // Static/mobile builds have no Python router or extension host.
       const provider_obj = providers.find(p => p.id === provider)
       if (!provider_obj) return []
       let base_url = provider_obj.attributes.base_url
       // Special case: Materials Project has a real OPTIMADE API at optimade.materialsproject.org
-      if (provider === `mp` || provider === `mpdd`) {
+      if (provider === `mp`) {
         base_url = `https://optimade.materialsproject.org`
       }
       url = `${base_url}/v1/structures?page_limit=${limit}&page_offset=0`
@@ -548,6 +570,28 @@ export interface OptimadeSearchResult {
   has_more: boolean
 }
 
+interface OptimadeResponseMeta {
+  data_returned?: number
+  data_available?: number
+  more_data_available?: boolean
+}
+
+function optimade_search_result(
+  data: { data?: OptimadeStructure[]; meta?: OptimadeResponseMeta },
+  limit: number,
+  offset: number,
+): OptimadeSearchResult {
+  const structures = sort_structures_by_stability(data.data || [])
+  // data_returned is only the size of THIS page. data_available is the total
+  // matching the query, and must win whenever the provider supplies it.
+  const total_count = data.meta?.data_available ?? data.meta?.data_returned
+  const has_more = data.meta?.more_data_available
+    ?? (total_count === undefined
+      ? structures.length === limit
+      : offset + structures.length < total_count)
+  return { structures, total_count, has_more }
+}
+
 /**
  * Parse elements from a chemical formula (e.g., "TiO2" -> ["Ti", "O"])
  */
@@ -650,6 +694,19 @@ export async function search_optimade_structures(
   options: OptimadeSearchOptions = {},
 ): Promise<OptimadeSearchResult> {
   try {
+    // MP's OPTIMADE adapter is an optional secondary surface and can be
+    // deployed without its data collections. When the user has configured an
+    // MP key, use the primary summary API for search instead.
+    if (provider === `mp` && has_mp_api_key()) {
+      return await search_mp_structures_as_optimade({
+        formula: options.formula,
+        elements: options.elements_only ?? options.elements,
+        num_elements: options.elements_only?.length ?? options.nelements,
+        limit: options.limit,
+        offset: options.offset,
+      })
+    }
+
     // Default to ascending sort by formation energy when caller doesn't specify.
     const sort = options.sort ?? default_sort_for_provider(provider)
 
@@ -695,13 +752,11 @@ export async function search_optimade_structures(
         })
       }
       if (!response.ok) throw new Error(`OPTIMADE API error (${response.status})`)
-      const data = await response.json() as { data?: OptimadeStructure[]; meta?: { data_returned?: number; data_available?: number } }
-      const structures = sort_structures_by_stability(data.data || [])
-      return {
-        structures,
-        total_count: data.meta?.data_returned ?? data.meta?.data_available,
-        has_more: structures.length === limit,
+      const data = await response.json() as {
+        data?: OptimadeStructure[]
+        meta?: OptimadeResponseMeta
       }
+      return optimade_search_result(data, limit, offset)
     }
 
     // Web app with backend: use backend proxy
@@ -734,28 +789,21 @@ export async function search_optimade_structures(
           }),
         })
         if (retry.ok) {
-          const retry_data = await retry.json() as { data?: OptimadeStructure[]; meta?: { data_returned?: number; data_available?: number } }
-          const retry_structs = sort_structures_by_stability(retry_data.data || [])
-          return {
-            structures: retry_structs,
-            total_count: retry_data.meta?.data_returned ?? retry_data.meta?.data_available,
-            has_more: retry_structs.length === limit,
+          const retry_data = await retry.json() as {
+            data?: OptimadeStructure[]
+            meta?: OptimadeResponseMeta
           }
+          return optimade_search_result(retry_data, limit, offset)
         }
       }
       throw new Error(`OPTIMADE API error (${response.status}): ${error_text}`)
     }
 
-    const data = await response.json() as { data?: OptimadeStructure[]; meta?: { data_returned?: number; data_available?: number } }
-
-    const structures = sort_structures_by_stability(data.data || [])
-    const total_count = data.meta?.data_returned ?? data.meta?.data_available
-
-    return {
-      structures,
-      total_count,
-      has_more: structures.length === limit,
+    const data = await response.json() as {
+      data?: OptimadeStructure[]
+      meta?: OptimadeResponseMeta
     }
+    return optimade_search_result(data, limit, offset)
   } catch (error) {
     console.warn(`Failed to search structures for ${provider}:`, error)
     throw error

--- a/src/lib/api/pubchem.ts
+++ b/src/lib/api/pubchem.ts
@@ -16,6 +16,9 @@ const IS_STATIC =
   (typeof __CATGO_STATIC_ONLY__ !== `undefined` && __CATGO_STATIC_ONLY__) ||
   isMobile()
 const PUBCHEM_API = `https://pubchem.ncbi.nlm.nih.gov/rest/pug`
+const PUBCHEM_SEARCH_PROPERTIES =
+  `MolecularFormula,MolecularWeight,IUPACName`
+const MAX_DIRECT_ELEMENT_CIDS = 2000
 
 // API base URL - same as compute.ts
 let API_BASE = _DEFAULT_API
@@ -219,6 +222,64 @@ function parse_elements_from_formula(formula: string): string[] {
   return matches ? [...new Set(matches)] : []
 }
 
+interface PubChemProperty {
+  CID: number
+  MolecularFormula?: string
+  MolecularWeight?: number | string
+  IUPACName?: string
+}
+
+function properties_to_compounds(
+  properties: PubChemProperty[],
+): PubChemSearchCompound[] {
+  return properties.map((property) => {
+    const parsed_weight = Number(property.MolecularWeight)
+    return {
+      cid: property.CID,
+      formula: property.MolecularFormula || ``,
+      weight: Number.isFinite(parsed_weight) ? parsed_weight : undefined,
+      name: property.IUPACName,
+    }
+  })
+}
+
+async function fetch_direct_list_key(search_url: string): Promise<{
+  list_key: string
+  size: number
+} | null> {
+  const response = await fetch(search_url)
+  if (response.status === 404) return null
+  if (!response.ok) throw new Error(`PubChem search failed: ${response.status}`)
+  const data = await response.json() as {
+    IdentifierList?: { ListKey?: string; Size?: number }
+  }
+  const list_key = data.IdentifierList?.ListKey
+  if (!list_key) return null
+  return {
+    list_key,
+    size: data.IdentifierList?.Size ?? 0,
+  }
+}
+
+async function fetch_direct_list_properties(
+  list_key: string,
+  offset: number,
+  limit: number,
+): Promise<PubChemProperty[]> {
+  if (limit <= 0) return []
+  const page_url =
+    `${PUBCHEM_API}/compound/listkey/${encodeURIComponent(list_key)}` +
+    `/property/${PUBCHEM_SEARCH_PROPERTIES}/JSON` +
+    `?listkey_start=${offset}&listkey_count=${limit}`
+  const response = await fetch(page_url)
+  if (response.status === 404) return []
+  if (!response.ok) throw new Error(`PubChem property fetch failed: ${response.status}`)
+  const data = await response.json() as {
+    PropertyTable?: { Properties?: PubChemProperty[] }
+  }
+  return data.PropertyTable?.Properties || []
+}
+
 /**
  * Autocomplete PubChem compound names for a partial search term.
  * Returns an array of name suggestions (up to `limit`).
@@ -294,7 +355,8 @@ export async function search_pubchem_compounds(
   }
 
   // Check cache (include search_type and offset in key)
-  const cache_key = `${search_type}:${term}:${elements?.join(`,`) ?? ``}:${offset}`
+  const cache_key =
+    `${search_type}:${term}:${normalized_elements?.join(`,`) ?? ``}:${limit}:${offset}`
   const now = Date.now()
   if (
     cached_search_results[cache_key] &&
@@ -310,51 +372,67 @@ export async function search_pubchem_compounds(
 
     if (IS_STATIC) {
       // Static mode: query PubChem REST API directly (CORS supported)
-      let url: string
       if (search_type === `cid`) {
-        url =
+        const url =
           `${PUBCHEM_API}/compound/cid/${term}/property/MolecularFormula,MolecularWeight,IUPACName/JSON`
-      } else if (search_type === `formula`) {
-        url = `${PUBCHEM_API}/compound/fastformula/${
-          encodeURIComponent(term)
-        }/property/MolecularFormula,MolecularWeight,IUPACName/JSON?MaxRecords=${limit}`
-      } else {
-        url = `${PUBCHEM_API}/compound/name/${
-          encodeURIComponent(term)
-        }/property/MolecularFormula,MolecularWeight,IUPACName/JSON?MaxRecords=${limit}`
-      }
-      const response = await fetch(url)
-      if (!response.ok) {
+        const response = await fetch(url)
         if (response.status === 404) {
-          // No results found
-          const result: PubChemSearchResponse = { compounds: [] }
-          cached_search_results[cache_key] = result
-          search_cache_time[cache_key] = now
-          return result
+          return { compounds: [], total_count: 0, has_more: false }
         }
-        throw new Error(`PubChem search failed: ${response.status}`)
-      }
-      const data = await response.json() as {
-        PropertyTable?: {
-          Properties?: Array<
-            {
-              CID: number
-              MolecularFormula?: string
-              MolecularWeight?: number
-              IUPACName?: string
-            }
-          >
+        if (!response.ok) throw new Error(`PubChem search failed: ${response.status}`)
+        const data = await response.json() as {
+          PropertyTable?: { Properties?: PubChemProperty[] }
         }
+        compounds = properties_to_compounds(data.PropertyTable?.Properties || [])
+        total_count = compounds.length
+        has_more = false
+      } else if (search_type === `element`) {
+        const primary = normalized_elements?.[0]
+        if (!primary) return { compounds: [], total_count: 0, has_more: false }
+        const search_url =
+          `${PUBCHEM_API}/compound/fastsubstructure/smiles/${
+            encodeURIComponent(`[${primary}]`)
+          }/cids/JSON?list_return=listkey&MaxRecords=${MAX_DIRECT_ELEMENT_CIDS}`
+        const list = await fetch_direct_list_key(search_url)
+        if (!list) return { compounds: [], total_count: 0, has_more: false }
+
+        const remaining = normalized_elements?.slice(1) || []
+        if (remaining.length === 0) {
+          compounds = properties_to_compounds(
+            await fetch_direct_list_properties(list.list_key, offset, limit),
+          )
+          total_count = list.size
+          has_more = offset + compounds.length < total_count
+        } else {
+          // PubChem has no multi-element namespace. Mirror the backend:
+          // cap the primary-element hit list, fetch formulas, then filter.
+          const capped_size = Math.min(list.size, MAX_DIRECT_ELEMENT_CIDS)
+          const all_properties = await fetch_direct_list_properties(
+            list.list_key,
+            0,
+            capped_size,
+          )
+          const matching = all_properties.filter((property) => {
+            const found = parse_elements_from_formula(property.MolecularFormula || ``)
+            return remaining.every((element) => found.includes(element))
+          })
+          total_count = matching.length
+          compounds = properties_to_compounds(matching.slice(offset, offset + limit))
+          has_more = offset + compounds.length < total_count
+        }
+      } else {
+        const namespace = search_type === `formula` ? `fastformula` : `name`
+        const search_url =
+          `${PUBCHEM_API}/compound/${namespace}/${encodeURIComponent(term)}` +
+          `/cids/JSON?list_return=listkey`
+        const list = await fetch_direct_list_key(search_url)
+        if (!list) return { compounds: [], total_count: 0, has_more: false }
+        compounds = properties_to_compounds(
+          await fetch_direct_list_properties(list.list_key, offset, limit),
+        )
+        total_count = list.size
+        has_more = offset + compounds.length < total_count
       }
-      const props = data.PropertyTable?.Properties || []
-      compounds = props.map((p) => ({
-        cid: p.CID,
-        formula: p.MolecularFormula || ``,
-        weight: p.MolecularWeight,
-        name: p.IUPACName,
-      }))
-      total_count = compounds.length
-      has_more = compounds.length === limit
     } else {
       // Backend proxy mode
       const params = new URLSearchParams({

--- a/tests/vitest/vite-vscode-wasm-resolution.test.ts
+++ b/tests/vitest/vite-vscode-wasm-resolution.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const extensionHostConfig = readFileSync(
+  resolve(import.meta.dirname, `../../extensions/vscode/vite.webview.config.ts`),
+  `utf8`,
+)
+const webviewConfig = readFileSync(
+  resolve(import.meta.dirname, `../../extensions/vscode/vite.config.mjs`),
+  `utf8`,
+)
+
+describe(`VS Code Vite WASM resolution`, () => {
+  it(`emits ES module workers in both extension builds`, () => {
+    expect(extensionHostConfig).toMatch(/worker:\s*\{\s*format:\s*`es`/)
+    expect(webviewConfig).toMatch(/worker:\s*\{\s*format:\s*`es`/)
+  })
+
+  it(`uses relative asset URLs inside the VS Code webview`, () => {
+    expect(webviewConfig).toMatch(/base:\s*`\.\/`/)
+  })
+})

--- a/tests/vitest/vscode-optimade-backend.test.ts
+++ b/tests/vitest/vscode-optimade-backend.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe(`VS Code OPTIMADE backend`, () => {
+  test(`resolves provider indexes and preserves pagination metadata and query options`, async () => {
+    const fetch_mock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url === `https://providers.optimade.org/v1/links`) {
+        return new Response(JSON.stringify({
+          data: [{
+            id: `mpdd`,
+            type: `links`,
+            attributes: {
+              name: `MPDD`,
+              base_url: `https://providers.optimade.org/index-metadbs/mpdd`,
+            },
+          }],
+        }))
+      }
+      if (url.endsWith(`/index-metadbs/mpdd/links`)) {
+        return new Response(JSON.stringify({
+          data: [{
+            type: `links`,
+            attributes: {
+              link_type: `child`,
+              base_url: `http://mpddoptimade.phaseslab.org`,
+            },
+          }],
+        }))
+      }
+      if (url.startsWith(`http://mpddoptimade.phaseslab.org/v1/structures?`)) {
+        return new Response(JSON.stringify({
+          data: [{ id: `mpdd-1`, type: `structures`, attributes: {} }],
+          meta: {
+            data_returned: 1,
+            data_available: 57,
+            more_data_available: true,
+          },
+        }))
+      }
+      return new Response(`unexpected URL: ${url}`, { status: 404 })
+    })
+    vi.stubGlobal(`fetch`, fetch_mock)
+
+    const { search_optimade_structures_backend } = await import(
+      `../../extensions/vscode/src/optimade-backend`
+    )
+    const result = await search_optimade_structures_backend(`mpdd`, {
+      limit: 1,
+      offset: 0,
+      response_fields: `chemical_formula_reduced,nsites`,
+      sort: `nsites`,
+    })
+
+    expect(fetch_mock).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^http:\/\/mpddoptimade\.phaseslab\.org\/v1\/structures\?/,
+      ),
+      expect.any(Object),
+    )
+    const search_url = String(fetch_mock.mock.calls.at(-1)?.[0])
+    expect(search_url).toContain(`response_fields=chemical_formula_reduced%2Cnsites`)
+    expect(search_url).toContain(`sort=nsites`)
+    expect(result).toEqual({
+      structures: [{ id: `mpdd-1`, type: `structures`, attributes: {} }],
+      total_count: 57,
+      has_more: true,
+    })
+  })
+
+  test(`supports provider base URLs that already include the API version`, async () => {
+    const fetch_mock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url === `https://providers.optimade.org/v1/links`) {
+        return new Response(JSON.stringify({
+          data: [{
+            id: `atomgpt`,
+            type: `links`,
+            attributes: {
+              name: `AtomGPT`,
+              base_url: `https://atomgpt.org/optimade/v1`,
+            },
+          }],
+        }))
+      }
+      if (url.endsWith(`/links`)) {
+        return new Response(`not an index`, { status: 404 })
+      }
+      if (url === `https://atomgpt.org/optimade/v1/structures?page_limit=2&page_offset=0`) {
+        return new Response(JSON.stringify({
+          data: [{ id: `JVASP-1`, type: `structures`, attributes: {} }],
+          meta: { data_available: 1, data_returned: 1 },
+        }))
+      }
+      return new Response(`unexpected URL: ${url}`, { status: 404 })
+    })
+    vi.stubGlobal(`fetch`, fetch_mock)
+
+    const { search_optimade_structures_backend } = await import(
+      `../../extensions/vscode/src/optimade-backend`
+    )
+    const result = await search_optimade_structures_backend(`atomgpt`, {
+      limit: 2,
+    })
+
+    expect(result.structures.map((entry) => entry.id)).toEqual([`JVASP-1`])
+    expect(fetch_mock).toHaveBeenCalledWith(
+      `https://atomgpt.org/optimade/v1/structures?page_limit=2&page_offset=0`,
+      expect.any(Object),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Restore structure and molecule database search in the web app and VS Code extension after upstream API/provider changes.

## Root causes

- Materials Project's OPTIMADE endpoint currently responds successfully but reports no available structures, while the official Materials Project REST API still returns records.
- Several previously selected OPTIMADE providers are unavailable or expose child implementation URLs that the VS Code backend did not resolve correctly.
- VS Code backend routing treated MPDD as Materials Project and lost pagination metadata.
- PubChem formula/name/element searches did not consistently honor pagination, and cache keys omitted pagination parameters.
- The VS Code webview emitted absolute asset URLs, which resolve against the `vscode-webview://` origin and can return empty WASM responses.

## Changes

- Use the official Materials Project REST summary endpoint when an MP API key is available, including formula/element queries, pagination, totals, and structure conversion.
- Add an MP REST fallback when the MP OPTIMADE endpoint returns no data.
- Update the Python Materials Project router to use current summary fields and exact counts.
- Harden OPTIMADE provider discovery and recovery:
  - resolve child provider URLs;
  - support provider bases that already end in `/v1`;
  - preserve pagination metadata and query options;
  - stop routing MPDD through the Materials Project endpoint;
  - exclude known unavailable providers and avoid permanently caching transient fallback state.
- Fix PubChem cache keys and implement paginated formula/name/element searches.
- Emit relative VS Code webview asset URLs so bundled WASM and worker files load from the extension package.
- Refresh the VS Code lockfile so frozen installs include the declared test/runtime dependencies.

## Validation

- `pnpm test`: 291 test files passed, 1 skipped; 5164 tests passed, 53 skipped.
- `pnpm check`: 0 errors (304 existing warnings).
- `pytest -q server/tests/test_materials_project_router.py server/tests/test_optimade_provider_recovery.py`: 5 passed.
- `pnpm --dir extensions/vscode install --frozen-lockfile`: passed.
- `pnpm --dir extensions/vscode run package`: produced `catgo-1.4.7.vsix`.
- Installed the generated VSIX locally and verified `guangsheng.catgo@1.4.7` is registered by VS Code Server 1.128.1.

## Notes

This branch is based on v1.4.7 and includes the already merged PR #560 scalar ferrox WASM selection. The implementation here does not duplicate that selector; it fixes the remaining webview asset URL and database routing failures.