### PR TITLE
Fix WebGPU slab bond rendering in large-system mode

### DIFF
--- a/src/lib/structure/gpu/LargeSystemOverlay.svelte
+++ b/src/lib/structure/gpu/LargeSystemOverlay.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { Color, type Camera } from 'three'
-  import type { AnyStructure, ElementSymbol } from '$lib/structure'
+  import type {
+    AnyStructure,
+    ElementSymbol,
+    Pbc,
+    PymatgenLattice,
+  } from '$lib/structure'
   import {
     get_webgpu_lease,
     invalidate_webgpu_lease,
@@ -16,7 +21,6 @@
   import { to_compute_options } from '$lib/structure/gpu/large-system-mode.svelte'
   import { should_show_bonds } from '$lib/structure/scene'
   import { DEFAULTS, type ShowBonds } from '$lib/settings'
-  import type { PymatgenLattice } from '$lib/structure'
   import {
     create_large_system_renderer,
     type LargeSystemRenderer,
@@ -424,11 +428,34 @@
   let bond_source: AnyStructure | undefined = undefined
   let bond_covalent: Float32Array = new Float32Array(0)
   let bond_lattice: Float32Array = new Float32Array(9)
-  let bond_periodic = false
+  // Preserve per-axis periodicity. Slabs are periodic only in-plane, so
+  // collapsing [true,true,false] to a boolean would incorrectly let the
+  // detector wrap through the vacuum direction.
+  let bond_pbc: Pbc | null = null
   let bond_options_sig = ``
   let bond_compute_opts = { tolerance: 0, max_bond_dist: 0, min_bond_dist: 0 }
   // Set when bond inputs changed and must be re-pushed to the renderer.
   let bonds_dirty = false
+
+  /** Resolve the exact periodic axes used by the ordinary viewer. A lattice
+   *  without an explicit mask is treated as fully periodic for compatibility
+   *  with older structures, while molecules remain non-periodic. */
+  function resolve_bond_pbc(
+    lattice: PymatgenLattice | undefined,
+    has_lattice: boolean,
+  ): Pbc | null {
+    if (!has_lattice) return null
+    const pbc = lattice?.pbc
+    return pbc
+      ? [!!pbc[0], !!pbc[1], !!pbc[2]]
+      : [true, true, true]
+  }
+
+  function lattice_signature(lattice: Float32Array, pbc: Pbc | null): string {
+    let sig = ``
+    for (let i = 0; i < 9; i++) sig += `${lattice[i]};`
+    return `${sig}|${pbc ? pbc.map(Number).join(``) : `none`}`
+  }
 
   // ── Per-element-pair distance-rule state ───────────────────────────────────
   // Encoded inputs for the GPU rule POST-FILTER (per-atom element ids + packed
@@ -633,10 +660,10 @@
       `${origin[0]},${origin[1]},${origin[2]}|${lat_sig}`
     if (sig === cell_sig) return false
     cell_sig = sig
-    // bond_periodic means the structure/current frame carries a lattice; pass
+    // bond_pbc means the structure/current frame carries a lattice; pass
     // null otherwise so molecules never draw a (degenerate) box.
     renderer.set_cell(
-      bond_periodic ? visible_cell_lattice : null,
+      bond_pbc ? visible_cell_lattice : null,
       show_cell,
       [cr, cg, cb],
       origin,
@@ -734,12 +761,12 @@
         ]
       : null
     packet_positions_revision++
-    let sig = ``
-    for (let i = 0; i < 9; i++) sig += `${packed[i]};`
+    const next_pbc = resolve_bond_pbc(structure_lattice, has_lattice)
+    const sig = lattice_signature(packed, next_pbc)
     if (sig !== frame_lattice_sig) {
       frame_lattice_sig = sig
       bond_lattice = packed
-      bond_periodic = has_lattice
+      bond_pbc = next_pbc
       bonds_dirty = true
     }
   }
@@ -766,7 +793,7 @@
     if (!sites || sites.length === 0) {
       bond_covalent = new Float32Array(0)
       bond_lattice = new Float32Array(9)
-      bond_periodic = false
+      bond_pbc = null
       return
     }
     // Bond compute runs over HOME atoms only (see bond_home_count): slice off
@@ -791,13 +818,12 @@
       raw_lattice,
       current_view_transform(),
     )
-    bond_periodic = !!lat || frame_lattice?.length === 3
+    const has_lattice = !!lat || frame_lattice?.length === 3
+    bond_pbc = resolve_bond_pbc(lat, has_lattice)
     bond_compute_opts = to_compute_options(bonding_options ?? {})
     // Keep the per-frame lattice signature in lockstep so refresh_frame_positions
     // doesn't redundantly re-push the lattice it just packed here.
