### PR TITLE
docs: cite published CatGo article

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -338,7 +338,7 @@ jobs:
 
             > This work used CatGo (https://app.catgo-ucsd.org).
 
-            Please cite DOI [`10.26434/chemrxiv.15002984/v1`](https://doi.org/10.26434/chemrxiv.15002984/v1). This request is not an additional condition of the AGPL license. Third-party materials retain their own terms. Historical AGPL grants remain in effect.
+            Please cite the CatGo article in *Digital Discovery*, DOI [`10.1039/D6DD00273K`](https://doi.org/10.1039/D6DD00273K). This request is not an additional condition of the AGPL license. Third-party materials retain their own terms. Historical AGPL grants remain in effect.
 
             ### Downloads
             - **Windows** — `.msi` (recommended) or `.exe`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,8 +31,8 @@ preferred-citation:
     - family-names: Li
       given-names: Wan-Lu
   year: 2026
-  doi: 10.26434/chemrxiv.15002984/v1
-  url: https://doi.org/10.26434/chemrxiv.15002984/v1
+  journal: Digital Discovery
+  doi: 10.1039/D6DD00273K
+  url: https://doi.org/10.1039/D6DD00273K
   publisher:
-    name: ChemRxiv
-  notes: Preprint
+    name: Royal Society of Chemistry

--- a/extensions/rust-wasm/CITATION.cff
+++ b/extensions/rust-wasm/CITATION.cff
@@ -31,8 +31,8 @@ preferred-citation:
     - family-names: Li
       given-names: Wan-Lu
   year: 2026
-  doi: 10.26434/chemrxiv.15002984/v1
-  url: https://doi.org/10.26434/chemrxiv.15002984/v1
+  journal: Digital Discovery
+  doi: 10.1039/D6DD00273K
+  url: https://doi.org/10.1039/D6DD00273K
   publisher:
-    name: ChemRxiv
-  notes: Preprint
+    name: Royal Society of Chemistry

--- a/extensions/rust-wasm/README.md
+++ b/extensions/rust-wasm/README.md
@@ -7,7 +7,7 @@ request is not an additional condition of the AGPL license.
 
 > This work used CatGo (https://app.catgo-ucsd.org).
 
-Please cite CatGo using the preferred ChemRxiv DOI
-[10.26434/chemrxiv.15002984/v1](https://doi.org/10.26434/chemrxiv.15002984/v1).
+Please cite the CatGo article in *Digital Discovery*
+[10.1039/D6DD00273K](https://doi.org/10.1039/D6DD00273K).
 See `CITATION.cff` for the complete citation metadata and
 `THIRD_PARTY_NOTICES.md` for separately licensed material.

--- a/extensions/vscode/CITATION.cff
+++ b/extensions/vscode/CITATION.cff
@@ -31,8 +31,8 @@ preferred-citation:
     - family-names: Li
       given-names: Wan-Lu
   year: 2026
-  doi: 10.26434/chemrxiv.15002984/v1
-  url: https://doi.org/10.26434/chemrxiv.15002984/v1
+  journal: Digital Discovery
+  doi: 10.1039/D6DD00273K
+  url: https://doi.org/10.1039/D6DD00273K
   publisher:
-    name: ChemRxiv
-  notes: Preprint
+    name: Royal Society of Chemistry

--- a/extensions/vscode/readme.md
+++ b/extensions/vscode/readme.md
@@ -202,8 +202,8 @@ license.
 
 > This work used CatGo (https://app.catgo-ucsd.org).
 
-Please cite CatGo using the preferred ChemRxiv DOI
-[10.26434/chemrxiv.15002984/v1](https://doi.org/10.26434/chemrxiv.15002984/v1).
+Please cite the CatGo article in *Digital Discovery*
+[10.1039/D6DD00273K](https://doi.org/10.1039/D6DD00273K).
 See the repository's [CITATION.cff](../../CITATION.cff) for the canonical
 citation metadata.
 

--- a/readme.md
+++ b/readme.md
@@ -379,23 +379,22 @@ CatGo's structure viewer, periodic table, and parts of its core UI originate fro
 **CatRender** is CatGo's Rust/WASM molecular SVG renderer. It is implemented as a fidelity-oriented port of [aligfellow/xyzrender](https://github.com/aligfellow/xyzrender), whose lineage includes [xyz2svg](https://github.com/briling/xyz2svg), with CatGo-specific interactive controls and export integration.
 
 CatGo is licensed under AGPL-3.0-or-later. If CatGo contributes to your work,
-please include the following acknowledgement and the preferred ChemRxiv citation:
+please include the following acknowledgement and the preferred journal citation:
 
 ```
 This work used CatGo (https://app.catgo-ucsd.org).
 ```
 
-Use this preferred ChemRxiv citation:
+Use this preferred journal citation:
 
 ```bibtex
-@misc{liu2026catgo,
-  author    = {Liu, Guangsheng and Ma, Xiao and Zhang, Leshen and Pascasio, Jenedith and Yang, Jonathan and Chen, Yuxiang and Li, Wan-Lu},
-  title     = {CatGo: Bridging CLI Coding Agents with Interactive Structure and Workflow Management for Computational Chemistry},
-  year      = {2026},
-  doi       = {10.26434/chemrxiv.15002984/v1},
-  url       = {https://doi.org/10.26434/chemrxiv.15002984/v1},
-  publisher = {ChemRxiv},
-  note      = {Preprint},
+@article{liu2026catgo,
+  author  = {Liu, Guangsheng and Ma, Xiao and Zhang, Leshen and Pascasio, Jenedith and Yang, Jonathan and Chen, Yuxiang and Li, Wan-Lu},
+  title   = {CatGo: Bridging CLI Coding Agents with Interactive Structure and Workflow Management for Computational Chemistry},
+  journal = {Digital Discovery},
+  year    = {2026},
+  doi     = {10.1039/D6DD00273K},
+  url     = {https://doi.org/10.1039/D6DD00273K},
 }
 ```
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -379,23 +379,22 @@ CatGo 的结构查看器、元素周期表和部分核心 UI 源自并受到 [Ma
 
 **CatRender** 是 CatGo 的 Rust/WASM 分子 SVG 渲染器。它以忠实复现为目标移植自 [aligfellow/xyzrender](https://github.com/aligfellow/xyzrender)；后者的技术脉络还包括 [xyz2svg](https://github.com/briling/xyz2svg)。CatRender 在此基础上增加了 CatGo 的交互控制和导出集成。
 
-CatGo 采用 AGPL-3.0-or-later。若 CatGo 对你的工作有所帮助，请注明下列致谢并使用首选的 ChemRxiv 引用。
+CatGo 采用 AGPL-3.0-or-later。若 CatGo 对你的工作有所帮助，请注明下列致谢并使用首选期刊引用。
 
 ```
 This work used CatGo (https://app.catgo-ucsd.org).
 ```
 
-首选 ChemRxiv 引用如下：
+首选期刊引用如下：
 
 ```bibtex
-@misc{liu2026catgo,
-  author    = {Liu, Guangsheng and Ma, Xiao and Zhang, Leshen and Pascasio, Jenedith and Yang, Jonathan and Chen, Yuxiang and Li, Wan-Lu},
-  title     = {CatGo: Bridging CLI Coding Agents with Interactive Structure and Workflow Management for Computational Chemistry},
-  year      = {2026},
-  doi       = {10.26434/chemrxiv.15002984/v1},
-  url       = {https://doi.org/10.26434/chemrxiv.15002984/v1},
-  publisher = {ChemRxiv},
-  note      = {Preprint},
+@article{liu2026catgo,
+  author  = {Liu, Guangsheng and Ma, Xiao and Zhang, Leshen and Pascasio, Jenedith and Yang, Jonathan and Chen, Yuxiang and Li, Wan-Lu},
+  title   = {CatGo: Bridging CLI Coding Agents with Interactive Structure and Workflow Management for Computational Chemistry},
+  journal = {Digital Discovery},
+  year    = {2026},
+  doi     = {10.1039/D6DD00273K},
+  url     = {https://doi.org/10.1039/D6DD00273K},
 }
 ```
 

--- a/scripts/__tests__/docs-citation-license.test.mjs
+++ b/scripts/__tests__/docs-citation-license.test.mjs
@@ -52,7 +52,7 @@ test('CITATION.cff carries the exact non-binding citation request', () => {
     'license-url: https://github\\.com/Hello-QM/catgo-LRG/blob/main/license$',
     'm',
   ))
-  assert.match(cff, /^\s+doi: 10\.26434\/chemrxiv\.15002984\/v1$/m)
+  assert.match(cff, /^\s+doi: 10\.1039\/D6DD00273K$/m)
 })
 
 function escapeRegExp(value) {

--- a/scripts/__tests__/license-policy.test.mjs
+++ b/scripts/__tests__/license-policy.test.mjs
@@ -21,7 +21,7 @@ import { legalBundleSources } from '../sync-legal-bundle.mjs'
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const read = (path) => readFileSync(resolve(ROOT, path), 'utf8')
 const ACK = 'This work used CatGo (https://app.catgo-ucsd.org).'
-const DOI = '10.26434/chemrxiv.15002984/v1'
+const DOI = '10.1039/D6DD00273K'
 const AGPL_ID = 'AGPL-3.0-or-later'
 const CITATION_REQUEST =
   'If CatGo contributes to your work, please acknowledge and cite it as ' +

--- a/server/CITATION.cff
+++ b/server/CITATION.cff
@@ -31,8 +31,8 @@ preferred-citation:
     - family-names: Li
       given-names: Wan-Lu
   year: 2026
-  doi: 10.26434/chemrxiv.15002984/v1
-  url: https://doi.org/10.26434/chemrxiv.15002984/v1
+  journal: Digital Discovery
+  doi: 10.1039/D6DD00273K
+  url: https://doi.org/10.1039/D6DD00273K
   publisher:
-    name: ChemRxiv
-  notes: Preprint
+    name: Royal Society of Chemistry

--- a/server/README-pypi.md
+++ b/server/README-pypi.md
@@ -43,8 +43,8 @@ is not an additional condition of the AGPL license.
 This work used CatGo (https://app.catgo-ucsd.org).
 ```
 
-Please cite CatGo using the preferred ChemRxiv DOI:
-[10.26434/chemrxiv.15002984/v1](https://doi.org/10.26434/chemrxiv.15002984/v1),
+Please cite the CatGo article in *Digital Discovery*:
+[10.1039/D6DD00273K](https://doi.org/10.1039/D6DD00273K),
 and the canonical
 [CITATION.cff](https://github.com/Hello-QM/catgo-LRG/blob/main/CITATION.cff).
 Third-party materials retain their own terms and are excluded from this license.


### PR DESCRIPTION
## Summary

- replace the ChemRxiv preprint citation with the published *Digital Discovery* article, DOI `10.1039/D6DD00273K`
- synchronize `CITATION.cff` across the root, PyPI, VS Code, and Rust/WASM distributions
- update active English/Chinese README and release-workflow citation surfaces
- preserve the acknowledgement text and AGPL-3.0-or-later terms; historical changelog and release notes remain unchanged

The RSC/Crossref record does not yet provide volume, issue, or page numbers, so the citation includes only confirmed metadata.

## Validation

- CFF 1.2.0 schema validation: 4/4 files passed
- `node --test scripts/__tests__/license-policy.test.mjs scripts/__tests__/docs-citation-license.test.mjs`: 25/25 passed
- `node scripts/sync-legal-bundle.mjs && node scripts/verify-legal-distributions.mjs`: passed
- `node scripts/verify-release-version.mjs`: passed
