### PR TITLE
fix(release): harden packaged backends for v1.4.12

### DIFF
--- a/.github/release-notes/v1.4.12.md
+++ b/.github/release-notes/v1.4.12.md
@@ -1,0 +1,183 @@
+## CatGo 1.4.12
+
+CatGo 1.4.12 is a cross-platform reliability release for CatBot, scientific
+workflows, large trajectories, and the integrated terminal. It includes the
+unpublished 1.4.10 and 1.4.11 improvements, plus release-time fixes verified on
+the Windows, macOS Apple Silicon, and Linux packaged build paths.
+
+### Highlights
+
+- **CatBot works from installed desktop packages** — Claude, Codex, and Gemini
+  CLI discovery follows platform-native user paths, while the bundled backend
+  and Agent Bridge expose the same Provider, MCP, Skills, voice, structure,
+  workflow, and Campaign capabilities as the source build.
+- **Packaged backends start with a coherent native runtime** — Linux bundles
+  one ABI-compatible conda C++ runtime, and Windows Campaign cold starts are
+  validated with reliable full-process-tree cleanup.
+- **Attachments reach the selected model** — images, PDFs, text files, and
+  general files are carried through SDK, direct-provider, and backend-relay
+  paths instead of being silently discarded.
+- **Surface workflows are scientifically complete** — the clean slab is
+  relaxed before adsorbate branches, frozen atoms stay consistent through
+  geometry optimization and frequency calculations, and workflow status comes
+  from actual task evidence.
+- **Large trajectories and terminals remain responsive and complete** — bounded
+  frame caches reduce memory pressure, while terminal resizing preserves CJK
+  cells and keeps the final column clear of the scrollbar.
+
+### Added
+
+#### Packaged CatBot verification
+
+- Added all-platform frozen-backend smoke tests covering the Provider catalogue,
+  native voice health, bundled core Skills, all 21 CatGo MCP tools, structure and
+  pane access, workflows, and real REST/MCP Campaign creation.
+- Added compiled Agent Bridge smoke tests for Claude, Codex, and Gemini session,
+  attachment, permission, failure, and stream-completion paths.
+- Added native attachment transport for Claude image/PDF blocks, Codex local
+  images, Gemini ACP images, and safe temporary file access for other formats.
+- Added a release boundary that publishes the VS Code extension to Marketplace
+  and Open VSX only after the exact-version Linux, macOS, and Windows sidecars
+  and their SHA256 metadata are available on the public mirror.
+
+#### CatBot and Codex integration
+
+- Added live Codex model discovery so CatBot's provider label follows the
+  installed CLI instead of carrying a stale hard-coded model version.
+- Preserved the user's Codex skills and MCP configuration while registering the
+  desktop CatGo server under its own namespace.
+- Routed CatBot structure, workflow, and export actions through the active CatGo
+  runtime connection rather than fixed localhost ports.
+- Added structure recovery for pop-out chat windows and viewer panels so closing
+  a presentation window does not erase the underlying structure.
+
+#### Workflow management and surface science
+
+- Added safe bulk selection and deletion to project and workflow views, with
+  durable success or failure feedback.
+- Added task-derived workflow state aggregation for CHECK, PAUSED, FAILED,
+  REMOTE_ERROR, RUNNING, and completed work.
+- Added a clean-slab geometry-optimization node before adsorbate branches in
+  generated surface workflows.
+- Persisted exact frozen-atom indices from slab generation through slab
+  optimization, adsorbate geometry optimization, and adsorbate-only frequency
+  calculations.
+
+### Fixed
+
+#### Cross-platform CatBot runtime
+
+- Fixed Linux frozen backends mixing Ubuntu 22.04's older `libstdc++` with
+  conda ICU. PyInstaller now selects the conda `libstdc++`/`libgcc` pair and
+  verifies that it provides every collected CXXABI and GLIBCXX version.
+- Fixed Windows packaged Campaign verification using a five-second generic API
+  timeout for the first frozen invocation. The smoke test now gives Campaign a
+  realistic cold-start budget and terminates the complete PyInstaller process
+  tree before removing logs.
+- Fixed GUI-launched Windows and macOS apps failing to find user-installed
+  Claude, Codex, or Gemini CLIs because desktop launchers supplied a reduced
+  PATH.
+- Fixed installed Windows local terminals opening with the wrong shell or losing
+  the selected shell and current directory across runtime transitions.
+- Fixed frozen desktop backends launching Campaign as `python -m catgo`, which
+  recursively invoked the packaged executable instead of the CatGo CLI.
+- Fixed the first microphone action racing the delayed voice router and becoming
+  stuck on an unavailable browser fallback.
+- Fixed CatBot attachments appearing in the composer but never reaching SDK,
+  direct-provider, or backend-relay requests.
+- Fixed migrated tool-registry tests importing the obsolete pre-package module
+  path, restoring coverage of packaged tool discovery.
+- Fixed official VS Code builds becoming visible before their matching server
+  sidecars, which previously produced unrecoverable HTTP 404 downloads.
+
+#### Workflow correctness and recovery
+
+- Fixed workflows that were reported as generated but never appeared in the
+  visible CatGo workspace.
+- Fixed completed, failed, or checking workflows that remained labeled RUNNING,
+  while continuing to protect genuinely executing tasks and unresolved remote
+  jobs from deletion.
+- Fixed slab and geometry-optimization previews showing different frozen layers
+  despite sharing the same structure.
+- Fixed manual freeze edits that appeared selected but were not persisted into
+  downstream inputs.
+
+#### Database and networking
+
+- Prevented Materials Project, OPTIMADE, and PubChem requests from inheriting
+  agent-only SOCKS proxy settings. Normal HTTP proxy configuration remains
+  available to the backend.
+- Improved OPTIMADE provider recovery so a failed upstream request is reported
+  accurately instead of leaving database search unusable.
+
+#### Trajectory and terminal rendering
+
+- Synchronized typed trajectory positions with topology and bond snapshots in
+  Large System Performance Mode.
+- Bounded decoded frame caches and refreshed bond snapshots without retaining an
+  unbounded object graph during playback.
+- Reserved terminal columns beside the scrollbar so the right edge is visible.
+- Reflowed active full-screen terminal applications on font changes and repaired
+  pre-existing tabs after hot reload, preventing CJK character loss.
+
+#### Citation
+
+- Updated the preferred CatGo citation to the published *Digital Discovery*
+  article, DOI `10.1039/D6DD00273K`.
+
+### Upgrade notes
+
+- No project, workflow database, structure-file, or trajectory migration is
+  required.
+- Existing Codex skills and MCP configuration are retained. CatGo's desktop MCP
+  entry is isolated automatically; remove obsolete hand-written CatGo entries
+  only if you previously added duplicates yourself.
+- Workflow deletion remains unavailable for tasks that are executing or whose
+  remote job identity is unresolved. This is an intentional safety boundary.
+- Generated surface workflows contain a clean-slab relaxation node. Review slab
+  constraints before submitting a newly generated DAG.
+- CatBot keeps attachment metadata in restored chat history but does not persist
+  attachment bytes in browser storage. Reattach a file before asking a follow-up
+  question that requires rereading it.
+- VS Code, Cursor, VSCodium, and Theia users should install the Marketplace or
+  Open VSX build. A manually version-edited VSIX has no matching sidecar and is
+  intentionally rejected instead of silently running a different backend.
+
+### Included pull requests
+
+- [#571](https://github.com/Hello-QM/catgo-LRG/pull/571) — Update the preferred
+  citation to the published *Digital Discovery* article.
+- [#574](https://github.com/Hello-QM/catgo-LRG/pull/574) — Harden CatBot,
+  workflow lifecycle and slab constraints, provider networking, large-system
+  trajectories, and terminal resizing.
+- [#576](https://github.com/Hello-QM/catgo-LRG/pull/576) — Repair Windows local
+  shells and working-directory synchronization, then harden the complete
+  packaged CatBot runtime across supported desktop platforms.
+
+### Downloads
+
+- **Windows x86-64** — `.msi` or `-setup.exe`
+- **macOS Apple Silicon** — Developer-ID signed `.dmg`
+- **Linux x86-64** — `.deb` or `.rpm`
+- **Android** — `CatGo-v*-android-universal.apk`
+- **iOS** — [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
+- **VS Code** — `.vsix`
+- **Headless/HPC** — platform sidecars and `catgo-hpc-bundle.tar.gz`
+
+### License and citation
+
+CatGo 1.4.12 distributions use **AGPL-3.0-or-later**.
+
+If CatGo contributes to your work, please include this acknowledgement and the
+preferred citation:
+
+> This work used CatGo (https://app.catgo-ucsd.org).
+
+Please cite DOI
+[`10.1039/D6DD00273K`](https://doi.org/10.1039/D6DD00273K).
+This request is not an additional condition of the AGPL license. Third-party
+materials retain their own terms. Historical AGPL grants remain in effect.
+
+See the
+[CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md)
+for the complete release history.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -350,7 +350,7 @@ jobs:
             One window for the whole loop: **read almost any code's files → build & edit → run DFT / ML / MD → submit to HPC → analyse → publish.** Ships with the bundled backend server (MLP libraries excluded to keep the download lean).
 
             ### License and citation
-            CatGo 1.4.11 distributions use **AGPL-3.0-or-later**.
+            CatGo 1.4.12 distributions use **AGPL-3.0-or-later**.
 
             If CatGo contributes to your work, please include this acknowledgement and the preferred citation:
 
@@ -380,7 +380,8 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
-            ### New in 1.4.11
+            ### New in 1.4.12
+            - **Packaged backends start reliably on Linux and Windows** — Linux bundles one ABI-compatible conda C++ runtime, while Windows Campaign cold starts are verified with complete process-tree cleanup.
             - **Installed CatBot is complete across supported desktops** — Claude, Codex, and Gemini discovery, attachments, voice, Skills, MCP tools, structures, workflows, and Campaigns are covered by packaged-runtime smoke tests.
             - **Windows terminal and Campaign workflows are reliable** — native shell selection, working-directory synchronization, GUI PATH recovery, and frozen Campaign dispatch use the correct runtime.
             - **Surface workflows relax slabs and preserve constraints** — clean-slab optimization precedes adsorption branches, with exact frozen atoms inherited by geometry and frequency steps.
@@ -563,7 +564,7 @@ jobs:
         run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"
 
       - name: Finalize canonical release body
-        if: env.CATGO_RELEASE_TAG == 'v1.4.11'
+        if: env.CATGO_RELEASE_TAG == 'v1.4.12'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.12] - 2026-08-25
+
+### Fixed
+
+- **Linux packaged backend startup** — PyInstaller now bundles the coherent conda `libstdc++`/`libgcc` pair and verifies its CXXABI/GLIBCXX coverage, preventing conda ICU from loading against Ubuntu 22.04's older C++ runtime.
+- **Windows frozen Campaign verification** — packaged Campaign creation receives a realistic cold-start timeout, and smoke-test cleanup terminates the complete PyInstaller process tree without masking the original failure behind a locked log file.
+
 ## [1.4.11] - 2026-08-25
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.11
+version: 1.4.12
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/rust-wasm/CITATION.cff
+++ b/extensions/rust-wasm/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.11
+version: 1.4.12
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/CITATION.cff
+++ b/extensions/vscode/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.11
+version: 1.4.12
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures, molecules and MD / optimization trajectories — reads the file formats of VASP, Quantum ESPRESSO, CP2K, ABACUS, ORCA, Gaussian, CASTEP, SIESTA, OpenMX, LAMMPS and ASE: POSCAR/CONTCAR · CIF · XYZ/extXYZ · mol2 · PDB · vasprun.xml · OUTCAR · XDATCAR · .traj · HDF5 · cube/CHGCAR isosurfaces. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, trajectory scrubbing with energy/force overlays, themes that follow VS Code. Right-click → Render, or Ctrl/Cmd+Shift+V.",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/scripts/__tests__/docs-citation-license.test.mjs
+++ b/scripts/__tests__/docs-citation-license.test.mjs
@@ -48,7 +48,7 @@ test('CITATION.cff carries the exact non-binding citation request', () => {
   assert.equal(message, CITATION_REQUEST)
   assert.match(cff, new RegExp(
     `^cff-version: 1\\.2\\.0\\nmessage: ${escapeRegExp(CITATION_REQUEST)}\\n` +
-    'version: 1\\.4\\.11\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
+    'version: 1\\.4\\.12\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
     'license-url: https://github\\.com/Hello-QM/catgo-LRG/blob/main/license$',
     'm',
   ))

--- a/scripts/__tests__/license-policy.test.mjs
+++ b/scripts/__tests__/license-policy.test.mjs
@@ -158,6 +158,7 @@ const licenseClaimInventory = {
     '.github/release-notes/v1.4.9.md',
     '.github/release-notes/v1.4.10.md',
     '.github/release-notes/v1.4.11.md',
+    '.github/release-notes/v1.4.12.md',
     '.github/workflows/tauri-build.yml',
   ],
   historicalOnly: [
@@ -296,7 +297,7 @@ test('canonical citation file requests citation without adding an AGPL condition
   assert.equal(existsSync(resolve(ROOT, 'citation.cff')), false)
   const text = read('CITATION.cff')
   assert.match(text, /^cff-version: 1\.2\.0$/m)
-  assert.match(text, /^version: 1\.4\.11$/m)
+  assert.match(text, /^version: 1\.4\.12$/m)
   assert.match(text, /^license: AGPL-3\.0-or-later$/m)
   assert.match(text, /^license-url: https:\/\/github\.com\/Hello-QM\/catgo-LRG\/blob\/main\/license$/m)
   assert.match(text, /CatGo: Bridging CLI Coding Agents/)

--- a/scripts/__tests__/release-body.test.mjs
+++ b/scripts/__tests__/release-body.test.mjs
@@ -14,7 +14,7 @@ import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
-const TAG = 'v1.4.11'
+const TAG = 'v1.4.12'
 const NOTES = resolve(ROOT, `.github/release-notes/${TAG}.md`)
 const WORKFLOW = readFileSync(
   resolve(ROOT, '.github/workflows/tauri-build.yml'),
@@ -79,11 +79,11 @@ test('canonical current release body contains every mandatory disclosure', () =>
 test('existing release is always edited to the canonical body', () => {
   const { result, calls } = runEnsure({ existing: true })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release view v1\.4\.11$/m)
+  assert.match(calls, /^release view v1\.4\.12$/m)
   assert.doesNotMatch(calls, /^release create /m)
   assert.match(
     calls,
-    /^release edit v1\.4\.11 --title CatGo v1\.4\.11 --notes-file \.github\/release-notes\/v1\.4\.11\.md$/m,
+    /^release edit v1\.4\.12 --title CatGo v1\.4\.12 --notes-file \.github\/release-notes\/v1\.4\.12\.md$/m,
   )
 })
 
@@ -93,9 +93,9 @@ test('concurrent draft creation still converges through an explicit edit', () =>
     createStatus: 1,
   })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release create v1\.4\.11 --draft /m)
-  assert.match(calls, /^release view v1\.4\.11$/m)
-  assert.match(calls, /^release edit v1\.4\.11 /m)
+  assert.match(calls, /^release create v1\.4\.12 --draft /m)
+  assert.match(calls, /^release view v1\.4\.12$/m)
+  assert.match(calls, /^release edit v1\.4\.12 /m)
 })
 
 test('Tauri workflow finalizes the canonical body after tauri-action', () => {
@@ -104,7 +104,7 @@ test('Tauri workflow finalizes the canonical body after tauri-action', () => {
   assert.ok(action >= 0)
   assert.ok(finalize > action)
   const block = WORKFLOW.slice(finalize)
-  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.11'/)
+  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.12'/)
   assert.match(block, /scripts\/ensure-release-body\.sh "\$CATGO_RELEASE_TAG"/)
 })
 

--- a/scripts/__tests__/release-version-verifier.test.mjs
+++ b/scripts/__tests__/release-version-verifier.test.mjs
@@ -53,7 +53,7 @@ function runVerifierWithEnvironment(root, environment) {
   })
 }
 
-function replaceVersion(root, path, from = '1.4.11', to = '1.4.9') {
+function replaceVersion(root, path, from = '1.4.12', to = '1.4.9') {
   const target = resolve(root, path)
   const current = readFileSync(target, 'utf8')
   assert.match(current, new RegExp(from.replaceAll('.', '\\.')), path)
@@ -63,9 +63,9 @@ function replaceVersion(root, path, from = '1.4.11', to = '1.4.9') {
 test('accepts a consistent release tree and its exact v-prefixed tag', () => {
   const root = fixture()
   try {
-    const result = runVerifier(root, '--tag', 'v1.4.11')
+    const result = runVerifier(root, '--tag', 'v1.4.12')
     assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /release version 1\.4\.11 verified/)
+    assert.match(result.stdout, /release version 1\.4\.12 verified/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -78,7 +78,7 @@ test('accepts Windows CRLF checkouts', () => {
       const target = resolve(root, path)
       writeFileSync(target, readFileSync(target, 'utf8').replaceAll('\n', '\r\n'))
     }
-    const result = runVerifier(root, '--tag', 'v1.4.11')
+    const result = runVerifier(root, '--tag', 'v1.4.12')
     assert.equal(result.status, 0, result.stderr)
   } finally {
     rmSync(root, { recursive: true, force: true })
@@ -106,7 +106,7 @@ test('rejects a tag that does not exactly match the manifest version', () => {
   try {
     const result = runVerifier(root, '--tag', 'v1.4.9')
     assert.notEqual(result.status, 0)
-    assert.match(result.stderr, /expected v1\.4\.11/)
+    assert.match(result.stderr, /expected v1\.4\.12/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -127,7 +127,7 @@ test('honors the workflow tag and publishing requirement environment', () => {
   const root = fixture()
   try {
     const matching = runVerifierWithEnvironment(root, {
-      RELEASE_VERSION_TAG: 'v1.4.11',
+      RELEASE_VERSION_TAG: 'v1.4.12',
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.equal(matching.status, 0, matching.stderr)
@@ -137,7 +137,7 @@ test('honors the workflow tag and publishing requirement environment', () => {
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.notEqual(mismatched.status, 0)
-    assert.match(mismatched.stderr, /expected v1\.4\.11/)
+    assert.match(mismatched.stderr, /expected v1\.4\.12/)
 
     const missing = runVerifierWithEnvironment(root, {
       RELEASE_VERSION_TAG: '',

--- a/scripts/__tests__/version-consistency.test.mjs
+++ b/scripts/__tests__/version-consistency.test.mjs
@@ -6,7 +6,7 @@ import test from 'node:test'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const source = (path) => readFileSync(resolve(ROOT, path), 'utf8')
-const APP_VERSION = '1.4.11'
+const APP_VERSION = '1.4.12'
 const WORKFLOW_INVENTORY = {
   'android-build.yml': {
     classification: 'root-versioned-publisher',
@@ -134,7 +134,7 @@ function workflowStep(path, name) {
   return workflow.slice(start, next === -1 ? undefined : next)
 }
 
-test('all CatGo application version surfaces target v1.4.11', () => {
+test('all CatGo application version surfaces target v1.4.12', () => {
   const packageJson = JSON.parse(source('package.json'))
   const tauriConfig = JSON.parse(source('src-tauri/tauri.conf.json'))
   const cargoLockMatch =
@@ -156,7 +156,7 @@ test('all CatGo application version surfaces target v1.4.11', () => {
   )
 })
 
-test('VSIX and citation package metadata target v1.4.11', () => {
+test('VSIX and citation package metadata target v1.4.12', () => {
   const vscodePackage = JSON.parse(source('extensions/vscode/package.json'))
   assert.equal(vscodePackage.version, APP_VERSION)
 
@@ -177,10 +177,11 @@ test('the dependency lock remains a pnpm v9 root-importer lock', () => {
   assert.match(lock, /^importers:\n\n  \.:\n/m)
 })
 
-test('the desktop draft release notes describe v1.4.11', () => {
+test('the desktop draft release notes describe v1.4.12', () => {
   const workflow = source('.github/workflows/tauri-build.yml')
 
-  assert.match(workflow, /### New in 1\.4\.11/)
+  assert.match(workflow, /### New in 1\.4\.12/)
+  assert.match(workflow, /Packaged backends start reliably on Linux and Windows/)
   assert.match(workflow, /Installed CatBot is complete across supported desktops/)
   assert.match(workflow, /Windows terminal and Campaign workflows are reliable/)
   assert.match(workflow, /Surface workflows relax slabs and preserve constraints/)

--- a/scripts/__tests__/vscode-sidecar-availability.test.mjs
+++ b/scripts/__tests__/vscode-sidecar-availability.test.mjs
@@ -25,13 +25,13 @@ test('accepts all three version-coupled sidecars and exact checksums', async () 
   }
 
   const result = await verifyVscodeSidecars({
-    version: '1.4.11',
+    version: '1.4.12',
     fetchImpl,
   })
 
   assert.deepEqual(result.map(({ asset }) => asset), VSCODE_SIDECAR_ASSETS)
   assert.equal(requests.length, 6)
-  assert.ok(requests.every(([url]) => url.includes('/v1.4.11/')))
+  assert.ok(requests.every(([url]) => url.includes('/v1.4.12/')))
 })
 
 test('fails closed before marketplace publication when a checksum is absent', async () => {
@@ -55,7 +55,7 @@ test('checksum metadata must name the exact platform asset', () => {
 test('rejects insecure sidecar origins', async () => {
   await assert.rejects(
     verifyVscodeSidecars({
-      version: '1.4.11',
+      version: '1.4.12',
       baseUrl: 'http://dl.catgo-ucsd.org',
       fetchImpl: async () => new Response(null, { status: 200 }),
     }),

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -16,6 +16,7 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
     '648f687ef61ec6b876a2af34a42cb984c93d66efa66603335d41d21825f262c8',
     'eb477bebe6f161f3aa1c3080e5a2750f15f80a37022f93737fe462322cfd97bf',
     '411285e85b193b3eb85dbdca7e428cbc97d28752bc89df8d67c572e4c1b4b8a8',
+    '7b98d77d6abb48449dcb896a9d6edb3f8a5adee1597b5eddc146f143bea650c8',
   ]),
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',

--- a/scripts/smoke-frozen-catbot.py
+++ b/scripts/smoke-frozen-catbot.py
@@ -12,6 +12,7 @@ import argparse
 import asyncio
 import json
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -35,7 +36,12 @@ def _free_port() -> int:
 _OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 
-def _request_json(url: str, payload: dict | None = None) -> dict:
+def _request_json(
+    url: str,
+    payload: dict | None = None,
+    *,
+    timeout: float = 5,
+) -> dict:
     data = None if payload is None else json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(
         url,
@@ -43,8 +49,46 @@ def _request_json(url: str, payload: dict | None = None) -> dict:
         headers={"Content-Type": "application/json"} if data else {},
         method="POST" if data else "GET",
     )
-    with _OPENER.open(request, timeout=5) as response:
+    with _OPENER.open(request, timeout=timeout) as response:
         return json.load(response)
+
+
+def _process_group_options() -> dict[str, int | bool]:
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> None:
+    """Stop a one-file PyInstaller launcher and the extracted child process."""
+
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    elif process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+    try:
+        process.wait(timeout=10)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    if os.name != "nt":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.kill()
+    process.wait(timeout=10)
 
 
 def _direct_httpx_client(
@@ -158,6 +202,7 @@ def main() -> int:
                     "CATGO_CODEX_PATH": sys.executable,
                     "CATGO_GEMINI_PATH": sys.executable,
                 },
+                **_process_group_options(),
             )
             try:
                 base = f"http://127.0.0.1:{port}"
@@ -227,6 +272,10 @@ def main() -> int:
                             "blank",
                         ],
                     },
+                    # The first frozen Campaign invocation imports its CLI and
+                    # stages bundled skills. Windows CI can legitimately need
+                    # more than the generic five-second API smoke budget.
+                    timeout=60,
                 )
                 if not result.get("ok"):
                     raise RuntimeError(f"campaign bridge failed: {result}")
@@ -235,12 +284,7 @@ def main() -> int:
 
                 asyncio.run(_smoke_mcp(base, mcp_campaign))
             finally:
-                process.terminate()
-                try:
-                    process.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=10)
+                _terminate_process_tree(process)
 
     print(f"Frozen CatBot smoke test passed: {backend}")
     return 0

--- a/scripts/verify-legal-distributions.mjs
+++ b/scripts/verify-legal-distributions.mjs
@@ -323,7 +323,7 @@ function verifyReleaseAssets() {
     'the download mirror must validate assets against legal material from the target tag',
   )
   requireMatch(
-    '.github/release-notes/v1.4.11.md',
+    '.github/release-notes/v1.4.12.md',
     /AGPL-3\.0-or-later[\s\S]*This work used CatGo \(https:\/\/app\.catgo-ucsd\.org\)\.[\s\S]*10\.1039\/D6DD00273K[\s\S]*not an additional condition/i,
     'release body must prominently disclose AGPL, the requested acknowledgement, DOI, and its non-binding status',
   )

--- a/server/CITATION.cff
+++ b/server/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.11
+version: 1.4.12
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/server/catgo_server.spec
+++ b/server/catgo_server.spec
@@ -15,9 +15,13 @@ This creates a standalone executable that bundles:
 MACE and other ML potentials are excluded to keep the bundle size reasonable.
 """
 
+import os
 import sys
 from pathlib import Path
+from PyInstaller.building.datastruct import TOC
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs
+
+from pyinstaller_runtime import replace_linux_conda_cxx_runtime
 
 block_cipher = None
 
@@ -280,6 +284,19 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
+
+# A conda build can otherwise mix Ubuntu 22.04's old libstdc++ with conda's
+# newer ICU, producing a frozen executable that fails at import time with a
+# missing CXXABI symbol.  Replace both C++ runtime libraries as one pair and
+# verify that the selected libstdc++ satisfies every collected native library.
+if sys.platform.startswith('linux'):
+    _conda_prefix = os.environ.get('CONDA_PREFIX')
+    if not _conda_prefix and (Path(sys.prefix) / 'conda-meta').is_dir():
+        _conda_prefix = sys.prefix
+    if _conda_prefix:
+        a.binaries = TOC(
+            replace_linux_conda_cxx_runtime(a.binaries, Path(_conda_prefix))
+        )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 

--- a/server/pyinstaller_runtime.py
+++ b/server/pyinstaller_runtime.py
@@ -1,0 +1,72 @@
+"""Build-time helpers for native libraries collected by PyInstaller."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+_LINUX_CXX_RUNTIME_NAMES = frozenset({"libgcc_s.so.1", "libstdc++.so.6"})
+_CXX_VERSION_PATTERN = re.compile(rb"(?:CXXABI|GLIBCXX)_[0-9]+(?:\.[0-9]+)+")
+
+
+def _version_tokens(path: Path) -> set[bytes]:
+    """Return C++ ABI symbol-version strings embedded in an ELF binary."""
+
+    try:
+        return set(_CXX_VERSION_PATTERN.findall(path.read_bytes()))
+    except (OSError, ValueError):
+        return set()
+
+
+def replace_linux_conda_cxx_runtime(
+    binaries: Iterable[Sequence[str]],
+    conda_prefix: Path,
+) -> list[tuple[str, str, str]]:
+    """Use one coherent conda C++ runtime for a Linux PyInstaller bundle.
+
+    PyInstaller may otherwise combine Ubuntu's system ``libstdc++.so.6`` with
+    conda libraries such as ICU.  A newer conda ICU can require CXXABI symbols
+    that Ubuntu 22.04's runtime does not export, causing the frozen executable
+    to fail before the FastAPI application starts.
+    """
+
+    entries = [tuple(entry) for entry in binaries]
+    runtime_dir = Path(conda_prefix) / "lib"
+    replacements: dict[str, Path] = {}
+    for name in sorted(_LINUX_CXX_RUNTIME_NAMES):
+        candidate = runtime_dir / name
+        if not candidate.is_file():
+            raise RuntimeError(
+                f"activated conda environment is missing required Linux runtime: {candidate}"
+            )
+        replacements[name] = candidate.resolve()
+
+    provided = _version_tokens(replacements["libstdc++.so.6"])
+    required: set[bytes] = set()
+    for entry in entries:
+        if len(entry) < 2 or Path(entry[0]).name in _LINUX_CXX_RUNTIME_NAMES:
+            continue
+        source = Path(entry[1])
+        if source.is_file():
+            required.update(_version_tokens(source))
+
+    missing = sorted(required - provided)
+    if missing:
+        formatted = ", ".join(token.decode("ascii") for token in missing)
+        raise RuntimeError(
+            "conda libstdc++.so.6 does not satisfy collected native libraries: "
+            f"{formatted}"
+        )
+
+    coherent = [
+        entry
+        for entry in entries
+        if len(entry) >= 1 and Path(entry[0]).name not in _LINUX_CXX_RUNTIME_NAMES
+    ]
+    coherent.extend(
+        (name, str(source), "BINARY")
+        for name, source in sorted(replacements.items())
+    )
+    return coherent

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catgo"
-version = "1.4.11"
+version = "1.4.12"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
 readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"

--- a/server/tests/test_pyinstaller_runtime.py
+++ b/server/tests/test_pyinstaller_runtime.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from pyinstaller_runtime import replace_linux_conda_cxx_runtime
+
+
+def _write(path: Path, payload: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return path
+
+
+def test_replaces_mixed_linux_cxx_runtime_with_conda_pair(tmp_path: Path):
+    prefix = tmp_path / "conda"
+    stdcxx = _write(
+        prefix / "lib" / "libstdc++.so.6",
+        b"CXXABI_1.3.13\0CXXABI_1.3.15\0GLIBCXX_3.4.30",
+    )
+    libgcc = _write(prefix / "lib" / "libgcc_s.so.1", b"libgcc")
+    consumer = _write(
+        tmp_path / "libicui18n.so.78",
+        b"CXXABI_1.3.15\0GLIBCXX_3.4.30",
+    )
+
+    result = replace_linux_conda_cxx_runtime(
+        [
+            ("libstdc++.so.6", "/usr/lib/libstdc++.so.6", "BINARY"),
+            ("libgcc_s.so.1", "/usr/lib/libgcc_s.so.1", "BINARY"),
+            ("libicui18n.so.78", str(consumer), "BINARY"),
+        ],
+        prefix,
+    )
+
+    by_name = {entry[0]: entry for entry in result}
+    assert by_name["libstdc++.so.6"] == (
+        "libstdc++.so.6",
+        str(stdcxx.resolve()),
+        "BINARY",
+    )
+    assert by_name["libgcc_s.so.1"] == (
+        "libgcc_s.so.1",
+        str(libgcc.resolve()),
+        "BINARY",
+    )
+    assert by_name["libicui18n.so.78"][1] == str(consumer)
+
+
+def test_rejects_conda_runtime_that_cannot_satisfy_collected_library(tmp_path: Path):
+    prefix = tmp_path / "conda"
+    _write(prefix / "lib" / "libstdc++.so.6", b"CXXABI_1.3.13")
+    _write(prefix / "lib" / "libgcc_s.so.1", b"libgcc")
+    consumer = _write(tmp_path / "libicui18n.so.78", b"CXXABI_1.3.15")
+
+    with pytest.raises(RuntimeError, match="CXXABI_1.3.15"):
+        replace_linux_conda_cxx_runtime(
+            [("libicui18n.so.78", str(consumer), "BINARY")],
+            prefix,
+        )
+
+
+def test_rejects_incomplete_conda_runtime_pair(tmp_path: Path):
+    prefix = tmp_path / "conda"
+    _write(prefix / "lib" / "libstdc++.so.6", b"CXXABI_1.3.15")
+
+    with pytest.raises(RuntimeError, match="libgcc_s.so.1"):
+        replace_linux_conda_cxx_runtime([], prefix)

--- a/server/tests/test_smoke_frozen_catbot.py
+++ b/server/tests/test_smoke_frozen_catbot.py
@@ -1,0 +1,49 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "smoke-frozen-catbot.py"
+_SPEC = importlib.util.spec_from_file_location("smoke_frozen_catbot", _SCRIPT)
+assert _SPEC and _SPEC.loader
+smoke = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(smoke)
+
+
+def test_request_json_forwards_explicit_timeout(monkeypatch):
+    response = Mock()
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    response.read.return_value = b'{"ok": true}'
+    response.getcode.return_value = 200
+    opener = Mock()
+    opener.open.return_value = response
+    monkeypatch.setattr(smoke, "_OPENER", opener)
+
+    assert smoke._request_json("http://127.0.0.1/test", timeout=60) == {"ok": True}
+    assert opener.open.call_args.kwargs["timeout"] == 60
+
+
+def test_posix_process_group_is_isolated(monkeypatch):
+    monkeypatch.setattr(smoke.os, "name", "posix")
+    assert smoke._process_group_options() == {"start_new_session": True}
+
+
+def test_windows_cleanup_terminates_entire_process_tree(monkeypatch):
+    monkeypatch.setattr(smoke.os, "name", "nt")
+    run = Mock()
+    monkeypatch.setattr(smoke.subprocess, "run", run)
+    process = Mock()
+    process.pid = 1234
+    process.wait.return_value = 0
+
+    smoke._terminate_process_tree(process)
+
+    run.assert_called_once_with(
+        ["taskkill", "/PID", "1234", "/T", "/F"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    process.wait.assert_called_once_with(timeout=10)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.11"
+version = "1.4.12"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
## Summary

- publish the immutable successor release metadata for CatGo 1.4.12
- make Linux PyInstaller bundles use one ABI-compatible conda `libstdc++` / `libgcc` runtime pair and fail the build if collected native libraries require unsupported CXXABI or GLIBCXX symbols
- give the first frozen Campaign invocation a realistic Windows cold-start budget and terminate the complete PyInstaller process tree before temporary logs are removed
- add regression tests and a canonical full release Description for 1.4.12

## Why 1.4.12

The v1.4.11 tag is immutable and its Desktop release smoke exposed two platform-specific blockers after tagging:

- Linux loaded conda ICU 78 against Ubuntu 22.04's older bundled `libstdc++.so.6`, which lacked `CXXABI_1.3.15`.
- Windows used the generic five-second HTTP timeout for the first frozen Campaign scaffold, then left the PyInstaller child holding `backend.log`, masking the timeout with `WinError 32` during cleanup.

The existing v1.4.11 tag and draft release are intentionally left unchanged.

## Verification

- `python -m pytest server/tests/test_pyinstaller_runtime.py server/tests/test_smoke_frozen_catbot.py -q` — 6 passed
- `pnpm test:node` — 360 passed
- `node scripts/verify-release-version.mjs` — 1.4.12 verified
- `node scripts/verify-release-rights.mjs` — 2 ledgers verified
- `node scripts/verify-legal-distributions.mjs` — 10 contracts and 27 files verified
- `python -m py_compile server/pyinstaller_runtime.py scripts/smoke-frozen-catbot.py server/tests/test_pyinstaller_runtime.py server/tests/test_smoke_frozen_catbot.py`
- `git diff origin/main...HEAD --check`

## Release evidence

- Linux failure: https://github.com/Hello-QM/catgo-LRG/actions/runs/32859739223/job/97840468579
- Windows failure: https://github.com/Hello-QM/catgo-LRG/actions/runs/32859739223/job/97840468628