-    let lat_sig = ``
-    for (let i = 0; i < 9; i++) lat_sig += `${bond_lattice[i]};`
-    frame_lattice_sig = lat_sig
+    frame_lattice_sig = lattice_signature(bond_lattice, bond_pbc)
   }
 
   // Hex -> linear RGB, matching the WebGL path (StructureScene.__hex_to_linear_rgb).
@@ -1236,7 +1262,7 @@
     if (bonds_visible && !authoritative_bonds_active) {
       rebuild_bonds_if_needed()
       if (bonds_dirty) {
-        renderer.set_bond_data(bond_covalent, bond_lattice, bond_compute_opts, bond_periodic)
+        renderer.set_bond_data(bond_covalent, bond_lattice, bond_compute_opts, bond_pbc)
         bonds_dirty = false
         dirty = true
       }

--- a/src/lib/structure/gpu/large-system-renderer.ts
+++ b/src/lib/structure/gpu/large-system-renderer.ts
@@ -34,6 +34,7 @@ import {
   MAX_DIRECT_ATOMS,
   plan_bond_dispatch,
 } from '$lib/structure/workers/bond-backend-policy'
+import type { Pbc } from '$lib/structure'
 import { diff_render_packet } from '$lib/structure/scene/render-packet'
 import type {
   BaseBondGraph,
@@ -2090,10 +2091,14 @@ export type ReplicaRendererDiagnostics = {
   /** Bond count of the ACTIVE draw graph (packet-, GPU-, or wasm-produced). */
   active_bond_count: number
   /** Non-null while the dispatch policy refuses the GPU compute path
-   *  (periodic thin cell / grid storage budget). Bonds are then routed
-   *  through the rust-wasm worker (Bonds T6); the reason persists so hosts
-   *  can surface the backend in diagnostics. */
-  required_backend: 'periodic-thin-cell' | 'grid-storage-limit' | null
+   *  (partial periodicity / periodic thin cell / grid storage budget). Bonds
+   *  are then routed through the rust-wasm worker (Bonds T6); the reason
+   *  persists so hosts can surface the backend in diagnostics. */
+  required_backend:
+    | 'partial-periodic-cell'
+    | 'periodic-thin-cell'
+    | 'grid-storage-limit'
+    | null
   /** Active writer of shared GPU state; legacy writes invalidate packet cache. */
   ownership: 'legacy' | 'packet'
   /** Base-cell atom count (CPU stays at exactly N sites). */
@@ -2186,13 +2191,15 @@ export type LargeSystemRenderer = {
    *  used for sphere size). `lattice` is the 9-float row-major detector matrix
    *  (rows a,b,c). In legacy mode it also owns the bond-render lattice; packet
    *  mode keeps render geometry owned by `frame.lattice`. `options` carries the
-   *  bond cutoffs; `periodic` toggles min-image PBC. Marks bonds dirty so the
+   *  bond cutoffs; `pbc` preserves per-axis minimum-image periodicity. A
+   *  boolean remains accepted for compatibility with older direct callers.
+   *  Marks bonds dirty so the
    *  next render re-runs the compute dispatch — NOT every frame. */
   set_bond_data(
     covalent_radii: Float32Array,
     lattice: Float32Array,
     options: { tolerance: number; max_bond_dist: number; min_bond_dist: number },
-    periodic: boolean,
+    pbc: Pbc | boolean | null,
   ): void
   /** Mirror the viewer's bond visual settings without changing packet/legacy
    *  ownership or invalidating the scientific bond graph. Repeated equal style
@@ -2642,6 +2649,7 @@ export function create_large_system_renderer(
   let bond_render_lattice = new Float32Array(9)
   let bond_style = normalize_bond_style()
   let bond_options = { tolerance: 0, max_bond_dist: 0, min_bond_dist: 0 }
+  let bond_pbc: Pbc | null = null
   let bond_periodic = false
   let bond_n = 0 // atom count the detection should range over
   // ── Dirty-kind split (design §8.2 items 4-6). `graph_dirty`: the base bond
@@ -2671,7 +2679,11 @@ export function create_large_system_renderer(
   // budget): Bonds T6 routes those graphs through the Rust-WASM worker
   // (compute_bonds_typed). While set, the GPU compute never dispatches; the
   // ACTIVE graph stays on screen until the typed result uploads over it.
-  let required_backend: 'periodic-thin-cell' | 'grid-storage-limit' | null = null
+  let required_backend:
+    | 'partial-periodic-cell'
+    | 'periodic-thin-cell'
+    | 'grid-storage-limit'
+    | null = null
   // One typed rust-wasm request in flight at a time (latest wins): while set,
   // a still-dirty graph waits — completion wakes the host, whose next render
   // re-dispatches against the newest inputs.
@@ -4349,7 +4361,7 @@ export function create_large_system_renderer(
           [L[6], L[7], L[8]],
         ]
         : null,
-      pbc: bond_periodic ? [true, true, true] : null,
+      pbc: bond_pbc ? [bond_pbc[0], bond_pbc[1], bond_pbc[2]] : null,
       options: { ...bond_options },
     }
     // The injected seam is called synchronously (deterministic tests); the
@@ -4537,7 +4549,7 @@ export function create_large_system_renderer(
       covalent_radii: Float32Array,
       lattice: Float32Array,
       options: { tolerance: number; max_bond_dist: number; min_bond_dist: number },
-      periodic: boolean,
+      pbc: Pbc | boolean | null,
     ): void {
       if (destroyed || device_lost) return
       bonds_configured = true
@@ -4548,7 +4560,10 @@ export function create_large_system_renderer(
       // detector refreshes must not mutate the displayed periodic shift.
       if (ownership === `legacy`) bond_render_lattice = lattice.slice(0, 9)
       bond_options = { ...options }
-      bond_periodic = periodic
+      bond_pbc = typeof pbc === `boolean`
+        ? pbc ? [true, true, true] : null
+        : pbc ? [!!pbc[0], !!pbc[1], !!pbc[2]] : null
+      bond_periodic = bond_pbc?.some(Boolean) ?? false
 
       // Capacity heuristic: max(1024, n_atoms * 16). The controller's capacity
       // floor rises with the atom count; never shrinks (avoids churn on tweaks).
@@ -5066,17 +5081,27 @@ export function create_large_system_renderer(
         // over the storage budget ⇒ REFUSE — those must go to the Rust-WASM
         // worker (wired in Task 6), never to an all-pairs GPU fallback. The
         // active graph stays on screen while refused.
-        const plan = plan_bond_dispatch({
-          periodic: bond_periodic,
-          lattice: bond_detector_lattice,
-          max_bond_dist: bond_options.max_bond_dist,
-          positions: last_positions ?? new Float32Array(0),
-          n: bond_n,
-          atom_count: bond_n,
-          direct_limit: MAX_DIRECT_ATOMS,
-          max_storage_bytes: device.limits?.maxStorageBufferBindingSize ??
-            (1 << 27),
-        })
+        // The WebGPU grid/direct shaders currently support either no PBC or
+        // all-axis PBC. A slab's mixed mask (typically [true,true,false]) must
+        // not be widened to [true,true,true]: doing so searches through the
+        // vacuum axis and turns ordinary layer bonds into incorrect boundary
+        // jimages. Route mixed-PBC cells through the existing typed Rust/WASM
+        // detector, which consumes the exact three-axis mask used by WebGL.
+        const partial_periodic = bond_pbc !== null &&
+          bond_pbc.some(Boolean) && !bond_pbc.every(Boolean)
+        const plan = partial_periodic
+          ? { kind: `rust-wasm`, reason: `partial-periodic-cell` } as const
+          : plan_bond_dispatch({
+            periodic: bond_periodic,
+            lattice: bond_detector_lattice,
+            max_bond_dist: bond_options.max_bond_dist,
+            positions: last_positions ?? new Float32Array(0),
+            n: bond_n,
+            atom_count: bond_n,
+            direct_limit: MAX_DIRECT_ATOMS,
+            max_storage_bytes: device.limits?.maxStorageBufferBindingSize ??
+              (1 << 27),
+          })
         if (plan.kind === `rust-wasm`) {
           if (required_backend !== plan.reason) {
             console.warn(

--- a/tests/vitest/structure/gpu/large-system-overlay-packet.svelte.test.ts
+++ b/tests/vitest/structure/gpu/large-system-overlay-packet.svelte.test.ts
@@ -413,6 +413,35 @@ describe(`LargeSystemOverlay authoritative packet bridge`, () => {
     expect(mocks.renderer.set_bond_data).toHaveBeenCalled()
   })
 
+  it(`preserves a slab's per-axis PBC mask in the fallback bond input`, async () => {
+    const structure = make_structure()
+    ;(structure as { lattice: { pbc: [boolean, boolean, boolean] } }).lattice.pbc =
+      [true, true, false]
+    const props = $state({
+      enabled: true,
+      structure,
+      packet_owner_id: 14,
+      visual_state_source: make_visual_source(
+        1,
+        new Float32Array([1, 0, 0, 0, 0, 1]),
+      ).source,
+      periodic_decoration_source: null,
+      show_bonds: `always` as const,
+    })
+    const component = mount(LargeSystemOverlay, {
+      target: document.body,
+      props,
+    })
+    mounted.push(component)
+    await settle()
+
+    run_overlay_frame()
+
+    const call = mocks.renderer.set_bond_data.mock.calls.at(-1)
+    expect(call).toBeDefined()
+    expect(call?.[3]).toEqual([true, true, false])
+  })
+
   it(`expands ordinary 1x images onto the visual-supercell outer surface`, async () => {
     const structure = make_structure()
     const graph: BaseBondGraph = {

--- a/tests/vitest/structure/gpu/large-system-renderer.test.ts
+++ b/tests/vitest/structure/gpu/large-system-renderer.test.ts
@@ -1297,4 +1297,81 @@ describe(`large-system renderer bond dirty-kind split (mock device)`, () => {
     renderer.destroy()
     warn.mockRestore()
   })
+
+  it(`routes mixed-PBC slabs through the typed detector with the exact axis mask`, async () => {
+    const warn = vi.spyOn(console, `warn`).mockImplementation(() => {})
+    const raw = make_mock_device()
+    const fake = vi.fn((_input: TypedBondInput) =>
+      Promise.resolve({
+        backend: `rust-wasm-scalar` as const,
+        elapsed_ms: 1,
+        table: {
+          pairs: Uint32Array.from([0, 1]),
+          images: Int8Array.from([0, 0, 0]),
+          lengths: Float32Array.from([2.4]),
+          strengths: Float32Array.from([1]),
+        },
+      })
+    )
+    const renderer = create_large_system_renderer(
+      raw as unknown as GPUDevice,
+      make_mock_canvas() as unknown as HTMLCanvasElement,
+      { compute_bonds_typed: fake },
+    )
+
+    const positions = Float32Array.from([0, 0, 0, 2.4, 0, 0])
+    const slab = new Float32Array([10, 0, 0, 0, 10, 0, 0, 0, 25])
+    const topology = {
+      version: 1,
+      atom_count: 2,
+      site_ids: Uint32Array.from([0, 1]),
+      atomic_numbers: Uint8Array.from([14, 14]),
+      radii: new Float32Array(2).fill(0.5),
+      colors: new Float32Array(6).fill(0.5),
+    }
+    renderer.set_packet({
+      topology,
+      frame: {
+        owner: { tag: `slab` },
+        frame_idx: 0,
+        positions_version: 0,
+        positions,
+        lattice: slab,
+      },
+      replicas: {
+        version: 1,
+        dims: [1, 1, 1] as const,
+        boundary_policy: `stub` as const,
+        semantics: `visual-shared-base` as const,
+      },
+    }, {
+      count: 0,
+      base_sites: new Uint32Array(0),
+      jimages: new Int8Array(0),
+    })
+    renderer.set_bond_data(
+      new Float32Array(2).fill(1.11),
+      slab,
+      { tolerance: 0.45, max_bond_dist: 3, min_bond_dist: 0.1 },
+      [true, true, false],
+    )
+    renderer.render()
+
+    expect(renderer.debug_bond_state().dispatches.detect).toBe(0)
+    expect(renderer.get_diagnostics().required_backend).toBe(
+      `partial-periodic-cell`,
+    )
+    expect(fake).toHaveBeenCalledTimes(1)
+    const input = fake.mock.calls[0][0]
+    expect(input.atomic_numbers).toBe(topology.atomic_numbers)
+    expect(input.pbc).toEqual([true, true, false])
+    expect(input.lattice_matrix).toEqual([[10, 0, 0], [0, 10, 0], [0, 0, 25]])
+
+    await flush()
+    expect(renderer.get_diagnostics().active_bond_count).toBe(1)
+    expect(renderer.get_diagnostics().ownership).toBe(`packet`)
+
+    renderer.destroy()
+    warn.mockRestore()
+  })
 })


### PR DESCRIPTION
### Summary

Fix missing/incorrect bonds after cutting a periodic structure into a slab and enabling Large System Performance Mode.

Slabs use partial periodic boundary conditions (`[true, true, false]`), but the WebGPU fallback path previously widened this to full 3D periodicity. This incorrectly applied minimum-image bonding across the vacuum direction.

### Changes

- Preserve the exact per-axis PBC mask from the structure to the large-system renderer.
- Route mixed-PBC systems such as slabs through the shared Rust/WASM typed bond detector, matching WebGL bonding behavior.
- Keep existing WebGPU fast paths for fully periodic crystals and non-periodic molecules.
- Add regression tests for slab PBC propagation and mixed-PBC bond dispatch.

### Validation

- Relevant GPU/bond tests pass.
- Svelte/TypeScript check passes with 0 errors.