### PR TITLE
chore(release): prepare v1.4.8

### DIFF
--- a/.github/release-notes/v1.4.8.md
+++ b/.github/release-notes/v1.4.8.md
@@ -1,0 +1,88 @@
+## CatGo 1.4.8
+
+CatGo 1.4.8 restores database search and completes the shared WebGL/WebGPU
+rendering work for periodic structures. Standard rendering and Large System
+Performance Mode now use the same authoritative atom, bond, boundary, camera,
+and visual-state data while retaining the WebGPU fast path for large structures.
+
+### Highlights
+
+- **Consistent periodic structures in both rendering modes** — standard WebGL
+  and Large System Performance Mode now agree on atom positions, bond geometry,
+  periodic boundary images, lattice vectors, colors, radii, shading, camera
+  orientation, and the axis gizmo.
+- **Database search works again across the app and VS Code** — Materials
+  Project, OPTIMADE, and PubChem searches have been updated for current provider
+  APIs, pagination, and extension-host routing.
+- **Large System Performance Mode remains WebGPU-accelerated** — the shared
+  rendering contract removes visual drift without replacing the WebGPU fast
+  path with the standard WebGL renderer.
+
+### Fixed
+
+#### Structure rendering
+
+- Fixed missing or extra boundary atoms, incomplete boundary bonds, dangling
+  bonds, and transient long bonds after physical supercell expansion.
+- Fixed atom and bond placement differences when toggling Large System
+  Performance Mode, including 1× and 3× periodic/supercell views.
+- Aligned bond thickness, endpoint colors, atom overlap, lighting, depth cueing,
+  background color, lattice vectors, camera transforms, and gizmo placement.
+- Kept atom movement, selected-atom rotation, camera motion, and visual-setting
+  changes live while the WebGPU overlay is active.
+- Fixed replica picking and the Three.js WebGL context failure reported as
+  `TypeError: error2 is not a function`.
+
+#### Database and VS Code search
+
+- Uses the official Materials Project REST summary endpoint when an API key is
+  available, including formula and element queries, pagination, totals, and
+  structure conversion.
+- Falls back to the official Materials Project REST route when its OPTIMADE
+  endpoint returns no structures.
+- Resolves OPTIMADE child-provider URLs and `/v1` bases correctly, preserves
+  pagination metadata, and avoids unavailable or misrouted providers.
+- Adds reliable PubChem pagination and emits relative VS Code webview asset URLs
+  so bundled WASM and worker files load from the extension package.
+
+### Upgrade notes
+
+- No project, structure-file, or workflow-data migration is required.
+- Large System Performance Mode still requires WebGPU; systems without WebGPU
+  continue to use the standard viewer fallback.
+- Configure a Materials Project API key to use the official MP REST results.
+
+### Included pull requests
+
+- [#563](https://github.com/Hello-QM/catgo-LRG/pull/563) — Restore Materials
+  Project, OPTIMADE, and PubChem search.
+- [#564](https://github.com/Hello-QM/catgo-LRG/pull/564) — Unify WebGL and
+  WebGPU periodic boundary rendering; supersedes #540 and #562.
+
+### Downloads
+
+- **Windows** — `.msi` or `-setup.exe`
+- **macOS** — `.dmg` for Apple Silicon
+- **Linux** — `.deb` or `.rpm`
+- **Android** — `CatGo-v*-android-universal.apk`
+- **iOS** — [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
+
+### License and citation
+
+CatGo 1.4.8 distributions use **AGPL-3.0-or-later**.
+
+If CatGo contributes to your work, please include this acknowledgement and the
+preferred citation:
+
+> This work used CatGo (https://catgo-ucsd.org).
+
+Please cite DOI
+[`10.26434/chemrxiv.15002984/v1`](https://doi.org/10.26434/chemrxiv.15002984/v1).
+This request is not an additional condition of the AGPL license. Third-party
+materials retain their own terms.
+
+Historical AGPL grants remain in effect.
+
+See the
+[CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md)
+for the complete release history.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -332,7 +332,7 @@ jobs:
             One window for the whole loop: **read almost any code's files → build & edit → run DFT / ML / MD → submit to HPC → analyse → publish.** Ships with the bundled backend server (MLP libraries excluded to keep the download lean).
 
             ### License and citation
-            CatGo 1.4.7 distributions use **AGPL-3.0-or-later**.
+            CatGo 1.4.8 distributions use **AGPL-3.0-or-later**.
 
             If CatGo contributes to your work, please include this acknowledgement and the preferred citation:
 
@@ -362,10 +362,10 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
-            ### New in 1.4.7
-            - **Windows desktop app closes normally again** — guarded shutdown can destroy the Tauri window and clean up bundled backend processes after Exit is confirmed.
-            - **VS Code structure generation consistently loads compatible WASM** — threaded builds that import shared memory are rejected, so the scalar runtime is selected regardless of directory order.
-            - **More reliable multi-platform releases** — draft validation, artifact paths, signatures, provenance, updater metadata, and the Cloudflare R2 mirror are aligned across release jobs.
+            ### New in 1.4.8
+            - **Consistent periodic structures in both rendering modes** — standard WebGL and Large System Performance Mode now share atom, bond, boundary, camera, and visual-state data.
+            - **Database search works again across the app and VS Code** — Materials Project, OPTIMADE, and PubChem now use current provider APIs, pagination, and extension-host routing.
+            - **Large System Performance Mode remains WebGPU-accelerated** — the shared rendering contract removes visual drift while retaining the fast path and live interaction updates.
 
             See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for the full list.
           releaseDraft: true
@@ -525,8 +525,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ensure-v1.4.6-release-body.sh "$CATGO_RELEASE_TAG"
 
-      - name: Finalize canonical release body
+      - name: Finalize canonical v1.4.7 release body
         if: env.CATGO_RELEASE_TAG == 'v1.4.7'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"
+
+      - name: Finalize canonical release body
+        if: env.CATGO_RELEASE_TAG == 'v1.4.8'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.8] - 2026-07-30
+
+### Fixed
+
+- **Consistent periodic rendering in standard and large-system modes** — WebGL and WebGPU now share authoritative atom, bond, boundary, camera, and visual-state data, fixing missing or extra boundary atoms, dangling or transient long bonds, lattice-vector differences, and stale interaction updates.
+- **Materials Project, OPTIMADE, and PubChem search restored** — provider routing, current API fields, fallbacks, pagination, totals, and cache keys now behave consistently in the app and VS Code extension.
+- **VS Code bundled assets load reliably** — relative webview URLs keep packaged WASM and worker files on the extension resource path.
+
 ## [1.4.7] - 2026-07-28
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.7
+version: 1.4.8
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/rust-wasm/CITATION.cff
+++ b/extensions/rust-wasm/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.7
+version: 1.4.8
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/rust-wasm/third_party/provenance/pormake-database-provenance.json
+++ b/extensions/rust-wasm/third_party/provenance/pormake-database-provenance.json
@@ -13,7 +13,7 @@
   "releaseEvidence": {
     "algorithm": "sha256sum-manifest-v1",
     "fileCount": 3277,
-    "manifestSha256": "646f28aa8e3bc8958629bbc47e48ca51923cc3bca6502c2b4bd2e9e16af4b602"
+    "manifestSha256": "9a4f41d0960feea59357bea7d0dbf84034cb9bcb5853a0a511a47a48b4ab55f9"
   },
   "pormake": {
     "repository": "https://github.com/Sangwon91/PORMAKE",

--- a/extensions/rust-wasm/third_party/provenance/pymatgen-ase-xterm-provenance.json
+++ b/extensions/rust-wasm/third_party/provenance/pymatgen-ase-xterm-provenance.json
@@ -29,7 +29,7 @@
   "releaseEvidence": {
     "algorithm": "sha256sum-manifest-v1",
     "fileCount": 20,
-    "manifestSha256": "e92b0291502c4fb30b8ec656bc7d29881ef1e80945395ef656c44215894990ab"
+    "manifestSha256": "55086f448a727bf5bc4ad81126c97f89f067c61c57a4bf04c335196e135ab3a6"
   },
   "intermediaries": [
     {

--- a/extensions/vscode/CITATION.cff
+++ b/extensions/vscode/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.7
+version: 1.4.8
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures, molecules and MD / optimization trajectories — reads the file formats of VASP, Quantum ESPRESSO, CP2K, ABACUS, ORCA, Gaussian, CASTEP, SIESTA, OpenMX, LAMMPS and ASE: POSCAR/CONTCAR · CIF · XYZ/extXYZ · mol2 · PDB · vasprun.xml · OUTCAR · XDATCAR · .traj · HDF5 · cube/CHGCAR isosurfaces. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, trajectory scrubbing with energy/force overlays, themes that follow VS Code. Right-click → Render, or Ctrl/Cmd+Shift+V.",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/extensions/vscode/third_party/provenance/pormake-database-provenance.json
+++ b/extensions/vscode/third_party/provenance/pormake-database-provenance.json
@@ -13,7 +13,7 @@
   "releaseEvidence": {
     "algorithm": "sha256sum-manifest-v1",
     "fileCount": 3277,
-    "manifestSha256": "646f28aa8e3bc8958629bbc47e48ca51923cc3bca6502c2b4bd2e9e16af4b602"
+    "manifestSha256": "9a4f41d0960feea59357bea7d0dbf84034cb9bcb5853a0a511a47a48b4ab55f9"
   },
   "pormake": {
     "repository": "https://github.com/Sangwon91/PORMAKE",

--- a/extensions/vscode/third_party/provenance/pymatgen-ase-xterm-provenance.json
+++ b/extensions/vscode/third_party/provenance/pymatgen-ase-xterm-provenance.json
@@ -29,7 +29,7 @@
   "releaseEvidence": {
     "algorithm": "sha256sum-manifest-v1",
     "fileCount": 20,
-    "manifestSha256": "e92b0291502c4fb30b8ec656bc7d29881ef1e80945395ef656c44215894990ab"
+    "manifestSha256": "55086f448a727bf5bc4ad81126c97f89f067c61c57a4bf04c335196e135ab3a6"
   },
   "intermediaries": [
     {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/scripts/__tests__/docs-citation-license.test.mjs
+++ b/scripts/__tests__/docs-citation-license.test.mjs
@@ -48,7 +48,7 @@ test('CITATION.cff carries the exact non-binding citation request', () => {
   assert.equal(message, CITATION_REQUEST)
   assert.match(cff, new RegExp(
     `^cff-version: 1\\.2\\.0\\nmessage: ${escapeRegExp(CITATION_REQUEST)}\\n` +
-    'version: 1\\.4\\.7\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
+    'version: 1\\.4\\.8\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
     'license-url: https://github\\.com/Hello-QM/catgo-LRG/blob/main/license$',
     'm',
   ))

--- a/scripts/__tests__/license-policy.test.mjs
+++ b/scripts/__tests__/license-policy.test.mjs
@@ -153,6 +153,7 @@ const licenseClaimInventory = {
   historicalGrantPreservation: [
     '.github/release-notes/v1.4.6.md',
     '.github/release-notes/v1.4.7.md',
+    '.github/release-notes/v1.4.8.md',
     '.github/workflows/tauri-build.yml',
   ],
   historicalOnly: [
@@ -291,7 +292,7 @@ test('canonical citation file requests citation without adding an AGPL condition
   assert.equal(existsSync(resolve(ROOT, 'citation.cff')), false)
   const text = read('CITATION.cff')
   assert.match(text, /^cff-version: 1\.2\.0$/m)
-  assert.match(text, /^version: 1\.4\.7$/m)
+  assert.match(text, /^version: 1\.4\.8$/m)
   assert.match(text, /^license: AGPL-3\.0-or-later$/m)
   assert.match(text, /^license-url: https:\/\/github\.com\/Hello-QM\/catgo-LRG\/blob\/main\/license$/m)
   assert.match(text, /CatGo: Bridging CLI Coding Agents/)

--- a/scripts/__tests__/release-body.test.mjs
+++ b/scripts/__tests__/release-body.test.mjs
@@ -14,7 +14,7 @@ import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
-const TAG = 'v1.4.7'
+const TAG = 'v1.4.8'
 const NOTES = resolve(ROOT, `.github/release-notes/${TAG}.md`)
 const WORKFLOW = readFileSync(
   resolve(ROOT, '.github/workflows/tauri-build.yml'),
@@ -79,11 +79,11 @@ test('canonical current release body contains every mandatory disclosure', () =>
 test('existing release is always edited to the canonical body', () => {
   const { result, calls } = runEnsure({ existing: true })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release view v1\.4\.7$/m)
+  assert.match(calls, /^release view v1\.4\.8$/m)
   assert.doesNotMatch(calls, /^release create /m)
   assert.match(
     calls,
-    /^release edit v1\.4\.7 --title CatGo v1\.4\.7 --notes-file \.github\/release-notes\/v1\.4\.7\.md$/m,
+    /^release edit v1\.4\.8 --title CatGo v1\.4\.8 --notes-file \.github\/release-notes\/v1\.4\.8\.md$/m,
   )
 })
 
@@ -93,9 +93,9 @@ test('concurrent draft creation still converges through an explicit edit', () =>
     createStatus: 1,
   })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release create v1\.4\.7 --draft /m)
-  assert.match(calls, /^release view v1\.4\.7$/m)
-  assert.match(calls, /^release edit v1\.4\.7 /m)
+  assert.match(calls, /^release create v1\.4\.8 --draft /m)
+  assert.match(calls, /^release view v1\.4\.8$/m)
+  assert.match(calls, /^release edit v1\.4\.8 /m)
 })
 
 test('Tauri workflow finalizes the canonical body after tauri-action', () => {
@@ -104,7 +104,7 @@ test('Tauri workflow finalizes the canonical body after tauri-action', () => {
   assert.ok(action >= 0)
   assert.ok(finalize > action)
   const block = WORKFLOW.slice(finalize)
-  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.7'/)
+  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.8'/)
   assert.match(block, /scripts\/ensure-release-body\.sh "\$CATGO_RELEASE_TAG"/)
 })
 
@@ -112,6 +112,13 @@ test('Tauri workflow retains the v1.4.6 backfill finalizer', () => {
   assert.match(
     WORKFLOW,
     /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.6'[\s\S]*scripts\/ensure-v1\.4\.6-release-body\.sh "\$CATGO_RELEASE_TAG"/,
+  )
+})
+
+test('Tauri workflow retains the v1.4.7 canonical finalizer', () => {
+  assert.match(
+    WORKFLOW,
+    /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.7'[\s\S]*scripts\/ensure-release-body\.sh "\$CATGO_RELEASE_TAG"/,
   )
 })
 

--- a/scripts/__tests__/release-version-verifier.test.mjs
+++ b/scripts/__tests__/release-version-verifier.test.mjs
@@ -53,7 +53,7 @@ function runVerifierWithEnvironment(root, environment) {
   })
 }
 
-function replaceVersion(root, path, from = '1.4.7', to = '1.4.6') {
+function replaceVersion(root, path, from = '1.4.8', to = '1.4.7') {
   const target = resolve(root, path)
   const current = readFileSync(target, 'utf8')
   assert.match(current, new RegExp(from.replaceAll('.', '\\.')), path)
@@ -63,9 +63,9 @@ function replaceVersion(root, path, from = '1.4.7', to = '1.4.6') {
 test('accepts a consistent release tree and its exact v-prefixed tag', () => {
   const root = fixture()
   try {
-    const result = runVerifier(root, '--tag', 'v1.4.7')
+    const result = runVerifier(root, '--tag', 'v1.4.8')
     assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /release version 1\.4\.7 verified/)
+    assert.match(result.stdout, /release version 1\.4\.8 verified/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -78,7 +78,7 @@ test('accepts Windows CRLF checkouts', () => {
       const target = resolve(root, path)
       writeFileSync(target, readFileSync(target, 'utf8').replaceAll('\n', '\r\n'))
     }
-    const result = runVerifier(root, '--tag', 'v1.4.7')
+    const result = runVerifier(root, '--tag', 'v1.4.8')
     assert.equal(result.status, 0, result.stderr)
   } finally {
     rmSync(root, { recursive: true, force: true })
@@ -104,9 +104,9 @@ test('rejects every inconsistent release manifest', async (t) => {
 test('rejects a tag that does not exactly match the manifest version', () => {
   const root = fixture()
   try {
-    const result = runVerifier(root, '--tag', 'v1.4.6')
+    const result = runVerifier(root, '--tag', 'v1.4.7')
     assert.notEqual(result.status, 0)
-    assert.match(result.stderr, /expected v1\.4\.7/)
+    assert.match(result.stderr, /expected v1\.4\.8/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -127,17 +127,17 @@ test('honors the workflow tag and publishing requirement environment', () => {
   const root = fixture()
   try {
     const matching = runVerifierWithEnvironment(root, {
-      RELEASE_VERSION_TAG: 'v1.4.7',
+      RELEASE_VERSION_TAG: 'v1.4.8',
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.equal(matching.status, 0, matching.stderr)
 
     const mismatched = runVerifierWithEnvironment(root, {
-      RELEASE_VERSION_TAG: 'v1.4.6',
+      RELEASE_VERSION_TAG: 'v1.4.7',
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.notEqual(mismatched.status, 0)
-    assert.match(mismatched.stderr, /expected v1\.4\.7/)
+    assert.match(mismatched.stderr, /expected v1\.4\.8/)
 
     const missing = runVerifierWithEnvironment(root, {
       RELEASE_VERSION_TAG: '',

--- a/scripts/__tests__/version-consistency.test.mjs
+++ b/scripts/__tests__/version-consistency.test.mjs
@@ -6,7 +6,7 @@ import test from 'node:test'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const source = (path) => readFileSync(resolve(ROOT, path), 'utf8')
-const APP_VERSION = '1.4.7'
+const APP_VERSION = '1.4.8'
 const WORKFLOW_INVENTORY = {
   'android-build.yml': {
     classification: 'root-versioned-publisher',
@@ -131,7 +131,7 @@ function workflowStep(path, name) {
   return workflow.slice(start, next === -1 ? undefined : next)
 }
 
-test('all CatGo application version surfaces target v1.4.7', () => {
+test('all CatGo application version surfaces target v1.4.8', () => {
   const packageJson = JSON.parse(source('package.json'))
   const tauriConfig = JSON.parse(source('src-tauri/tauri.conf.json'))
   const cargoLockMatch =
@@ -153,7 +153,7 @@ test('all CatGo application version surfaces target v1.4.7', () => {
   )
 })
 
-test('VSIX and citation package metadata target v1.4.7', () => {
+test('VSIX and citation package metadata target v1.4.8', () => {
   const vscodePackage = JSON.parse(source('extensions/vscode/package.json'))
   assert.equal(vscodePackage.version, APP_VERSION)
 
@@ -174,13 +174,13 @@ test('the dependency lock remains a pnpm v9 root-importer lock', () => {
   assert.match(lock, /^importers:\n\n  \.:\n/m)
 })
 
-test('the desktop draft release notes describe v1.4.7', () => {
+test('the desktop draft release notes describe v1.4.8', () => {
   const workflow = source('.github/workflows/tauri-build.yml')
 
-  assert.match(workflow, /### New in 1\.4\.7/)
-  assert.match(workflow, /Windows desktop app closes normally again/)
-  assert.match(workflow, /VS Code structure generation consistently loads compatible WASM/)
-  assert.match(workflow, /More reliable multi-platform releases/)
+  assert.match(workflow, /### New in 1\.4\.8/)
+  assert.match(workflow, /Consistent periodic structures in both rendering modes/)
+  assert.match(workflow, /Database search works again across the app and VS Code/)
+  assert.match(workflow, /Large System Performance Mode remains WebGPU-accelerated/)
 })
 
 test('VSIX publishing fails on duplicate marketplace versions', () => {

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -11,6 +11,7 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
     '6dff73ab93babff2d03a2a313330e1bd981c47ab3bcf72687352daa7e7eaf46b',
     'ceddcb4f7e0ed52fce1c0e56d53d787770a90936d4cc401bc9d72a6f94f753e7',
     'abc4a14a9dd54d1255aab9d57819299a5e58b63c3f8ea60cb495295755e50ae1',
+    '67c5d92493e47f812d582cc667a772645ee9270ccd4c1bb3fe51e666301c63d0',
   ]),
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',

--- a/scripts/verify-legal-distributions.mjs
+++ b/scripts/verify-legal-distributions.mjs
@@ -323,7 +323,7 @@ function verifyReleaseAssets() {
     'the download mirror must validate assets against legal material from the target tag',
   )
   requireMatch(
-    '.github/release-notes/v1.4.7.md',
+    '.github/release-notes/v1.4.8.md',
     /AGPL-3\.0-or-later[\s\S]*This work used CatGo \(https:\/\/catgo-ucsd\.org\)\.[\s\S]*10\.26434\/chemrxiv\.15002984\/v1[\s\S]*not an additional condition/i,
     'release body must prominently disclose AGPL, the requested acknowledgement, DOI, and its non-binding status',
   )

--- a/server/CITATION.cff
+++ b/server/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.7
+version: 1.4.8
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catgo"
-version = "1.4.7"
+version = "1.4.8"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
 readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"

--- a/server/third_party/provenance/pormake-database-provenance.json
+++ b/server/third_party/provenance/pormake-database-provenance.json
@@ -13,7 +13,7 @@
   "releaseEvidence": {
     "algorithm": "sha256sum-manifest-v1",
     "fileCount": 3277,
-    "manifestSha256": "646f28aa8e3bc8958629bbc47e48ca51923cc3bca6502c2b4bd2e9e16af4b602"
+    "manifestSha256": "9a4f41d0960feea59357bea7d0dbf84034cb9bcb5853a0a511a47a48b4ab55f9"
   },
   "pormake": {
     "repository": "https://github.com/Sangwon91/PORMAKE",

--- a/server/third_party/provenance/pymatgen-ase-xterm-provenance.json
+++ b/server/third_party/provenance/pymatgen-ase-xterm-provenance.json
@@ -29,7 +29,7 @@
   "releaseEvidence": {
     "algorithm": "sha256sum-manifest-v1",
     "fileCount": 20,
-    "manifestSha256": "e92b0291502c4fb30b8ec656bc7d29881ef1e80945395ef656c44215894990ab"
+    "manifestSha256": "55086f448a727bf5bc4ad81126c97f89f067c61c57a4bf04c335196e135ab3a6"
   },
   "intermediaries": [
     {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.7"
+version = "1.4.8"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.7"
+version = "1.4.8"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
## Summary

- Prepare canonical CatGo v1.4.8 version metadata and changelog.
- Add the complete v1.4.8 release description for #563 and #564.
- Retain deterministic draft finalization and trust the exact release workflow bytes.
- Refresh package-local legal provenance copies.

## Included changes

- #563 — Restore Materials Project, OPTIMADE, and PubChem search.
- #564 — Unify WebGL and WebGPU boundary rendering; supersedes #540 and #562.

## Validation

- Node release-policy tests: 353 passed.
- Vitest: 5,319 passed, 53 skipped. One local cold-transform test required a temporary 60-second timeout; the repository file remains unchanged and current main CI is green.
- `pnpm check`: 0 errors (304 existing warnings).
- `pnpm build:wasm && pnpm verify:wasm`.
- Release version, rights, source, legal-distribution, and diff checks passed.

## Release plan

- Merge only after CI is green.
- Tag the exact merged `main` commit as v1.4.8.
- Wait for desktop, HPC, VSIX, and sidecar artifacts.
- Dispatch signed Android and iOS/TestFlight builds.
- Finalize with `finalize-release.yml` after all assets and attestations pass.
