### PR TITLE
fix(release): restore Windows Campaign and prepare v1.4.13

### DIFF
--- a/.github/release-notes/v1.4.13.md
+++ b/.github/release-notes/v1.4.13.md
@@ -1,0 +1,183 @@
+## CatGo 1.4.13
+
+CatGo 1.4.13 is a cross-platform reliability release for CatBot, scientific
+workflows, large trajectories, and the integrated terminal. It includes the
+unpublished 1.4.10, 1.4.11, and 1.4.12 improvements, plus release-time fixes
+verified on the Windows, macOS Apple Silicon, and Linux packaged build paths.
+
+### Highlights
+
+- **CatBot works from installed desktop packages** — Claude, Codex, and Gemini
+  CLI discovery follows platform-native user paths, while the bundled backend
+  and Agent Bridge expose the same Provider, MCP, Skills, voice, structure,
+  workflow, and Campaign capabilities as the source build.
+- **Packaged backends avoid redundant cold starts** — Linux bundles one
+  ABI-compatible conda C++ runtime, while Windows frozen Campaign actions run
+  inside the already-extracted backend without relaunching the one-file EXE.
+- **Attachments reach the selected model** — images, PDFs, text files, and
+  general files are carried through SDK, direct-provider, and backend-relay
+  paths instead of being silently discarded.
+- **Surface workflows are scientifically complete** — the clean slab is
+  relaxed before adsorbate branches, frozen atoms stay consistent through
+  geometry optimization and frequency calculations, and workflow status comes
+  from actual task evidence.
+- **Large trajectories and terminals remain responsive and complete** — bounded
+  frame caches reduce memory pressure, while terminal resizing preserves CJK
+  cells and keeps the final column clear of the scrollbar.
+
+### Added
+
+#### Packaged CatBot verification
+
+- Added all-platform frozen-backend smoke tests covering the Provider catalogue,
+  native voice health, bundled core Skills, all 21 CatGo MCP tools, structure and
+  pane access, workflows, and real REST/MCP Campaign creation.
+- Added compiled Agent Bridge smoke tests for Claude, Codex, and Gemini session,
+  attachment, permission, failure, and stream-completion paths.
+- Added native attachment transport for Claude image/PDF blocks, Codex local
+  images, Gemini ACP images, and safe temporary file access for other formats.
+- Added a release boundary that publishes the VS Code extension to Marketplace
+  and Open VSX only after the exact-version Linux, macOS, and Windows sidecars
+  and their SHA256 metadata are available on the public mirror.
+
+#### CatBot and Codex integration
+
+- Added live Codex model discovery so CatBot's provider label follows the
+  installed CLI instead of carrying a stale hard-coded model version.
+- Preserved the user's Codex skills and MCP configuration while registering the
+  desktop CatGo server under its own namespace.
+- Routed CatBot structure, workflow, and export actions through the active CatGo
+  runtime connection rather than fixed localhost ports.
+- Added structure recovery for pop-out chat windows and viewer panels so closing
+  a presentation window does not erase the underlying structure.
+
+#### Workflow management and surface science
+
+- Added safe bulk selection and deletion to project and workflow views, with
+  durable success or failure feedback.
+- Added task-derived workflow state aggregation for CHECK, PAUSED, FAILED,
+  REMOTE_ERROR, RUNNING, and completed work.
+- Added a clean-slab geometry-optimization node before adsorbate branches in
+  generated surface workflows.
+- Persisted exact frozen-atom indices from slab generation through slab
+  optimization, adsorbate geometry optimization, and adsorbate-only frequency
+  calculations.
+
+### Fixed
+
+#### Cross-platform CatBot runtime
+
+- Fixed Linux frozen backends mixing Ubuntu 22.04's older `libstdc++` with
+  conda ICU. PyInstaller now selects the conda `libstdc++`/`libgcc` pair and
+  verifies that it provides every collected CXXABI and GLIBCXX version.
+- Fixed Windows frozen Campaign actions relaunching and unpacking the complete
+  PyInstaller one-file backend for every request. Packaged Campaign dispatch now
+  runs in-process while preserving output, exit codes, validation, timeouts, and
+  asynchronous HTTP/MCP handling.
+- Fixed GUI-launched Windows and macOS apps failing to find user-installed
+  Claude, Codex, or Gemini CLIs because desktop launchers supplied a reduced
+  PATH.
+- Fixed installed Windows local terminals opening with the wrong shell or losing
+  the selected shell and current directory across runtime transitions.
+- Fixed frozen desktop backends launching Campaign as `python -m catgo`, which
+  recursively invoked the packaged executable instead of the CatGo CLI.
+- Fixed the first microphone action racing the delayed voice router and becoming
+  stuck on an unavailable browser fallback.
+- Fixed CatBot attachments appearing in the composer but never reaching SDK,
+  direct-provider, or backend-relay requests.
+- Fixed migrated tool-registry tests importing the obsolete pre-package module
+  path, restoring coverage of packaged tool discovery.
+- Fixed official VS Code builds becoming visible before their matching server
+  sidecars, which previously produced unrecoverable HTTP 404 downloads.
+
+#### Workflow correctness and recovery
+
+- Fixed workflows that were reported as generated but never appeared in the
+  visible CatGo workspace.
+- Fixed completed, failed, or checking workflows that remained labeled RUNNING,
+  while continuing to protect genuinely executing tasks and unresolved remote
+  jobs from deletion.
+- Fixed slab and geometry-optimization previews showing different frozen layers
+  despite sharing the same structure.
+- Fixed manual freeze edits that appeared selected but were not persisted into
+  downstream inputs.
+
+#### Database and networking
+
+- Prevented Materials Project, OPTIMADE, and PubChem requests from inheriting
+  agent-only SOCKS proxy settings. Normal HTTP proxy configuration remains
+  available to the backend.
+- Improved OPTIMADE provider recovery so a failed upstream request is reported
+  accurately instead of leaving database search unusable.
+
+#### Trajectory and terminal rendering
+
+- Synchronized typed trajectory positions with topology and bond snapshots in
+  Large System Performance Mode.
+- Bounded decoded frame caches and refreshed bond snapshots without retaining an
+  unbounded object graph during playback.
+- Reserved terminal columns beside the scrollbar so the right edge is visible.
+- Reflowed active full-screen terminal applications on font changes and repaired
+  pre-existing tabs after hot reload, preventing CJK character loss.
+
+#### Citation
+
+- Updated the preferred CatGo citation to the published *Digital Discovery*
+  article, DOI `10.1039/D6DD00273K`.
+
+### Upgrade notes
+
+- No project, workflow database, structure-file, or trajectory migration is
+  required.
+- Existing Codex skills and MCP configuration are retained. CatGo's desktop MCP
+  entry is isolated automatically; remove obsolete hand-written CatGo entries
+  only if you previously added duplicates yourself.
+- Workflow deletion remains unavailable for tasks that are executing or whose
+  remote job identity is unresolved. This is an intentional safety boundary.
+- Generated surface workflows contain a clean-slab relaxation node. Review slab
+  constraints before submitting a newly generated DAG.
+- CatBot keeps attachment metadata in restored chat history but does not persist
+  attachment bytes in browser storage. Reattach a file before asking a follow-up
+  question that requires rereading it.
+- VS Code, Cursor, VSCodium, and Theia users should install the Marketplace or
+  Open VSX build. A manually version-edited VSIX has no matching sidecar and is
+  intentionally rejected instead of silently running a different backend.
+
+### Included pull requests
+
+- [#571](https://github.com/Hello-QM/catgo-LRG/pull/571) — Update the preferred
+  citation to the published *Digital Discovery* article.
+- [#574](https://github.com/Hello-QM/catgo-LRG/pull/574) — Harden CatBot,
+  workflow lifecycle and slab constraints, provider networking, large-system
+  trajectories, and terminal resizing.
+- [#576](https://github.com/Hello-QM/catgo-LRG/pull/576) — Repair Windows local
+  shells and working-directory synchronization, then harden the complete
+  packaged CatBot runtime across supported desktop platforms.
+
+### Downloads
+
+- **Windows x86-64** — `.msi` or `-setup.exe`
+- **macOS Apple Silicon** — Developer-ID signed `.dmg`
+- **Linux x86-64** — `.deb` or `.rpm`
+- **Android** — `CatGo-v*-android-universal.apk`
+- **iOS** — [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
+- **VS Code** — `.vsix`
+- **Headless/HPC** — platform sidecars and `catgo-hpc-bundle.tar.gz`
+
+### License and citation
+
+CatGo 1.4.13 distributions use **AGPL-3.0-or-later**.
+
+If CatGo contributes to your work, please include this acknowledgement and the
+preferred citation:
+
+> This work used CatGo (https://app.catgo-ucsd.org).
+
+Please cite DOI
+[`10.1039/D6DD00273K`](https://doi.org/10.1039/D6DD00273K).
+This request is not an additional condition of the AGPL license. Third-party
+materials retain their own terms. Historical AGPL grants remain in effect.
+
+See the
+[CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md)
+for the complete release history.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -350,7 +350,7 @@ jobs:
             One window for the whole loop: **read almost any code's files → build & edit → run DFT / ML / MD → submit to HPC → analyse → publish.** Ships with the bundled backend server (MLP libraries excluded to keep the download lean).
 
             ### License and citation
-            CatGo 1.4.12 distributions use **AGPL-3.0-or-later**.
+            CatGo 1.4.13 distributions use **AGPL-3.0-or-later**.
 
             If CatGo contributes to your work, please include this acknowledgement and the preferred citation:
 
@@ -380,8 +380,9 @@ jobs:
             - **Analysis** — DOS / band / COHP, Brillouin zone, XRD, phase diagrams, Gibbs & volcano plots
             - Built-in xTB / EMT calculators · OPTIMADE & PubChem search · HD render & trajectory video export
 
-            ### New in 1.4.12
-            - **Packaged backends start reliably on Linux and Windows** — Linux bundles one ABI-compatible conda C++ runtime, while Windows Campaign cold starts are verified with complete process-tree cleanup.
+            ### New in 1.4.13
+            - **Windows Campaigns start without relaunching the packaged backend** — frozen actions execute inside the already-extracted server process, eliminating the reproducible one-file unpack timeout.
+            - **Packaged backends start reliably on Linux and Windows** — Linux bundles one ABI-compatible conda C++ runtime, while Windows smoke cleanup terminates the complete process tree.
             - **Installed CatBot is complete across supported desktops** — Claude, Codex, and Gemini discovery, attachments, voice, Skills, MCP tools, structures, workflows, and Campaigns are covered by packaged-runtime smoke tests.
             - **Windows terminal and Campaign workflows are reliable** — native shell selection, working-directory synchronization, GUI PATH recovery, and frozen Campaign dispatch use the correct runtime.
             - **Surface workflows relax slabs and preserve constraints** — clean-slab optimization precedes adsorption branches, with exact frozen atoms inherited by geometry and frequency steps.
@@ -564,7 +565,7 @@ jobs:
         run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"
 
       - name: Finalize canonical release body
-        if: env.CATGO_RELEASE_TAG == 'v1.4.12'
+        if: env.CATGO_RELEASE_TAG == 'v1.4.13'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ensure-release-body.sh "$CATGO_RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.13] - 2026-08-25
+
+### Fixed
+
+- **Windows packaged Campaign dispatch** — frozen backends now run Campaign actions inside the already-extracted server process instead of launching and unpacking the complete PyInstaller one-file executable again. This removes the reproducible 60-second `/api/campaign/run` timeout while preserving CLI output, exit codes, validation, and asynchronous request handling.
+
 ## [1.4.12] - 2026-08-25
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.12
+version: 1.4.13
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/rust-wasm/CITATION.cff
+++ b/extensions/rust-wasm/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.12
+version: 1.4.13
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/CITATION.cff
+++ b/extensions/vscode/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.12
+version: 1.4.13
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "catgo",
   "displayName": "CatGo",
   "description": "3D viewer for crystal structures, molecules and MD / optimization trajectories — reads the file formats of VASP, Quantum ESPRESSO, CP2K, ABACUS, ORCA, Gaussian, CASTEP, SIESTA, OpenMX, LAMMPS and ASE: POSCAR/CONTCAR · CIF · XYZ/extXYZ · mol2 · PDB · vasprun.xml · OUTCAR · XDATCAR · .traj · HDF5 · cube/CHGCAR isosurfaces. Cross-cell PBC bond rendering, moyo space-group + Wyckoff symmetry, trajectory scrubbing with energy/force overlays, themes that follow VS Code. Right-click → Render, or Ctrl/Cmd+Shift+V.",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "license": "AGPL-3.0-or-later",
   "publisher": "Guangsheng",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/Hello-QM/catgo-LRG",
   "repository": "https://github.com/Hello-QM/catgo-LRG",
   "license": "AGPL-3.0-or-later",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "bugs": "https://github.com/Hello-QM/catgo-LRG/issues",

--- a/scripts/__tests__/docs-citation-license.test.mjs
+++ b/scripts/__tests__/docs-citation-license.test.mjs
@@ -48,7 +48,7 @@ test('CITATION.cff carries the exact non-binding citation request', () => {
   assert.equal(message, CITATION_REQUEST)
   assert.match(cff, new RegExp(
     `^cff-version: 1\\.2\\.0\\nmessage: ${escapeRegExp(CITATION_REQUEST)}\\n` +
-    'version: 1\\.4\\.12\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
+    'version: 1\\.4\\.13\\ntitle: CatGo\\nlicense: AGPL-3\\.0-or-later\\n' +
     'license-url: https://github\\.com/Hello-QM/catgo-LRG/blob/main/license$',
     'm',
   ))

--- a/scripts/__tests__/license-policy.test.mjs
+++ b/scripts/__tests__/license-policy.test.mjs
@@ -159,6 +159,7 @@ const licenseClaimInventory = {
     '.github/release-notes/v1.4.10.md',
     '.github/release-notes/v1.4.11.md',
     '.github/release-notes/v1.4.12.md',
+    '.github/release-notes/v1.4.13.md',
     '.github/workflows/tauri-build.yml',
   ],
   historicalOnly: [
@@ -297,7 +298,7 @@ test('canonical citation file requests citation without adding an AGPL condition
   assert.equal(existsSync(resolve(ROOT, 'citation.cff')), false)
   const text = read('CITATION.cff')
   assert.match(text, /^cff-version: 1\.2\.0$/m)
-  assert.match(text, /^version: 1\.4\.12$/m)
+  assert.match(text, /^version: 1\.4\.13$/m)
   assert.match(text, /^license: AGPL-3\.0-or-later$/m)
   assert.match(text, /^license-url: https:\/\/github\.com\/Hello-QM\/catgo-LRG\/blob\/main\/license$/m)
   assert.match(text, /CatGo: Bridging CLI Coding Agents/)

--- a/scripts/__tests__/release-body.test.mjs
+++ b/scripts/__tests__/release-body.test.mjs
@@ -14,7 +14,7 @@ import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
-const TAG = 'v1.4.12'
+const TAG = 'v1.4.13'
 const NOTES = resolve(ROOT, `.github/release-notes/${TAG}.md`)
 const WORKFLOW = readFileSync(
   resolve(ROOT, '.github/workflows/tauri-build.yml'),
@@ -79,11 +79,11 @@ test('canonical current release body contains every mandatory disclosure', () =>
 test('existing release is always edited to the canonical body', () => {
   const { result, calls } = runEnsure({ existing: true })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release view v1\.4\.12$/m)
+  assert.match(calls, /^release view v1\.4\.13$/m)
   assert.doesNotMatch(calls, /^release create /m)
   assert.match(
     calls,
-    /^release edit v1\.4\.12 --title CatGo v1\.4\.12 --notes-file \.github\/release-notes\/v1\.4\.12\.md$/m,
+    /^release edit v1\.4\.13 --title CatGo v1\.4\.13 --notes-file \.github\/release-notes\/v1\.4\.13\.md$/m,
   )
 })
 
@@ -93,9 +93,9 @@ test('concurrent draft creation still converges through an explicit edit', () =>
     createStatus: 1,
   })
   assert.equal(result.status, 0, result.stderr || result.stdout)
-  assert.match(calls, /^release create v1\.4\.12 --draft /m)
-  assert.match(calls, /^release view v1\.4\.12$/m)
-  assert.match(calls, /^release edit v1\.4\.12 /m)
+  assert.match(calls, /^release create v1\.4\.13 --draft /m)
+  assert.match(calls, /^release view v1\.4\.13$/m)
+  assert.match(calls, /^release edit v1\.4\.13 /m)
 })
 
 test('Tauri workflow finalizes the canonical body after tauri-action', () => {
@@ -104,7 +104,7 @@ test('Tauri workflow finalizes the canonical body after tauri-action', () => {
   assert.ok(action >= 0)
   assert.ok(finalize > action)
   const block = WORKFLOW.slice(finalize)
-  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.12'/)
+  assert.match(block, /if: env\.CATGO_RELEASE_TAG == 'v1\.4\.13'/)
   assert.match(block, /scripts\/ensure-release-body\.sh "\$CATGO_RELEASE_TAG"/)
 })
 

--- a/scripts/__tests__/release-version-verifier.test.mjs
+++ b/scripts/__tests__/release-version-verifier.test.mjs
@@ -53,7 +53,7 @@ function runVerifierWithEnvironment(root, environment) {
   })
 }
 
-function replaceVersion(root, path, from = '1.4.12', to = '1.4.9') {
+function replaceVersion(root, path, from = '1.4.13', to = '1.4.9') {
   const target = resolve(root, path)
   const current = readFileSync(target, 'utf8')
   assert.match(current, new RegExp(from.replaceAll('.', '\\.')), path)
@@ -63,9 +63,9 @@ function replaceVersion(root, path, from = '1.4.12', to = '1.4.9') {
 test('accepts a consistent release tree and its exact v-prefixed tag', () => {
   const root = fixture()
   try {
-    const result = runVerifier(root, '--tag', 'v1.4.12')
+    const result = runVerifier(root, '--tag', 'v1.4.13')
     assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /release version 1\.4\.12 verified/)
+    assert.match(result.stdout, /release version 1\.4\.13 verified/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -78,7 +78,7 @@ test('accepts Windows CRLF checkouts', () => {
       const target = resolve(root, path)
       writeFileSync(target, readFileSync(target, 'utf8').replaceAll('\n', '\r\n'))
     }
-    const result = runVerifier(root, '--tag', 'v1.4.12')
+    const result = runVerifier(root, '--tag', 'v1.4.13')
     assert.equal(result.status, 0, result.stderr)
   } finally {
     rmSync(root, { recursive: true, force: true })
@@ -106,7 +106,7 @@ test('rejects a tag that does not exactly match the manifest version', () => {
   try {
     const result = runVerifier(root, '--tag', 'v1.4.9')
     assert.notEqual(result.status, 0)
-    assert.match(result.stderr, /expected v1\.4\.12/)
+    assert.match(result.stderr, /expected v1\.4\.13/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -127,7 +127,7 @@ test('honors the workflow tag and publishing requirement environment', () => {
   const root = fixture()
   try {
     const matching = runVerifierWithEnvironment(root, {
-      RELEASE_VERSION_TAG: 'v1.4.12',
+      RELEASE_VERSION_TAG: 'v1.4.13',
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.equal(matching.status, 0, matching.stderr)
@@ -137,7 +137,7 @@ test('honors the workflow tag and publishing requirement environment', () => {
       RELEASE_VERSION_REQUIRE_TAG: 'true',
     })
     assert.notEqual(mismatched.status, 0)
-    assert.match(mismatched.stderr, /expected v1\.4\.12/)
+    assert.match(mismatched.stderr, /expected v1\.4\.13/)
 
     const missing = runVerifierWithEnvironment(root, {
       RELEASE_VERSION_TAG: '',

--- a/scripts/__tests__/version-consistency.test.mjs
+++ b/scripts/__tests__/version-consistency.test.mjs
@@ -6,7 +6,7 @@ import test from 'node:test'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const source = (path) => readFileSync(resolve(ROOT, path), 'utf8')
-const APP_VERSION = '1.4.12'
+const APP_VERSION = '1.4.13'
 const WORKFLOW_INVENTORY = {
   'android-build.yml': {
     classification: 'root-versioned-publisher',
@@ -134,7 +134,7 @@ function workflowStep(path, name) {
   return workflow.slice(start, next === -1 ? undefined : next)
 }
 
-test('all CatGo application version surfaces target v1.4.12', () => {
+test('all CatGo application version surfaces target v1.4.13', () => {
   const packageJson = JSON.parse(source('package.json'))
   const tauriConfig = JSON.parse(source('src-tauri/tauri.conf.json'))
   const cargoLockMatch =
@@ -156,7 +156,7 @@ test('all CatGo application version surfaces target v1.4.12', () => {
   )
 })
 
-test('VSIX and citation package metadata target v1.4.12', () => {
+test('VSIX and citation package metadata target v1.4.13', () => {
   const vscodePackage = JSON.parse(source('extensions/vscode/package.json'))
   assert.equal(vscodePackage.version, APP_VERSION)
 
@@ -177,10 +177,10 @@ test('the dependency lock remains a pnpm v9 root-importer lock', () => {
   assert.match(lock, /^importers:\n\n  \.:\n/m)
 })
 
-test('the desktop draft release notes describe v1.4.12', () => {
+test('the desktop draft release notes describe v1.4.13', () => {
   const workflow = source('.github/workflows/tauri-build.yml')
 
-  assert.match(workflow, /### New in 1\.4\.12/)
+  assert.match(workflow, /### New in 1\.4\.13/)
   assert.match(workflow, /Packaged backends start reliably on Linux and Windows/)
   assert.match(workflow, /Installed CatBot is complete across supported desktops/)
   assert.match(workflow, /Windows terminal and Campaign workflows are reliable/)

--- a/scripts/__tests__/vscode-sidecar-availability.test.mjs
+++ b/scripts/__tests__/vscode-sidecar-availability.test.mjs
@@ -25,13 +25,13 @@ test('accepts all three version-coupled sidecars and exact checksums', async () 
   }
 
   const result = await verifyVscodeSidecars({
-    version: '1.4.12',
+    version: '1.4.13',
     fetchImpl,
   })
 
   assert.deepEqual(result.map(({ asset }) => asset), VSCODE_SIDECAR_ASSETS)
   assert.equal(requests.length, 6)
-  assert.ok(requests.every(([url]) => url.includes('/v1.4.12/')))
+  assert.ok(requests.every(([url]) => url.includes('/v1.4.13/')))
 })
 
 test('fails closed before marketplace publication when a checksum is absent', async () => {
@@ -55,7 +55,7 @@ test('checksum metadata must name the exact platform asset', () => {
 test('rejects insecure sidecar origins', async () => {
   await assert.rejects(
     verifyVscodeSidecars({
-      version: '1.4.12',
+      version: '1.4.13',
       baseUrl: 'http://dl.catgo-ucsd.org',
       fetchImpl: async () => new Response(null, { status: 200 }),
     }),

--- a/scripts/release-trust-policy.mjs
+++ b/scripts/release-trust-policy.mjs
@@ -17,6 +17,7 @@ export const RELEASE_TRUST_POLICY = Object.freeze({
     'eb477bebe6f161f3aa1c3080e5a2750f15f80a37022f93737fe462322cfd97bf',
     '411285e85b193b3eb85dbdca7e428cbc97d28752bc89df8d67c572e4c1b4b8a8',
     '7b98d77d6abb48449dcb896a9d6edb3f8a5adee1597b5eddc146f143bea650c8',
+    'eb9665abbb3d2debf3708c9e5a90e7d8b0bb434c5b468aefc6fb41a72d1b2140',
   ]),
   tauriUpdaterPubkey:
     'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5QUM5OTQwNjdENjIyMjYKUldRbUl0Wm5RSm1zS2N5L2xiM3VrU2VteUtZSzNySkp6VlZmNmk0UHFoVmNuR2NqZ0ZKNzQzMnoK',

--- a/scripts/verify-legal-distributions.mjs
+++ b/scripts/verify-legal-distributions.mjs
@@ -323,7 +323,7 @@ function verifyReleaseAssets() {
     'the download mirror must validate assets against legal material from the target tag',
   )
   requireMatch(
-    '.github/release-notes/v1.4.12.md',
+    '.github/release-notes/v1.4.13.md',
     /AGPL-3\.0-or-later[\s\S]*This work used CatGo \(https:\/\/app\.catgo-ucsd\.org\)\.[\s\S]*10\.1039\/D6DD00273K[\s\S]*not an additional condition/i,
     'release body must prominently disclose AGPL, the requested acknowledgement, DOI, and its non-binding status',
   )

--- a/server/CITATION.cff
+++ b/server/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: If CatGo contributes to your work, please acknowledge and cite it as described below. This request is not an additional condition of AGPL-3.0-or-later.
-version: 1.4.12
+version: 1.4.13
 title: CatGo
 license: AGPL-3.0-or-later
 license-url: https://github.com/Hello-QM/catgo-LRG/blob/main/license

--- a/server/catgo/campaign_cli.py
+++ b/server/catgo/campaign_cli.py
@@ -12,8 +12,12 @@ that is not ``server/``, so a bare ``python -m catgo`` subprocess fails with
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import io
 import os
 import sys
+import threading
+import traceback
 
 CAMPAIGN_ACTIONS = (
     "new", "fetch-ref", "submit", "poll", "aggregate", "report", "ingest", "archive",
@@ -21,20 +25,52 @@ CAMPAIGN_ACTIONS = (
 
 # server/ — this file is server/catgo/campaign_cli.py, so two dirnames up.
 _SERVER_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_IN_PROCESS_CAPTURE_LOCK = threading.Lock()
 
 
 def campaign_argv(action: str, extra: list[str]) -> list[str]:
-    """Build argv for the campaign subprocess (pure).
+    """Build argv for the source/wheel Campaign subprocess (pure).
 
-    In a PyInstaller bundle, ``sys.executable`` is the ``catgo-server``
-    sidecar itself rather than a Python interpreter.  That executable exposes
-    the regular CatGo CLI as ``catgo-server campaign ...``; passing ``-m`` to
-    it would instead enter the backend argument parser and fail.  Source and
-    wheel installs continue to use ``python -m catgo``.
+    A PyInstaller one-file bundle cannot safely launch ``sys.executable`` here:
+    that is the complete ``catgo-server`` sidecar, not a Python interpreter,
+    and Windows would unpack the hundreds-of-MB backend again for every
+    Campaign action. Frozen callers must use the in-process path in
+    :func:`run_campaign_cli`.
     """
     if getattr(sys, "frozen", False):
-        return [sys.executable, "campaign", action, *extra]
+        raise RuntimeError("frozen Campaign actions execute in-process")
     return [sys.executable, "-m", "catgo", "campaign", action, *extra]
+
+
+def _run_campaign_in_process(action: str, extra: list[str]) -> tuple[str, int]:
+    """Run one Campaign action inside an already-extracted frozen backend."""
+
+    from catgo.cli.campaign_cmd import run_campaign
+
+    output = io.StringIO()
+    # redirect_stdout/redirect_stderr are process-global. Serialize Campaign
+    # invocations so two agent requests cannot steal each other's CLI output.
+    # The server's logging handler already owns its original stream, so normal
+    # backend logs remain visible while this short-lived capture is active.
+    with (
+        _IN_PROCESS_CAPTURE_LOCK,
+        contextlib.redirect_stdout(output),
+        contextlib.redirect_stderr(output),
+    ):
+        try:
+            code = int(run_campaign([action, *extra]) or 0)
+        except SystemExit as exc:
+            if exc.code is None:
+                code = 0
+            elif isinstance(exc.code, int):
+                code = exc.code
+            else:
+                print(exc.code, file=sys.stderr)
+                code = 1
+        except Exception:  # noqa: BLE001 — match subprocess traceback semantics
+            traceback.print_exc()
+            code = 1
+    return output.getvalue(), code
 
 
 async def run_campaign_cli(
@@ -50,6 +86,15 @@ async def run_campaign_cli(
         raise ValueError(
             f"action must be one of {', '.join(CAMPAIGN_ACTIONS)}"
         )
+    if getattr(sys, "frozen", False):
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(_run_campaign_in_process, action, extra),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            return ("", -1)
+
     env = {
         **os.environ,
         "PYTHONPATH": _SERVER_DIR + os.pathsep + os.environ.get("PYTHONPATH", ""),

--- a/server/catgo/mcp_tools/server_claude_code.py
+++ b/server/catgo/mcp_tools/server_claude_code.py
@@ -2625,7 +2625,8 @@ async def _handle_skills(args: dict) -> list[TextContent]:
 
 # Pure argv builder kept as a thin alias over the shared helper so the SDK-agent
 # path and the client-direct HTTP route stay in lock-step (DRY). The PYTHONPATH
-# fix + subprocess live in catgo.campaign_cli.run_campaign_cli.
+# source subprocess and frozen in-process dispatch live in
+# catgo.campaign_cli.run_campaign_cli.
 from catgo.campaign_cli import campaign_argv as _campaign_argv  # noqa: E402
 from catgo.campaign_cli import run_campaign_cli as _run_campaign_cli  # noqa: E402
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "catgo"
-version = "1.4.12"
+version = "1.4.13"
 description = "CatGo — AI-driven workbench for computational materials science (3D viewer + workflow engine + MCP)"
 readme = "README-pypi.md"
 license = "AGPL-3.0-or-later"

--- a/server/tests/test_campaign_cli.py
+++ b/server/tests/test_campaign_cli.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+from catgo import campaign_cli
 from catgo.campaign_cli import CAMPAIGN_ACTIONS, campaign_argv, run_campaign_cli
 
 
@@ -15,11 +16,41 @@ def test_campaign_argv():
 
 
 def test_campaign_argv_in_frozen_backend(monkeypatch):
-    """The bundled sidecar is the CLI host; it is not a Python interpreter."""
+    """The bundled sidecar must never be treated as a Python interpreter."""
     monkeypatch.setattr(sys, 'frozen', True, raising=False)
-    assert campaign_argv('new', ['p', '--template', 'blank']) == [
-        sys.executable, 'campaign', 'new', 'p', '--template', 'blank',
-    ]
+    with pytest.raises(RuntimeError, match='execute in-process'):
+        campaign_argv('new', ['p', '--template', 'blank'])
+
+
+def test_frozen_backend_runs_campaign_in_process(tmp_path, monkeypatch):
+    """Regression: Windows one-file backends must not unpack themselves again."""
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+
+    async def forbidden_subprocess(*args, **kwargs):
+        raise AssertionError('frozen Campaign attempted to spawn catgo-server')
+
+    monkeypatch.setattr(asyncio, 'create_subprocess_exec', forbidden_subprocess)
+    root = tmp_path / 'camp'
+    out, code = asyncio.run(run_campaign_cli(
+        'new', [str(root), '--name', 'Frozen Windows', '--template', 'blank'],
+    ))
+
+    assert code == 0
+    assert "created campaign 'Frozen Windows'" in out
+    assert (root / 'plan.md').is_file()
+
+
+def test_frozen_backend_preserves_cli_failures(monkeypatch):
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+
+    def fail(action, extra):
+        return ('campaign failed loudly\n', 7)
+
+    monkeypatch.setattr(campaign_cli, '_run_campaign_in_process', fail)
+    out, code = asyncio.run(run_campaign_cli('poll', []))
+
+    assert code == 7
+    assert out == 'campaign failed loudly\n'
 
 
 def test_bad_action_raises():

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "catgo"
-version = "1.4.12"
+version = "1.4.13"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catgo"
-version = "1.4.12"
+version = "1.4.13"
 description = "Interactive visualizations for materials science"
 authors = ["LRG <gul026@ucsd.edu>"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CatGo",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "identifier": "com.catgo.app",
   "build": {
     "frontendDist": "../build-desktop",


### PR DESCRIPTION
## CatGo 1.4.13

CatGo 1.4.13 is a cross-platform reliability release for CatBot, scientific
workflows, large trajectories, and the integrated terminal. It includes the
unpublished 1.4.10, 1.4.11, and 1.4.12 improvements, plus release-time fixes
verified on the Windows, macOS Apple Silicon, and Linux packaged build paths.

### Highlights

- **CatBot works from installed desktop packages** — Claude, Codex, and Gemini
  CLI discovery follows platform-native user paths, while the bundled backend
  and Agent Bridge expose the same Provider, MCP, Skills, voice, structure,
  workflow, and Campaign capabilities as the source build.
- **Packaged backends avoid redundant cold starts** — Linux bundles one
  ABI-compatible conda C++ runtime, while Windows frozen Campaign actions run
  inside the already-extracted backend without relaunching the one-file EXE.
- **Attachments reach the selected model** — images, PDFs, text files, and
  general files are carried through SDK, direct-provider, and backend-relay
  paths instead of being silently discarded.
- **Surface workflows are scientifically complete** — the clean slab is
  relaxed before adsorbate branches, frozen atoms stay consistent through
  geometry optimization and frequency calculations, and workflow status comes
  from actual task evidence.
- **Large trajectories and terminals remain responsive and complete** — bounded
  frame caches reduce memory pressure, while terminal resizing preserves CJK
  cells and keeps the final column clear of the scrollbar.

### Added

#### Packaged CatBot verification

- Added all-platform frozen-backend smoke tests covering the Provider catalogue,
  native voice health, bundled core Skills, all 21 CatGo MCP tools, structure and
  pane access, workflows, and real REST/MCP Campaign creation.
- Added compiled Agent Bridge smoke tests for Claude, Codex, and Gemini session,
  attachment, permission, failure, and stream-completion paths.
- Added native attachment transport for Claude image/PDF blocks, Codex local
  images, Gemini ACP images, and safe temporary file access for other formats.
- Added a release boundary that publishes the VS Code extension to Marketplace
  and Open VSX only after the exact-version Linux, macOS, and Windows sidecars
  and their SHA256 metadata are available on the public mirror.

#### CatBot and Codex integration

- Added live Codex model discovery so CatBot's provider label follows the
  installed CLI instead of carrying a stale hard-coded model version.
- Preserved the user's Codex skills and MCP configuration while registering the
  desktop CatGo server under its own namespace.
- Routed CatBot structure, workflow, and export actions through the active CatGo
  runtime connection rather than fixed localhost ports.
- Added structure recovery for pop-out chat windows and viewer panels so closing
  a presentation window does not erase the underlying structure.

#### Workflow management and surface science

- Added safe bulk selection and deletion to project and workflow views, with
  durable success or failure feedback.
- Added task-derived workflow state aggregation for CHECK, PAUSED, FAILED,
  REMOTE_ERROR, RUNNING, and completed work.
- Added a clean-slab geometry-optimization node before adsorbate branches in
  generated surface workflows.
- Persisted exact frozen-atom indices from slab generation through slab
  optimization, adsorbate geometry optimization, and adsorbate-only frequency
  calculations.

### Fixed

#### Cross-platform CatBot runtime

- Fixed Linux frozen backends mixing Ubuntu 22.04's older `libstdc++` with
  conda ICU. PyInstaller now selects the conda `libstdc++`/`libgcc` pair and
  verifies that it provides every collected CXXABI and GLIBCXX version.
- Fixed Windows frozen Campaign actions relaunching and unpacking the complete
  PyInstaller one-file backend for every request. Packaged Campaign dispatch now
  runs in-process while preserving output, exit codes, validation, timeouts, and
  asynchronous HTTP/MCP handling.
- Fixed GUI-launched Windows and macOS apps failing to find user-installed
  Claude, Codex, or Gemini CLIs because desktop launchers supplied a reduced
  PATH.
- Fixed installed Windows local terminals opening with the wrong shell or losing
  the selected shell and current directory across runtime transitions.
- Fixed frozen desktop backends launching Campaign as `python -m catgo`, which
  recursively invoked the packaged executable instead of the CatGo CLI.
- Fixed the first microphone action racing the delayed voice router and becoming
  stuck on an unavailable browser fallback.
- Fixed CatBot attachments appearing in the composer but never reaching SDK,
  direct-provider, or backend-relay requests.
- Fixed migrated tool-registry tests importing the obsolete pre-package module
  path, restoring coverage of packaged tool discovery.
- Fixed official VS Code builds becoming visible before their matching server
  sidecars, which previously produced unrecoverable HTTP 404 downloads.

#### Workflow correctness and recovery

- Fixed workflows that were reported as generated but never appeared in the
  visible CatGo workspace.
- Fixed completed, failed, or checking workflows that remained labeled RUNNING,
  while continuing to protect genuinely executing tasks and unresolved remote
  jobs from deletion.
- Fixed slab and geometry-optimization previews showing different frozen layers
  despite sharing the same structure.
- Fixed manual freeze edits that appeared selected but were not persisted into
  downstream inputs.

#### Database and networking

- Prevented Materials Project, OPTIMADE, and PubChem requests from inheriting
  agent-only SOCKS proxy settings. Normal HTTP proxy configuration remains
  available to the backend.
- Improved OPTIMADE provider recovery so a failed upstream request is reported
  accurately instead of leaving database search unusable.

#### Trajectory and terminal rendering

- Synchronized typed trajectory positions with topology and bond snapshots in
  Large System Performance Mode.
- Bounded decoded frame caches and refreshed bond snapshots without retaining an
  unbounded object graph during playback.
- Reserved terminal columns beside the scrollbar so the right edge is visible.
- Reflowed active full-screen terminal applications on font changes and repaired
  pre-existing tabs after hot reload, preventing CJK character loss.

#### Citation

- Updated the preferred CatGo citation to the published *Digital Discovery*
  article, DOI `10.1039/D6DD00273K`.

### Upgrade notes

- No project, workflow database, structure-file, or trajectory migration is
  required.
- Existing Codex skills and MCP configuration are retained. CatGo's desktop MCP
  entry is isolated automatically; remove obsolete hand-written CatGo entries
  only if you previously added duplicates yourself.
- Workflow deletion remains unavailable for tasks that are executing or whose
  remote job identity is unresolved. This is an intentional safety boundary.
- Generated surface workflows contain a clean-slab relaxation node. Review slab
  constraints before submitting a newly generated DAG.
- CatBot keeps attachment metadata in restored chat history but does not persist
  attachment bytes in browser storage. Reattach a file before asking a follow-up
  question that requires rereading it.
- VS Code, Cursor, VSCodium, and Theia users should install the Marketplace or
  Open VSX build. A manually version-edited VSIX has no matching sidecar and is
  intentionally rejected instead of silently running a different backend.

### Included pull requests

- [#571](https://github.com/Hello-QM/catgo-LRG/pull/571) — Update the preferred
  citation to the published *Digital Discovery* article.
- [#574](https://github.com/Hello-QM/catgo-LRG/pull/574) — Harden CatBot,
  workflow lifecycle and slab constraints, provider networking, large-system
  trajectories, and terminal resizing.
- [#576](https://github.com/Hello-QM/catgo-LRG/pull/576) — Repair Windows local
  shells and working-directory synchronization, then harden the complete
  packaged CatBot runtime across supported desktop platforms.

### Downloads

- **Windows x86-64** — `.msi` or `-setup.exe`
- **macOS Apple Silicon** — Developer-ID signed `.dmg`
- **Linux x86-64** — `.deb` or `.rpm`
- **Android** — `CatGo-v*-android-universal.apk`
- **iOS** — [TestFlight beta](https://testflight.apple.com/join/FdHup5Hz)
- **VS Code** — `.vsix`
- **Headless/HPC** — platform sidecars and `catgo-hpc-bundle.tar.gz`

### License and citation

CatGo 1.4.13 distributions use **AGPL-3.0-or-later**.

If CatGo contributes to your work, please include this acknowledgement and the
preferred citation:

> This work used CatGo (https://app.catgo-ucsd.org).

Please cite DOI
[`10.1039/D6DD00273K`](https://doi.org/10.1039/D6DD00273K).
This request is not an additional condition of the AGPL license. Third-party
materials retain their own terms. Historical AGPL grants remain in effect.

See the
[CHANGELOG](https://github.com/Hello-QM/catgo-LRG/blob/main/CHANGELOG.md)
for the complete release history.
