### PR TITLE
docs: Claude CLI install command names a package that is not on npm

### DIFF
--- a/docs/guide/catbot.md
+++ b/docs/guide/catbot.md
@@ -69,6 +69,6 @@ CatBot reads provider API keys from environment variables or the *Settings* dial
 
 ## Troubleshooting
 
-- **"native binary not found"** — the Claude SDK couldn't find the `claude` CLI. Install it (`npm i -g @anthropic-ai/claude-cli`) or switch to Gemini / Codex. Fixed in v1.0.1 — `resolveClaudeExecutable()` now falls back to `PATH` lookups.
+- **"native binary not found"** — the Claude SDK couldn't find the `claude` CLI. Install it (`npm i -g @anthropic-ai/claude-code`) or switch to Gemini / Codex. Fixed in v1.0.1 — `resolveClaudeExecutable()` now falls back to `PATH` lookups.
 - **Stream stalls mid-response** — the sidecar dropped the SSE connection. Restart CatBot from the chat pane; transcript is preserved on disk under `~/.catgo/agents/<provider>/`.
 - **Tool call returns wrong panel** — CatBot defaults to `panel_id=default`. Pass `panel_id=structure-1` (or whichever pane is active) in the tool call, or specify the panel in your prompt.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -142,7 +142,7 @@ The server listens on `http://localhost:8000` with CORS enabled for the frontend
 ### Windows
 
 - **HPC connect fails with `ImportError` for `pywintypes` or `pythoncom`** — fixed in v1.0.1. If you're on an older build, upgrade. The bundled backend now ships the required `pywin32` DLLs.
-- **CatBot chat exits immediately** — the agent-bridge sidecar requires the `claude` CLI for the Claude provider. Install it via `npm i -g @anthropic-ai/claude-cli`, or switch CatBot to the Gemini / Codex provider in *Settings*.
+- **CatBot chat exits immediately** — the agent-bridge sidecar requires the `claude` CLI for the Claude provider. Install it via `npm i -g @anthropic-ai/claude-code`, or switch CatBot to the Gemini / Codex provider in *Settings*.
 
 ### Linux (`.AppImage`)
 

--- a/docs/zh/guide/catbot.md
+++ b/docs/zh/guide/catbot.md
@@ -69,6 +69,6 @@ CatBot 会从环境变量或 *Settings* 对话框读取 provider API key。密�
 
 ## 故障排查
 
-- **"native binary not found"** - Claude SDK 找不到 `claude` CLI。安装它（`npm i -g @anthropic-ai/claude-cli`），或切换到 Gemini / Codex。v1.0.1 已修复该问题，`resolveClaudeExecutable()` 现在会回退到 `PATH` 查找。
+- **"native binary not found"** - Claude SDK 找不到 `claude` CLI。安装它（`npm i -g @anthropic-ai/claude-code`），或切换到 Gemini / Codex。v1.0.1 已修复该问题，`resolveClaudeExecutable()` 现在会回退到 `PATH` 查找。
 - **Stream stalls mid-response** - sidecar 的 SSE 连接中断。可从聊天面板重启 CatBot；transcript 会保留在 `~/.catgo/agents/<provider>/` 下。
 - **Tool call returns wrong panel** - CatBot 默认使用 `panel_id=default`。请在工具调用中传入 `panel_id=structure-1`（或当前活动面板），也可以在 prompt 中指定面板。

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -142,7 +142,7 @@ python main.py
 ### Windows
 
 - **HPC 连接因 `pywintypes` 或 `pythoncom` 的 `ImportError` 失败** - v1.0.1 已修复。如果你使用更早版本，请升级。内置后端现在会包含所需的 `pywin32` DLL。
-- **CatBot 聊天立即退出** - Claude provider 的 agent-bridge sidecar 需要 `claude` CLI。可通过 `npm i -g @anthropic-ai/claude-cli` 安装，或在 *Settings* 中把 CatBot 切换到 Gemini / Codex provider。
+- **CatBot 聊天立即退出** - Claude provider 的 agent-bridge sidecar 需要 `claude` CLI。可通过 `npm i -g @anthropic-ai/claude-code` 安装，或在 *Settings* 中把 CatBot 切换到 Gemini / Codex provider。
 
 ### Linux (`.AppImage`)
 


### PR DESCRIPTION
> Disclosure: I am an AI agent (Claude), contributing with review by @tonydzi. Every command and every line of output below was run on a real machine and is reproducible.

## What was broken

Both troubleshooting entries that tell a user how to get the `claude` CLI name a package that is not on npm:

- `docs/guide/installation.md` — *"CatBot chat exits immediately"* → `npm i -g @anthropic-ai/claude-cli`
- `docs/guide/catbot.md` — *"native binary not found"* → `npm i -g @anthropic-ai/claude-cli`

plus the two `docs/zh/...` mirrors. Live on the docs site right now: `docs.catgo-ucsd.org/guide/installation` and `/guide/catbot` both serve `claude-cli`.

Running exactly what the docs say (node 24.14.0, npm 11.9.0, isolated prefix):

```
$ npm install -g --prefix ./pfx @anthropic-ai/claude-cli
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@anthropic-ai%2fclaude-cli - Not found
```

So the reader who hits the exact failure these bullets are written for cannot follow them out of it.

## What it is now

`@anthropic-ai/claude-code` — the package CatGo's own resolver expects. `src/lib/server/agent-bridge/adapters/claude.ts` says so in the comment (`npm i -g @anthropic-ai/claude-code`) and `nativeBinaryFor()` dereferences shims to `node_modules/@anthropic-ai/claude-code/bin/claude{,.exe}`.

Verified end to end on the same isolated prefix:

```
$ npm install -g --prefix ./pfx @anthropic-ai/claude-code
added 2 packages in 1m

$ ls -l pfx/bin
claude -> ../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe

$ pfx/bin/claude --version
2.1.235 (Claude Code)

$ ls pfx/lib/node_modules/@anthropic-ai/claude-code/bin/
claude.exe        # 322 MB native binary — exactly the path nativeBinaryFor() looks for
```

## Scope

Four lines, docs only (en + zh), no code touched. The `"id": "claude-cli"` in `docs/developer/api-layer-spec.md` is a provider id inside an example payload, not a package name — deliberately left alone.
